### PR TITLE
Voice-First Home Screen

### DIFF
--- a/AscendApp/Features/Home/Views/ConversationalHomeView.swift
+++ b/AscendApp/Features/Home/Views/ConversationalHomeView.swift
@@ -1,0 +1,423 @@
+//
+//  ConversationalHomeView.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+import SwiftData
+
+/// Voice-first home screen for logging workouts conversationally
+struct ConversationalHomeView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.modelContext) private var modelContext
+    @Environment(AuthenticationViewModel.self) private var authVM
+    
+    @State private var themeManager = ThemeManager.shared
+    @State private var voiceManager = VoiceInputManager()
+    @State private var userInput: String = ""
+    @State private var isProcessing = false
+    @State private var showConfirmation = false
+    @State private var parsedData: ParsedWorkoutData?
+    @State private var errorMessage: String?
+    @State private var showError = false
+    
+    @Query(sort: \Workout.date, order: .reverse)
+    private var recentWorkouts: [Workout]
+    
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: colorScheme)
+    }
+    
+    private let examplePhrases = [
+        "I did 30 minutes on the stairstepper...",
+        "3000 steps with my 20lb vest...",
+        "Three intervals: 5, 10, and 5 minutes...",
+        "Quick 20 min session, felt great...",
+        "45 minutes, 4500 steps, wore ankle weights..."
+    ]
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // Header
+                headerSection
+                
+                // Voice/Text Input Card
+                inputCard
+                
+                // Recent Workouts
+                if !recentWorkouts.isEmpty {
+                    recentWorkoutsSection
+                }
+                
+                Spacer(minLength: 40)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+        }
+        .scrollIndicators(.hidden)
+        .themedBackground()
+        .sheet(isPresented: $showConfirmation) {
+            if let data = parsedData {
+                WorkoutConfirmationView(
+                    parsedData: data,
+                    originalText: userInput,
+                    onConfirm: { confirmedData in
+                        saveWorkout(confirmedData)
+                        showConfirmation = false
+                        userInput = ""
+                    },
+                    onCancel: {
+                        showConfirmation = false
+                    }
+                )
+            }
+        }
+        .alert("Error", isPresented: $showError) {
+            Button("OK") { }
+        } message: {
+            Text(errorMessage ?? "Something went wrong")
+        }
+    }
+    
+    // MARK: - Header
+    
+    private var headerSection: some View {
+        VStack(spacing: 8) {
+            Text("Log Workout")
+                .font(.montserratBold(size: 28))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            Text("Speak or type to log your session")
+                .font(.montserratRegular(size: 15))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 20)
+    }
+    
+    // MARK: - Input Card
+    
+    private var inputCard: some View {
+        VStack(spacing: 16) {
+            // Animated placeholder or user input
+            if userInput.isEmpty && !voiceManager.isRecording {
+                TypewriterTextWithCursor(
+                    phrases: examplePhrases,
+                    typingSpeed: 0.04,
+                    pauseDuration: 2.5,
+                    gradient: LinearGradient(
+                        colors: [
+                            Color(red: 0.4, green: 0.7, blue: 1.0),
+                            Color(red: 0.6, green: 0.5, blue: 1.0),
+                            Color(red: 0.9, green: 0.5, blue: 0.8)
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .frame(minHeight: 60)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            } else {
+                // Show transcribed/typed text
+                TextField("Describe your workout...", text: $userInput, axis: .vertical)
+                    .font(.montserratMedium(size: 17))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    .lineLimit(3...6)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+            }
+            
+            // Live transcription indicator
+            if voiceManager.isRecording {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(Color.red)
+                        .frame(width: 8, height: 8)
+                        .opacity(voiceManager.isRecording ? 1 : 0)
+                        .animation(.easeInOut(duration: 0.5).repeatForever(), value: voiceManager.isRecording)
+                    
+                    Text("Listening...")
+                        .font(.montserratMedium(size: 14))
+                        .foregroundStyle(.red)
+                }
+                .padding(.bottom, 8)
+            }
+            
+            Divider()
+                .background(effectiveColorScheme == .dark ? Color.white.opacity(0.1) : Color.gray.opacity(0.2))
+            
+            // Action buttons
+            HStack(spacing: 16) {
+                // Voice button
+                Button {
+                    handleVoiceButton()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: voiceManager.isRecording ? "stop.circle.fill" : "mic.circle.fill")
+                            .font(.system(size: 24))
+                        Text(voiceManager.isRecording ? "Stop" : "Speak")
+                            .font(.montserratSemiBold(size: 15))
+                    }
+                    .foregroundStyle(voiceManager.isRecording ? .red : .accent)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(voiceManager.isRecording 
+                                  ? Color.red.opacity(0.15) 
+                                  : Color.accentColor.opacity(0.15))
+                    )
+                }
+                .disabled(isProcessing)
+                
+                // Submit button
+                Button {
+                    processInput()
+                } label: {
+                    HStack(spacing: 8) {
+                        if isProcessing {
+                            ProgressView()
+                                .scaleEffect(0.8)
+                                .tint(.white)
+                        } else {
+                            Image(systemName: "arrow.up.circle.fill")
+                                .font(.system(size: 24))
+                        }
+                        Text(isProcessing ? "Processing" : "Log")
+                            .font(.montserratSemiBold(size: 15))
+                    }
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(userInput.isEmpty ? Color.gray : Color.accentColor)
+                    )
+                }
+                .disabled(userInput.isEmpty || isProcessing)
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(effectiveColorScheme == .dark ? Color.white.opacity(0.1) : Color.gray.opacity(0.15), lineWidth: 1)
+                )
+        )
+        .onChange(of: voiceManager.transcribedText) { _, newValue in
+            if !newValue.isEmpty {
+                userInput = newValue
+            }
+        }
+    }
+    
+    // MARK: - Recent Workouts
+    
+    private var recentWorkoutsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Recent Workouts")
+                .font(.montserratSemiBold(size: 18))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            ForEach(recentWorkouts.prefix(3)) { workout in
+                NavigationLink(destination: WorkoutDetailView(workout: workout)) {
+                    RecentWorkoutRow(workout: workout, colorScheme: effectiveColorScheme)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+    }
+    
+    // MARK: - Actions
+    
+    private func handleVoiceButton() {
+        HapticsManager.shared.trigger(.selection)
+        
+        if voiceManager.isRecording {
+            voiceManager.stopRecording()
+        } else {
+            do {
+                try voiceManager.startRecording()
+            } catch {
+                errorMessage = error.localizedDescription
+                showError = true
+            }
+        }
+    }
+    
+    private func processInput() {
+        guard !userInput.isEmpty else { return }
+        
+        HapticsManager.shared.trigger(.selection)
+        isProcessing = true
+        
+        Task {
+            do {
+                let service = WorkoutParsingService()
+                let parsed = try await service.parseWorkoutDescription(userInput)
+                
+                await MainActor.run {
+                    parsedData = parsed
+                    showConfirmation = true
+                    isProcessing = false
+                }
+            } catch {
+                await MainActor.run {
+                    // Fallback to regex parser
+                    let fallbackData = FallbackWorkoutParser.parse(userInput)
+                    if fallbackData.durationMinutes != nil || fallbackData.steps != nil {
+                        parsedData = fallbackData
+                        showConfirmation = true
+                    } else {
+                        errorMessage = error.localizedDescription
+                        showError = true
+                    }
+                    isProcessing = false
+                }
+            }
+        }
+    }
+    
+    private func saveWorkout(_ data: ParsedWorkoutData) {
+        let settingsManager = SettingsManager.shared
+        
+        // Convert parsed data to workout
+        let duration = TimeInterval((data.durationMinutes ?? 0) * 60)
+        let steps = data.steps ?? 0
+        let floors = data.floors ?? Workout.stepsToFloors(steps, stepsPerFloor: settingsManager.stepsPerFloor)
+        
+        let workout = Workout(
+            name: Workout.generateDefaultName(for: Date()),
+            date: Date(),
+            duration: duration,
+            steps: steps,
+            floors: floors,
+            stepsPerFloor: settingsManager.stepsPerFloor,
+            avgHeartRate: data.heartRateAvg,
+            maxHeartRate: data.heartRateMax,
+            caloriesBurned: data.calories,
+            notes: data.notes
+        )
+        
+        // Add weight configuration if present
+        if let weightItems = data.weightEquipment, !weightItems.isEmpty {
+            var entries: [WeightConfiguration.Entry] = []
+            for item in weightItems {
+                if let type = WeightEquipmentType.fromString(item.type) {
+                    entries.append(WeightConfiguration.Entry(
+                        equipmentType: type,
+                        weightLbs: item.weightLbs,
+                        isEnabled: true
+                    ))
+                }
+            }
+            if !entries.isEmpty {
+                workout.weightConfiguration = WeightConfiguration(entries: entries)
+            }
+        }
+        
+        modelContext.insert(workout)
+        
+        do {
+            try modelContext.save()
+            HapticsManager.shared.trigger(.success)
+        } catch {
+            print("Failed to save workout: \(error)")
+        }
+    }
+}
+
+// MARK: - Recent Workout Row
+
+private struct RecentWorkoutRow: View {
+    let workout: Workout
+    let colorScheme: ColorScheme
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(workout.name)
+                    .font(.montserratSemiBold(size: 15))
+                    .foregroundStyle(colorScheme == .dark ? .white : .black)
+                    .lineLimit(1)
+                
+                Text(formattedDate)
+                    .font(.montserratRegular(size: 13))
+                    .foregroundStyle(colorScheme == .dark ? .white.opacity(0.6) : .gray)
+            }
+            
+            Spacer()
+            
+            VStack(alignment: .trailing, spacing: 4) {
+                Text("\(workout.steps) steps")
+                    .font(.montserratSemiBold(size: 14))
+                    .foregroundStyle(.accent)
+                
+                Text(formattedDuration)
+                    .font(.montserratRegular(size: 13))
+                    .foregroundStyle(colorScheme == .dark ? .white.opacity(0.6) : .gray)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(colorScheme == .dark ? Color.white.opacity(0.04) : Color.black.opacity(0.02))
+        )
+    }
+    
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        if Calendar.current.isDateInToday(workout.date) {
+            formatter.dateFormat = "'Today at' h:mm a"
+        } else if Calendar.current.isDateInYesterday(workout.date) {
+            formatter.dateFormat = "'Yesterday at' h:mm a"
+        } else {
+            formatter.dateFormat = "MMM d 'at' h:mm a"
+        }
+        return formatter.string(from: workout.date)
+    }
+    
+    private var formattedDuration: String {
+        let minutes = Int(workout.duration / 60)
+        if minutes >= 60 {
+            return "\(minutes / 60)h \(minutes % 60)m"
+        }
+        return "\(minutes) min"
+    }
+}
+
+// MARK: - Weight Equipment Type Extension
+
+extension WeightEquipmentType {
+    static func fromString(_ string: String) -> WeightEquipmentType? {
+        let lowercased = string.lowercased()
+        switch lowercased {
+        case "vest", "weighted vest", "weight vest":
+            return .vest
+        case "ankle_weights", "ankle weights", "ankleweights":
+            return .ankleWeights
+        case "backpack", "weighted backpack":
+            return .backpack
+        case "dumbbells", "dumbbell":
+            return .dumbbells
+        case "wrist_weights", "wrist weights", "wristweights":
+            return .wristWeights
+        default:
+            return nil
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ConversationalHomeView()
+    }
+    .environment(AuthenticationViewModel())
+}

--- a/AscendApp/Features/Home/Views/WorkoutConfirmationView.swift
+++ b/AscendApp/Features/Home/Views/WorkoutConfirmationView.swift
@@ -1,0 +1,377 @@
+//
+//  WorkoutConfirmationView.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+
+/// Confirmation view for reviewing parsed workout data before saving
+struct WorkoutConfirmationView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dismiss) private var dismiss
+    
+    @State private var themeManager = ThemeManager.shared
+    @State private var editedData: ParsedWorkoutData
+    
+    let originalText: String
+    let onConfirm: (ParsedWorkoutData) -> Void
+    let onCancel: () -> Void
+    
+    init(
+        parsedData: ParsedWorkoutData,
+        originalText: String,
+        onConfirm: @escaping (ParsedWorkoutData) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self._editedData = State(initialValue: parsedData)
+        self.originalText = originalText
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+    }
+    
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: colorScheme)
+    }
+    
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Original input
+                    originalInputCard
+                    
+                    // Parsed data fields
+                    parsedDataCard
+                    
+                    // Weight equipment
+                    if let weights = editedData.weightEquipment, !weights.isEmpty {
+                        weightEquipmentCard(weights)
+                    }
+                    
+                    // Intervals
+                    if let intervals = editedData.intervals, !intervals.isEmpty {
+                        intervalsCard(intervals)
+                    }
+                    
+                    // Notes
+                    if editedData.notes != nil {
+                        notesCard
+                    }
+                    
+                    Spacer(minLength: 20)
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+            }
+            .scrollIndicators(.hidden)
+            .themedBackground()
+            .navigationTitle("Confirm Workout")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        onCancel()
+                    }
+                    .foregroundStyle(.accent)
+                }
+                
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        HapticsManager.shared.trigger(.success)
+                        onConfirm(editedData)
+                    }
+                    .font(.montserratSemiBold(size: 16))
+                    .foregroundStyle(.accent)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Original Input Card
+    
+    private var originalInputCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("What you said", systemImage: "quote.bubble")
+                .font(.montserratSemiBold(size: 14))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
+            
+            Text("\"\(originalText)\"")
+                .font(.montserratRegular(size: 15))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.8) : .black.opacity(0.7))
+                .italic()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.04) : Color.black.opacity(0.02))
+        )
+    }
+    
+    // MARK: - Parsed Data Card
+    
+    private var parsedDataCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Workout Details")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            // Duration
+            EditableField(
+                icon: "clock",
+                label: "Duration",
+                value: Binding(
+                    get: { editedData.durationMinutes.map { "\($0)" } ?? "" },
+                    set: { editedData.durationMinutes = Int($0) }
+                ),
+                unit: "minutes",
+                colorScheme: effectiveColorScheme
+            )
+            
+            // Steps
+            EditableField(
+                icon: "figure.stairs",
+                label: "Steps",
+                value: Binding(
+                    get: { editedData.steps.map { "\($0)" } ?? "" },
+                    set: { editedData.steps = Int($0) }
+                ),
+                unit: "steps",
+                colorScheme: effectiveColorScheme
+            )
+            
+            // Floors
+            EditableField(
+                icon: "building.2",
+                label: "Floors",
+                value: Binding(
+                    get: { editedData.floors.map { "\($0)" } ?? "" },
+                    set: { editedData.floors = Int($0) }
+                ),
+                unit: "floors",
+                colorScheme: effectiveColorScheme
+            )
+            
+            // Heart Rate
+            if editedData.heartRateAvg != nil || editedData.heartRateMax != nil {
+                HStack(spacing: 16) {
+                    EditableField(
+                        icon: "heart.fill",
+                        label: "Avg HR",
+                        value: Binding(
+                            get: { editedData.heartRateAvg.map { "\($0)" } ?? "" },
+                            set: { editedData.heartRateAvg = Int($0) }
+                        ),
+                        unit: "bpm",
+                        colorScheme: effectiveColorScheme
+                    )
+                    
+                    EditableField(
+                        icon: "bolt.heart",
+                        label: "Max HR",
+                        value: Binding(
+                            get: { editedData.heartRateMax.map { "\($0)" } ?? "" },
+                            set: { editedData.heartRateMax = Int($0) }
+                        ),
+                        unit: "bpm",
+                        colorScheme: effectiveColorScheme
+                    )
+                }
+            }
+            
+            // Calories
+            if editedData.calories != nil {
+                EditableField(
+                    icon: "flame.fill",
+                    label: "Calories",
+                    value: Binding(
+                        get: { editedData.calories.map { "\($0)" } ?? "" },
+                        set: { editedData.calories = Int($0) }
+                    ),
+                    unit: "kcal",
+                    colorScheme: effectiveColorScheme
+                )
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+        )
+    }
+    
+    // MARK: - Weight Equipment Card
+    
+    private func weightEquipmentCard(_ weights: [ParsedWorkoutData.WeightEquipmentItem]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Weight Equipment", systemImage: "scalemass")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            ForEach(Array(weights.enumerated()), id: \.offset) { index, item in
+                HStack {
+                    Image(systemName: iconForWeightType(item.type))
+                        .foregroundStyle(.accent)
+                        .frame(width: 24)
+                    
+                    Text(item.type.capitalized.replacingOccurrences(of: "_", with: " "))
+                        .font(.montserratMedium(size: 15))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    
+                    Spacer()
+                    
+                    if let qty = item.quantity, qty > 1 {
+                        Text("\(qty)x")
+                            .font(.montserratRegular(size: 14))
+                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
+                    }
+                    
+                    Text("\(Int(item.weightLbs)) lbs")
+                        .font(.montserratSemiBold(size: 15))
+                        .foregroundStyle(.accent)
+                }
+                .padding(.vertical, 8)
+                
+                if index < weights.count - 1 {
+                    Divider()
+                }
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+        )
+    }
+    
+    private func iconForWeightType(_ type: String) -> String {
+        switch type.lowercased() {
+        case "vest": return "tshirt"
+        case "ankle_weights", "ankle weights": return "shoe"
+        case "backpack": return "bag"
+        case "dumbbells": return "dumbbell"
+        default: return "scalemass"
+        }
+    }
+    
+    // MARK: - Intervals Card
+    
+    private func intervalsCard(_ intervals: [ParsedWorkoutData.IntervalItem]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Intervals", systemImage: "chart.bar")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            ForEach(Array(intervals.enumerated()), id: \.offset) { index, interval in
+                HStack {
+                    Text("Interval \(index + 1)")
+                        .font(.montserratMedium(size: 15))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    
+                    Spacer()
+                    
+                    if let duration = interval.durationMinutes {
+                        Text("\(duration) min")
+                            .font(.montserratSemiBold(size: 15))
+                            .foregroundStyle(.accent)
+                    }
+                    
+                    if let steps = interval.steps {
+                        Text("• \(steps) steps")
+                            .font(.montserratRegular(size: 14))
+                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
+                    }
+                }
+                .padding(.vertical, 6)
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+        )
+    }
+    
+    // MARK: - Notes Card
+    
+    private var notesCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Notes", systemImage: "note.text")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            Text(editedData.notes ?? "")
+                .font(.montserratRegular(size: 15))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.8) : .black.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+        )
+    }
+}
+
+// MARK: - Editable Field
+
+private struct EditableField: View {
+    let icon: String
+    let label: String
+    @Binding var value: String
+    let unit: String
+    let colorScheme: ColorScheme
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(.accent)
+                .frame(width: 24)
+            
+            Text(label)
+                .font(.montserratMedium(size: 15))
+                .foregroundStyle(colorScheme == .dark ? .white.opacity(0.7) : .gray)
+            
+            Spacer()
+            
+            HStack(spacing: 4) {
+                TextField("--", text: $value)
+                    .font(.montserratSemiBold(size: 16))
+                    .foregroundStyle(colorScheme == .dark ? .white : .black)
+                    .keyboardType(.numberPad)
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 60)
+                
+                Text(unit)
+                    .font(.montserratRegular(size: 14))
+                    .foregroundStyle(colorScheme == .dark ? .white.opacity(0.5) : .gray)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview {
+    WorkoutConfirmationView(
+        parsedData: ParsedWorkoutData(
+            durationMinutes: 30,
+            steps: 3000,
+            floors: 25,
+            weightEquipment: [
+                .init(type: "vest", weightLbs: 20, quantity: 1),
+                .init(type: "ankle_weights", weightLbs: 2.5, quantity: 2)
+            ],
+            intervals: [
+                .init(durationMinutes: 5, steps: nil),
+                .init(durationMinutes: 10, steps: nil),
+                .init(durationMinutes: 5, steps: nil)
+            ],
+            notes: "Felt great today!"
+        ),
+        originalText: "I did 30 minutes on the stairstepper with my 20 pound vest and ankle weights, 3000 steps total",
+        onConfirm: { _ in },
+        onCancel: { }
+    )
+}

--- a/AscendApp/Features/Progress/Views/BestEffortsListView.swift
+++ b/AscendApp/Features/Progress/Views/BestEffortsListView.swift
@@ -8,6 +8,31 @@
 import SwiftUI
 import SwiftData
 
+/// Time period for filtering best efforts
+enum BestEffortsTimePeriod: String, CaseIterable, Identifiable {
+    case week = "Week"
+    case month = "Month"
+    case year = "Year"
+    case allTime = "All Time"
+    
+    var id: String { rawValue }
+    
+    /// Returns the start date for this time period
+    func startDate(from referenceDate: Date = Date()) -> Date? {
+        let calendar = Calendar.current
+        switch self {
+        case .week:
+            return calendar.date(byAdding: .day, value: -7, to: referenceDate)
+        case .month:
+            return calendar.date(byAdding: .month, value: -1, to: referenceDate)
+        case .year:
+            return calendar.date(byAdding: .year, value: -1, to: referenceDate)
+        case .allTime:
+            return nil
+        }
+    }
+}
+
 struct BestEffortsListView: View {
     let workouts: [Workout]
 
@@ -15,6 +40,7 @@ struct BestEffortsListView: View {
     @Environment(\.modelContext) private var modelContext
     @State private var themeManager = ThemeManager.shared
     @State private var settingsManager = SettingsManager.shared
+    @State private var selectedTimePeriod: BestEffortsTimePeriod = .allTime
 
     // Weight records state
     @State private var weightRecordsSections: [WeightRecordsSection] = []
@@ -23,9 +49,17 @@ struct BestEffortsListView: View {
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
     }
+    
+    /// Filter workouts based on selected time period
+    private var filteredWorkouts: [Workout] {
+        guard let startDate = selectedTimePeriod.startDate() else {
+            return workouts // All time - no filtering
+        }
+        return workouts.filter { $0.date >= startDate }
+    }
 
     private var efforts: [BestEffort] {
-        BestEffortsBuilder.bestEfforts(from: workouts)
+        BestEffortsBuilder.bestEfforts(from: filteredWorkouts)
     }
 
     private var hasWeightRecords: Bool {
@@ -35,6 +69,9 @@ struct BestEffortsListView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
+                // Time Period Picker
+                timePeriodPicker
+                
                 if efforts.isEmpty && !hasWeightRecords {
                     emptyState
                 } else {
@@ -42,8 +79,8 @@ struct BestEffortsListView: View {
                         effortsList
                     }
 
-                    // Weight Records Section
-                    if hasWeightRecords {
+                    // Weight Records Section (only show for all-time)
+                    if hasWeightRecords && selectedTimePeriod == .allTime {
                         weightRecordsSection
                     }
                 }
@@ -60,7 +97,7 @@ struct BestEffortsListView: View {
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                NavigationLink(destination: BestEffortsProgressView(workouts: workouts)) {
+                NavigationLink(destination: BestEffortsProgressView(workouts: filteredWorkouts)) {
                     Image(systemName: "chart.line.uptrend.xyaxis")
                         .font(.system(size: 16, weight: .medium))
                         .foregroundStyle(.accent)
@@ -70,6 +107,39 @@ struct BestEffortsListView: View {
         .onAppear {
             loadWeightRecords()
         }
+    }
+    
+    private var timePeriodPicker: some View {
+        HStack(spacing: 8) {
+            ForEach(BestEffortsTimePeriod.allCases) { period in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        selectedTimePeriod = period
+                    }
+                    HapticsManager.shared.trigger(.selection)
+                } label: {
+                    Text(period.rawValue)
+                        .font(.montserratMedium(size: 13))
+                        .foregroundStyle(
+                            selectedTimePeriod == period
+                                ? .white
+                                : (effectiveColorScheme == .dark ? .white.opacity(0.6) : .black.opacity(0.6))
+                        )
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(selectedTimePeriod == period ? Color.accentColor : Color.clear)
+                        )
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.05))
+        )
     }
     
     private var effortsList: some View {
@@ -85,11 +155,11 @@ struct BestEffortsListView: View {
     
     private var emptyState: some View {
         VStack(spacing: 12) {
-            Text("No Best Efforts Yet")
+            Text(emptyStateTitle)
                 .font(.montserratSemiBold(size: 18))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
 
-            Text("Start logging workouts to see your all‑time best sessions for steps, duration, heart rate, and more.")
+            Text(emptyStateMessage)
                 .font(.montserratRegular(size: 14))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
                 .multilineTextAlignment(.center)
@@ -100,6 +170,32 @@ struct BestEffortsListView: View {
             RoundedRectangle(cornerRadius: 20)
                 .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.05) : Color.black.opacity(0.03))
         )
+    }
+    
+    private var emptyStateTitle: String {
+        switch selectedTimePeriod {
+        case .week:
+            return "No Workouts This Week"
+        case .month:
+            return "No Workouts This Month"
+        case .year:
+            return "No Workouts This Year"
+        case .allTime:
+            return "No Best Efforts Yet"
+        }
+    }
+    
+    private var emptyStateMessage: String {
+        switch selectedTimePeriod {
+        case .week:
+            return "Log a workout this week to see your best efforts."
+        case .month:
+            return "Log a workout this month to see your best efforts."
+        case .year:
+            return "Log a workout this year to see your best efforts."
+        case .allTime:
+            return "Start logging workouts to see your all‑time best sessions for steps, duration, heart rate, and more."
+        }
     }
 
     // MARK: - Weight Records Section

--- a/AscendApp/Features/Progress/Views/BestEffortsListView.swift
+++ b/AscendApp/Features/Progress/Views/BestEffortsListView.swift
@@ -38,9 +38,11 @@ struct BestEffortsListView: View {
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.modelContext) private var modelContext
+    @Environment(AuthenticationViewModel.self) private var authVM
     @State private var themeManager = ThemeManager.shared
     @State private var settingsManager = SettingsManager.shared
     @State private var selectedTimePeriod: BestEffortsTimePeriod = .allTime
+    @State private var effortToShare: BestEffort?
 
     // Weight records state
     @State private var weightRecordsSections: [WeightRecordsSection] = []
@@ -149,7 +151,27 @@ struct BestEffortsListView: View {
                     BestEffortCard(effort: effort, colorScheme: effectiveColorScheme)
                 }
                 .buttonStyle(PlainButtonStyle())
+                .contextMenu {
+                    Button {
+                        effortToShare = effort
+                    } label: {
+                        Label("Share PR", systemImage: "square.and.arrow.up")
+                    }
+                    
+                    Button {
+                        // Navigate handled by NavigationLink
+                    } label: {
+                        Label("View Workout", systemImage: "eye")
+                    }
+                }
             }
+        }
+        .sheet(item: $effortToShare) { effort in
+            PRShareSheet(
+                effort: effort,
+                previousValue: nil, // TODO: Calculate previous value from workout history
+                displayName: authVM.displayName ?? "Athlete"
+            )
         }
     }
     

--- a/AscendApp/Features/Progress/Views/PRShareCardView.swift
+++ b/AscendApp/Features/Progress/Views/PRShareCardView.swift
@@ -1,0 +1,315 @@
+//
+//  PRShareCardView.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+
+/// A shareable card displaying a personal record achievement
+struct PRShareCardView: View {
+    let effort: BestEffort
+    let previousValue: String?
+    let displayName: String
+    
+    // Card dimensions for Instagram Stories
+    private let cardWidth: CGFloat = 390
+    private let cardHeight: CGFloat = 520
+    
+    var body: some View {
+        ZStack {
+            // Background gradient
+            LinearGradient(
+                colors: [
+                    Color(red: 0.1, green: 0.1, blue: 0.2),
+                    Color(red: 0.05, green: 0.15, blue: 0.25)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            
+            // Content
+            VStack(spacing: 0) {
+                Spacer()
+                
+                // NEW PR Badge
+                HStack(spacing: 8) {
+                    Image(systemName: "star.fill")
+                        .font(.system(size: 16))
+                    Text("NEW PERSONAL RECORD")
+                        .font(.montserratBold(size: 14))
+                        .tracking(2)
+                }
+                .foregroundStyle(.yellow)
+                .padding(.horizontal, 20)
+                .padding(.vertical, 10)
+                .background(
+                    Capsule()
+                        .fill(Color.yellow.opacity(0.2))
+                )
+                
+                Spacer()
+                    .frame(height: 32)
+                
+                // Icon
+                Image(systemName: effort.iconName)
+                    .font(.system(size: 60, weight: .medium))
+                    .foregroundStyle(.accent)
+                    .padding(.bottom, 16)
+                
+                // PR Type
+                Text(effort.title)
+                    .font(.montserratSemiBold(size: 18))
+                    .foregroundStyle(.white.opacity(0.8))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 20)
+                
+                Spacer()
+                    .frame(height: 20)
+                
+                // Value
+                Text(effort.valueText)
+                    .font(.montserratBold(size: 48))
+                    .foregroundStyle(.white)
+                    .minimumScaleFactor(0.7)
+                    .lineLimit(1)
+                
+                // Previous value comparison
+                if let previous = previousValue {
+                    HStack(spacing: 4) {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(.system(size: 14))
+                        Text("Previous: \(previous)")
+                            .font(.montserratMedium(size: 14))
+                    }
+                    .foregroundStyle(.green)
+                    .padding(.top, 8)
+                }
+                
+                Spacer()
+                    .frame(height: 20)
+                
+                // Date
+                Text(formattedDate)
+                    .font(.montserratMedium(size: 14))
+                    .foregroundStyle(.white.opacity(0.6))
+                
+                Spacer()
+                
+                // Footer with branding
+                HStack {
+                    Text(displayName)
+                        .font(.montserratMedium(size: 13))
+                        .foregroundStyle(.white.opacity(0.5))
+                    
+                    Spacer()
+                    
+                    HStack(spacing: 6) {
+                        Image("AscendLogo")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(height: 18)
+                        Text("Ascend")
+                            .font(.montserratSemiBold(size: 13))
+                    }
+                    .foregroundStyle(.white.opacity(0.5))
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
+            }
+        }
+        .frame(width: cardWidth, height: cardHeight)
+        .clipShape(RoundedRectangle(cornerRadius: 24))
+    }
+    
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        return formatter.string(from: effort.date)
+    }
+}
+
+// MARK: - Image Rendering Extension
+
+extension PRShareCardView {
+    /// Render the card as a UIImage for sharing
+    @MainActor
+    func renderAsImage() -> UIImage? {
+        let renderer = ImageRenderer(content: self)
+        renderer.scale = UIScreen.main.scale
+        return renderer.uiImage
+    }
+}
+
+// MARK: - PR Share Sheet
+
+struct PRShareSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+    
+    let effort: BestEffort
+    let previousValue: String?
+    let displayName: String
+    
+    @State private var themeManager = ThemeManager.shared
+    @State private var isSharing = false
+    @State private var shareImage: UIImage?
+    
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: colorScheme)
+    }
+    
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Spacer()
+                
+                // Preview card
+                PRShareCardView(
+                    effort: effort,
+                    previousValue: previousValue,
+                    displayName: displayName
+                )
+                .scaleEffect(0.85)
+                
+                Spacer()
+                
+                // Share button
+                Button {
+                    shareCard()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "square.and.arrow.up")
+                        Text("Share")
+                    }
+                    .font(.montserratSemiBold(size: 16))
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .background(
+                        RoundedRectangle(cornerRadius: 14)
+                            .fill(Color.accentColor)
+                    )
+                }
+                .disabled(isSharing)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 20)
+            }
+            .themedBackground()
+            .navigationTitle("Share PR")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .foregroundStyle(.accent)
+                }
+            }
+        }
+    }
+    
+    private func shareCard() {
+        isSharing = true
+        
+        let cardView = PRShareCardView(
+            effort: effort,
+            previousValue: previousValue,
+            displayName: displayName
+        )
+        
+        guard let image = cardView.renderAsImage() else {
+            isSharing = false
+            return
+        }
+        
+        let activityVC = UIActivityViewController(
+            activityItems: [image],
+            applicationActivities: nil
+        )
+        
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let rootVC = windowScene.windows.first?.rootViewController {
+            // Find the topmost presented view controller
+            var topController = rootVC
+            while let presented = topController.presentedViewController {
+                topController = presented
+            }
+            
+            // For iPad
+            activityVC.popoverPresentationController?.sourceView = topController.view
+            activityVC.popoverPresentationController?.sourceRect = CGRect(
+                x: topController.view.bounds.midX,
+                y: topController.view.bounds.midY,
+                width: 0,
+                height: 0
+            )
+            
+            topController.present(activityVC, animated: true) {
+                isSharing = false
+            }
+        } else {
+            isSharing = false
+        }
+    }
+}
+
+#Preview {
+    let sampleWorkout = Workout(
+        name: "Morning Climb",
+        date: Date(),
+        duration: 45 * 60,
+        steps: 5200,
+        floors: 40,
+        stepsPerFloor: 16,
+        avgHeartRate: 135,
+        maxHeartRate: 168,
+        caloriesBurned: 520
+    )
+    
+    let effort = BestEffort(
+        type: .mostSteps,
+        title: "Most Steps in a Workout",
+        valueText: "5,200 steps",
+        detailText: "Feb 19, 2026",
+        date: Date(),
+        workout: sampleWorkout,
+        iconName: "figure.stairs"
+    )
+    
+    return PRShareSheet(
+        effort: effort,
+        previousValue: "4,800 steps",
+        displayName: "Tyler"
+    )
+}
+
+#Preview("Card Only") {
+    let sampleWorkout = Workout(
+        name: "Morning Climb",
+        date: Date(),
+        duration: 45 * 60,
+        steps: 5200,
+        floors: 40,
+        stepsPerFloor: 16
+    )
+    
+    let effort = BestEffort(
+        type: .highestStepsPerMinute,
+        title: "Highest Steps per Minute",
+        valueText: "115 / min",
+        detailText: "Feb 19, 2026",
+        date: Date(),
+        workout: sampleWorkout,
+        iconName: "speedometer"
+    )
+    
+    return PRShareCardView(
+        effort: effort,
+        previousValue: "108 / min",
+        displayName: "Tyler"
+    )
+    .padding()
+    .background(Color.gray)
+}

