### PR TITLE
Fix deploy pipeline gem compatibility by pinning Ruby 3.1

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Decode production Firebase plist
@@ -260,7 +260,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Download production IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Decode Firebase plist files
@@ -237,7 +237,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Download staging IPA artifact


### PR DESCRIPTION
## Summary
This PR fixes the staging deploy failure in `Set up Ruby` by pinning deploy workflows to Ruby 3.1 instead of 3.2.

## Root Cause
The deploy workflow was using Ruby 3.2, but a locked dependency chain currently resolves `CFPropertyList 3.0.9`, which requires Ruby `< 3.2`.

Error seen in GitHub Actions:

```text
CFPropertyList-3.0.9 requires ruby version < 3.2, which is incompatible with the current version, 3.2.10
```

## Changes
- Updated `.github/workflows/deploy-staging.yml`
  - `ruby-version: "3.2"` -> `ruby-version: "3.1"` (both Ruby setup steps)
- Updated `.github/workflows/deploy-production.yml`
  - `ruby-version: "3.2"` -> `ruby-version: "3.1"` (both Ruby setup steps)

## Why this fix
- Restores compatibility with current lockfile dependencies
- Unblocks `Build iOS IPA (Staging)` so deploy pipeline can proceed
- Keeps change minimal and focused on CI runtime only

## Validation
- Workflow YAML syntax validated locally
- Scoped to deploy workflow Ruby version only
