### PR TITLE
Fix deploy bundler crash by upgrading lockfile bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,4 +230,4 @@ DEPENDENCIES
   fastlane (~> 2.227)
 
 BUNDLED WITH
-   1.17.2
+   2.5.23


### PR DESCRIPTION
## Summary
This PR fixes the staging deploy failure where `ruby/setup-ruby` tried to run Bundler `1.17.2` on Ruby `3.2`, which crashes in CI (`untaint` NoMethodError).

## Root Cause
`Gemfile.lock` was generated with:

```text
BUNDLED WITH
  1.17.2
```

`ruby/setup-ruby` respects the lockfile bundler version and attempted to use Bundler 1.x, which is incompatible with Ruby 3.2 on the GitHub runner.

## Change
- Updated `Gemfile.lock`:
  - `BUNDLED WITH` from `1.17.2` -> `2.5.23`

## Why this fix
- Keeps current workflow Ruby pin (`3.2`) working
- Allows `bundler-cache: true` to run successfully
- Unblocks `Build iOS IPA (Staging)` so the deploy pipeline can proceed

## Validation
- Minimal scoped change (lockfile only)
- No app/runtime code changes
