### PR TITLE
Specify Ruby version in deploy workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Decode production Firebase plist
@@ -259,6 +260,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Download production IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Decode Firebase plist files
@@ -236,6 +237,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Download staging IPA artifact


### PR DESCRIPTION
## Summary
This PR fixes the staging/production deploy workflow failure caused by `ruby/setup-ruby` missing an explicit Ruby version.

## Root Cause
`ruby/setup-ruby@v1` requires `ruby-version` when no `.ruby-version` or `.tool-versions` file exists in the repo.  
Without it, the deploy job failed immediately before build steps started.

## Changes
- Updated `.github/workflows/deploy-staging.yml`
  - Added `ruby-version: "3.2"` to both `Set up Ruby` steps
- Updated `.github/workflows/deploy-production.yml`
  - Added `ruby-version: "3.2"` to both `Set up Ruby` steps

## Why this fix
- Makes Ruby setup deterministic in CI
- Removes dependency on runner defaults
- Unblocks deploy pipeline startup for staging and production workflows

## Validation
- Workflow YAML syntax validated locally
- Change is scoped only to Ruby setup in deploy workflows
