### PR TITLE
Fix staging signing scope to avoid SPM profile failures

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -144,47 +144,21 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH"
 
+          if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -q "Apple Distribution"; then
+            echo "::error::No Apple Distribution identity with private key found in BUILD_CERTIFICATE_BASE64_PRODUCTION."
+            echo "Re-export the production certificate from Keychain Access as a .p12 including the private key."
+            exit 1
+          fi
+
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           cp "$PP_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles"
 
-      - name: Decode production ExportOptions.plist
-        env:
-          EXPORT_OPTIONS_PLIST: ${{ secrets.EXPORT_OPTIONS_PLIST_PRODUCTION }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          decode_base64_required() {
-            local secret_name="$1"
-            local encoded="$2"
-            local output_path="$3"
-
-            if [ -z "$encoded" ]; then
-              echo "::error::Required secret ${secret_name} is missing or empty."
-              exit 1
-            fi
-
-            if ! (printf "%s" "$encoded" | base64 --decode > "$output_path" 2>/dev/null || printf "%s" "$encoded" | base64 -D > "$output_path" 2>/dev/null); then
-              echo "::error::Failed to decode secret ${secret_name} as base64."
-              exit 1
-            fi
-
-            if [ ! -s "$output_path" ]; then
-              echo "::error::Decoded file for ${secret_name} is empty."
-              exit 1
-            fi
-
-            if ! plutil -lint "$output_path" >/dev/null; then
-              echo "::error::Decoded file for ${secret_name} is not a valid plist."
-              exit 1
-            fi
-          }
-
-          decode_base64_required "EXPORT_OPTIONS_PLIST_PRODUCTION" "$EXPORT_OPTIONS_PLIST" "$RUNNER_TEMP/ExportOptions.plist"
-
       - name: Build production IPA via Fastlane
         env:
-          EXPORT_OPTIONS_PLIST_PATH: ${{ runner.temp }}/ExportOptions.plist
+          IOS_SIGNING_IDENTITY: Apple Distribution
+          IOS_PROVISIONING_PROFILE_SPECIFIER: AscendApp - Production - AppStore
+          IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
+          IOS_PRODUCTION_BUNDLE_ID: com.TylerPavay.AscendApp
         run: bundle exec fastlane build_production
 
       - name: Upload production IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -128,50 +128,21 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH"
 
+          if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -q "Apple Distribution"; then
+            echo "::error::No Apple Distribution identity with private key found in BUILD_CERTIFICATE_BASE64."
+            echo "Re-export the certificate from Keychain Access as a .p12 including the private key."
+            exit 1
+          fi
+
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           cp "$PP_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles"
 
-      - name: Decode ExportOptions.plist
-        env:
-          EXPORT_OPTIONS_PLIST: ${{ secrets.EXPORT_OPTIONS_PLIST }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          decode_base64_required() {
-            local secret_name="$1"
-            local encoded="$2"
-            local output_path="$3"
-
-            if [ -z "$encoded" ]; then
-              echo "::error::Required secret ${secret_name} is missing or empty."
-              exit 1
-            fi
-
-            if ! (printf "%s" "$encoded" | base64 --decode > "$output_path" 2>/dev/null || printf "%s" "$encoded" | base64 -D > "$output_path" 2>/dev/null); then
-              echo "::error::Failed to decode secret ${secret_name} as base64."
-              exit 1
-            fi
-
-            if [ ! -s "$output_path" ]; then
-              echo "::error::Decoded file for ${secret_name} is empty."
-              exit 1
-            fi
-
-            if ! plutil -lint "$output_path" >/dev/null; then
-              echo "::error::Decoded file for ${secret_name} is not a valid plist."
-              exit 1
-            fi
-          }
-
-          decode_base64_required "EXPORT_OPTIONS_PLIST" "$EXPORT_OPTIONS_PLIST" "$RUNNER_TEMP/ExportOptions.plist"
-
       - name: Build staging IPA via Fastlane
         env:
-          EXPORT_OPTIONS_PLIST_PATH: ${{ runner.temp }}/ExportOptions.plist
           IOS_SIGNING_IDENTITY: Apple Distribution
           IOS_PROVISIONING_PROFILE_SPECIFIER: AscendApp - Staging - AppStore
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
+          IOS_STAGING_BUNDLE_ID: com.TylerPavay.AscendApp.staging
         run: bundle exec fastlane build_staging
 
       - name: Upload staging IPA artifact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,7 @@ If using CloudKit sync: never use `@Attribute(.unique)`, properties must have de
   - `build_staging`
   - `build_production`
   - `upload_testflight`
+- iOS deploy lanes generate export options dynamically from environment variables (`IOS_SIGNING_IDENTITY`, `IOS_PROVISIONING_PROFILE_SPECIFIER`, `IOS_DEVELOPMENT_TEAM`, and environment bundle ID), rather than relying on base64-encoded `ExportOptions.plist` secrets.
 
 ### Firebase Hosting
 Website source lives in `web/` and is built to `web/dist/` before deploy.

--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -266,7 +266,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = AscendApp/AscendApp.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
@@ -293,7 +293,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.TylerPavay.AscendApp.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "AscendApp - Staging - Development";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "AscendApp - Staging - AppStore";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -434,7 +434,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = AscendApp/AscendApp.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -506,7 +506,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.TylerPavay.AscendApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "AscendApp - Production - Development";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "AscendApp - Production - AppStore";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,7 @@ If using CloudKit sync: never use `@Attribute(.unique)`, properties must have de
   - `build_staging`
   - `build_production`
   - `upload_testflight`
+- iOS deploy lanes generate export options dynamically from environment variables (`IOS_SIGNING_IDENTITY`, `IOS_PROVISIONING_PROFILE_SPECIFIER`, `IOS_DEVELOPMENT_TEAM`, and environment bundle ID), rather than relying on base64-encoded `ExportOptions.plist` secrets.
 
 ### Firebase Hosting
 Website source lives in `web/` and is built to `web/dist/` before deploy.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,6 +13,7 @@ platform :ios do
     staging_signing_identity = ENV.fetch("IOS_SIGNING_IDENTITY", "Apple Distribution")
     staging_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Staging - AppStore")
     staging_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
+    staging_bundle_identifier = ENV.fetch("IOS_STAGING_BUNDLE_ID", "com.TylerPavay.AscendApp.staging")
 
     build_app(
       project: "AscendApp.xcodeproj",
@@ -22,10 +23,17 @@ platform :ios do
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(staging_signing_identity)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
-        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(staging_profile_specifier)}"
+        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}"
       ].join(" "),
