### PR TITLE
Allow saving workout without entering steps

### DIFF
--- a/AscendApp/Features/Workouts/ViewModels/WorkoutFormViewModel.swift
+++ b/AscendApp/Features/Workouts/ViewModels/WorkoutFormViewModel.swift
@@ -134,14 +134,16 @@ class WorkoutFormViewModel {
 
     // MARK: - Computed Properties
     var isFormValid: Bool {
+        // Steps/floors is optional - only validate if provided
+        let metricValid = metricValue.isEmpty || Int(metricValue) != nil
+        
         let basicValidation = !workoutName.isEmpty &&
         workoutName.count <= 50 &&
         !durationMinutes.isEmpty &&
         !durationSeconds.isEmpty &&
-        !metricValue.isEmpty &&
+        metricValid &&
         Int(durationMinutes) != nil &&
         Int(durationSeconds) != nil &&
-        Int(metricValue) != nil &&
         (Int(durationMinutes) ?? 0) < 60 &&
         (Int(durationSeconds) ?? 0) < 60 &&
         (durationHours.isEmpty || (Int(durationHours) != nil && (Int(durationHours) ?? 0) <= 999))
@@ -418,10 +420,12 @@ class WorkoutFormViewModel {
     // MARK: - Helper Methods
     private func createWorkoutRequest() throws -> CreateWorkoutRequest {
         guard let minutes = Int(durationMinutes),
-              let seconds = Int(durationSeconds),
-              let value = Int(metricValue) else {
+              let seconds = Int(durationSeconds) else {
             throw WorkoutFormError.invalidInput
         }
+        
+        // Steps/floors is optional - default to 0 if not provided
+        let value = Int(metricValue) ?? 0
 
         let hours = Int(durationHours) ?? 0
         let totalDuration = TimeInterval(hours * 3600 + minutes * 60 + seconds)


### PR DESCRIPTION
## Summary

Steps/floors is now optional when logging a workout manually. Users can save with just duration and title.

## Changes

- Updated `isFormValid` to not require metricValue (steps/floors)
- Updated `createWorkoutRequest()` to default to 0 if no steps provided

## Testing

1. Open manual workout log
2. Enter a title and duration only (leave steps empty)
3. Save should work ✓

Closes #3