### PR TITLE
Live Activity: Real-time workout on lock screen & Dynamic Island

### DIFF
--- a/AscendApp/Shared/LiveActivity/SETUP.md
+++ b/AscendApp/Shared/LiveActivity/SETUP.md
@@ -1,0 +1,113 @@
+# Live Activity Setup Guide
+
+## Overview
+
+Live Activities show real-time workout stats on the lock screen and Dynamic Island during an active workout.
+
+## What Users See
+
+**Lock Screen:**
+- Workout name and duration (large)
+- Steps count
+- Floors climbed
+- Heart rate (if available)
+- Weight equipment (if used)
+
+**Dynamic Island (Compact):**
+- Duration on left
+- Steps on right
+
+**Dynamic Island (Expanded):**
+- Full stats: duration, steps, floors, SPM, heart rate, calories
+
+## Setup Steps
+
+### 1. Enable Live Activities in Info.plist
+
+Add to your `Info.plist`:
+```xml
+<key>NSSupportsLiveActivities</key>
+<true/>
+```
+
+### 2. Create Widget Extension (if not already done)
+
+If you don't have a widget extension:
+1. File → New → Target → Widget Extension
+2. Name it "AscendWidgets"
+3. Check "Include Live Activity"
+
+### 3. Add Files to Widget Target
+
+Add these files to both the main app AND the widget extension target:
+- `WorkoutActivityAttributes.swift`
+- `WorkoutLiveActivityView.swift`
+
+### 4. Register the Live Activity Widget
+
+In your widget bundle (`AscendWidgets.swift`):
+```swift
+@main
+struct AscendWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        // Other widgets...
+        WorkoutLiveActivity()
+    }
+}
+```
+
+## Usage in App
+
+### Starting a Live Activity
+
+```swift
+// When user starts a workout
+LiveActivityManager.shared.startWorkoutActivity(
+    workoutName: "Morning Climb",
+    weightDescription: "20lb vest" // optional
+)
+```
+
+### Updating During Workout
+
+```swift
+// Call periodically (every 1-5 seconds)
+LiveActivityManager.shared.updateWorkoutActivity(
+    elapsedSeconds: 1847,
+    steps: 3250,
+    floors: 27,
+    currentHeartRate: 142,
+    calories: 380,
+    currentSPM: 78
+)
+```
+
+### Ending the Activity
+
+```swift
+// When workout completes
+LiveActivityManager.shared.endWorkoutActivity(
+    finalSteps: 4500,
+    finalFloors: 38,
+    finalDuration: 2700
+)
+```
+
+### Canceling (User Abandons Workout)
+
+```swift
+LiveActivityManager.shared.cancelActivity()
+```
+
+## Integration Points
+
+1. **Routine Timer View** - Start activity when routine begins, update during workout
+2. **Manual Workout Flow** - If you add a "Start Workout" feature
+3. **HealthKit Workout Session** - Sync with HKWorkoutSession for background updates
+
+## Notes
+
+- Live Activities auto-end after 8 hours (iOS limit)
+- Users can disable Live Activities in Settings
+- Check `ActivityAuthorizationInfo().areActivitiesEnabled` before starting
+- Updates are rate-limited by iOS; don't update more than every second