-      export_options: ENV.fetch("EXPORT_OPTIONS_PLIST_PATH"),
+      export_options: {
+        method: "app-store",
+        signingStyle: "manual",
+        signingCertificate: staging_signing_identity,
+        teamID: staging_development_team,
+        provisioningProfiles: {
+          staging_bundle_identifier => staging_profile_specifier
+        }
+      },
       output_directory: "build",
       output_name: "AscendApp-Staging.ipa"
     )
@@ -35,12 +43,30 @@ platform :ios do
   lane :build_production do
     setup_ci if ENV["CI"]
 
+    production_signing_identity = ENV.fetch("IOS_SIGNING_IDENTITY", "Apple Distribution")
+    production_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Production - AppStore")
+    production_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
+    production_bundle_identifier = ENV.fetch("IOS_PRODUCTION_BUNDLE_ID", "com.TylerPavay.AscendApp")
+
     build_app(
       project: "AscendApp.xcodeproj",
       scheme: "AscendApp",
       configuration: "Release",
       clean: true,
-      export_options: ENV.fetch("EXPORT_OPTIONS_PLIST_PATH"),
+      xcargs: [
+        "CODE_SIGN_STYLE=Manual",
+        "CODE_SIGN_IDENTITY=#{Shellwords.escape(production_signing_identity)}",
+        "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}"
+      ].join(" "),
+      export_options: {
+        method: "app-store",
+        signingStyle: "manual",
+        signingCertificate: production_signing_identity,
+        teamID: production_development_team,
+        provisioningProfiles: {
+          production_bundle_identifier => production_profile_specifier
+        }
+      },
       output_directory: "build",
       output_name: "AscendApp-Production.ipa"
     )


### PR DESCRIPTION
## Summary
This PR fixes the staging deploy failure by correcting how signing settings are passed to Xcode/Fastlane.

## Root Cause
- `PROVISIONING_PROFILE_SPECIFIER` was being passed through global `xcargs`, which applied to Swift Package targets and caused archive failures (`does not support provisioning profiles`).
- Staging/Release target signing settings in the project were still pinned to development-style values (`iPhone Developer`, `*-Development` profiles), which conflicted with CI App Store archive intent.
- Deploy workflows depended on base64 `ExportOptions.plist` secrets, which had drift risk and made signing behavior harder to reason about.

## Changes
- Updated `fastlane/Fastfile`:
  - Keep manual signing/team/identity in `xcargs`.
  - Remove global `PROVISIONING_PROFILE_SPECIFIER` injection.
  - Build `export_options` dynamically in lane using env vars + bundle ID mapping.
  - Applied same export-options pattern to `build_production` lane for consistency.
- Updated `AscendApp.xcodeproj/project.pbxproj`:
  - Staging config now uses `Apple Distribution` + `AscendApp - Staging - AppStore`.
  - Release config now uses `Apple Distribution` + `AscendApp - Production - AppStore`.
- Updated deploy workflows:
  - Removed `Decode ExportOptions.plist` steps.
  - Pass explicit env vars for signing identity/profile/team/bundle ID to Fastlane.
  - Added fail-fast check to verify an `Apple Distribution` identity with private key exists in imported cert secret.
- Synced docs:
  - Added matching Fastlane signing note to both `AGENTS.md` and `CLAUDE.md`.

## Validation
- Branch pushed with commit `37a49d0`.
- Diff reviewed to ensure no unrelated app feature files were included.
- Expected outcome: staging archive no longer applies provisioning profiles to SPM targets and signs app target with intended App Store profile mapping.

## Follow-up (Secrets)
- `BUILD_CERTIFICATE_BASE64` must be a `.p12` export that includes the private key for your Apple Distribution cert.
- `BUILD_PROVISION_PROFILE_BASE64` must be `AscendApp - Staging - AppStore.mobileprovision`.
