### PR TITLE
Fix staging CI signing and commit bundle ID config updates

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Decode production Firebase plist
@@ -259,6 +260,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Download production IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Build staging IPA via Fastlane
         env:
           EXPORT_OPTIONS_PLIST_PATH: ${{ runner.temp }}/ExportOptions.plist
+          IOS_SIGNING_IDENTITY: Apple Distribution
+          IOS_PROVISIONING_PROFILE_SPECIFIER: AscendApp - Staging - AppStore
+          IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
         run: bundle exec fastlane build_staging
 
       - name: Upload staging IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Decode Firebase plist files
@@ -236,6 +237,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Download staging IPA artifact

--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -266,9 +266,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = AscendApp/AscendApp.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = QWGVB7TN4T;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QWGVB7TN4T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = AscendApp/Info.plist;
@@ -288,8 +290,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.TylerPavay.AscendApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.TylerPavay.AscendApp.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "AscendApp - Staging - Development";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -430,10 +434,12 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = AscendApp/AscendApp.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = QWGVB7TN4T;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QWGVB7TN4T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = AscendApp/Info.plist;
@@ -453,8 +459,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.TylerPavay.AscendApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.TylerPavay.AscendApp.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "AscendApp - Dev - Development";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -471,9 +479,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = AscendApp/AscendApp.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = QWGVB7TN4T;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = QWGVB7TN4T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = AscendApp/Info.plist;
@@ -495,6 +505,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TylerPavay.AscendApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "AscendApp - Production - Development";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,11 +9,21 @@ platform :ios do
   lane :build_staging do
     setup_ci if ENV["CI"]
 
+    staging_signing_identity = ENV.fetch("IOS_SIGNING_IDENTITY", "Apple Distribution")
+    staging_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Staging - AppStore")
+    staging_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
+
     build_app(
       project: "AscendApp.xcodeproj",
       scheme: "AscendApp-Staging",
       configuration: "Staging",
       clean: true,
+      xcargs: [
+        "CODE_SIGN_STYLE=Manual",
+        "CODE_SIGN_IDENTITY=#{staging_signing_identity}",
+        "DEVELOPMENT_TEAM=#{staging_development_team}",
+        "PROVISIONING_PROFILE_SPECIFIER=#{staging_profile_specifier}"
+      ].join(" "),
       export_options: ENV.fetch("EXPORT_OPTIONS_PLIST_PATH"),
       output_directory: "build",
       output_name: "AscendApp-Staging.ipa"


### PR DESCRIPTION
## Summary
- Commits the Xcode project signing/bundle-id updates made locally so CI can see them.
- Fixes staging archive signing in CI by explicitly forcing distribution signing for the Fastlane staging lane.
- Keeps local dev signing profiles intact for on-device development.

## Root Cause
`develop` was building with stale project settings (old bundle/signing mapping) because local Xcode changes were not yet merged. The staging deploy archive also needed explicit CI-side signing inputs to avoid resolving to a development profile during archive.

## Changes
- Updated `AscendApp.xcodeproj/project.pbxproj`:
  - Distinct bundle IDs per config:
    - Debug: `com.TylerPavay.AscendApp.dev`
    - Staging: `com.TylerPavay.AscendApp.staging`
    - Release: `com.TylerPavay.AscendApp`
  - Manual provisioning profile specifiers for local development profiles.
- Updated `fastlane/Fastfile` (`build_staging`):
  - Adds CI-overridable `xcargs` forcing:
    - `CODE_SIGN_STYLE=Manual`
    - `CODE_SIGN_IDENTITY=Apple Distribution`
    - `DEVELOPMENT_TEAM=QWGVB7TN4T`
    - `PROVISIONING_PROFILE_SPECIFIER=AscendApp - Staging - AppStore`
- Updated `.github/workflows/deploy-staging.yml`:
  - Passes staging signing env vars used by Fastlane.

## Validation
- Branch pushed with commit `b6da639`.
- Ready to merge into `develop` and re-run `Deploy Staging`.

## Notes
- Ensure `BUILD_PROVISION_PROFILE_BASE64` secret contains `AscendApp - Staging - AppStore.mobileprovision`.
- Ensure `EXPORT_OPTIONS_PLIST` maps `com.TylerPavay.AscendApp.staging` to `AscendApp - Staging - AppStore`.