--- a/AscendApp/Shared/LiveActivity/WorkoutActivityAttributes.swift
+++ b/AscendApp/Shared/LiveActivity/WorkoutActivityAttributes.swift
@@ -1,0 +1,179 @@
+//
+//  WorkoutActivityAttributes.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import ActivityKit
+import Foundation
+
+/// Attributes for the live workout activity
+/// These define what data is shown on the lock screen and Dynamic Island
+struct WorkoutActivityAttributes: ActivityAttributes {
+    
+    /// Static content that doesn't change during the activity
+    public struct ContentState: Codable, Hashable {
+        // Dynamic content that updates during workout
+        var elapsedSeconds: Int
+        var steps: Int
+        var floors: Int
+        var currentHeartRate: Int?
+        var calories: Int?
+        var currentSPM: Double? // Steps per minute
+        
+        // Formatted helpers
+        var formattedDuration: String {
+            let hours = elapsedSeconds / 3600
+            let minutes = (elapsedSeconds % 3600) / 60
+            let seconds = elapsedSeconds % 60
+            
+            if hours > 0 {
+                return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+            } else {
+                return String(format: "%02d:%02d", minutes, seconds)
+            }
+        }
+        
+        var formattedSteps: String {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            return formatter.string(from: NSNumber(value: steps)) ?? "\(steps)"
+        }
+        
+        var formattedSPM: String {
+            guard let spm = currentSPM else { return "--" }
+            return String(format: "%.0f", spm)
+        }
+    }
+    
+    // Static attributes set when activity starts
+    var workoutName: String
+    var startTime: Date
+    var hasWeightEquipment: Bool
+    var weightDescription: String? // e.g., "20lb vest"
+}
+
+// MARK: - Live Activity Manager
+
+@MainActor
+@Observable
+final class LiveActivityManager {
+    static let shared = LiveActivityManager()
+    
+    private var currentActivity: Activity<WorkoutActivityAttributes>?
+    var isActivityActive: Bool { currentActivity != nil }
+    
+    private init() {}
+    
+    // MARK: - Start Activity
+    
+    func startWorkoutActivity(
+        workoutName: String,
+        weightDescription: String? = nil
+    ) {
+        // Check if Live Activities are supported
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            print("Live Activities not enabled")
+            return
+        }
+        
+        let attributes = WorkoutActivityAttributes(
+            workoutName: workoutName,
+            startTime: Date(),
+            hasWeightEquipment: weightDescription != nil,
+            weightDescription: weightDescription
+        )
+        
+        let initialState = WorkoutActivityAttributes.ContentState(
+            elapsedSeconds: 0,
+            steps: 0,
+            floors: 0,
+            currentHeartRate: nil,
+            calories: nil,
+            currentSPM: nil
+        )
+        
+        let content = ActivityContent(state: initialState, staleDate: nil)
+        
+        do {
+            currentActivity = try Activity.request(
+                attributes: attributes,
+                content: content,
+                pushType: nil
+            )
+            print("Started Live Activity: \(currentActivity?.id ?? "unknown")")
+        } catch {
+            print("Failed to start Live Activity: \(error)")
+        }
+    }
+    
+    // MARK: - Update Activity
+    
+    func updateWorkoutActivity(
+        elapsedSeconds: Int,
+        steps: Int,
+        floors: Int,
+        currentHeartRate: Int? = nil,
+        calories: Int? = nil,
+        currentSPM: Double? = nil
+    ) {
+        guard let activity = currentActivity else { return }
+        
+        let updatedState = WorkoutActivityAttributes.ContentState(
+            elapsedSeconds: elapsedSeconds,
+            steps: steps,
+            floors: floors,
+            currentHeartRate: currentHeartRate,
+            calories: calories,
+            currentSPM: currentSPM
+        )
+        
+        let content = ActivityContent(state: updatedState, staleDate: nil)
+        
+        Task {
+            await activity.update(content)
+        }
+    }
+    
+    // MARK: - End Activity
+    
+    func endWorkoutActivity(
+        finalSteps: Int,
+        finalFloors: Int,
+        finalDuration: Int
+    ) {
+        guard let activity = currentActivity else { return }
+        
+        let finalState = WorkoutActivityAttributes.ContentState(
+            elapsedSeconds: finalDuration,
+            steps: finalSteps,
+            floors: finalFloors,
+            currentHeartRate: nil,
+            calories: nil,
+            currentSPM: nil
+        )
+        
+        let content = ActivityContent(state: finalState, staleDate: nil)
+        
+        Task {
+            await activity.end(content, dismissalPolicy: .after(.now + 60)) // Show for 1 min after ending
+            await MainActor.run {
+                currentActivity = nil
+            }
+        }
+    }
+    
+    // MARK: - Cancel Activity
+    
+    func cancelActivity() {
+        guard let activity = currentActivity else { return }
+        
+        Task {
+            await activity.end(nil, dismissalPolicy: .immediate)
+            await MainActor.run {
+                currentActivity = nil
+            }
+        }
+    }
+}

