### PR TITLE
Implement remaining issues: #10, #11, #12, #7 (partial)

### DIFF
--- a/AscendApp/Features/Progress/Views/BestEffortsListView.swift
+++ b/AscendApp/Features/Progress/Views/BestEffortsListView.swift
@@ -8,6 +8,31 @@
 import SwiftUI
 import SwiftData
 
+/// Time period for filtering best efforts
+enum BestEffortsTimePeriod: String, CaseIterable, Identifiable {
+    case week = "Week"
+    case month = "Month"
+    case year = "Year"
+    case allTime = "All Time"
+    
+    var id: String { rawValue }
+    
+    /// Returns the start date for this time period
+    func startDate(from referenceDate: Date = Date()) -> Date? {
+        let calendar = Calendar.current
+        switch self {
+        case .week:
+            return calendar.date(byAdding: .day, value: -7, to: referenceDate)
+        case .month:
+            return calendar.date(byAdding: .month, value: -1, to: referenceDate)
+        case .year:
+            return calendar.date(byAdding: .year, value: -1, to: referenceDate)
+        case .allTime:
+            return nil
+        }
+    }
+}
+
 struct BestEffortsListView: View {
     let workouts: [Workout]
 
@@ -15,6 +40,7 @@ struct BestEffortsListView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var themeManager = ThemeManager.shared
     @State private var settingsManager = SettingsManager.shared
+    @State private var selectedTimePeriod: BestEffortsTimePeriod = .allTime
 
     // Weight records state
     @State private var weightRecordsSections: [WeightRecordsSection] = []
@@ -23,9 +49,17 @@ struct BestEffortsListView: View {
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
     }
+    
+    /// Filter workouts based on selected time period
+    private var filteredWorkouts: [Workout] {
+        guard let startDate = selectedTimePeriod.startDate() else {
+            return workouts // All time - no filtering
+        }
+        return workouts.filter { $0.date >= startDate }
+    }
 
     private var efforts: [BestEffort] {
-        BestEffortsBuilder.bestEfforts(from: workouts)
+        BestEffortsBuilder.bestEfforts(from: filteredWorkouts)
     }
 
     private var hasWeightRecords: Bool {
@@ -35,6 +69,9 @@ struct BestEffortsListView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
+                // Time Period Picker
+                timePeriodPicker
+                
                 if efforts.isEmpty && !hasWeightRecords {
                     emptyState
                 } else {
@@ -42,8 +79,8 @@ struct BestEffortsListView: View {
                         effortsList
                     }
 
-                    // Weight Records Section
-                    if hasWeightRecords {
+                    // Weight Records Section (only show for all-time)
+                    if hasWeightRecords && selectedTimePeriod == .allTime {
                         weightRecordsSection
                     }
                 }
@@ -60,7 +97,7 @@ struct BestEffortsListView: View {
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                NavigationLink(destination: BestEffortsProgressView(workouts: workouts)) {
+                NavigationLink(destination: BestEffortsProgressView(workouts: filteredWorkouts)) {
                     Image(systemName: "chart.line.uptrend.xyaxis")
                         .font(.system(size: 16, weight: .medium))
                         .foregroundStyle(.accent)
@@ -70,6 +107,39 @@ struct BestEffortsListView: View {
         .onAppear {
             loadWeightRecords()
         }
+    }
+    
+    private var timePeriodPicker: some View {
+        HStack(spacing: 8) {
+            ForEach(BestEffortsTimePeriod.allCases) { period in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        selectedTimePeriod = period
+                    }
+                    HapticsManager.shared.trigger(.selection)
+                } label: {
+                    Text(period.rawValue)
+                        .font(.montserratMedium(size: 13))
+                        .foregroundStyle(
+                            selectedTimePeriod == period
+                                ? .white
+                                : (effectiveColorScheme == .dark ? .white.opacity(0.6) : .black.opacity(0.6))
+                        )
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(selectedTimePeriod == period ? Color.accentColor : Color.clear)
+                        )
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.05))
+        )
     }
     
     private var effortsList: some View {
@@ -85,11 +155,11 @@ struct BestEffortsListView: View {
     
     private var emptyState: some View {
         VStack(spacing: 12) {
-            Text("No Best Efforts Yet")
+            Text(emptyStateTitle)
                 .font(.montserratSemiBold(size: 18))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
 
-            Text("Start logging workouts to see your all‑time best sessions for steps, duration, heart rate, and more.")
+            Text(emptyStateMessage)
                 .font(.montserratRegular(size: 14))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
                 .multilineTextAlignment(.center)
@@ -100,6 +170,32 @@ struct BestEffortsListView: View {
             RoundedRectangle(cornerRadius: 20)
                 .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.05) : Color.black.opacity(0.03))
         )
+    }
+    
+    private var emptyStateTitle: String {
+        switch selectedTimePeriod {
+        case .week:
+            return "No Workouts This Week"
+        case .month:
+            return "No Workouts This Month"
+        case .year:
+            return "No Workouts This Year"
+        case .allTime:
+            return "No Best Efforts Yet"
+        }
+    }
+    
+    private var emptyStateMessage: String {
+        switch selectedTimePeriod {
+        case .week:
+            return "Log a workout this week to see your best efforts."
+        case .month:
+            return "Log a workout this month to see your best efforts."
+        case .year:
+            return "Log a workout this year to see your best efforts."
+        case .allTime:
+            return "Start logging workouts to see your all‑time best sessions for steps, duration, heart rate, and more."
+        }
     }
 
     // MARK: - Weight Records Section

--- a/AscendApp/Features/Progress/Views/BestEffortsListView.swift
+++ b/AscendApp/Features/Progress/Views/BestEffortsListView.swift
@@ -38,9 +38,11 @@ struct BestEffortsListView: View {
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.modelContext) private var modelContext
+    @Environment(AuthenticationViewModel.self) private var authVM
     @State private var themeManager = ThemeManager.shared
     @State private var settingsManager = SettingsManager.shared
     @State private var selectedTimePeriod: BestEffortsTimePeriod = .allTime
+    @State private var effortToShare: BestEffort?
 
     // Weight records state
     @State private var weightRecordsSections: [WeightRecordsSection] = []
@@ -149,7 +151,27 @@ struct BestEffortsListView: View {
                     BestEffortCard(effort: effort, colorScheme: effectiveColorScheme)
                 }
                 .buttonStyle(PlainButtonStyle())
+                .contextMenu {
+                    Button {
+                        effortToShare = effort
+                    } label: {
+                        Label("Share PR", systemImage: "square.and.arrow.up")
+                    }
+                    
+                    Button {
+                        // Navigate handled by NavigationLink
+                    } label: {
+                        Label("View Workout", systemImage: "eye")
+                    }
+                }
             }
+        }
+        .sheet(item: $effortToShare) { effort in
+            PRShareSheet(
+                effort: effort,
+                previousValue: nil, // TODO: Calculate previous value from workout history
+                displayName: authVM.displayName ?? "Athlete"
+            )
         }
     }
     

--- a/AscendApp/Features/Progress/Views/PRShareCardView.swift
+++ b/AscendApp/Features/Progress/Views/PRShareCardView.swift
@@ -1,0 +1,315 @@
+//
+//  PRShareCardView.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+
+/// A shareable card displaying a personal record achievement
+struct PRShareCardView: View {
+    let effort: BestEffort
+    let previousValue: String?
+    let displayName: String
+    
+    // Card dimensions for Instagram Stories
+    private let cardWidth: CGFloat = 390
+    private let cardHeight: CGFloat = 520
+    
+    var body: some View {
+        ZStack {
+            // Background gradient
+            LinearGradient(
+                colors: [
+                    Color(red: 0.1, green: 0.1, blue: 0.2),
+                    Color(red: 0.05, green: 0.15, blue: 0.25)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            
+            // Content
+            VStack(spacing: 0) {
+                Spacer()
+                
+                // NEW PR Badge
+                HStack(spacing: 8) {
+                    Image(systemName: "star.fill")
+                        .font(.system(size: 16))
+                    Text("NEW PERSONAL RECORD")
+                        .font(.montserratBold(size: 14))
+                        .tracking(2)
+                }
+                .foregroundStyle(.yellow)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 10)
+                .background(
+                    Capsule()
+                        .fill(Color.yellow.opacity(0.2))
+                )
+                
+                Spacer()
+                    .frame(height: 32)
+                
+                // Icon
+                Image(systemName: effort.iconName)
+                    .font(.system(size: 60, weight: .medium))
+                    .foregroundStyle(.accent)
+                    .padding(.bottom, 16)
+                
+                // PR Type
+                Text(effort.title)
+                    .font(.montserratSemiBold(size: 18))
+                    .foregroundStyle(.white.opacity(0.8))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 20)
+                
+                Spacer()
+                    .frame(height: 20)
+                
+                // Value
+                Text(effort.valueText)
+                    .font(.montserratBold(size: 48))
+                    .foregroundStyle(.white)
+                    .minimumScaleFactor(0.7)
+                    .lineLimit(1)
+                
+                // Previous value comparison
+                if let previous = previousValue {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.system(size: 14))
+                        Text("Previous: \(previous)")
+                            .font(.montserratMedium(size: 14))
+                    }
+                    .foregroundStyle(.green)
+                    .padding(.top, 8)
+                }
+                
+                Spacer()
+                    .frame(height: 20)
+                
+                // Date
+                Text(formattedDate)
+                    .font(.montserratMedium(size: 14))
+                    .foregroundStyle(.white.opacity(0.6))
+                
+                Spacer()
+                
+                // Footer with branding
+                HStack {
+                    Text(displayName)
+                        .font(.montserratMedium(size: 13))
+                        .foregroundStyle(.white.opacity(0.5))
+                    
+                    Spacer()
+                    
+                    HStack(spacing: 6) {
+                        Image("AscendLogo")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 18)
+                        Text("Ascend")
+                            .font(.montserratSemiBold(size: 13))
+                    }
+                    .foregroundStyle(.white.opacity(0.5))
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
+            }
+        }
+        .frame(width: cardWidth, height: cardHeight)
+        .clipShape(RoundedRectangle(cornerRadius: 24))
+    }
+    
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        return formatter.string(from: effort.date)
+    }
+}
+
+// MARK: - Image Rendering Extension
+
+extension PRShareCardView {
+    /// Render the card as a UIImage for sharing
+    @MainActor
+    func renderAsImage() -> UIImage? {
+        let renderer = ImageRenderer(content: self)
+        renderer.scale = UIScreen.main.scale
+        return renderer.uiImage
+    }
+}
+
+// MARK: - PR Share Sheet
+
+struct PRShareSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    
+    let effort: BestEffort
+    let previousValue: String?
+    let displayName: String
+    
+    @State private var themeManager = ThemeManager.shared
+    @State private var isSharing = false
+    @State private var shareImage: UIImage?
+    
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: colorScheme)
+    }
+    
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Spacer()
+                
+                // Preview card
+                PRShareCardView(
+                    effort: effort,
+                    previousValue: previousValue,
+                    displayName: displayName
+                )
+                .scaleEffect(0.85)
+                
+                Spacer()
+                
+                // Share button
+                Button {
+                    shareCard()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "square.and.arrow.up")
+                        Text("Share")
+                    }
+                    .font(.montserratSemiBold(size: 16))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14)
+                            .fill(Color.accentColor)
+                    )
+                }
+                .disabled(isSharing)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 20)
+            }
+            .themedBackground()
+            .navigationTitle("Share PR")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .foregroundStyle(.accent)
+                }
+            }
+        }
+    }
+    
+    private func shareCard() {
+        isSharing = true
+        
+        let cardView = PRShareCardView(
+            effort: effort,
+            previousValue: previousValue,
+            displayName: displayName
+        )
+        
+        guard let image = cardView.renderAsImage() else {
+            isSharing = false
+            return
+        }
+        
+        let activityVC = UIActivityViewController(
+            activityItems: [image],
+            applicationActivities: nil
+        )
+        
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let rootVC = windowScene.windows.first?.rootViewController {
+            // Find the topmost presented view controller
+            var topController = rootVC
+            while let presented = topController.presentedViewController {
+                topController = presented
+            }
+            
+            // For iPad
+            activityVC.popoverPresentationController?.sourceView = topController.view
+            activityVC.popoverPresentationController?.sourceRect = CGRect(
+                x: topController.view.bounds.midX,
+                y: topController.view.bounds.midY,
+                width: 0,
+                height: 0
+            )
+            
+            topController.present(activityVC, animated: true) {
+                isSharing = false
+            }
+        } else {
+            isSharing = false
+        }
+    }
+}
+
+#Preview {
+    let sampleWorkout = Workout(
+        name: "Morning Climb",
+        date: Date(),
+        duration: 45 * 60,
+        steps: 5200,
+        floors: 40,
+        stepsPerFloor: 16,
+        avgHeartRate: 135,
+        maxHeartRate: 168,
+        caloriesBurned: 520
+    )
+    
+    let effort = BestEffort(
+        type: .mostSteps,
+        title: "Most Steps in a Workout",
+        valueText: "5,200 steps",
+        detailText: "Feb 19, 2026",
+        date: Date(),
+        workout: sampleWorkout,
+        iconName: "figure.stairs"
+    )
+    
+    return PRShareSheet(
+        effort: effort,
+        previousValue: "4,800 steps",
+        displayName: "Tyler"
+    )
+}
+
+#Preview("Card Only") {
+    let sampleWorkout = Workout(
+        name: "Morning Climb",
+        date: Date(),
+        duration: 45 * 60,
+        steps: 5200,
+        floors: 40,
+        stepsPerFloor: 16
+    )
+    
+    let effort = BestEffort(
+        type: .highestStepsPerMinute,
+        title: "Highest Steps per Minute",
+        valueText: "115 / min",
+        detailText: "Feb 19, 2026",
+        date: Date(),
+        workout: sampleWorkout,
+        iconName: "speedometer"
+    )
+    
+    return PRShareCardView(
+        effort: effort,
+        previousValue: "108 / min",
+        displayName: "Tyler"
+    )
+    .padding()
+    .background(Color.gray)
+}