--- a/AscendApp/Shared/Components/TypewriterText.swift
+++ b/AscendApp/Shared/Components/TypewriterText.swift
@@ -1,0 +1,259 @@
+//
+//  TypewriterText.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+
+/// Animated typewriter text with gradient coloring
+/// Cycles through example phrases with a typing animation
+struct TypewriterText: View {
+    let phrases: [String]
+    let typingSpeed: Double // seconds per character
+    let pauseDuration: Double // seconds to pause after typing complete
+    let gradient: LinearGradient
+    
+    @State private var displayedText: String = ""
+    @State private var currentPhraseIndex: Int = 0
+    @State private var isTyping: Bool = true
+    @State private var charIndex: Int = 0
+    
+    init(
+        phrases: [String],
+        typingSpeed: Double = 0.05,
+        pauseDuration: Double = 2.0,
+        gradient: LinearGradient = LinearGradient(
+            colors: [
+                Color(red: 0.4, green: 0.6, blue: 1.0),
+                Color(red: 0.6, green: 0.4, blue: 1.0),
+                Color(red: 0.8, green: 0.5, blue: 1.0)
+            ],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    ) {
+        self.phrases = phrases
+        self.typingSpeed = typingSpeed
+        self.pauseDuration = pauseDuration
+        self.gradient = gradient
+    }
+    
+    var body: some View {
+        Text(displayedText)
+            .font(.montserratMedium(size: 18))
+            .foregroundStyle(gradient)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .onAppear {
+                startTypingAnimation()
+            }
+    }
+    
+    private func startTypingAnimation() {
+        guard !phrases.isEmpty else { return }
+        typeNextCharacter()
+    }
+    
+    private func typeNextCharacter() {
+        let currentPhrase = phrases[currentPhraseIndex]
+        
+        if charIndex < currentPhrase.count {
+            // Still typing current phrase
+            let index = currentPhrase.index(currentPhrase.startIndex, offsetBy: charIndex)
+            displayedText = String(currentPhrase[...index])
+            charIndex += 1
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + typingSpeed) {
+                typeNextCharacter()
+            }
+        } else {
+            // Finished typing, pause then move to next phrase
+            DispatchQueue.main.asyncAfter(deadline: .now() + pauseDuration) {
+                eraseText()
+            }
+        }
+    }
+    
+    private func eraseText() {
+        if displayedText.count > 0 {
+            displayedText = String(displayedText.dropLast())
+            DispatchQueue.main.asyncAfter(deadline: .now() + typingSpeed / 2) {
+                eraseText()
+            }
+        } else {
+            // Move to next phrase
+            currentPhraseIndex = (currentPhraseIndex + 1) % phrases.count
+            charIndex = 0
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                typeNextCharacter()
+            }
+        }
+    }
+}
+
+/// A more advanced typewriter with cursor blink
+struct TypewriterTextWithCursor: View {
+    let phrases: [String]
+    let typingSpeed: Double
+    let pauseDuration: Double
+    let gradient: LinearGradient
+    
+    @State private var displayedText: String = ""
+    @State private var currentPhraseIndex: Int = 0
+    @State private var charIndex: Int = 0
+    @State private var showCursor: Bool = true
+    
+    init(
+        phrases: [String],
+        typingSpeed: Double = 0.05,
+        pauseDuration: Double = 2.0,
+        gradient: LinearGradient = LinearGradient(
+            colors: [
+                Color(red: 0.4, green: 0.6, blue: 1.0),
+                Color(red: 0.6, green: 0.4, blue: 1.0),
+                Color(red: 0.8, green: 0.5, blue: 1.0)
+            ],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    ) {
+        self.phrases = phrases
+        self.typingSpeed = typingSpeed
+        self.pauseDuration = pauseDuration
+        self.gradient = gradient
+    }
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(displayedText)
+                .font(.montserratMedium(size: 18))
+                .foregroundStyle(gradient)
+            
+            // Blinking cursor
+            Text("|")
+                .font(.montserratMedium(size: 18))
+                .foregroundStyle(gradient)
+                .opacity(showCursor ? 1 : 0)
+                .animation(.easeInOut(duration: 0.5).repeatForever(), value: showCursor)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear {
+            showCursor = true
+            startTypingAnimation()
+            startCursorBlink()
+        }
+    }
+    
+    private func startCursorBlink() {
+        Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+            // Cursor blink handled by animation
+        }
+    }
+    
+    private func startTypingAnimation() {
+        guard !phrases.isEmpty else { return }
+        typeNextCharacter()
+    }
+    
+    private func typeNextCharacter() {
+        let currentPhrase = phrases[currentPhraseIndex]
+        
+        if charIndex < currentPhrase.count {
+            let index = currentPhrase.index(currentPhrase.startIndex, offsetBy: charIndex)
+            displayedText = String(currentPhrase[...index])
+            charIndex += 1
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + typingSpeed) {
+                typeNextCharacter()
+            }
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + pauseDuration) {
+                eraseText()
+            }
+        }
+    }
+    
+    private func eraseText() {
+        if displayedText.count > 0 {
+            displayedText = String(displayedText.dropLast())
+            DispatchQueue.main.asyncAfter(deadline: .now() + typingSpeed / 2) {
+                eraseText()
+            }
+        } else {
+            currentPhraseIndex = (currentPhraseIndex + 1) % phrases.count
+            charIndex = 0
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                typeNextCharacter()
+            }
+        }
+    }
+}
+
+// MARK: - Shimmer Gradient Animation
+
+struct ShimmerGradientText: View {
+    let text: String
+    let font: Font
+    
+    @State private var gradientOffset: CGFloat = -1
+    
+    var body: some View {
+        Text(text)
+            .font(font)
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.4, green: 0.6, blue: 1.0),
+                        Color(red: 0.7, green: 0.5, blue: 1.0),
+                        Color(red: 1.0, green: 0.6, blue: 0.8),
+                        Color(red: 0.7, green: 0.5, blue: 1.0),
+                        Color(red: 0.4, green: 0.6, blue: 1.0)
+                    ],
+                    startPoint: UnitPoint(x: gradientOffset, y: 0),
+                    endPoint: UnitPoint(x: gradientOffset + 1, y: 0)
+                )
+            )
+            .onAppear {
+                withAnimation(.linear(duration: 2.0).repeatForever(autoreverses: false)) {
+                    gradientOffset = 1
+                }
+            }
+    }
+}
+
+#Preview("Typewriter") {
+    VStack {
+        TypewriterText(phrases: [
+            "I did 30 minutes on the stairstepper...",
+            "3000 steps with my 20lb vest...",
+            "Three intervals: 5, 10, and 5 minutes...",
+            "Quick session, felt great today..."
+        ])
+        .padding()
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.black)
+}
+
+#Preview("With Cursor") {
+    VStack {
+        TypewriterTextWithCursor(phrases: [
+            "I did 30 minutes on the stairstepper...",
+            "3000 steps with my 20lb vest...",
+            "Three intervals: 5, 10, and 5 minutes..."
+        ])
+        .padding()
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.black)
+}
+
+#Preview("Shimmer") {
+    ShimmerGradientText(
+        text: "Log your workout with voice...",
+        font: .montserratMedium(size: 18)
+    )
+    .padding()
+    .background(Color.black)
+}

