### PR TITLE
Voice-First Home Screen

### DIFF
--- a/AscendApp/Features/Home/Views/ConversationalHomeView.swift
+++ b/AscendApp/Features/Home/Views/ConversationalHomeView.swift
@@ -1,0 +1,423 @@
+//
+//  ConversationalHomeView.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+import SwiftData
+
+/// Voice-first home screen for logging workouts conversationally
+struct ConversationalHomeView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.modelContext) private var modelContext
+    @Environment(AuthenticationViewModel.self) private var authVM
+    
+    @State private var themeManager = ThemeManager.shared
+    @State private var voiceManager = VoiceInputManager()
+    @State private var userInput: String = ""
+    @State private var isProcessing = false
+    @State private var showConfirmation = false
+    @State private var parsedData: ParsedWorkoutData?
+    @State private var errorMessage: String?
+    @State private var showError = false
+    
+    @Query(sort: \Workout.date, order: .reverse)
+    private var recentWorkouts: [Workout]
+    
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: colorScheme)
+    }
+    
+    private let examplePhrases = [
+        "I did 30 minutes on the stairstepper...",
+        "3000 steps with my 20lb vest...",
+        "Three intervals: 5, 10, and 5 minutes...",
+        "Quick 20 min session, felt great...",
+        "45 minutes, 4500 steps, wore ankle weights..."
+    ]
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // Header
+                headerSection
+                
+                // Voice/Text Input Card
+                inputCard
+                
+                // Recent Workouts
+                if !recentWorkouts.isEmpty {
+                    recentWorkoutsSection
+                }
+                
+                Spacer(minLength: 40)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+        }
+        .scrollIndicators(.hidden)
+        .themedBackground()
+        .sheet(isPresented: $showConfirmation) {
+            if let data = parsedData {
+                WorkoutConfirmationView(
+                    parsedData: data,
+                    originalText: userInput,
+                    onConfirm: { confirmedData in
+                        saveWorkout(confirmedData)
+                        showConfirmation = false
+                        userInput = ""
+                    },
+                    onCancel: {
+                        showConfirmation = false
+                    }
+                )
+            }
+        }
+        .alert("Error", isPresented: $showError) {
+            Button("OK") { }
+        } message: {
+            Text(errorMessage ?? "Something went wrong")
+        }
+    }
+    
+    // MARK: - Header
+    
+    private var headerSection: some View {
+        VStack(spacing: 8) {
+            Text("Log Workout")
+                .font(.montserratBold(size: 28))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            Text("Speak or type to log your session")
+                .font(.montserratRegular(size: 15))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 20)
+    }
+    
+    // MARK: - Input Card
+    
+    private var inputCard: some View {
+        VStack(spacing: 16) {
+            // Animated placeholder or user input
+            if userInput.isEmpty && !voiceManager.isRecording {
+                TypewriterTextWithCursor(
+                    phrases: examplePhrases,
+                    typingSpeed: 0.04,
+                    pauseDuration: 2.5,
+                    gradient: LinearGradient(
+                        colors: [
+                            Color(red: 0.4, green: 0.7, blue: 1.0),
+                            Color(red: 0.6, green: 0.5, blue: 1.0),
+                            Color(red: 0.9, green: 0.5, blue: 0.8)
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .frame(minHeight: 60)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 12)
+            } else {
+                // Show transcribed/typed text
+                TextField("Describe your workout...", text: $userInput, axis: .vertical)
+                    .font(.montserratMedium(size: 17))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    .lineLimit(3...6)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+            }
+            
+            // Live transcription indicator
+            if voiceManager.isRecording {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(Color.red)
+                        .frame(width: 8, height: 8)
+                        .opacity(voiceManager.isRecording ? 1 : 0)
+                        .animation(.easeInOut(duration: 0.5).repeatForever(), value: voiceManager.isRecording)
+                    
+                    Text("Listening...")
+                        .font(.montserratMedium(size: 14))
+                        .foregroundStyle(.red)
+                }
+                .padding(.bottom, 8)
+            }
+            
+            Divider()
+                .background(effectiveColorScheme == .dark ? Color.white.opacity(0.1) : Color.gray.opacity(0.2))
+            
+            // Action buttons
+            HStack(spacing: 16) {
+                // Voice button
+                Button {
+                    handleVoiceButton()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: voiceManager.isRecording ? "stop.circle.fill" : "mic.circle.fill")
+                            .font(.system(size: 24))
+                        Text(voiceManager.isRecording ? "Stop" : "Speak")
+                            .font(.montserratSemiBold(size: 15))
+                    }
+                    .foregroundStyle(voiceManager.isRecording ? .red : .accent)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(voiceManager.isRecording 
+                                  ? Color.red.opacity(0.15) 
+                                  : Color.accentColor.opacity(0.15))
+                    )
+                }
+                .disabled(isProcessing)
+                
+                // Submit button
+                Button {
+                    processInput()
+                } label: {
+                    HStack(spacing: 8) {
+                        if isProcessing {
+                            ProgressView()
+                                .scaleEffect(0.8)
+                                .tint(.white)
+                        } else {
+                            Image(systemName: "arrow.up.circle.fill")
+                                .font(.system(size: 24))
+                        }
+                        Text(isProcessing ? "Processing" : "Log")
+                            .font(.montserratSemiBold(size: 15))
+                    }
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(userInput.isEmpty ? Color.gray : Color.accentColor)
+                    )
+                }
+                .disabled(userInput.isEmpty || isProcessing)
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: 20)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(effectiveColorScheme == .dark ? Color.white.opacity(0.1) : Color.gray.opacity(0.15), lineWidth: 1)
+                )
+        )
+        .onChange(of: voiceManager.transcribedText) { _, newValue in
+            if !newValue.isEmpty {
+                userInput = newValue
+            }
+        }
+    }
+    
+    // MARK: - Recent Workouts
+    
+    private var recentWorkoutsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Recent Workouts")
+                .font(.montserratSemiBold(size: 18))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            ForEach(recentWorkouts.prefix(3)) { workout in
+                NavigationLink(destination: WorkoutDetailView(workout: workout)) {
+                    RecentWorkoutRow(workout: workout, colorScheme: effectiveColorScheme)
+                }
+                .buttonStyle(PlainButtonStyle())
+            }
+        }
+    }
+    
+    // MARK: - Actions
+    
+    private func handleVoiceButton() {
+        HapticsManager.shared.trigger(.selection)
+        
+        if voiceManager.isRecording {
+            voiceManager.stopRecording()
+        } else {
+            do {
+                try voiceManager.startRecording()
+            } catch {
+                errorMessage = error.localizedDescription
+                showError = true
+            }
+        }
+    }
+    
+    private func processInput() {
+        guard !userInput.isEmpty else { return }
+        
+        HapticsManager.shared.trigger(.selection)
+        isProcessing = true
+        
+        Task {
+            do {
+                let service = WorkoutParsingService()
+                let parsed = try await service.parseWorkoutDescription(userInput)
+                
+                await MainActor.run {
+                    parsedData = parsed
+                    showConfirmation = true
+                    isProcessing = false
+                }
+            } catch {
+                await MainActor.run {
+                    // Fallback to regex parser
+                    let fallbackData = FallbackWorkoutParser.parse(userInput)
+                    if fallbackData.durationMinutes != nil || fallbackData.steps != nil {
+                        parsedData = fallbackData
+                        showConfirmation = true
+                    } else {
+                        errorMessage = error.localizedDescription
+                        showError = true
+                    }
+                    isProcessing = false
+                }
+            }
+        }
+    }
+    
+    private func saveWorkout(_ data: ParsedWorkoutData) {
+        let settingsManager = SettingsManager.shared
+        
+        // Convert parsed data to workout
+        let duration = TimeInterval((data.durationMinutes ?? 0) * 60)
+        let steps = data.steps ?? 0
+        let floors = data.floors ?? Workout.stepsToFloors(steps, stepsPerFloor: settingsManager.stepsPerFloor)
+        
+        let workout = Workout(
+            name: Workout.generateDefaultName(for: Date()),
+            date: Date(),
+            duration: duration,
+            steps: steps,
+            floors: floors,
+            stepsPerFloor: settingsManager.stepsPerFloor,
+            avgHeartRate: data.heartRateAvg,
+            maxHeartRate: data.heartRateMax,
+            caloriesBurned: data.calories,
+            notes: data.notes
+        )
+        
+        // Add weight configuration if present
+        if let weightItems = data.weightEquipment, !weightItems.isEmpty {
+            var entries: [WeightConfiguration.Entry] = []
+            for item in weightItems {
+                if let type = WeightEquipmentType.fromString(item.type) {
+                    entries.append(WeightConfiguration.Entry(
+                        equipmentType: type,
+                        weightLbs: item.weightLbs,
+                        isEnabled: true
+                    ))
+                }
+            }
+            if !entries.isEmpty {
+                workout.weightConfiguration = WeightConfiguration(entries: entries)
+            }
+        }
+        
+        modelContext.insert(workout)
+        
+        do {
+            try modelContext.save()
+            HapticsManager.shared.trigger(.success)
+        } catch {
+            print("Failed to save workout: \(error)")
+        }
+    }
+}
+
+// MARK: - Recent Workout Row
+
+private struct RecentWorkoutRow: View {
+    let workout: Workout
+    let colorScheme: ColorScheme
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(workout.name)
+                    .font(.montserratSemiBold(size: 15))
+                    .foregroundStyle(colorScheme == .dark ? .white : .black)
+                    .lineLimit(1)
+                
+                Text(formattedDate)
+                    .font(.montserratRegular(size: 13))
+                    .foregroundStyle(colorScheme == .dark ? .white.opacity(0.6) : .gray)
+            }
+            
+            Spacer()
+            
+            VStack(alignment: .trailing, spacing: 4) {
+                Text("\(workout.steps) steps")
+                    .font(.montserratSemiBold(size: 14))
+                    .foregroundStyle(.accent)
+                
+                Text(formattedDuration)
+                    .font(.montserratRegular(size: 13))
+                    .foregroundStyle(colorScheme == .dark ? .white.opacity(0.6) : .gray)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(colorScheme == .dark ? Color.white.opacity(0.04) : Color.black.opacity(0.02))
+        )
+    }
+    
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        if Calendar.current.isDateInToday(workout.date) {
+            formatter.dateFormat = "'Today at' h:mm a"
+        } else if Calendar.current.isDateInYesterday(workout.date) {
+            formatter.dateFormat = "'Yesterday at' h:mm a"
+        } else {
+            formatter.dateFormat = "MMM d 'at' h:mm a"
+        }
+        return formatter.string(from: workout.date)
+    }
+    
+    private var formattedDuration: String {
+        let minutes = Int(workout.duration / 60)
+        if minutes >= 60 {
+            return "\(minutes / 60)h \(minutes % 60)m"
+        }
+        return "\(minutes) min"
+    }
+}
+
+// MARK: - Weight Equipment Type Extension
+
+extension WeightEquipmentType {
+    static func fromString(_ string: String) -> WeightEquipmentType? {
+        let lowercased = string.lowercased()
+        switch lowercased {
+        case "vest", "weighted vest", "weight vest":
+            return .vest
+        case "ankle_weights", "ankle weights", "ankleweights":
+            return .ankleWeights
+        case "backpack", "weighted backpack":
+            return .backpack
+        case "dumbbells", "dumbbell":
+            return .dumbbells
+        case "wrist_weights", "wrist weights", "wristweights":
+            return .wristWeights
+        default:
+            return nil
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ConversationalHomeView()
+    }
+    .environment(AuthenticationViewModel())
+}

--- a/AscendApp/Features/Home/Views/WorkoutConfirmationView.swift
+++ b/AscendApp/Features/Home/Views/WorkoutConfirmationView.swift
@@ -1,0 +1,377 @@
+//
+//  WorkoutConfirmationView.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+
+/// Confirmation view for reviewing parsed workout data before saving
+struct WorkoutConfirmationView: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dismiss) private var dismiss
+    
+    @State private var themeManager = ThemeManager.shared
+    @State private var editedData: ParsedWorkoutData
+    
+    let originalText: String
+    let onConfirm: (ParsedWorkoutData) -> Void
+    let onCancel: () -> Void
+    
+    init(
+        parsedData: ParsedWorkoutData,
+        originalText: String,
+        onConfirm: @escaping (ParsedWorkoutData) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self._editedData = State(initialValue: parsedData)
+        self.originalText = originalText
+        self.onConfirm = onConfirm
+        self.onCancel = onCancel
+    }
+    
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: colorScheme)
+    }
+    
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 20) {
+                    // Original input
+                    originalInputCard
+                    
+                    // Parsed data fields
+                    parsedDataCard
+                    
+                    // Weight equipment
+                    if let weights = editedData.weightEquipment, !weights.isEmpty {
+                        weightEquipmentCard(weights)
+                    }
+                    
+                    // Intervals
+                    if let intervals = editedData.intervals, !intervals.isEmpty {
+                        intervalsCard(intervals)
+                    }
+                    
+                    // Notes
+                    if editedData.notes != nil {
+                        notesCard
+                    }
+                    
+                    Spacer(minLength: 20)
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+            }
+            .scrollIndicators(.hidden)
+            .themedBackground()
+            .navigationTitle("Confirm Workout")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        onCancel()
+                    }
+                    .foregroundStyle(.accent)
+                }
+                
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        HapticsManager.shared.trigger(.success)
+                        onConfirm(editedData)
+                    }
+                    .font(.montserratSemiBold(size: 16))
+                    .foregroundStyle(.accent)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Original Input Card
+    
+    private var originalInputCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("What you said", systemImage: "quote.bubble")
+                .font(.montserratSemiBold(size: 14))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
+            
+            Text("\"\(originalText)\"")
+                .font(.montserratRegular(size: 15))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.8) : .black.opacity(0.7))
+                .italic()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.04) : Color.black.opacity(0.02))
+        )
+    }
+    
+    // MARK: - Parsed Data Card
+    
+    private var parsedDataCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Workout Details")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            // Duration
+            EditableField(
+                icon: "clock",
+                label: "Duration",
+                value: Binding(
+                    get: { editedData.durationMinutes.map { "\($0)" } ?? "" },
+                    set: { editedData.durationMinutes = Int($0) }
+                ),
+                unit: "minutes",
+                colorScheme: effectiveColorScheme
+            )
+            
+            // Steps
+            EditableField(
+                icon: "figure.stairs",
+                label: "Steps",
+                value: Binding(
+                    get: { editedData.steps.map { "\($0)" } ?? "" },
+                    set: { editedData.steps = Int($0) }
+                ),
+                unit: "steps",
+                colorScheme: effectiveColorScheme
+            )
+            
+            // Floors
+            EditableField(
+                icon: "building.2",
+                label: "Floors",
+                value: Binding(
+                    get: { editedData.floors.map { "\($0)" } ?? "" },
+                    set: { editedData.floors = Int($0) }
+                ),
+                unit: "floors",
+                colorScheme: effectiveColorScheme
+            )
+            
+            // Heart Rate
+            if editedData.heartRateAvg != nil || editedData.heartRateMax != nil {
+                HStack(spacing: 16) {
+                    EditableField(
+                        icon: "heart.fill",
+                        label: "Avg HR",
+                        value: Binding(
+                            get: { editedData.heartRateAvg.map { "\($0)" } ?? "" },
+                            set: { editedData.heartRateAvg = Int($0) }
+                        ),
+                        unit: "bpm",
+                        colorScheme: effectiveColorScheme
+                    )
+                    
+                    EditableField(
+                        icon: "bolt.heart",
+                        label: "Max HR",
+                        value: Binding(
+                            get: { editedData.heartRateMax.map { "\($0)" } ?? "" },
+                            set: { editedData.heartRateMax = Int($0) }
+                        ),
+                        unit: "bpm",
+                        colorScheme: effectiveColorScheme
+                    )
+                }
+            }
+            
+            // Calories
+            if editedData.calories != nil {
+                EditableField(
+                    icon: "flame.fill",
+                    label: "Calories",
+                    value: Binding(
+                        get: { editedData.calories.map { "\($0)" } ?? "" },
+                        set: { editedData.calories = Int($0) }
+                    ),
+                    unit: "kcal",
+                    colorScheme: effectiveColorScheme
+                )
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+        )
+    }
+    
+    // MARK: - Weight Equipment Card
+    
+    private func weightEquipmentCard(_ weights: [ParsedWorkoutData.WeightEquipmentItem]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Weight Equipment", systemImage: "scalemass")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            ForEach(Array(weights.enumerated()), id: \.offset) { index, item in
+                HStack {
+                    Image(systemName: iconForWeightType(item.type))
+                        .foregroundStyle(.accent)
+                        .frame(width: 24)
+                    
+                    Text(item.type.capitalized.replacingOccurrences(of: "_", with: " "))
+                        .font(.montserratMedium(size: 15))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    
+                    Spacer()
+                    
+                    if let qty = item.quantity, qty > 1 {
+                        Text("\(qty)x")
+                            .font(.montserratRegular(size: 14))
+                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
+                    }
+                    
+                    Text("\(Int(item.weightLbs)) lbs")
+                        .font(.montserratSemiBold(size: 15))
+                        .foregroundStyle(.accent)
+                }
+                .padding(.vertical, 8)
+                
+                if index < weights.count - 1 {
+                    Divider()
+                }
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+        )
+    }
+    
+    private func iconForWeightType(_ type: String) -> String {
+        switch type.lowercased() {
+        case "vest": return "tshirt"
+        case "ankle_weights", "ankle weights": return "shoe"
+        case "backpack": return "bag"
+        case "dumbbells": return "dumbbell"
+        default: return "scalemass"
+        }
+    }
+    
+    // MARK: - Intervals Card
+    
+    private func intervalsCard(_ intervals: [ParsedWorkoutData.IntervalItem]) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("Intervals", systemImage: "chart.bar")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            ForEach(Array(intervals.enumerated()), id: \.offset) { index, interval in
+                HStack {
+                    Text("Interval \(index + 1)")
+                        .font(.montserratMedium(size: 15))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    
+                    Spacer()
+                    
+                    if let duration = interval.durationMinutes {
+                        Text("\(duration) min")
+                            .font(.montserratSemiBold(size: 15))
+                            .foregroundStyle(.accent)
+                    }
+                    
+                    if let steps = interval.steps {
+                        Text("• \(steps) steps")
+                            .font(.montserratRegular(size: 14))
+                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
+                    }
+                }
+                .padding(.vertical, 6)
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+        )
+    }
+    
+    // MARK: - Notes Card
+    
+    private var notesCard: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Label("Notes", systemImage: "note.text")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            
+            Text(editedData.notes ?? "")
+                .font(.montserratRegular(size: 15))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.8) : .black.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.03))
+        )
+    }
+}
+
+// MARK: - Editable Field
+
+private struct EditableField: View {
+    let icon: String
+    let label: String
+    @Binding var value: String
+    let unit: String
+    let colorScheme: ColorScheme
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .foregroundStyle(.accent)
+                .frame(width: 24)
+            
+            Text(label)
+                .font(.montserratMedium(size: 15))
+                .foregroundStyle(colorScheme == .dark ? .white.opacity(0.7) : .gray)
+            
+            Spacer()
+            
+            HStack(spacing: 4) {
+                TextField("--", text: $value)
+                    .font(.montserratSemiBold(size: 16))
+                    .foregroundStyle(colorScheme == .dark ? .white : .black)
+                    .keyboardType(.numberPad)
+                    .multilineTextAlignment(.trailing)
+                    .frame(width: 60)
+                
+                Text(unit)
+                    .font(.montserratRegular(size: 14))
+                    .foregroundStyle(colorScheme == .dark ? .white.opacity(0.5) : .gray)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+#Preview {
+    WorkoutConfirmationView(
+        parsedData: ParsedWorkoutData(
+            durationMinutes: 30,
+            steps: 3000,
+            floors: 25,
+            weightEquipment: [
+                .init(type: "vest", weightLbs: 20, quantity: 1),
+                .init(type: "ankle_weights", weightLbs: 2.5, quantity: 2)
+            ],
+            intervals: [
+                .init(durationMinutes: 5, steps: nil),
+                .init(durationMinutes: 10, steps: nil),
+                .init(durationMinutes: 5, steps: nil)
+            ],
+            notes: "Felt great today!"
+        ),
+        originalText: "I did 30 minutes on the stairstepper with my 20 pound vest and ankle weights, 3000 steps total",
+        onConfirm: { _ in },
+        onCancel: { }
+    )
+}

--- a/AscendApp/Shared/Components/TypewriterText.swift
+++ b/AscendApp/Shared/Components/TypewriterText.swift
@@ -1,0 +1,259 @@
+//
+//  TypewriterText.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import SwiftUI
+
+/// Animated typewriter text with gradient coloring
+/// Cycles through example phrases with a typing animation
+struct TypewriterText: View {
+    let phrases: [String]
+    let typingSpeed: Double // seconds per character
+    let pauseDuration: Double // seconds to pause after typing complete
+    let gradient: LinearGradient
+    
+    @State private var displayedText: String = ""
+    @State private var currentPhraseIndex: Int = 0
+    @State private var isTyping: Bool = true
+    @State private var charIndex: Int = 0
+    
+    init(
+        phrases: [String],
+        typingSpeed: Double = 0.05,
+        pauseDuration: Double = 2.0,
+        gradient: LinearGradient = LinearGradient(
+            colors: [
+                Color(red: 0.4, green: 0.6, blue: 1.0),
+                Color(red: 0.6, green: 0.4, blue: 1.0),
+                Color(red: 0.8, green: 0.5, blue: 1.0)
+            ],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    ) {
+        self.phrases = phrases
+        self.typingSpeed = typingSpeed
+        self.pauseDuration = pauseDuration
+        self.gradient = gradient
+    }
+    
+    var body: some View {
+        Text(displayedText)
+            .font(.montserratMedium(size: 18))
+            .foregroundStyle(gradient)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .onAppear {
+                startTypingAnimation()
+            }
+    }
+    
+    private func startTypingAnimation() {
+        guard !phrases.isEmpty else { return }
+        typeNextCharacter()
+    }
+    
+    private func typeNextCharacter() {
+        let currentPhrase = phrases[currentPhraseIndex]
+        
+        if charIndex < currentPhrase.count {
+            // Still typing current phrase
+            let index = currentPhrase.index(currentPhrase.startIndex, offsetBy: charIndex)
+            displayedText = String(currentPhrase[...index])
+            charIndex += 1
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + typingSpeed) {
+                typeNextCharacter()
+            }
+        } else {
+            // Finished typing, pause then move to next phrase
+            DispatchQueue.main.asyncAfter(deadline: .now() + pauseDuration) {
+                eraseText()
+            }
+        }
+    }
+    
+    private func eraseText() {
+        if displayedText.count > 0 {
+            displayedText = String(displayedText.dropLast())
+            DispatchQueue.main.asyncAfter(deadline: .now() + typingSpeed / 2) {
+                eraseText()
+            }
+        } else {
+            // Move to next phrase
+            currentPhraseIndex = (currentPhraseIndex + 1) % phrases.count
+            charIndex = 0
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                typeNextCharacter()
+            }
+        }
+    }
+}
+
+/// A more advanced typewriter with cursor blink
+struct TypewriterTextWithCursor: View {
+    let phrases: [String]
+    let typingSpeed: Double
+    let pauseDuration: Double
+    let gradient: LinearGradient
+    
+    @State private var displayedText: String = ""
+    @State private var currentPhraseIndex: Int = 0
+    @State private var charIndex: Int = 0
+    @State private var showCursor: Bool = true
+    
+    init(
+        phrases: [String],
+        typingSpeed: Double = 0.05,
+        pauseDuration: Double = 2.0,
+        gradient: LinearGradient = LinearGradient(
+            colors: [
+                Color(red: 0.4, green: 0.6, blue: 1.0),
+                Color(red: 0.6, green: 0.4, blue: 1.0),
+                Color(red: 0.8, green: 0.5, blue: 1.0)
+            ],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    ) {
+        self.phrases = phrases
+        self.typingSpeed = typingSpeed
+        self.pauseDuration = pauseDuration
+        self.gradient = gradient
+    }
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(displayedText)
+                .font(.montserratMedium(size: 18))
+                .foregroundStyle(gradient)
+            
+            // Blinking cursor
+            Text("|")
+                .font(.montserratMedium(size: 18))
+                .foregroundStyle(gradient)
+                .opacity(showCursor ? 1 : 0)
+                .animation(.easeInOut(duration: 0.5).repeatForever(), value: showCursor)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear {
+            showCursor = true
+            startTypingAnimation()
+            startCursorBlink()
+        }
+    }
+    
+    private func startCursorBlink() {
+        Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
+            // Cursor blink handled by animation
+        }
+    }
+    
+    private func startTypingAnimation() {
+        guard !phrases.isEmpty else { return }
+        typeNextCharacter()
+    }
+    
+    private func typeNextCharacter() {
+        let currentPhrase = phrases[currentPhraseIndex]
+        
+        if charIndex < currentPhrase.count {
+            let index = currentPhrase.index(currentPhrase.startIndex, offsetBy: charIndex)
+            displayedText = String(currentPhrase[...index])
+            charIndex += 1
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + typingSpeed) {
+                typeNextCharacter()
+            }
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + pauseDuration) {
+                eraseText()
+            }
+        }
+    }
+    
+    private func eraseText() {
+        if displayedText.count > 0 {
+            displayedText = String(displayedText.dropLast())
+            DispatchQueue.main.asyncAfter(deadline: .now() + typingSpeed / 2) {
+                eraseText()
+            }
+        } else {
+            currentPhraseIndex = (currentPhraseIndex + 1) % phrases.count
+            charIndex = 0
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                typeNextCharacter()
+            }
+        }
+    }
+}
+
+// MARK: - Shimmer Gradient Animation
+
+struct ShimmerGradientText: View {
+    let text: String
+    let font: Font
+    
+    @State private var gradientOffset: CGFloat = -1
+    
+    var body: some View {
+        Text(text)
+            .font(font)
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.4, green: 0.6, blue: 1.0),
+                        Color(red: 0.7, green: 0.5, blue: 1.0),
+                        Color(red: 1.0, green: 0.6, blue: 0.8),
+                        Color(red: 0.7, green: 0.5, blue: 1.0),
+                        Color(red: 0.4, green: 0.6, blue: 1.0)
+                    ],
+                    startPoint: UnitPoint(x: gradientOffset, y: 0),
+                    endPoint: UnitPoint(x: gradientOffset + 1, y: 0)
+                )
+            )
+            .onAppear {
+                withAnimation(.linear(duration: 2.0).repeatForever(autoreverses: false)) {
+                    gradientOffset = 1
+                }
+            }
+    }
+}
+
+#Preview("Typewriter") {
+    VStack {
+        TypewriterText(phrases: [
+            "I did 30 minutes on the stairstepper...",
+            "3000 steps with my 20lb vest...",
+            "Three intervals: 5, 10, and 5 minutes...",
+            "Quick session, felt great today..."
+        ])
+        .padding()
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.black)
+}
+
+#Preview("With Cursor") {
+    VStack {
+        TypewriterTextWithCursor(phrases: [
+            "I did 30 minutes on the stairstepper...",
+            "3000 steps with my 20lb vest...",
+            "Three intervals: 5, 10, and 5 minutes..."
+        ])
+        .padding()
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    .background(Color.black)
+}
+
+#Preview("Shimmer") {
+    ShimmerGradientText(
+        text: "Log your workout with voice...",
+        font: .montserratMedium(size: 18)
+    )
+    .padding()
+    .background(Color.black)
+}