--- a/AscendApp/Shared/Managers/AppStoreRatingManager.swift
+++ b/AscendApp/Shared/Managers/AppStoreRatingManager.swift
@@ -9,19 +9,28 @@ import StoreKit
 import SwiftUI
 
 /// Manages App Store rating prompts with intelligent timing
-/// Prompts at 20 workouts, then every 30 workouts thereafter
+/// Shows custom prompt first, then system prompt if user agrees
+/// Prompts at 10 workouts, then every 30 workouts thereafter
 @MainActor
+@Observable
 final class AppStoreRatingManager {
     static let shared = AppStoreRatingManager()
 
     private init() {}
 
+    // MARK: - Observable State
+    
+    /// Whether to show the custom rating prompt overlay
+    var showCustomPrompt = false
+
     // MARK: - Constants
 
     private enum Constants {
-        static let firstPromptThreshold = 20
+        static let firstPromptThreshold = 10  // Lowered from 20 for earlier engagement
         static let subsequentPromptInterval = 30
         static let userDefaultsKey = "lastRatingPromptWorkoutCount"
+        static let notNowDelayDays = 14  // Days to wait after user taps "Not Now"
+        static let lastNotNowDateKey = "lastRatingNotNowDate"
     }
 
     // MARK: - UserDefaults
@@ -29,6 +38,11 @@ final class AppStoreRatingManager {
     private var lastPromptedWorkoutCount: Int {
         get { UserDefaults.standard.integer(forKey: Constants.userDefaultsKey) }
         set { UserDefaults.standard.set(newValue, forKey: Constants.userDefaultsKey) }
+    }
+    
+    private var lastNotNowDate: Date? {
+        get { UserDefaults.standard.object(forKey: Constants.lastNotNowDateKey) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: Constants.lastNotNowDateKey) }
     }
 
     // MARK: - Public Methods
@@ -41,24 +55,47 @@ final class AppStoreRatingManager {
         guard currentWorkoutCount >= Constants.firstPromptThreshold else {
             return false
         }
+        
+        // Check if user recently tapped "Not Now"
+        if let lastNotNow = lastNotNowDate {
+            let daysSinceNotNow = Calendar.current.dateComponents([.day], from: lastNotNow, to: Date()).day ?? 0
+            if daysSinceNotNow < Constants.notNowDelayDays {
+                return false
+            }
+        }
 
-        // First time reaching 20 workouts
+        // First time reaching threshold
         if lastPromptedWorkoutCount == 0 && currentWorkoutCount >= Constants.firstPromptThreshold {
             return true
         }
 
-        // Check if we've reached another interval (50, 80, 110, etc.)
+        // Check if we've reached another interval
         let workoutsSinceLastPrompt = currentWorkoutCount - lastPromptedWorkoutCount
         return workoutsSinceLastPrompt >= Constants.subsequentPromptInterval
     }
-
-    /// Request an App Store rating prompt
-    /// Apple will decide whether to actually show it based on system limitations
+    
+    /// Show the custom rating prompt overlay
     /// - Parameter currentWorkoutCount: Current workout count to track when we prompted
-    func requestReview(currentWorkoutCount: Int) {
-        // Update the last prompted count
+    func showCustomRatingPrompt(currentWorkoutCount: Int) {
         lastPromptedWorkoutCount = currentWorkoutCount
+        showCustomPrompt = true
+    }
+    
+    /// Called when user taps "Rate Us" on custom prompt
+    func userTappedRateUs() {
+        showCustomPrompt = false
+        requestSystemReview()
+    }
+    
+    /// Called when user taps "Not Now" on custom prompt
+    func userTappedNotNow() {
+        showCustomPrompt = false
+        lastNotNowDate = Date()
+    }
 
+    /// Request the system App Store rating prompt
+    /// Apple will decide whether to actually show it based on system limitations
+    func requestSystemReview() {
         // Request the review from Apple
         // Note: Apple controls whether the prompt is actually shown based on:
         // - User's "In-App Ratings & Reviews" setting
@@ -75,8 +112,28 @@ final class AppStoreRatingManager {
             SKStoreReviewController.requestReview(in: scene)
         }
     }
+    
+    /// Legacy method - Request an App Store rating prompt directly
+    /// - Parameter currentWorkoutCount: Current workout count to track when we prompted
+    func requestReview(currentWorkoutCount: Int) {
+        lastPromptedWorkoutCount = currentWorkoutCount
+        requestSystemReview()
+    }
 
-    /// Check eligibility and request review if appropriate
+    /// Check eligibility and show custom prompt if appropriate
+    /// - Parameter currentWorkoutCount: Total number of workouts the user has logged
+    /// - Returns: True if a prompt was shown, false otherwise
+    @discardableResult
+    func checkAndShowPromptIfNeeded(currentWorkoutCount: Int) -> Bool {
+        guard shouldPromptForRating(currentWorkoutCount: currentWorkoutCount) else {
+            return false
+        }
+
+        showCustomRatingPrompt(currentWorkoutCount: currentWorkoutCount)
+        return true
+    }
+    
+    /// Legacy method - Check eligibility and request review if appropriate
     /// - Parameter currentWorkoutCount: Total number of workouts the user has logged
     /// - Returns: True if a review was requested, false otherwise
     @discardableResult

--- a/AscendApp/Shared/Views/MainTabView.swift
+++ b/AscendApp/Shared/Views/MainTabView.swift
@@ -12,6 +12,7 @@ struct MainTabView: View {
     @Environment(\.colorScheme) private var systemColorScheme
     @Environment(\.modelContext) private var modelContext
     @State private var themeManager = ThemeManager.shared
+    @State private var ratingManager = AppStoreRatingManager.shared
     @StateObject private var tabRouter = TabRouter()
     @State private var hasCheckedRatingOnLaunch = false
 
@@ -55,6 +56,17 @@ struct MainTabView: View {
             generator.impactOccurred()
         }
         .themeAware()
+        .overlay {
+            RatingPromptOverlay(
+                isPresented: $ratingManager.showCustomPrompt,
+                onRateUs: {
+                    ratingManager.userTappedRateUs()
+                },
+                onNotNow: {
+                    ratingManager.userTappedNotNow()
+                }
+            )
+        }
     }
 
     private func checkForRatingPromptOnLaunch() {
@@ -67,7 +79,7 @@ struct MainTabView: View {
         // Note: We fetch count on-demand rather than using @Query to avoid crashes
         // when workouts are deleted (e.g., during account deletion) while this view is in the hierarchy
         let workoutCount = (try? modelContext.fetchCount(FetchDescriptor<Workout>())) ?? 0
-        AppStoreRatingManager.shared.checkAndRequestReviewIfNeeded(currentWorkoutCount: workoutCount)
+        AppStoreRatingManager.shared.checkAndShowPromptIfNeeded(currentWorkoutCount: workoutCount)
     }
     
     private func getIconName(for tab: TabItem, isSelected: Bool) -> String {

--- a/AscendApp/Shared/Views/RatingPromptView.swift
+++ b/AscendApp/Shared/Views/RatingPromptView.swift
@@ -1,0 +1,152 @@
+//
+//  RatingPromptView.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+
+/// Custom rating prompt shown before the system App Store review dialog
+/// Inspired by Partiful's personal approach to rating requests
+struct RatingPromptView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var themeManager = ThemeManager.shared
+    
+    let onRateUs: () -> Void
+    let onNotNow: () -> Void
+    
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: colorScheme)
+    }
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            // Emoji header
+            Text("🏔️")
+                .font(.system(size: 60))
+            
+            // Personal message
+            VStack(spacing: 12) {
+                Text("Enjoying Ascend?")
+                    .font(.montserratBold(size: 24))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                
+                Text("Hey! I'm Tyler, the developer behind Ascend. I built this app because I couldn't find a workout tracker that truly understood stairstepper training.\n\nIf Ascend has helped you crush your fitness goals, would you mind leaving a quick review? It really helps other fitness enthusiasts discover the app.")
+                    .font(.montserratRegular(size: 15))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.8) : .black.opacity(0.7))
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+            }
+            
+            // Buttons
+            VStack(spacing: 12) {
+                Button(action: {
+                    HapticsManager.shared.trigger(.selection)
+                    onRateUs()
+                }) {
+                    Text("Rate Ascend ⭐")
+                        .font(.montserratSemiBold(size: 16))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(Color.accentColor)
+                        .cornerRadius(12)
+                }
+                
+                Button(action: {
+                    HapticsManager.shared.trigger(.selection)
+                    onNotNow()
+                }) {
+                    Text("Maybe Later")
+                        .font(.montserratMedium(size: 15))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .black.opacity(0.5))
+                }
+                .padding(.top, 4)
+            }
+        }
+        .padding(24)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(effectiveColorScheme == .dark ? Color.jetLighter : Color.white)
+        )
+        .shadow(color: .black.opacity(0.2), radius: 20, x: 0, y: 10)
+        .padding(.horizontal, 32)
+    }
+}
+
+/// Full-screen overlay for the rating prompt
+struct RatingPromptOverlay: View {
+    @Binding var isPresented: Bool
+    let onRateUs: () -> Void
+    var onNotNow: (() -> Void)? = nil
+    
+    var body: some View {
+        if isPresented {
+            ZStack {
+                // Dimmed background
+                Color.black.opacity(0.5)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        // Dismiss on background tap (counts as "not now")
+                        withAnimation(.spring(response: 0.3)) {
+                            isPresented = false
+                        }
+                        onNotNow?()
+                    }
+                
+                // Prompt card
+                RatingPromptView(
+                    onRateUs: {
+                        withAnimation(.spring(response: 0.3)) {
+                            isPresented = false
+                        }
+                        // Small delay to let animation complete
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            onRateUs()
+                        }
+                    },
+                    onNotNow: {
+                        withAnimation(.spring(response: 0.3)) {
+                            isPresented = false
+                        }
+                        onNotNow?()
+                    }
+                )
+                .transition(.scale.combined(with: .opacity))
+            }
+            .animation(.spring(response: 0.3), value: isPresented)
+        }
+    }
+}
+
+#Preview {
+    RatingPromptView(
+        onRateUs: { print("Rate us tapped") },
+        onNotNow: { print("Not now tapped") }
+    )
+    .padding()
+    .background(Color.gray.opacity(0.3))
+}
+
+#Preview("Dark Mode") {
+    RatingPromptView(
+        onRateUs: { print("Rate us tapped") },
+        onNotNow: { print("Not now tapped") }
+    )
+    .padding()
+    .background(Color.black)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Overlay") {
+    ZStack {
+        Color.blue
+            .ignoresSafeArea()
+        
+        RatingPromptOverlay(
+            isPresented: .constant(true),
+            onRateUs: { print("Rate us!") }
+        )
+    }
+}