--- a/AscendApp/Shared/Managers/AppStoreRatingManager.swift
+++ b/AscendApp/Shared/Managers/AppStoreRatingManager.swift
@@ -9,19 +9,28 @@ import StoreKit
 import SwiftUI
 
 /// Manages App Store rating prompts with intelligent timing
-/// Prompts at 20 workouts, then every 30 workouts thereafter
+/// Shows custom prompt first, then system prompt if user agrees
+/// Prompts at 10 workouts, then every 30 workouts thereafter
 @MainActor
+@Observable
 final class AppStoreRatingManager {
     static let shared = AppStoreRatingManager()
 
     private init() {}
 
+    // MARK: - Observable State
+    
+    /// Whether to show the custom rating prompt overlay
+    var showCustomPrompt = false
+
     // MARK: - Constants
 
     private enum Constants {
-        static let firstPromptThreshold = 20
+        static let firstPromptThreshold = 10  // Lowered from 20 for earlier engagement
         static let subsequentPromptInterval = 30
         static let userDefaultsKey = "lastRatingPromptWorkoutCount"
+        static let notNowDelayDays = 14  // Days to wait after user taps "Not Now"
+        static let lastNotNowDateKey = "lastRatingNotNowDate"
     }
 
     // MARK: - UserDefaults
@@ -29,6 +38,11 @@ final class AppStoreRatingManager {
     private var lastPromptedWorkoutCount: Int {
         get { UserDefaults.standard.integer(forKey: Constants.userDefaultsKey) }
         set { UserDefaults.standard.set(newValue, forKey: Constants.userDefaultsKey) }
+    }
+    
+    private var lastNotNowDate: Date? {
+        get { UserDefaults.standard.object(forKey: Constants.lastNotNowDateKey) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: Constants.lastNotNowDateKey) }
     }
 
     // MARK: - Public Methods
@@ -41,24 +55,47 @@ final class AppStoreRatingManager {
         guard currentWorkoutCount >= Constants.firstPromptThreshold else {
             return false
         }
+        
+        // Check if user recently tapped "Not Now"
+        if let lastNotNow = lastNotNowDate {
+            let daysSinceNotNow = Calendar.current.dateComponents([.day], from: lastNotNow, to: Date()).day ?? 0
+            if daysSinceNotNow < Constants.notNowDelayDays {
+                return false
+            }
+        }
 
-        // First time reaching 20 workouts
+        // First time reaching threshold
         if lastPromptedWorkoutCount == 0 && currentWorkoutCount >= Constants.firstPromptThreshold {
             return true
         }
 
-        // Check if we've reached another interval (50, 80, 110, etc.)
+        // Check if we've reached another interval
         let workoutsSinceLastPrompt = currentWorkoutCount - lastPromptedWorkoutCount
         return workoutsSinceLastPrompt >= Constants.subsequentPromptInterval
     }
-
-    /// Request an App Store rating prompt
-    /// Apple will decide whether to actually show it based on system limitations
+    
+    /// Show the custom rating prompt overlay
     /// - Parameter currentWorkoutCount: Current workout count to track when we prompted
-    func requestReview(currentWorkoutCount: Int) {
-        // Update the last prompted count
+    func showCustomRatingPrompt(currentWorkoutCount: Int) {
         lastPromptedWorkoutCount = currentWorkoutCount
+        showCustomPrompt = true
+    }
+    
+    /// Called when user taps "Rate Us" on custom prompt
+    func userTappedRateUs() {
+        showCustomPrompt = false
+        requestSystemReview()
+    }
+    
+    /// Called when user taps "Not Now" on custom prompt
+    func userTappedNotNow() {
+        showCustomPrompt = false
+        lastNotNowDate = Date()
+    }
 
+    /// Request the system App Store rating prompt
+    /// Apple will decide whether to actually show it based on system limitations
+    func requestSystemReview() {
         // Request the review from Apple
         // Note: Apple controls whether the prompt is actually shown based on:
         // - User's "In-App Ratings & Reviews" setting
@@ -75,8 +112,28 @@ final class AppStoreRatingManager {
             SKStoreReviewController.requestReview(in: scene)
         }
     }
+    
+    /// Legacy method - Request an App Store rating prompt directly
+    /// - Parameter currentWorkoutCount: Current workout count to track when we prompted
+    func requestReview(currentWorkoutCount: Int) {
+        lastPromptedWorkoutCount = currentWorkoutCount
+        requestSystemReview()
+    }
 
-    /// Check eligibility and request review if appropriate
+    /// Check eligibility and show custom prompt if appropriate
+    /// - Parameter currentWorkoutCount: Total number of workouts the user has logged
+    /// - Returns: True if a prompt was shown, false otherwise
+    @discardableResult
+    func checkAndShowPromptIfNeeded(currentWorkoutCount: Int) -> Bool {
+        guard shouldPromptForRating(currentWorkoutCount: currentWorkoutCount) else {
+            return false
+        }
+
+        showCustomRatingPrompt(currentWorkoutCount: currentWorkoutCount)
+        return true
+    }
+    
+    /// Legacy method - Check eligibility and request review if appropriate
     /// - Parameter currentWorkoutCount: Total number of workouts the user has logged
     /// - Returns: True if a review was requested, false otherwise
     @discardableResult

--- a/AscendApp/Shared/Services/VoiceInputManager.swift
+++ b/AscendApp/Shared/Services/VoiceInputManager.swift
@@ -1,0 +1,191 @@
+//
+//  VoiceInputManager.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import Foundation
+import Speech
+import AVFoundation
+
+/// Manages voice input using iOS Speech framework
+@MainActor
+@Observable
+final class VoiceInputManager: NSObject {
+    
+    // MARK: - State
+    
+    var isRecording = false
+    var transcribedText = ""
+    var errorMessage: String?
+    var isAuthorized = false
+    
+    // MARK: - Private Properties
+    
+    private var audioEngine: AVAudioEngine?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+    
+    // MARK: - Initialization
+    
+    override init() {
+        super.init()
+        checkAuthorizationStatus()
+    }
+    
+    // MARK: - Authorization
+    
+    func checkAuthorizationStatus() {
+        SFSpeechRecognizer.requestAuthorization { [weak self] status in
+            DispatchQueue.main.async {
+                switch status {
+                case .authorized:
+                    self?.isAuthorized = true
+                case .denied, .restricted, .notDetermined:
+                    self?.isAuthorized = false
+                    self?.errorMessage = "Speech recognition not authorized"
+                @unknown default:
+                    self?.isAuthorized = false
+                }
+            }
+        }
+    }
+    
+    func requestAuthorization() async -> Bool {
+        return await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                DispatchQueue.main.async {
+                    self.isAuthorized = status == .authorized
+                    continuation.resume(returning: status == .authorized)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Recording
+    
+    func startRecording() throws {
+        guard isAuthorized else {
+            throw VoiceInputError.notAuthorized
+        }
+        
+        guard let speechRecognizer = speechRecognizer, speechRecognizer.isAvailable else {
+            throw VoiceInputError.recognizerNotAvailable
+        }
+        
+        // Cancel any existing task
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        
+        // Configure audio session
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        
+        // Create audio engine
+        audioEngine = AVAudioEngine()
+        guard let audioEngine = audioEngine else {
+            throw VoiceInputError.audioEngineError
+        }
+        
+        // Create recognition request
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        guard let recognitionRequest = recognitionRequest else {
+            throw VoiceInputError.requestCreationFailed
+        }
+        
+        recognitionRequest.shouldReportPartialResults = true
+        recognitionRequest.taskHint = .dictation
+        
+        // Configure input node
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak self] buffer, _ in
+            self?.recognitionRequest?.append(buffer)
+        }
+        
+        // Start recognition task
+        recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
+            guard let self = self else { return }
+            
+            if let result = result {
+                DispatchQueue.main.async {
+                    self.transcribedText = result.bestTranscription.formattedString
+                }
+            }
+            
+            if error != nil || (result?.isFinal ?? false) {
+                DispatchQueue.main.async {
+                    self.stopRecording()
+                }
+            }
+        }
+        
+        // Start audio engine
+        audioEngine.prepare()
+        try audioEngine.start()
+        
+        isRecording = true
+        transcribedText = ""
+        errorMessage = nil
+    }
+    
+    func stopRecording() {
+        audioEngine?.stop()
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+        
+        audioEngine = nil
+        recognitionRequest = nil
+        recognitionTask = nil
+        
+        isRecording = false
+        
+        // Deactivate audio session
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+    
+    func toggleRecording() {
+        if isRecording {
+            stopRecording()
+        } else {
+            do {
+                try startRecording()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+    
+    func reset() {
+        stopRecording()
+        transcribedText = ""
+        errorMessage = nil
+    }
+}
+
+// MARK: - Errors
+
+enum VoiceInputError: LocalizedError {
+    case notAuthorized
+    case recognizerNotAvailable
+    case audioEngineError
+    case requestCreationFailed
+    
+    var errorDescription: String? {
+        switch self {
+        case .notAuthorized:
+            return "Speech recognition is not authorized. Please enable it in Settings."
+        case .recognizerNotAvailable:
+            return "Speech recognition is not available on this device."
+        case .audioEngineError:
+            return "Could not initialize audio engine."
+        case .requestCreationFailed:
+            return "Could not create speech recognition request."
+        }
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutParsingService.swift
+++ b/AscendApp/Shared/Services/WorkoutParsingService.swift
@@ -1,0 +1,260 @@
+//
+//  WorkoutParsingService.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import Foundation
+
+/// Parsed workout data from voice input
+struct ParsedWorkoutData: Codable {
+    var durationMinutes: Int?
+    var steps: Int?
+    var floors: Int?
+    var weightEquipment: [WeightEquipmentItem]?
+    var intervals: [IntervalItem]?
+    var heartRateAvg: Int?
+    var heartRateMax: Int?
+    var calories: Int?
+    var notes: String?
+    
+    struct WeightEquipmentItem: Codable {
+        let type: String
+        let weightLbs: Double
+        let quantity: Int?
+        
+        enum CodingKeys: String, CodingKey {
+            case type
+            case weightLbs = "weight_lbs"
+            case quantity
+        }
+    }
+    
+    struct IntervalItem: Codable {
+        let durationMinutes: Int?
+        let steps: Int?
+        
+        enum CodingKeys: String, CodingKey {
+            case durationMinutes = "duration_minutes"
+            case steps
+        }
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case durationMinutes = "duration_minutes"
+        case steps
+        case floors
+        case weightEquipment = "weight_equipment"
+        case intervals
+        case heartRateAvg = "heart_rate_avg"
+        case heartRateMax = "heart_rate_max"
+        case calories
+        case notes
+    }
+}
+
+/// Service for parsing natural language workout descriptions using LLM
+actor WorkoutParsingService {
+    
+    // MARK: - Configuration
+    
+    /// API endpoint - defaults to Anthropic Claude
+    private let apiEndpoint = "https://api.anthropic.com/v1/messages"
+    
+    /// Model to use - Claude Haiku for cost efficiency
+    private let model = "claude-3-haiku-20240307"
+    
+    /// API key stored in environment or config
+    /// In production, this should come from secure storage
+    private var apiKey: String? {
+        // Try to get from UserDefaults (set during onboarding or settings)
+        if let key = UserDefaults.standard.string(forKey: "anthropic_api_key"), !key.isEmpty {
+            return key
+        }
+        // Fallback to environment variable (for development)
+        return ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"]
+    }
+    
+    // MARK: - Parsing
+    
+    /// Parse a natural language workout description into structured data
+    /// - Parameter text: The transcribed voice input
+    /// - Returns: Parsed workout data
+    func parseWorkoutDescription(_ text: String) async throws -> ParsedWorkoutData {
+        guard let apiKey = apiKey else {
+            throw ParsingError.noApiKey
+        }
+        
+        let prompt = buildPrompt(for: text)
+        let response = try await callClaudeAPI(prompt: prompt, apiKey: apiKey)
+        let parsed = try parseResponse(response)
+        
+        return parsed
+    }
+    
+    /// Build the system prompt and user message for the LLM
+    private func buildPrompt(for userInput: String) -> String {
+        """
+        Extract workout data from this voice input. Return ONLY valid JSON, no other text.
+        
+        Fields to extract (all optional):
+        - duration_minutes: number (total workout duration)
+        - steps: number (total steps climbed)
+        - floors: number (total floors climbed)
+        - weight_equipment: array of objects with:
+          - type: string (e.g., "vest", "ankle_weights", "backpack", "dumbbells")
+          - weight_lbs: number
+          - quantity: number (default 1, use 2 for "both ankles" etc.)
+        - intervals: array of objects with:
+          - duration_minutes: number
+          - steps: number (optional)
+        - heart_rate_avg: number
+        - heart_rate_max: number
+        - calories: number
+        - notes: string (any other details)
+        
+        Examples:
+        Input: "30 minutes, 3000 steps, wore my 20 pound vest"
+        Output: {"duration_minutes": 30, "steps": 3000, "weight_equipment": [{"type": "vest", "weight_lbs": 20, "quantity": 1}]}
+        
+        Input: "did three intervals, 5 minutes then 10 minutes then 5 minutes, 2000 total steps, had 2.5 pound ankle weights on both ankles"
+        Output: {"duration_minutes": 20, "steps": 2000, "intervals": [{"duration_minutes": 5}, {"duration_minutes": 10}, {"duration_minutes": 5}], "weight_equipment": [{"type": "ankle_weights", "weight_lbs": 2.5, "quantity": 2}]}
+        
+        Input: "quick 20 minute session, felt really good, got my heart rate up to 165"
+        Output: {"duration_minutes": 20, "heart_rate_max": 165, "notes": "felt really good"}
+        
+        Now parse this input:
+        \(userInput)
+        """
+    }
+    
+    /// Call the Claude API
+    private func callClaudeAPI(prompt: String, apiKey: String) async throws -> String {
+        var request = URLRequest(url: URL(string: apiEndpoint)!)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.addValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 500,
+            "messages": [
+                ["role": "user", "content": prompt]
+            ]
+        ]
+        
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ParsingError.invalidResponse
+        }
+        
+        guard httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw ParsingError.apiError(statusCode: httpResponse.statusCode, message: errorBody)
+        }
+        
+        // Parse Claude's response
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]],
+              let firstContent = content.first,
+              let text = firstContent["text"] as? String else {
+            throw ParsingError.invalidResponse
+        }
+        
+        return text
+    }
+    
+    /// Parse the LLM response into structured data
+    private func parseResponse(_ response: String) throws -> ParsedWorkoutData {
+        // Clean up response - remove any markdown code blocks if present
+        var cleanedResponse = response
+            .replacingOccurrences(of: "```json", with: "")
+            .replacingOccurrences(of: "```", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        // Try to find JSON in the response
+        if let startIndex = cleanedResponse.firstIndex(of: "{"),
+           let endIndex = cleanedResponse.lastIndex(of: "}") {
+            cleanedResponse = String(cleanedResponse[startIndex...endIndex])
+        }
+        
+        guard let jsonData = cleanedResponse.data(using: .utf8) else {
+            throw ParsingError.invalidJSON
+        }
+        
+        let decoder = JSONDecoder()
+        do {
+            return try decoder.decode(ParsedWorkoutData.self, from: jsonData)
+        } catch {
+            print("JSON parsing error: \(error)")
+            print("Response was: \(cleanedResponse)")
+            throw ParsingError.invalidJSON
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum ParsingError: LocalizedError {
+    case noApiKey
+    case invalidResponse
+    case apiError(statusCode: Int, message: String)
+    case invalidJSON
+    
+    var errorDescription: String? {
+        switch self {
+        case .noApiKey:
+            return "No API key configured. Please add your Anthropic API key in Settings."
+        case .invalidResponse:
+            return "Received an invalid response from the server."
+        case .apiError(let statusCode, let message):
+            return "API error (\(statusCode)): \(message)"
+        case .invalidJSON:
+            return "Could not parse the workout data. Please try again."
+        }
+    }
+}
+
+// MARK: - Fallback Regex Parser
+
+/// Simple regex-based parser for when LLM is not available
+struct FallbackWorkoutParser {
+    
+    static func parse(_ text: String) -> ParsedWorkoutData {
+        var data = ParsedWorkoutData()
+        let lowercased = text.lowercased()
+        
+        // Extract duration
+        if let match = lowercased.range(of: #"(\d+)\s*(minutes?|mins?|min)"#, options: .regularExpression) {
+            let numStr = String(lowercased[match]).components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+            data.durationMinutes = Int(numStr)
+        }
+        
+        // Extract steps
+        if let match = lowercased.range(of: #"(\d+)\s*steps?"#, options: .regularExpression) {
+            let numStr = String(lowercased[match]).components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+            data.steps = Int(numStr)
+        }
+        
+        // Extract floors
+        if let match = lowercased.range(of: #"(\d+)\s*floors?"#, options: .regularExpression) {
+            let numStr = String(lowercased[match]).components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+            data.floors = Int(numStr)
+        }
+        
+        // Extract vest weight
+        if let match = lowercased.range(of: #"(\d+)\s*(pound|lb)s?\s*(weighted\s*)?vest"#, options: .regularExpression) {
+            let numStr = String(lowercased[match]).components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+            if let weight = Double(numStr) {
+                data.weightEquipment = [ParsedWorkoutData.WeightEquipmentItem(type: "vest", weightLbs: weight, quantity: 1)]
+            }
+        }
+        
+        return data
+    }
+}

--- a/AscendApp/Shared/Views/MainTabView.swift
+++ b/AscendApp/Shared/Views/MainTabView.swift
@@ -12,6 +12,7 @@ struct MainTabView: View {
     @Environment(\.colorScheme) private var systemColorScheme
     @Environment(\.modelContext) private var modelContext
     @State private var themeManager = ThemeManager.shared
+    @State private var ratingManager = AppStoreRatingManager.shared
     @StateObject private var tabRouter = TabRouter()
     @State private var hasCheckedRatingOnLaunch = false
 
@@ -55,6 +56,17 @@ struct MainTabView: View {
             generator.impactOccurred()
         }
         .themeAware()
+        .overlay {
+            RatingPromptOverlay(
+                isPresented: $ratingManager.showCustomPrompt,
+                onRateUs: {
+                    ratingManager.userTappedRateUs()
+                },
+                onNotNow: {
+                    ratingManager.userTappedNotNow()
+                }
+            )
+        }
     }
 
     private func checkForRatingPromptOnLaunch() {
@@ -67,7 +79,7 @@ struct MainTabView: View {
         // Note: We fetch count on-demand rather than using @Query to avoid crashes
         // when workouts are deleted (e.g., during account deletion) while this view is in the hierarchy
         let workoutCount = (try? modelContext.fetchCount(FetchDescriptor<Workout>())) ?? 0
-        AppStoreRatingManager.shared.checkAndRequestReviewIfNeeded(currentWorkoutCount: workoutCount)
+        AppStoreRatingManager.shared.checkAndShowPromptIfNeeded(currentWorkoutCount: workoutCount)
     }
     
     private func getIconName(for tab: TabItem, isSelected: Bool) -> String {

--- a/AscendApp/Shared/Views/RatingPromptView.swift
+++ b/AscendApp/Shared/Views/RatingPromptView.swift
@@ -1,0 +1,152 @@
+//
+//  RatingPromptView.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+
+/// Custom rating prompt shown before the system App Store review dialog
+/// Inspired by Partiful's personal approach to rating requests
+struct RatingPromptView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var themeManager = ThemeManager.shared
+    
+    let onRateUs: () -> Void
+    let onNotNow: () -> Void
+    
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: colorScheme)
+    }
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            // Emoji header
+            Text("🏔️")
+                .font(.system(size: 60))
+            
+            // Personal message
+            VStack(spacing: 12) {
+                Text("Enjoying Ascend?")
+                    .font(.montserratBold(size: 24))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                
+                Text("Hey! I'm Tyler, the developer behind Ascend. I built this app because I couldn't find a workout tracker that truly understood stairstepper training.\n\nIf Ascend has helped you crush your fitness goals, would you mind leaving a quick review? It really helps other fitness enthusiasts discover the app.")
+                    .font(.montserratRegular(size: 15))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.8) : .black.opacity(0.7))
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(4)
+            }
+            
+            // Buttons
+            VStack(spacing: 12) {
+                Button(action: {
+                    HapticsManager.shared.trigger(.selection)
+                    onRateUs()
+                }) {
+                    Text("Rate Ascend ⭐")
+                        .font(.montserratSemiBold(size: 16))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(Color.accentColor)
+                        .cornerRadius(12)
+                }
+                
+                Button(action: {
+                    HapticsManager.shared.trigger(.selection)
+                    onNotNow()
+                }) {
+                    Text("Maybe Later")
+                        .font(.montserratMedium(size: 15))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .black.opacity(0.5))
+                }
+                .padding(.top, 4)
+            }
+        }
+        .padding(24)
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(effectiveColorScheme == .dark ? Color.jetLighter : Color.white)
+        )
+        .shadow(color: .black.opacity(0.2), radius: 20, x: 0, y: 10)
+        .padding(.horizontal, 32)
+    }
+}
+
+/// Full-screen overlay for the rating prompt
+struct RatingPromptOverlay: View {
+    @Binding var isPresented: Bool
+    let onRateUs: () -> Void
+    var onNotNow: (() -> Void)? = nil
+    
+    var body: some View {
+        if isPresented {
+            ZStack {
+                // Dimmed background
+                Color.black.opacity(0.5)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        // Dismiss on background tap (counts as "not now")
+                        withAnimation(.spring(response: 0.3)) {
+                            isPresented = false
+                        }
+                        onNotNow?()
+                    }
+                
+                // Prompt card
+                RatingPromptView(
+                    onRateUs: {
+                        withAnimation(.spring(response: 0.3)) {
+                            isPresented = false
+                        }
+                        // Small delay to let animation complete
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            onRateUs()
+                        }
+                    },
+                    onNotNow: {
+                        withAnimation(.spring(response: 0.3)) {
+                            isPresented = false
+                        }
+                        onNotNow?()
+                    }
+                )
+                .transition(.scale.combined(with: .opacity))
+            }
+            .animation(.spring(response: 0.3), value: isPresented)
+        }
+    }
+}
+
+#Preview {
+    RatingPromptView(
+        onRateUs: { print("Rate us tapped") },
+        onNotNow: { print("Not now tapped") }
+    )
+    .padding()
+    .background(Color.gray.opacity(0.3))
+}
+
+#Preview("Dark Mode") {
+    RatingPromptView(
+        onRateUs: { print("Rate us tapped") },
+        onNotNow: { print("Not now tapped") }
+    )
+    .padding()
+    .background(Color.black)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Overlay") {
+    ZStack {
+        Color.blue
+            .ignoresSafeArea()
+        
+        RatingPromptOverlay(
+            isPresented: .constant(true),
+            onRateUs: { print("Rate us!") }
+        )
+    }
+}

