### PR TITLE
Add manual trigger for deploy-staging workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,6 +1,7 @@
 name: Deploy Staging
 
 on:
+  workflow_dispatch:
   push:
     branches: [develop]
     paths:


### PR DESCRIPTION
Summary: add workflow_dispatch to deploy-staging while keeping push-to-develop trigger unchanged. Why: restore Run workflow button for manual reruns. Validation: one-line trigger addition only.