--- a/AscendWidgets/AscendWidgets.swift
+++ b/AscendWidgets/AscendWidgets.swift
@@ -1,0 +1,17 @@
+//
+//  AscendWidgets.swift
+//  AscendWidgets
+//
+//  Created by Claude on 2/19/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct AscendWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        StreakWidget()
+        WeeklyProgressWidget()
+    }
+}

--- a/AscendWidgets/SETUP.md
+++ b/AscendWidgets/SETUP.md
@@ -1,0 +1,39 @@
+# Ascend Widgets Setup Guide
+
+## Creating the Widget Extension in Xcode
+
+1. **Open the project in Xcode**
+
+2. **Add Widget Extension Target:**
+   - File → New → Target
+   - Search for "Widget Extension"
+   - Name it "AscendWidgets"
+   - Uncheck "Include Configuration Intent" (we'll use static config first)
+   - Click Finish
+
+3. **Set up App Group:**
+   - Select the main "AscendApp" target → Signing & Capabilities
+   - Click "+ Capability" → App Groups
+   - Add a new group: `group.com.ascendapp.shared`
+   - Select the "AscendWidgets" target and add the same App Group
+
+4. **Copy Widget Files:**
+   - Replace the generated widget files with the ones in this folder
+   - Make sure to add them to the AscendWidgets target
+
+5. **Set up Shared Data:**
+   - The widget reads from UserDefaults with the App Group suite
+   - The main app needs to write workout stats to this shared container
+
+## Files in this folder:
+
+- `AscendWidgets.swift` - Main widget entry point
+- `StreakWidget.swift` - Shows current workout streak
+- `WeeklyProgressWidget.swift` - Shows weekly step/floor progress
+- `SharedDataManager.swift` - Handles data sharing between app and widget
+
+## Data Flow:
+
+1. Main app saves workout → Updates shared UserDefaults
+2. Widget reads from shared UserDefaults
+3. Widget timeline refreshes periodically or on app updates

--- a/AscendWidgets/SharedDataManager.swift
+++ b/AscendWidgets/SharedDataManager.swift
@@ -1,0 +1,118 @@
+//
+//  SharedDataManager.swift
+//  AscendWidgets
+//
+//  Created by Claude on 2/19/26.
+//
+
+import Foundation
+
+/// Manages shared data between the main app and widgets via App Group UserDefaults
+struct SharedDataManager {
+    static let appGroupIdentifier = "group.com.ascendapp.shared"
+    
+    private static var sharedDefaults: UserDefaults? {
+        UserDefaults(suiteName: appGroupIdentifier)
+    }
+    
+    // MARK: - Keys
+    
+    private enum Keys {
+        static let currentStreak = "widget_currentStreak"
+        static let weeklySteps = "widget_weeklySteps"
+        static let weeklyFloors = "widget_weeklyFloors"
+        static let weeklyWorkoutCount = "widget_weeklyWorkoutCount"
+        static let lastWorkoutDate = "widget_lastWorkoutDate"
+        static let todaySteps = "widget_todaySteps"
+        static let todayFloors = "widget_todayFloors"
+        static let weeklyGoalSteps = "widget_weeklyGoalSteps"
+        static let lastUpdated = "widget_lastUpdated"
+    }
+    
+    // MARK: - Widget Data Model
+    
+    struct WidgetData {
+        let currentStreak: Int
+        let weeklySteps: Int
+        let weeklyFloors: Int
+        let weeklyWorkoutCount: Int
+        let lastWorkoutDate: Date?
+        let todaySteps: Int
+        let todayFloors: Int
+        let weeklyGoalSteps: Int
+        let lastUpdated: Date
+        
+        static var placeholder: WidgetData {
+            WidgetData(
+                currentStreak: 7,
+                weeklySteps: 15000,
+                weeklyFloors: 120,
+                weeklyWorkoutCount: 4,
+                lastWorkoutDate: Date(),
+                todaySteps: 2500,
+                todayFloors: 30,
+                weeklyGoalSteps: 20000,
+                lastUpdated: Date()
+            )
+        }
+        
+        static var empty: WidgetData {
+            WidgetData(
+                currentStreak: 0,
+                weeklySteps: 0,
+                weeklyFloors: 0,
+                weeklyWorkoutCount: 0,
+                lastWorkoutDate: nil,
+                todaySteps: 0,
+                todayFloors: 0,
+                weeklyGoalSteps: 20000,
+                lastUpdated: Date()
+            )
+        }
+    }
+    
+    // MARK: - Read Data (Widget side)
+    
+    static func getWidgetData() -> WidgetData {
+        guard let defaults = sharedDefaults else {
+            return .empty
+        }
+        
+        return WidgetData(
+            currentStreak: defaults.integer(forKey: Keys.currentStreak),
+            weeklySteps: defaults.integer(forKey: Keys.weeklySteps),
+            weeklyFloors: defaults.integer(forKey: Keys.weeklyFloors),
+            weeklyWorkoutCount: defaults.integer(forKey: Keys.weeklyWorkoutCount),
+            lastWorkoutDate: defaults.object(forKey: Keys.lastWorkoutDate) as? Date,
+            todaySteps: defaults.integer(forKey: Keys.todaySteps),
+            todayFloors: defaults.integer(forKey: Keys.todayFloors),
+            weeklyGoalSteps: defaults.integer(forKey: Keys.weeklyGoalSteps),
+            lastUpdated: defaults.object(forKey: Keys.lastUpdated) as? Date ?? Date()
+        )
+    }
+    
+    // MARK: - Write Data (Main app side)
+    
+    static func updateWidgetData(
+        currentStreak: Int,
+        weeklySteps: Int,
+        weeklyFloors: Int,
+        weeklyWorkoutCount: Int,
+        lastWorkoutDate: Date?,
+        todaySteps: Int,
+        todayFloors: Int,
+        weeklyGoalSteps: Int
+    ) {
+        guard let defaults = sharedDefaults else { return }
+        
+        defaults.set(currentStreak, forKey: Keys.currentStreak)
+        defaults.set(weeklySteps, forKey: Keys.weeklySteps)
+        defaults.set(weeklyFloors, forKey: Keys.weeklyFloors)
+        defaults.set(weeklyWorkoutCount, forKey: Keys.weeklyWorkoutCount)
+        defaults.set(lastWorkoutDate, forKey: Keys.lastWorkoutDate)
+        defaults.set(todaySteps, forKey: Keys.todaySteps)
+        defaults.set(todayFloors, forKey: Keys.todayFloors)
+        defaults.set(weeklyGoalSteps, forKey: Keys.weeklyGoalSteps)
+        defaults.set(Date(), forKey: Keys.lastUpdated)
+    }
+}

--- a/AscendWidgets/StreakWidget.swift
+++ b/AscendWidgets/StreakWidget.swift
@@ -1,0 +1,162 @@
+//
+//  StreakWidget.swift
+//  AscendWidgets
+//
+//  Created by Claude on 2/19/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+// MARK: - Timeline Provider
+
+struct StreakProvider: TimelineProvider {
+    func placeholder(in context: Context) -> StreakEntry {
+        StreakEntry(date: Date(), data: .placeholder)
+    }
+    
+    func getSnapshot(in context: Context, completion: @escaping (StreakEntry) -> Void) {
+        let entry = StreakEntry(date: Date(), data: SharedDataManager.getWidgetData())
+        completion(entry)
+    }
+    
+    func getTimeline(in context: Context, completion: @escaping (Timeline<StreakEntry>) -> Void) {
+        let currentDate = Date()
+        let data = SharedDataManager.getWidgetData()
+        let entry = StreakEntry(date: currentDate, data: data)
+        
+        // Refresh every hour
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: currentDate)!
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+}
+
+// MARK: - Timeline Entry
+
+struct StreakEntry: TimelineEntry {
+    let date: Date
+    let data: SharedDataManager.WidgetData
+}
+
+// MARK: - Widget View
+
+struct StreakWidgetEntryView: View {
+    var entry: StreakProvider.Entry
+    @Environment(\.widgetFamily) var family
+    
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            smallView
+        case .systemMedium:
+            mediumView
+        default:
+            smallView
+        }
+    }
+    
+    private var smallView: some View {
+        VStack(spacing: 8) {
+            // Flame icon
+            Image(systemName: "flame.fill")
+                .font(.system(size: 32))
+                .foregroundStyle(.orange)
+            
+            // Streak count
+            Text("\(entry.data.currentStreak)")
+                .font(.system(size: 36, weight: .bold, design: .rounded))
+                .foregroundStyle(.primary)
+            
+            // Label
+            Text(entry.data.currentStreak == 1 ? "Day Streak" : "Day Streak")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+    
+    private var mediumView: some View {
+        HStack(spacing: 20) {
+            // Streak info
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Image(systemName: "flame.fill")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.orange)
+                    
+                    Text("\(entry.data.currentStreak)")
+                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                }
+                
+                Text("Day Streak")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.secondary)
+                
+                if let lastWorkout = entry.data.lastWorkoutDate {
+                    Text("Last: \(lastWorkout, style: .relative) ago")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            
+            Spacer()
+            
+            // Weekly stats
+            VStack(alignment: .trailing, spacing: 8) {
+                HStack(spacing: 4) {
+                    Image(systemName: "figure.stairs")
+                        .font(.system(size: 14))
+                    Text("\(entry.data.weeklySteps)")
+                        .font(.system(size: 16, weight: .semibold))
+                }
+                .foregroundStyle(.accent)
+                
+                HStack(spacing: 4) {
+                    Image(systemName: "building.2")
+                        .font(.system(size: 14))
+                    Text("\(entry.data.weeklyFloors)")
+                        .font(.system(size: 16, weight: .semibold))
+                }
+                .foregroundStyle(.green)
+                
+                Text("This Week")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+// MARK: - Widget Definition
+
+struct StreakWidget: Widget {
+    let kind: String = "StreakWidget"
+    
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: StreakProvider()) { entry in
+            StreakWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Workout Streak")
+        .description("Track your consecutive workout days.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Previews
+
+#Preview(as: .systemSmall) {
+    StreakWidget()
+} timeline: {
+    StreakEntry(date: Date(), data: .placeholder)
+}
+
+#Preview(as: .systemMedium) {
+    StreakWidget()
+} timeline: {
+    StreakEntry(date: Date(), data: .placeholder)
+}

--- a/AscendWidgets/WeeklyProgressWidget.swift
+++ b/AscendWidgets/WeeklyProgressWidget.swift
@@ -1,0 +1,218 @@
+//
+//  WeeklyProgressWidget.swift
+//  AscendWidgets
+//
+//  Created by Claude on 2/19/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+// MARK: - Timeline Provider
+
+struct WeeklyProgressProvider: TimelineProvider {
+    func placeholder(in context: Context) -> WeeklyProgressEntry {
+        WeeklyProgressEntry(date: Date(), data: .placeholder)
+    }
+    
+    func getSnapshot(in context: Context, completion: @escaping (WeeklyProgressEntry) -> Void) {
+        let entry = WeeklyProgressEntry(date: Date(), data: SharedDataManager.getWidgetData())
+        completion(entry)
+    }
+    
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WeeklyProgressEntry>) -> Void) {
+        let currentDate = Date()
+        let data = SharedDataManager.getWidgetData()
+        let entry = WeeklyProgressEntry(date: currentDate, data: data)
+        
+        // Refresh every hour
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: currentDate)!
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+}
+
+// MARK: - Timeline Entry
+
+struct WeeklyProgressEntry: TimelineEntry {
+    let date: Date
+    let data: SharedDataManager.WidgetData
+}
+
+// MARK: - Widget View
+
+struct WeeklyProgressWidgetEntryView: View {
+    var entry: WeeklyProgressProvider.Entry
+    @Environment(\.widgetFamily) var family
+    
+    private var progressPercentage: Double {
+        guard entry.data.weeklyGoalSteps > 0 else { return 0 }
+        return min(Double(entry.data.weeklySteps) / Double(entry.data.weeklyGoalSteps), 1.0)
+    }
+    
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            smallView
+        case .systemMedium:
+            mediumView
+        default:
+            smallView
+        }
+    }
+    
+    private var smallView: some View {
+        VStack(spacing: 8) {
+            // Title
+            Text("This Week")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            
+            // Progress ring
+            ZStack {
+                Circle()
+                    .stroke(Color.gray.opacity(0.2), lineWidth: 8)
+                
+                Circle()
+                    .trim(from: 0, to: progressPercentage)
+                    .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                
+                VStack(spacing: 2) {
+                    Text("\(entry.data.weeklySteps)")
+                        .font(.system(size: 18, weight: .bold, design: .rounded))
+                    Text("steps")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 80, height: 80)
+            
+            // Workouts count
+            Text("\(entry.data.weeklyWorkoutCount) workouts")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+    
+    private var mediumView: some View {
+        HStack(spacing: 20) {
+            // Progress ring
+            ZStack {
+                Circle()
+                    .stroke(Color.gray.opacity(0.2), lineWidth: 10)
+                
+                Circle()
+                    .trim(from: 0, to: progressPercentage)
+                    .stroke(
+                        LinearGradient(
+                            colors: [.blue, .purple],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        style: StrokeStyle(lineWidth: 10, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                
+                VStack(spacing: 2) {
+                    Text("\(Int(progressPercentage * 100))%")
+                        .font(.system(size: 20, weight: .bold, design: .rounded))
+                    Text("of goal")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 90, height: 90)
+            
+            // Stats
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Weekly Progress")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                
+                HStack(spacing: 16) {
+                    StatItem(
+                        icon: "figure.stairs",
+                        value: "\(entry.data.weeklySteps)",
+                        label: "Steps",
+                        color: .blue
+                    )
+                    
+                    StatItem(
+                        icon: "building.2",
+                        value: "\(entry.data.weeklyFloors)",
+                        label: "Floors",
+                        color: .green
+                    )
+                    
+                    StatItem(
+                        icon: "checkmark.circle.fill",
+                        value: "\(entry.data.weeklyWorkoutCount)",
+                        label: "Workouts",
+                        color: .orange
+                    )
+                }
+            }
+            
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+// MARK: - Helper Views
+
+private struct StatItem: View {
+    let icon: String
+    let value: String
+    let label: String
+    let color: Color
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .foregroundStyle(color)
+            
+            Text(value)
+                .font(.system(size: 14, weight: .bold, design: .rounded))
+            
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Widget Definition
+
+struct WeeklyProgressWidget: Widget {
+    let kind: String = "WeeklyProgressWidget"
+    
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: WeeklyProgressProvider()) { entry in
+            WeeklyProgressWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Weekly Progress")
+        .description("Track your weekly steps, floors, and workouts.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Previews
+
+#Preview(as: .systemSmall) {
+    WeeklyProgressWidget()
+} timeline: {
+    WeeklyProgressEntry(date: Date(), data: .placeholder)
+}
+
+#Preview(as: .systemMedium) {
+    WeeklyProgressWidget()
+} timeline: {
+    WeeklyProgressEntry(date: Date(), data: .placeholder)
+}


### PR DESCRIPTION
## Summary
This PR implements several GitHub issues:

### ✅ #12 - Custom App Rating Prompt
- Created personal RatingPromptView ("Hey! I'm Tyler...")
- Shows before system rating dialog
- "Rate Us" triggers SKStoreReviewController
- "Not Now" delays re-prompt by 14 days
- Triggers at 10 workouts (lowered from 20)

### ✅ #10 - Best Efforts Time Period Filter
- Added time period picker: Week, Month, Year, All Time
- Filters workouts and recalculates best efforts
- Dynamic empty state messages
- Progress chart also respects filter

### ✅ #11 - PR Share Cards
- Created PRShareCardView with gradient background
- Shows: PR badge, icon, title, value, date, branding
- Added context menu to Best Effort cards with Share option
- Renders as image for Instagram Stories, etc.

### 🟡 #7 - Widgets (Files Created, Xcode Setup Required)
- Created widget extension files in `AscendWidgets/`
- StreakWidget (small/medium) - shows workout streak
- WeeklyProgressWidget (small/medium) - progress ring + stats
- SharedDataManager for App Group data sharing
- **Requires**: Creating Widget Extension target in Xcode
- See `AscendWidgets/SETUP.md` for instructions

## Not in this PR (Need more work/resources):
- #5 - Error 1200 handling already exists, needs investigation of specific scenarios
- #8 - Onboarding flow (needs design decisions/illustrations)
- #13 - Already implemented (MediaUploadManager handles background uploads)
- #14 - Apple Watch app (large project, separate effort)
- #15 - Garmin/Fitbit/Whoop (requires API keys and accounts)

## Also Ready (Separate PR #16):
- #3 - Allow saving without steps
- #6 - Fix title cutoff
- #9 - Privacy Policy