--- a/AscendApp/Shared/Services/VoiceInputManager.swift
+++ b/AscendApp/Shared/Services/VoiceInputManager.swift
@@ -1,0 +1,191 @@
+//
+//  VoiceInputManager.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import Foundation
+import Speech
+import AVFoundation
+
+/// Manages voice input using iOS Speech framework
+@MainActor
+@Observable
+final class VoiceInputManager: NSObject {
+    
+    // MARK: - State
+    
+    var isRecording = false
+    var transcribedText = ""
+    var errorMessage: String?
+    var isAuthorized = false
+    
+    // MARK: - Private Properties
+    
+    private var audioEngine: AVAudioEngine?
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let speechRecognizer = SFSpeechRecognizer(locale: Locale(identifier: "en-US"))
+    
+    // MARK: - Initialization
+    
+    override init() {
+        super.init()
+        checkAuthorizationStatus()
+    }
+    
+    // MARK: - Authorization
+    
+    func checkAuthorizationStatus() {
+        SFSpeechRecognizer.requestAuthorization { [weak self] status in
+            DispatchQueue.main.async {
+                switch status {
+                case .authorized:
+                    self?.isAuthorized = true
+                case .denied, .restricted, .notDetermined:
+                    self?.isAuthorized = false
+                    self?.errorMessage = "Speech recognition not authorized"
+                @unknown default:
+                    self?.isAuthorized = false
+                }
+            }
+        }
+    }
+    
+    func requestAuthorization() async -> Bool {
+        return await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                DispatchQueue.main.async {
+                    self.isAuthorized = status == .authorized
+                    continuation.resume(returning: status == .authorized)
+                }
+            }
+        }
+    }
+    
+    // MARK: - Recording
+    
+    func startRecording() throws {
+        guard isAuthorized else {
+            throw VoiceInputError.notAuthorized
+        }
+        
+        guard let speechRecognizer = speechRecognizer, speechRecognizer.isAvailable else {
+            throw VoiceInputError.recognizerNotAvailable
+        }
+        
+        // Cancel any existing task
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        
+        // Configure audio session
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
+        
+        // Create audio engine
+        audioEngine = AVAudioEngine()
+        guard let audioEngine = audioEngine else {
+            throw VoiceInputError.audioEngineError
+        }
+        
+        // Create recognition request
+        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
+        guard let recognitionRequest = recognitionRequest else {
+            throw VoiceInputError.requestCreationFailed
+        }
+        
+        recognitionRequest.shouldReportPartialResults = true
+        recognitionRequest.taskHint = .dictation
+        
+        // Configure input node
+        let inputNode = audioEngine.inputNode
+        let recordingFormat = inputNode.outputFormat(forBus: 0)
+        
+        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { [weak self] buffer, _ in
+            self?.recognitionRequest?.append(buffer)
+        }
+        
+        // Start recognition task
+        recognitionTask = speechRecognizer.recognitionTask(with: recognitionRequest) { [weak self] result, error in
+            guard let self = self else { return }
+            
+            if let result = result {
+                DispatchQueue.main.async {
+                    self.transcribedText = result.bestTranscription.formattedString
+                }
+            }
+            
+            if error != nil || (result?.isFinal ?? false) {
+                DispatchQueue.main.async {
+                    self.stopRecording()
+                }
+            }
+        }
+        
+        // Start audio engine
+        audioEngine.prepare()
+        try audioEngine.start()
+        
+        isRecording = true
+        transcribedText = ""
+        errorMessage = nil
+    }
+    
+    func stopRecording() {
+        audioEngine?.stop()
+        audioEngine?.inputNode.removeTap(onBus: 0)
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+        
+        audioEngine = nil
+        recognitionRequest = nil
+        recognitionTask = nil
+        
+        isRecording = false
+        
+        // Deactivate audio session
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+    
+    func toggleRecording() {
+        if isRecording {
+            stopRecording()
+        } else {
+            do {
+                try startRecording()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+    
+    func reset() {
+        stopRecording()
+        transcribedText = ""
+        errorMessage = nil
+    }
+}
+
+// MARK: - Errors
+
+enum VoiceInputError: LocalizedError {
+    case notAuthorized
+    case recognizerNotAvailable
+    case audioEngineError
+    case requestCreationFailed
+    
+    var errorDescription: String? {
+        switch self {
+        case .notAuthorized:
+            return "Speech recognition is not authorized. Please enable it in Settings."
+        case .recognizerNotAvailable:
+            return "Speech recognition is not available on this device."
+        case .audioEngineError:
+            return "Could not initialize audio engine."
+        case .requestCreationFailed:
+            return "Could not create speech recognition request."
+        }
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutParsingService.swift
+++ b/AscendApp/Shared/Services/WorkoutParsingService.swift
@@ -1,0 +1,260 @@
+//
+//  WorkoutParsingService.swift
+//  AscendApp
+//
+//  Created by Claude on 2/19/26.
+//
+
+import Foundation
+
+/// Parsed workout data from voice input
+struct ParsedWorkoutData: Codable {
+    var durationMinutes: Int?
+    var steps: Int?
+    var floors: Int?
+    var weightEquipment: [WeightEquipmentItem]?
+    var intervals: [IntervalItem]?
+    var heartRateAvg: Int?
+    var heartRateMax: Int?
+    var calories: Int?
+    var notes: String?
+    
+    struct WeightEquipmentItem: Codable {
+        let type: String
+        let weightLbs: Double
+        let quantity: Int?
+        
+        enum CodingKeys: String, CodingKey {
+            case type
+            case weightLbs = "weight_lbs"
+            case quantity
+        }
+    }
+    
+    struct IntervalItem: Codable {
+        let durationMinutes: Int?
+        let steps: Int?
+        
+        enum CodingKeys: String, CodingKey {
+            case durationMinutes = "duration_minutes"
+            case steps
+        }
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case durationMinutes = "duration_minutes"
+        case steps
+        case floors
+        case weightEquipment = "weight_equipment"
+        case intervals
+        case heartRateAvg = "heart_rate_avg"
+        case heartRateMax = "heart_rate_max"
+        case calories
+        case notes
+    }
+}
+
+/// Service for parsing natural language workout descriptions using LLM
+actor WorkoutParsingService {
+    
+    // MARK: - Configuration
+    
+    /// API endpoint - defaults to Anthropic Claude
+    private let apiEndpoint = "https://api.anthropic.com/v1/messages"
+    
+    /// Model to use - Claude Haiku for cost efficiency
+    private let model = "claude-3-haiku-20240307"
+    
+    /// API key stored in environment or config
+    /// In production, this should come from secure storage
+    private var apiKey: String? {
+        // Try to get from UserDefaults (set during onboarding or settings)
+        if let key = UserDefaults.standard.string(forKey: "anthropic_api_key"), !key.isEmpty {
+            return key
+        }
+        // Fallback to environment variable (for development)
+        return ProcessInfo.processInfo.environment["ANTHROPIC_API_KEY"]
+    }
+    
+    // MARK: - Parsing
+    
+    /// Parse a natural language workout description into structured data
+    /// - Parameter text: The transcribed voice input
+    /// - Returns: Parsed workout data
+    func parseWorkoutDescription(_ text: String) async throws -> ParsedWorkoutData {
+        guard let apiKey = apiKey else {
+            throw ParsingError.noApiKey
+        }
+        
+        let prompt = buildPrompt(for: text)
+        let response = try await callClaudeAPI(prompt: prompt, apiKey: apiKey)
+        let parsed = try parseResponse(response)
+        
+        return parsed
+    }
+    
+    /// Build the system prompt and user message for the LLM
+    private func buildPrompt(for userInput: String) -> String {
+        """
+        Extract workout data from this voice input. Return ONLY valid JSON, no other text.
+        
+        Fields to extract (all optional):
+        - duration_minutes: number (total workout duration)
+        - steps: number (total steps climbed)
+        - floors: number (total floors climbed)
+        - weight_equipment: array of objects with:
+          - type: string (e.g., "vest", "ankle_weights", "backpack", "dumbbells")
+          - weight_lbs: number
+          - quantity: number (default 1, use 2 for "both ankles" etc.)
+        - intervals: array of objects with:
+          - duration_minutes: number
+          - steps: number (optional)
+        - heart_rate_avg: number
+        - heart_rate_max: number
+        - calories: number
+        - notes: string (any other details)
+        
+        Examples:
+        Input: "30 minutes, 3000 steps, wore my 20 pound vest"
+        Output: {"duration_minutes": 30, "steps": 3000, "weight_equipment": [{"type": "vest", "weight_lbs": 20, "quantity": 1}]}
+        
+        Input: "did three intervals, 5 minutes then 10 minutes then 5 minutes, 2000 total steps, had 2.5 pound ankle weights on both ankles"
+        Output: {"duration_minutes": 20, "steps": 2000, "intervals": [{"duration_minutes": 5}, {"duration_minutes": 10}, {"duration_minutes": 5}], "weight_equipment": [{"type": "ankle_weights", "weight_lbs": 2.5, "quantity": 2}]}
+        
+        Input: "quick 20 minute session, felt really good, got my heart rate up to 165"
+        Output: {"duration_minutes": 20, "heart_rate_max": 165, "notes": "felt really good"}
+        
+        Now parse this input:
+        \(userInput)
+        """
+    }
+    
+    /// Call the Claude API
+    private func callClaudeAPI(prompt: String, apiKey: String) async throws -> String {
+        var request = URLRequest(url: URL(string: apiEndpoint)!)
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.addValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 500,
+            "messages": [
+                ["role": "user", "content": prompt]
+            ]
+        ]
+        
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ParsingError.invalidResponse
+        }
+        
+        guard httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "Unknown error"
+            throw ParsingError.apiError(statusCode: httpResponse.statusCode, message: errorBody)
+        }
+        
+        // Parse Claude's response
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let content = json["content"] as? [[String: Any]],
+              let firstContent = content.first,
+              let text = firstContent["text"] as? String else {
+            throw ParsingError.invalidResponse
+        }
+        
+        return text
+    }
+    
+    /// Parse the LLM response into structured data
+    private func parseResponse(_ response: String) throws -> ParsedWorkoutData {
+        // Clean up response - remove any markdown code blocks if present
+        var cleanedResponse = response
+            .replacingOccurrences(of: "```json", with: "")
+            .replacingOccurrences(of: "```", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        // Try to find JSON in the response
+        if let startIndex = cleanedResponse.firstIndex(of: "{"),
+           let endIndex = cleanedResponse.lastIndex(of: "}") {
+            cleanedResponse = String(cleanedResponse[startIndex...endIndex])
+        }
+        
+        guard let jsonData = cleanedResponse.data(using: .utf8) else {
+            throw ParsingError.invalidJSON
+        }
+        
+        let decoder = JSONDecoder()
+        do {
+            return try decoder.decode(ParsedWorkoutData.self, from: jsonData)
+        } catch {
+            print("JSON parsing error: \(error)")
+            print("Response was: \(cleanedResponse)")
+            throw ParsingError.invalidJSON
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum ParsingError: LocalizedError {
+    case noApiKey
+    case invalidResponse
+    case apiError(statusCode: Int, message: String)
+    case invalidJSON
+    
+    var errorDescription: String? {
+        switch self {
+        case .noApiKey:
+            return "No API key configured. Please add your Anthropic API key in Settings."
+        case .invalidResponse:
+            return "Received an invalid response from the server."
+        case .apiError(let statusCode, let message):
+            return "API error (\(statusCode)): \(message)"
+        case .invalidJSON:
+            return "Could not parse the workout data. Please try again."
+        }
+    }
+}
+
+// MARK: - Fallback Regex Parser
+
+/// Simple regex-based parser for when LLM is not available
+struct FallbackWorkoutParser {
+    
+    static func parse(_ text: String) -> ParsedWorkoutData {
+        var data = ParsedWorkoutData()
+        let lowercased = text.lowercased()
+        
+        // Extract duration
+        if let match = lowercased.range(of: #"(\d+)\s*(minutes?|mins?|min)"#, options: .regularExpression) {
+            let numStr = String(lowercased[match]).components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+            data.durationMinutes = Int(numStr)
+        }
+        
+        // Extract steps
+        if let match = lowercased.range(of: #"(\d+)\s*steps?"#, options: .regularExpression) {
+            let numStr = String(lowercased[match]).components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+            data.steps = Int(numStr)
+        }
+        
+        // Extract floors
+        if let match = lowercased.range(of: #"(\d+)\s*floors?"#, options: .regularExpression) {
+            let numStr = String(lowercased[match]).components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+            data.floors = Int(numStr)
+        }
+        
+        // Extract vest weight
+        if let match = lowercased.range(of: #"(\d+)\s*(pound|lb)s?\s*(weighted\s*)?vest"#, options: .regularExpression) {
+            let numStr = String(lowercased[match]).components(separatedBy: CharacterSet.decimalDigits.inverted).joined()
+            if let weight = Double(numStr) {
+                data.weightEquipment = [ParsedWorkoutData.WeightEquipmentItem(type: "vest", weightLbs: weight, quantity: 1)]
+            }
+        }
+        
+        return data
+    }
+}


### PR DESCRIPTION
Closes #18

## Summary

Transforms the home screen into a conversational, voice-first workout logging interface.

**This PR is clean from main** — can be merged independently.

## Features

- **Animated typewriter text** — Cycles through example inputs with gradient coloring
- **Voice input** — iOS Speech framework, tap to record
- **Text fallback** — Type if you prefer
- **LLM parsing** — Claude Haiku extracts structured data (~$0.002/call)
- **Confirmation view** — Review/edit before saving

## New Files

- `TypewriterText.swift` — Animated gradient text components
- `VoiceInputManager.swift` — Speech framework wrapper
- `WorkoutParsingService.swift` — LLM + regex parsing
- `ConversationalHomeView.swift` — New home screen
- `WorkoutConfirmationView.swift` — Review parsed data

## Example Flow

1. User taps mic: "I did 30 minutes, 3000 steps, wore my 20 pound vest"
2. App transcribes with iOS Speech (free, on-device)
3. Sends to Claude Haiku → extracts structured data
4. Shows confirmation: Duration: 30 min, Steps: 3000, Vest: 20lb
5. User confirms → workout saved

## Setup Required

- Add speech/mic permissions to Info.plist
- (Optional) Configure Anthropic API key for LLM parsing