--- a/AscendApp/Shared/LiveActivity/WorkoutLiveActivityView.swift
+++ b/AscendApp/Shared/LiveActivity/WorkoutLiveActivityView.swift
@@ -1,0 +1,358 @@
+//
+//  WorkoutLiveActivityView.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+/// Live Activity Widget for workout tracking
+/// Shows on lock screen and Dynamic Island during active workout
+struct WorkoutLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: WorkoutActivityAttributes.self) { context in
+            // Lock screen / banner view
+            LockScreenView(context: context)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // Expanded view (long press)
+                DynamicIslandExpandedRegion(.leading) {
+                    ExpandedLeadingView(context: context)
+                }
+                
+                DynamicIslandExpandedRegion(.trailing) {
+                    ExpandedTrailingView(context: context)
+                }
+                
+                DynamicIslandExpandedRegion(.bottom) {
+                    ExpandedBottomView(context: context)
+                }
+                
+                DynamicIslandExpandedRegion(.center) {
+                    ExpandedCenterView(context: context)
+                }
+            } compactLeading: {
+                // Compact left side
+                CompactLeadingView(context: context)
+            } compactTrailing: {
+                // Compact right side
+                CompactTrailingView(context: context)
+            } minimal: {
+                // Minimal view (when multiple activities)
+                MinimalView(context: context)
+            }
+        }
+    }
+}
+
+// MARK: - Lock Screen View
+
+private struct LockScreenView: View {
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+    
+    var body: some View {
+        HStack(spacing: 16) {
+            // Left side - Duration
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Image(systemName: "figure.stair.stepper")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.accent)
+                    
+                    Text(context.attributes.workoutName)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                }
+                
+                Text(context.state.formattedDuration)
+                    .font(.system(size: 32, weight: .bold, design: .rounded))
+                    .foregroundStyle(.primary)
+                    .contentTransition(.numericText())
+                
+                if let weight = context.attributes.weightDescription {
+                    Text(weight)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            
+            Spacer()
+            
+            // Right side - Stats
+            VStack(alignment: .trailing, spacing: 8) {
+                StatRow(
+                    icon: "figure.stairs",
+                    value: context.state.formattedSteps,
+                    label: "steps"
+                )
+                
+                StatRow(
+                    icon: "building.2",
+                    value: "\(context.state.floors)",
+                    label: "floors"
+                )
+                
+                if let hr = context.state.currentHeartRate {
+                    StatRow(
+                        icon: "heart.fill",
+                        value: "\(hr)",
+                        label: "bpm",
+                        color: .red
+                    )
+                }
+            }
+        }
+        .padding(16)
+        .background(Color.black.opacity(0.8))
+        .activityBackgroundTint(Color.black.opacity(0.8))
+    }
+}
+
+private struct StatRow: View {
+    let icon: String
+    let value: String
+    let label: String
+    var color: Color = .accent
+    
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(color)
+            
+            Text(value)
+                .font(.system(size: 16, weight: .bold, design: .rounded))
+                .foregroundStyle(.primary)
+                .contentTransition(.numericText())
+            
+            Text(label)
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Dynamic Island Views
+
+private struct CompactLeadingView: View {
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "figure.stair.stepper")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.accent)
+            
+            Text(context.state.formattedDuration)
+                .font(.system(size: 14, weight: .bold, design: .rounded))
+                .foregroundStyle(.primary)
+                .contentTransition(.numericText())
+        }
+    }
+}
+
+private struct CompactTrailingView: View {
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+    
+    var body: some View {
+        Text(context.state.formattedSteps)
+            .font(.system(size: 14, weight: .bold, design: .rounded))
+            .foregroundStyle(.accent)
+            .contentTransition(.numericText())
+    }
+}
+
+private struct MinimalView: View {
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+    
+    var body: some View {
+        Image(systemName: "figure.stair.stepper")
+            .font(.system(size: 12, weight: .semibold))
+            .foregroundStyle(.accent)
+    }
+}
+
+// MARK: - Expanded Dynamic Island Views
+
+private struct ExpandedLeadingView: View {
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Duration")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+            
+            Text(context.state.formattedDuration)
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundStyle(.primary)
+                .contentTransition(.numericText())
+        }
+    }
+}
+
+private struct ExpandedTrailingView: View {
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+    
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Text("Steps")
+                .font(.system(size: 10))
+                .foregroundStyle(.secondary)
+            
+            Text(context.state.formattedSteps)
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundStyle(.accent)
+                .contentTransition(.numericText())
+        }
+    }
+}
+
+private struct ExpandedCenterView: View {
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "figure.stair.stepper")
+                .foregroundStyle(.accent)
+            
+            Text(context.attributes.workoutName)
+                .font(.system(size: 12, weight: .semibold))
+                .lineLimit(1)
+        }
+    }
+}
+
+private struct ExpandedBottomView: View {
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+    
+    var body: some View {
+        HStack(spacing: 20) {
+            // Floors
+            VStack(spacing: 2) {
+                Image(systemName: "building.2")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.green)
+                
+                Text("\(context.state.floors)")
+                    .font(.system(size: 16, weight: .bold, design: .rounded))
+                    .contentTransition(.numericText())
+                
+                Text("floors")
+                    .font(.system(size: 9))
+                    .foregroundStyle(.secondary)
+            }
+            
+            // SPM
+            if let spm = context.state.currentSPM {
+                VStack(spacing: 2) {
+                    Image(systemName: "speedometer")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.orange)
+                    
+                    Text(String(format: "%.0f", spm))
+                        .font(.system(size: 16, weight: .bold, design: .rounded))
+                        .contentTransition(.numericText())
+                    
+                    Text("SPM")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            
+            // Heart Rate
+            if let hr = context.state.currentHeartRate {
+                VStack(spacing: 2) {
+                    Image(systemName: "heart.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.red)
+                    
+                    Text("\(hr)")
+                        .font(.system(size: 16, weight: .bold, design: .rounded))
+                        .contentTransition(.numericText())
+                    
+                    Text("bpm")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            
+            // Calories
+            if let cal = context.state.calories {
+                VStack(spacing: 2) {
+                    Image(systemName: "flame.fill")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.orange)
+                    
+                    Text("\(cal)")
+                        .font(.system(size: 16, weight: .bold, design: .rounded))
+                        .contentTransition(.numericText())
+                    
+                    Text("kcal")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Lock Screen", as: .content, using: WorkoutActivityAttributes(
+    workoutName: "Morning Climb",
+    startTime: Date(),
+    hasWeightEquipment: true,
+    weightDescription: "20lb vest"
+)) {
+    WorkoutLiveActivity()
+} contentStates: {
+    WorkoutActivityAttributes.ContentState(
+        elapsedSeconds: 1847,
+        steps: 3250,
+        floors: 27,
+        currentHeartRate: 142,
+        calories: 380,
+        currentSPM: 78
+    )
+}
+
+#Preview("Dynamic Island Compact", as: .dynamicIsland(.compact), using: WorkoutActivityAttributes(
+    workoutName: "Workout",
+    startTime: Date(),
+    hasWeightEquipment: false,
+    weightDescription: nil
+)) {
+    WorkoutLiveActivity()
+} contentStates: {
+    WorkoutActivityAttributes.ContentState(
+        elapsedSeconds: 1230,
+        steps: 2100,
+        floors: 18,
+        currentHeartRate: 135,
+        calories: nil,
+        currentSPM: 72
+    )
+}
+
+#Preview("Dynamic Island Expanded", as: .dynamicIsland(.expanded), using: WorkoutActivityAttributes(
+    workoutName: "Evening Session",
+    startTime: Date(),
+    hasWeightEquipment: true,
+    weightDescription: "Ankle weights"
+)) {
+    WorkoutLiveActivity()
+} contentStates: {
+    WorkoutActivityAttributes.ContentState(
+        elapsedSeconds: 2500,
+        steps: 4200,
+        floors: 35,
+        currentHeartRate: 155,
+        calories: 520,
+        currentSPM: 85
+    )
+}


### PR DESCRIPTION
Closes #21

## Summary

Adds Live Activity support for showing real-time workout stats on the lock screen and Dynamic Island during active workouts.

**This PR is clean from main** — can be merged independently.

## What it looks like

**Lock Screen:**
```
┌────────────────────────────────┐
│ 🏃 Morning Climb               │
│  30:47         ⬆️ 3,250 steps  │
│  20lb vest     🏢 27 floors    │
│                ❤️ 142 bpm      │
└────────────────────────────────┘
```

**Dynamic Island (Compact):**
```
[ 🏃 30:47 ····················· 3,250 ]
```

## Files

- `WorkoutActivityAttributes.swift` — Data model + LiveActivityManager
- `WorkoutLiveActivityView.swift` — All widget views
- `SETUP.md` — Integration guide

## Usage

```swift
LiveActivityManager.shared.startWorkoutActivity(workoutName: "Morning Climb")
LiveActivityManager.shared.updateWorkoutActivity(elapsedSeconds: 1847, steps: 3250, ...)
LiveActivityManager.shared.endWorkoutActivity(...)
```

## Setup Required

1. Add `NSSupportsLiveActivities = true` to Info.plist
2. Add files to Widget Extension target
3. Register `WorkoutLiveActivity()` in widget bundle