### PR TITLE
Fix staging deploy signing arg splitting in Fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "base64"
+require "shellwords"
 
 default_platform(:ios)
 
@@ -20,9 +21,9 @@ platform :ios do
       clean: true,
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
-        "CODE_SIGN_IDENTITY=#{staging_signing_identity}",
-        "DEVELOPMENT_TEAM=#{staging_development_team}",
-        "PROVISIONING_PROFILE_SPECIFIER=#{staging_profile_specifier}"
+        "CODE_SIGN_IDENTITY=#{Shellwords.escape(staging_signing_identity)}",
+        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
+        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(staging_profile_specifier)}"
       ].join(" "),
       export_options: ENV.fetch("EXPORT_OPTIONS_PLIST_PATH"),
       output_directory: "build",


### PR DESCRIPTION
## Summary
- Fixes staging archive signing argument parsing in Fastlane.
- Prevents `xcodebuild` from splitting signing values that contain spaces (e.g. `Apple Distribution`, `AscendApp - Staging - AppStore`).

## Root Cause
The staging lane passed signing values via `xcargs` without shell escaping. Values with spaces were split into multiple shell tokens, producing broken build args and failures like:
- `xcodebuild: error: Unknown build action 'Distribution'.`

## Changes
- Updated `fastlane/Fastfile`:
  - Added `require "shellwords"`
  - Escaped staging signing values in `xcargs` with `Shellwords.escape(...)`.

## Validation
- `ruby -c fastlane/Fastfile` passes.
- This change is scoped to staging lane argument construction only.

## Follow-up
- If deploy still fails later at export, verify `EXPORT_OPTIONS_PLIST` secret maps:
  - `com.TylerPavay.AscendApp.staging` -> `AscendApp - Staging - AppStore`