--- a/AscendWidgets/AscendWidgets.swift
+++ b/AscendWidgets/AscendWidgets.swift
@@ -1,0 +1,17 @@
+//
+//  AscendWidgets.swift
+//  AscendWidgets
+//
+//  Created by Claude on 2/19/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct AscendWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        StreakWidget()
+        WeeklyProgressWidget()
+    }
+}

--- a/AscendWidgets/SETUP.md
+++ b/AscendWidgets/SETUP.md
@@ -1,0 +1,39 @@
+# Ascend Widgets Setup Guide
+
+## Creating the Widget Extension in Xcode
+
+1. **Open the project in Xcode**
+
+2. **Add Widget Extension Target:**
+   - File → New → Target
+   - Search for "Widget Extension"
+   - Name it "AscendWidgets"
+   - Uncheck "Include Configuration Intent" (we'll use static config first)
+   - Click Finish
+
+3. **Set up App Group:**
+   - Select the main "AscendApp" target → Signing & Capabilities
+   - Click "+ Capability" → App Groups
+   - Add a new group: `group.com.ascendapp.shared`
+   - Select the "AscendWidgets" target and add the same App Group
+
+4. **Copy Widget Files:**
+   - Replace the generated widget files with the ones in this folder
+   - Make sure to add them to the AscendWidgets target
+
+5. **Set up Shared Data:**
+   - The widget reads from UserDefaults with the App Group suite
+   - The main app needs to write workout stats to this shared container
+
+## Files in this folder:
+
+- `AscendWidgets.swift` - Main widget entry point
+- `StreakWidget.swift` - Shows current workout streak
+- `WeeklyProgressWidget.swift` - Shows weekly step/floor progress
+- `SharedDataManager.swift` - Handles data sharing between app and widget
+
+## Data Flow:
+
+1. Main app saves workout → Updates shared UserDefaults
+2. Widget reads from shared UserDefaults
+3. Widget timeline refreshes periodically or on app updates

--- a/AscendWidgets/SharedDataManager.swift
+++ b/AscendWidgets/SharedDataManager.swift
@@ -1,0 +1,118 @@
+//
+//  SharedDataManager.swift
+//  AscendWidgets
+//
+//  Created by Claude on 2/19/26.
+//
+
+import Foundation
+
+/// Manages shared data between the main app and widgets via App Group UserDefaults
+struct SharedDataManager {
+    static let appGroupIdentifier = "group.com.ascendapp.shared"
+    
+    private static var sharedDefaults: UserDefaults? {
+        UserDefaults(suiteName: appGroupIdentifier)
+    }
+    
+    // MARK: - Keys
+    
+    private enum Keys {
+        static let currentStreak = "widget_currentStreak"
+        static let weeklySteps = "widget_weeklySteps"
+        static let weeklyFloors = "widget_weeklyFloors"
+        static let weeklyWorkoutCount = "widget_weeklyWorkoutCount"
+        static let lastWorkoutDate = "widget_lastWorkoutDate"
+        static let todaySteps = "widget_todaySteps"
+        static let todayFloors = "widget_todayFloors"
+        static let weeklyGoalSteps = "widget_weeklyGoalSteps"
+        static let lastUpdated = "widget_lastUpdated"
+    }
+    
+    // MARK: - Widget Data Model
+    
+    struct WidgetData {
+        let currentStreak: Int
+        let weeklySteps: Int
+        let weeklyFloors: Int
+        let weeklyWorkoutCount: Int
+        let lastWorkoutDate: Date?
+        let todaySteps: Int
+        let todayFloors: Int
+        let weeklyGoalSteps: Int
+        let lastUpdated: Date
+        
+        static var placeholder: WidgetData {
+            WidgetData(
+                currentStreak: 7,
+                weeklySteps: 15000,
+                weeklyFloors: 120,
+                weeklyWorkoutCount: 4,
+                lastWorkoutDate: Date(),
+                todaySteps: 2500,
+                todayFloors: 30,
+                weeklyGoalSteps: 20000,
+                lastUpdated: Date()
+            )
+        }
+        
+        static var empty: WidgetData {
+            WidgetData(
+                currentStreak: 0,
+                weeklySteps: 0,
+                weeklyFloors: 0,
+                weeklyWorkoutCount: 0,
+                lastWorkoutDate: nil,
+                todaySteps: 0,
+                todayFloors: 0,
+                weeklyGoalSteps: 20000,
+                lastUpdated: Date()
+            )
+        }
+    }
+    
+    // MARK: - Read Data (Widget side)
+    
+    static func getWidgetData() -> WidgetData {
+        guard let defaults = sharedDefaults else {
+            return .empty
+        }
+        
+        return WidgetData(
+            currentStreak: defaults.integer(forKey: Keys.currentStreak),
+            weeklySteps: defaults.integer(forKey: Keys.weeklySteps),
+            weeklyFloors: defaults.integer(forKey: Keys.weeklyFloors),
+            weeklyWorkoutCount: defaults.integer(forKey: Keys.weeklyWorkoutCount),
+            lastWorkoutDate: defaults.object(forKey: Keys.lastWorkoutDate) as? Date,
+            todaySteps: defaults.integer(forKey: Keys.todaySteps),
+            todayFloors: defaults.integer(forKey: Keys.todayFloors),
+            weeklyGoalSteps: defaults.integer(forKey: Keys.weeklyGoalSteps),
+            lastUpdated: defaults.object(forKey: Keys.lastUpdated) as? Date ?? Date()
+        )
+    }
+    
+    // MARK: - Write Data (Main app side)
+    
+    static func updateWidgetData(
+        currentStreak: Int,
+        weeklySteps: Int,
+        weeklyFloors: Int,
+        weeklyWorkoutCount: Int,
+        lastWorkoutDate: Date?,
+        todaySteps: Int,
+        todayFloors: Int,
+        weeklyGoalSteps: Int
+    ) {
+        guard let defaults = sharedDefaults else { return }
+        
+        defaults.set(currentStreak, forKey: Keys.currentStreak)
+        defaults.set(weeklySteps, forKey: Keys.weeklySteps)
+        defaults.set(weeklyFloors, forKey: Keys.weeklyFloors)
+        defaults.set(weeklyWorkoutCount, forKey: Keys.weeklyWorkoutCount)
+        defaults.set(lastWorkoutDate, forKey: Keys.lastWorkoutDate)
+        defaults.set(todaySteps, forKey: Keys.todaySteps)
+        defaults.set(todayFloors, forKey: Keys.todayFloors)
+        defaults.set(weeklyGoalSteps, forKey: Keys.weeklyGoalSteps)
+        defaults.set(Date(), forKey: Keys.lastUpdated)
+    }
+}

--- a/AscendWidgets/StreakWidget.swift
+++ b/AscendWidgets/StreakWidget.swift
@@ -1,0 +1,162 @@
+//
+//  StreakWidget.swift
+//  AscendWidgets
+//
+//  Created by Claude on 2/19/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+// MARK: - Timeline Provider
+
+struct StreakProvider: TimelineProvider {
+    func placeholder(in context: Context) -> StreakEntry {
+        StreakEntry(date: Date(), data: .placeholder)
+    }
+    
+    func getSnapshot(in context: Context, completion: @escaping (StreakEntry) -> Void) {
+        let entry = StreakEntry(date: Date(), data: SharedDataManager.getWidgetData())
+        completion(entry)
+    }
+    
+    func getTimeline(in context: Context, completion: @escaping (Timeline<StreakEntry>) -> Void) {
+        let currentDate = Date()
+        let data = SharedDataManager.getWidgetData()
+        let entry = StreakEntry(date: currentDate, data: data)
+        
+        // Refresh every hour
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: currentDate)!
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+}
+
+// MARK: - Timeline Entry
+
+struct StreakEntry: TimelineEntry {
+    let date: Date
+    let data: SharedDataManager.WidgetData
+}
+
+// MARK: - Widget View
+
+struct StreakWidgetEntryView: View {
+    var entry: StreakProvider.Entry
+    @Environment(\.widgetFamily) var family
+    
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            smallView
+        case .systemMedium:
+            mediumView
+        default:
+            smallView
+        }
+    }
+    
+    private var smallView: some View {
+        VStack(spacing: 8) {
+            // Flame icon
+            Image(systemName: "flame.fill")
+                .font(.system(size: 32))
+                .foregroundStyle(.orange)
+            
+            // Streak count
+            Text("\(entry.data.currentStreak)")
+                .font(.system(size: 36, weight: .bold, design: .rounded))
+                .foregroundStyle(.primary)
+            
+            // Label
+            Text(entry.data.currentStreak == 1 ? "Day Streak" : "Day Streak")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+    
+    private var mediumView: some View {
+        HStack(spacing: 20) {
+            // Streak info
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Image(systemName: "flame.fill")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.orange)
+                    
+                    Text("\(entry.data.currentStreak)")
+                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                }
+                
+                Text("Day Streak")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.secondary)
+                
+                if let lastWorkout = entry.data.lastWorkoutDate {
+                    Text("Last: \(lastWorkout, style: .relative) ago")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            
+            Spacer()
+            
+            // Weekly stats
+            VStack(alignment: .trailing, spacing: 8) {
+                HStack(spacing: 4) {
+                    Image(systemName: "figure.stairs")
+                        .font(.system(size: 14))
+                    Text("\(entry.data.weeklySteps)")
+                        .font(.system(size: 16, weight: .semibold))
+                }
+                .foregroundStyle(.accent)
+                
+                HStack(spacing: 4) {
+                    Image(systemName: "building.2")
+                        .font(.system(size: 14))
+                    Text("\(entry.data.weeklyFloors)")
+                        .font(.system(size: 16, weight: .semibold))
+                }
+                .foregroundStyle(.green)
+                
+                Text("This Week")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+// MARK: - Widget Definition
+
+struct StreakWidget: Widget {
+    let kind: String = "StreakWidget"
+    
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: StreakProvider()) { entry in
+            StreakWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Workout Streak")
+        .description("Track your consecutive workout days.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Previews
+
+#Preview(as: .systemSmall) {
+    StreakWidget()
+} timeline: {
+    StreakEntry(date: Date(), data: .placeholder)
+}
+
+#Preview(as: .systemMedium) {
+    StreakWidget()
+} timeline: {
+    StreakEntry(date: Date(), data: .placeholder)
+}

--- a/AscendWidgets/WeeklyProgressWidget.swift
+++ b/AscendWidgets/WeeklyProgressWidget.swift
@@ -1,0 +1,218 @@
+//
+//  WeeklyProgressWidget.swift
+//  AscendWidgets
+//
+//  Created by Claude on 2/19/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+// MARK: - Timeline Provider
+
+struct WeeklyProgressProvider: TimelineProvider {
+    func placeholder(in context: Context) -> WeeklyProgressEntry {
+        WeeklyProgressEntry(date: Date(), data: .placeholder)
+    }
+    
+    func getSnapshot(in context: Context, completion: @escaping (WeeklyProgressEntry) -> Void) {
+        let entry = WeeklyProgressEntry(date: Date(), data: SharedDataManager.getWidgetData())
+        completion(entry)
+    }
+    
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WeeklyProgressEntry>) -> Void) {
+        let currentDate = Date()
+        let data = SharedDataManager.getWidgetData()
+        let entry = WeeklyProgressEntry(date: currentDate, data: data)
+        
+        // Refresh every hour
+        let nextUpdate = Calendar.current.date(byAdding: .hour, value: 1, to: currentDate)!
+        let timeline = Timeline(entries: [entry], policy: .after(nextUpdate))
+        completion(timeline)
+    }
+}
+
+// MARK: - Timeline Entry
+
+struct WeeklyProgressEntry: TimelineEntry {
+    let date: Date
+    let data: SharedDataManager.WidgetData
+}
+
+// MARK: - Widget View
+
+struct WeeklyProgressWidgetEntryView: View {
+    var entry: WeeklyProgressProvider.Entry
+    @Environment(\.widgetFamily) var family
+    
+    private var progressPercentage: Double {
+        guard entry.data.weeklyGoalSteps > 0 else { return 0 }
+        return min(Double(entry.data.weeklySteps) / Double(entry.data.weeklyGoalSteps), 1.0)
+    }
+    
+    var body: some View {
+        switch family {
+        case .systemSmall:
+            smallView
+        case .systemMedium:
+            mediumView
+        default:
+            smallView
+        }
+    }
+    
+    private var smallView: some View {
+        VStack(spacing: 8) {
+            // Title
+            Text("This Week")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            
+            // Progress ring
+            ZStack {
+                Circle()
+                    .stroke(Color.gray.opacity(0.2), lineWidth: 8)
+                
+                Circle()
+                    .trim(from: 0, to: progressPercentage)
+                    .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                    .rotationEffect(.degrees(-90))
+                
+                VStack(spacing: 2) {
+                    Text("\(entry.data.weeklySteps)")
+                        .font(.system(size: 18, weight: .bold, design: .rounded))
+                    Text("steps")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 80, height: 80)
+            
+            // Workouts count
+            Text("\(entry.data.weeklyWorkoutCount) workouts")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+    
+    private var mediumView: some View {
+        HStack(spacing: 20) {
+            // Progress ring
+            ZStack {
+                Circle()
+                    .stroke(Color.gray.opacity(0.2), lineWidth: 10)
+                
+                Circle()
+                    .trim(from: 0, to: progressPercentage)
+                    .stroke(
+                        LinearGradient(
+                            colors: [.blue, .purple],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        style: StrokeStyle(lineWidth: 10, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                
+                VStack(spacing: 2) {
+                    Text("\(Int(progressPercentage * 100))%")
+                        .font(.system(size: 20, weight: .bold, design: .rounded))
+                    Text("of goal")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .frame(width: 90, height: 90)
+            
+            // Stats
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Weekly Progress")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                
+                HStack(spacing: 16) {
+                    StatItem(
+                        icon: "figure.stairs",
+                        value: "\(entry.data.weeklySteps)",
+                        label: "Steps",
+                        color: .blue
+                    )
+                    
+                    StatItem(
+                        icon: "building.2",
+                        value: "\(entry.data.weeklyFloors)",
+                        label: "Floors",
+                        color: .green
+                    )
+                    
+                    StatItem(
+                        icon: "checkmark.circle.fill",
+                        value: "\(entry.data.weeklyWorkoutCount)",
+                        label: "Workouts",
+                        color: .orange
+                    )
+                }
+            }
+            
+            Spacer()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(.fill.tertiary, for: .widget)
+    }
+}
+
+// MARK: - Helper Views
+
+private struct StatItem: View {
+    let icon: String
+    let value: String
+    let label: String
+    let color: Color
+    
+    var body: some View {
+        VStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 16))
+                .foregroundStyle(color)
+            
+            Text(value)
+                .font(.system(size: 14, weight: .bold, design: .rounded))
+            
+            Text(label)
+                .font(.system(size: 9))
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Widget Definition
+
+struct WeeklyProgressWidget: Widget {
+    let kind: String = "WeeklyProgressWidget"
+    
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: WeeklyProgressProvider()) { entry in
+            WeeklyProgressWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("Weekly Progress")
+        .description("Track your weekly steps, floors, and workouts.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}
+
+// MARK: - Previews
+
+#Preview(as: .systemSmall) {
+    WeeklyProgressWidget()
+} timeline: {
+    WeeklyProgressEntry(date: Date(), data: .placeholder)
+}
+
+#Preview(as: .systemMedium) {
+    WeeklyProgressWidget()
+} timeline: {
+    WeeklyProgressEntry(date: Date(), data: .placeholder)
+}


### PR DESCRIPTION
## Summary

Implements the voice-first conversational logging feature from issue #18.

## New Components

### TypewriterText.swift
- `TypewriterText` — Animated gradient text with typewriter effect
- `TypewriterTextWithCursor` — Same with blinking cursor
- `ShimmerGradientText` — Animated shimmer gradient

### VoiceInputManager.swift
- iOS Speech framework integration
- Authorization handling
- Real-time transcription
- Start/stop recording controls

### WorkoutParsingService.swift
- Claude Haiku API integration (~$0.002/call)
- `ParsedWorkoutData` model with:
  - Duration, steps, floors
  - Weight equipment array
  - Intervals array
  - Heart rate, calories, notes
- `FallbackWorkoutParser` — Regex fallback when API unavailable

### ConversationalHomeView.swift
New home screen with:
- Animated typewriter placeholder cycling through examples
- Gradient text coloring (blue → purple → pink)
- Voice input button with live transcription
- Text input fallback
- Recent workouts list
- Processing state with spinner

### WorkoutConfirmationView.swift
- Shows parsed data for review
- Editable fields (duration, steps, floors, etc.)
- Weight equipment display
- Intervals display
- Save/cancel actions

## Screenshots

The home screen shows:
```
┌─────────────────────────────┐
│       Log Workout           │
│                             │
│ ┌─────────────────────────┐ │
│ │ "I did 30 minutes on... │ │  ← Animated typewriter
│ └─────────────────────────┘ │
│                             │
│   [🎤 Speak]    [↑ Log]     │
│                             │
│   ── Recent Workouts ──     │
│   Today: 45 min, 4200 steps │
└─────────────────────────────┘
```

## Setup Required

1. **Info.plist permissions:**
   ```xml
   <key>NSSpeechRecognitionUsageDescription</key>
   <string>Ascend uses speech recognition to log workouts with your voice.</string>
   <key>NSMicrophoneUsageDescription</key>
   <string>Ascend needs microphone access to hear your workout descriptions.</string>
   ```

2. **API Key (optional):**
   - For LLM parsing, add Anthropic API key to UserDefaults key `anthropic_api_key`
   - Without API key, falls back to regex parser (less flexible)

## Integration Note

This creates a new `ConversationalHomeView` but doesn't replace the existing home yet. To use it:
- Update `MainTabView` to use `ConversationalHomeView` as the home tab
- Or create a toggle in settings for "Voice-First Mode"

## Cost

- iOS Speech: **Free** (on-device)
- Claude Haiku: ~**$0.002** per voice log
- 100 logs/month ≈ **$0.20**