### PR TITLE
Migrate iOS deploy signing to fastlane match

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -62,6 +62,17 @@ jobs:
           ruby-version: "3.1"
           bundler-cache: true
 
+      - name: Configure SSH for match repository
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
+
+      - name: Trust GitHub host key
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.ssh"
+          ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
+
       - name: Decode production Firebase plist
         env:
           GOOGLE_SERVICE_INFO_PRODUCTION_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_PRODUCTION_BASE64 }}
@@ -98,63 +109,30 @@ jobs:
           mkdir -p AscendApp/App/Firebase
           decode_base64_required "GOOGLE_SERVICE_INFO_PRODUCTION_BASE64" "$GOOGLE_SERVICE_INFO_PRODUCTION_BASE64" "AscendApp/App/Firebase/GoogleService-Info-Production.plist"
 
-      - name: Install certificate and provisioning profile
+      - name: Validate match secrets
         env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64_PRODUCTION }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD_PRODUCTION }}
-          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64_PRODUCTION }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD_PRODUCTION }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         shell: bash
         run: |
           set -euo pipefail
 
-          decode_base64_required() {
-            local secret_name="$1"
-            local encoded="$2"
-            local output_path="$3"
-
-            if [ -z "$encoded" ]; then
-              echo "::error::Required secret ${secret_name} is missing or empty."
-              exit 1
-            fi
-
-            if ! (printf "%s" "$encoded" | base64 --decode > "$output_path" 2>/dev/null || printf "%s" "$encoded" | base64 -D > "$output_path" 2>/dev/null); then
-              echo "::error::Failed to decode secret ${secret_name} as base64."
-              exit 1
-            fi
-
-            if [ ! -s "$output_path" ]; then
-              echo "::error::Decoded file for ${secret_name} is empty."
-              exit 1
-            fi
-          }
-
-          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
-          PP_PATH="$RUNNER_TEMP/build_pp.mobileprovision"
-          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
-
-          decode_base64_required "BUILD_CERTIFICATE_BASE64_PRODUCTION" "$BUILD_CERTIFICATE_BASE64" "$CERTIFICATE_PATH"
-          decode_base64_required "BUILD_PROVISION_PROFILE_BASE64_PRODUCTION" "$BUILD_PROVISION_PROFILE_BASE64" "$PP_PATH"
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          security import "$CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-
-          if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -q "Apple Distribution"; then
-            echo "::error::No Apple Distribution identity with private key found in BUILD_CERTIFICATE_BASE64_PRODUCTION."
-            echo "Re-export the production certificate from Keychain Access as a .p12 including the private key."
+          if [ -z "$MATCH_GIT_URL" ]; then
+            echo "::error::Required secret MATCH_GIT_URL is missing or empty."
             exit 1
           fi
 
-          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-          cp "$PP_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles"
+          if [ -z "$MATCH_PASSWORD" ]; then
+            echo "::error::Required secret MATCH_PASSWORD is missing or empty."
+            exit 1
+          fi
 
       - name: Build production IPA via Fastlane
         env:
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BRANCH: main
+          MATCH_READONLY: "true"
           IOS_SIGNING_IDENTITY: Apple Distribution
           IOS_PROVISIONING_PROFILE_SPECIFIER: AscendApp - Production - AppStore
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
@@ -167,11 +145,6 @@ jobs:
           name: AscendApp-Production-IPA
           path: build/AscendApp-Production.ipa
           retention-days: 14
-
-      - name: Clean up keychain
-        if: always()
-        shell: bash
-        run: security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" || true
 
   deploy-firebase:
     name: Deploy Firebase (Production)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,6 +45,17 @@ jobs:
           ruby-version: "3.1"
           bundler-cache: true
 
+      - name: Configure SSH for match repository
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
+
+      - name: Trust GitHub host key
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.ssh"
+          ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
+
       - name: Decode Firebase plist files
         env:
           GOOGLE_SERVICE_INFO_DEV_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_DEV_BASE64 }}
@@ -83,63 +94,30 @@ jobs:
           decode_base64_required "GOOGLE_SERVICE_INFO_DEV_BASE64" "$GOOGLE_SERVICE_INFO_DEV_BASE64" "AscendApp/App/Firebase/GoogleService-Info-Dev.plist"
           decode_base64_required "GOOGLE_SERVICE_INFO_STAGING_BASE64" "$GOOGLE_SERVICE_INFO_STAGING_BASE64" "AscendApp/App/Firebase/GoogleService-Info-Staging.plist"
 
-      - name: Install certificate and provisioning profile
+      - name: Validate match secrets
         env:
-          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
-          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
-          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
         shell: bash
         run: |
           set -euo pipefail
 
-          decode_base64_required() {
-            local secret_name="$1"
-            local encoded="$2"
-            local output_path="$3"
-
-            if [ -z "$encoded" ]; then
-              echo "::error::Required secret ${secret_name} is missing or empty."
-              exit 1
-            fi
-
-            if ! (printf "%s" "$encoded" | base64 --decode > "$output_path" 2>/dev/null || printf "%s" "$encoded" | base64 -D > "$output_path" 2>/dev/null); then
-              echo "::error::Failed to decode secret ${secret_name} as base64."
-              exit 1
-            fi
-
-            if [ ! -s "$output_path" ]; then
-              echo "::error::Decoded file for ${secret_name} is empty."
-              exit 1
-            fi
-          }
-
-          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
-          PP_PATH="$RUNNER_TEMP/build_pp.mobileprovision"
-          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
-
-          decode_base64_required "BUILD_CERTIFICATE_BASE64" "$BUILD_CERTIFICATE_BASE64" "$CERTIFICATE_PATH"
-          decode_base64_required "BUILD_PROVISION_PROFILE_BASE64" "$BUILD_PROVISION_PROFILE_BASE64" "$PP_PATH"
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          security import "$CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
-
-          if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -q "Apple Distribution"; then
-            echo "::error::No Apple Distribution identity with private key found in BUILD_CERTIFICATE_BASE64."
-            echo "Re-export the certificate from Keychain Access as a .p12 including the private key."
+          if [ -z "$MATCH_GIT_URL" ]; then
+            echo "::error::Required secret MATCH_GIT_URL is missing or empty."
             exit 1
           fi
 
-          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-          cp "$PP_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles"
+          if [ -z "$MATCH_PASSWORD" ]; then
+            echo "::error::Required secret MATCH_PASSWORD is missing or empty."
+            exit 1
+          fi
 
       - name: Build staging IPA via Fastlane
         env:
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_BRANCH: main
+          MATCH_READONLY: "true"
           IOS_SIGNING_IDENTITY: Apple Distribution
           IOS_PROVISIONING_PROFILE_SPECIFIER: AscendApp - Staging - AppStore
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
@@ -152,11 +130,6 @@ jobs:
           name: AscendApp-Staging-IPA
           path: build/AscendApp-Staging.ipa
           retention-days: 14
-
-      - name: Clean up keychain
-        if: always()
-        shell: bash
-        run: security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" || true
 
   deploy-firebase:
     name: Deploy Firebase (Staging)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,17 @@ If using CloudKit sync: never use `@Attribute(.unique)`, properties must have de
   - `build_staging`
   - `build_production`
   - `upload_testflight`
-- iOS deploy lanes generate export options dynamically from environment variables (`IOS_SIGNING_IDENTITY`, `IOS_PROVISIONING_PROFILE_SPECIFIER`, `IOS_DEVELOPMENT_TEAM`, and environment bundle ID), rather than relying on base64-encoded `ExportOptions.plist` secrets.
+- iOS deploy lanes use `fastlane match` for signing material sync (CI runs in `readonly` mode).
+- Required iOS signing secrets for CI:
+  - `MATCH_GIT_URL`
+  - `MATCH_PASSWORD`
+  - `MATCH_GIT_PRIVATE_KEY`
+- Legacy manual-signing CI secrets are deprecated:
+  - `BUILD_CERTIFICATE_BASE64`
+  - `BUILD_PROVISION_PROFILE_BASE64`
+  - `P12_PASSWORD`
+  - `KEYCHAIN_PASSWORD`
+  - production-specific `*_PRODUCTION` variants of the above
 
 ### Firebase Hosting
 Website source lives in `web/` and is built to `web/dist/` before deploy.
@@ -208,4 +218,4 @@ Website source lives in `web/` and is built to `web/dist/` before deploy.
 - `.github/workflows/ci.yml` — PR validation
 - `.github/workflows/deploy-staging.yml` — staging deploy pipeline
 - `.github/workflows/deploy-production.yml` — production deploy pipeline (gated)
-- `Gemfile`, `fastlane/Appfile`, `fastlane/Fastfile` — iOS build/TestFlight automation
+- `Gemfile`, `fastlane/Appfile`, `fastlane/Fastfile`, `fastlane/Matchfile` — iOS build/signing/TestFlight automation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,7 +195,17 @@ If using CloudKit sync: never use `@Attribute(.unique)`, properties must have de
   - `build_staging`
   - `build_production`
   - `upload_testflight`
-- iOS deploy lanes generate export options dynamically from environment variables (`IOS_SIGNING_IDENTITY`, `IOS_PROVISIONING_PROFILE_SPECIFIER`, `IOS_DEVELOPMENT_TEAM`, and environment bundle ID), rather than relying on base64-encoded `ExportOptions.plist` secrets.
+- iOS deploy lanes use `fastlane match` for signing material sync (CI runs in `readonly` mode).
+- Required iOS signing secrets for CI:
+  - `MATCH_GIT_URL`
+  - `MATCH_PASSWORD`
+  - `MATCH_GIT_PRIVATE_KEY`
+- Legacy manual-signing CI secrets are deprecated:
+  - `BUILD_CERTIFICATE_BASE64`
+  - `BUILD_PROVISION_PROFILE_BASE64`
+  - `P12_PASSWORD`
+  - `KEYCHAIN_PASSWORD`
+  - production-specific `*_PRODUCTION` variants of the above
 
 ### Firebase Hosting
 Website source lives in `web/` and is built to `web/dist/` before deploy.
@@ -208,4 +218,4 @@ Website source lives in `web/` and is built to `web/dist/` before deploy.
 - `.github/workflows/ci.yml` — PR validation
 - `.github/workflows/deploy-staging.yml` — staging deploy pipeline
 - `.github/workflows/deploy-production.yml` — production deploy pipeline (gated)
-- `Gemfile`, `fastlane/Appfile`, `fastlane/Fastfile` — iOS build/TestFlight automation
+- `Gemfile`, `fastlane/Appfile`, `fastlane/Fastfile`, `fastlane/Matchfile` — iOS build/signing/TestFlight automation

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,6 +5,32 @@ require "shellwords"
 
 default_platform(:ios)
 
+def match_readonly_enabled?
+  return ENV.fetch("MATCH_READONLY", "").casecmp("true").zero? if ENV.key?("MATCH_READONLY")
+
+  ENV["CI"].to_s == "true"
+end
+
+def match_options_for(bundle_identifier)
+  options = {
+    type: "appstore",
+    readonly: match_readonly_enabled?,
+    app_identifier: [bundle_identifier],
+    git_branch: ENV.fetch("MATCH_GIT_BRANCH", "main")
+  }
+
+  match_git_url = ENV["MATCH_GIT_URL"]
+  options[:git_url] = match_git_url if match_git_url && !match_git_url.empty?
+
+  match_keychain_name = ENV["MATCH_KEYCHAIN_NAME"]
+  options[:keychain_name] = match_keychain_name if match_keychain_name && !match_keychain_name.empty?
+
+  match_keychain_password = ENV["MATCH_KEYCHAIN_PASSWORD"]
+  options[:keychain_password] = match_keychain_password if match_keychain_password && !match_keychain_password.empty?
+
+  options
+end
+
 platform :ios do
   desc "Build a signed staging IPA"
   lane :build_staging do
@@ -14,6 +40,8 @@ platform :ios do
     staging_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Staging - AppStore")
     staging_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
     staging_bundle_identifier = ENV.fetch("IOS_STAGING_BUNDLE_ID", "com.TylerPavay.AscendApp.staging")
+
+    match(**match_options_for(staging_bundle_identifier))
 
     build_app(
       project: "AscendApp.xcodeproj",
@@ -47,6 +75,8 @@ platform :ios do
     production_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Production - AppStore")
     production_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
     production_bundle_identifier = ENV.fetch("IOS_PRODUCTION_BUNDLE_ID", "com.TylerPavay.AscendApp")
+
+    match(**match_options_for(production_bundle_identifier))
 
     build_app(
       project: "AscendApp.xcodeproj",

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,0 +1,6 @@
+git_url(ENV.fetch("MATCH_GIT_URL", "git@github.com:tpavay/ascend-match-signing.git"))
+storage_mode("git")
+type("appstore")
+git_branch(ENV.fetch("MATCH_GIT_BRANCH", "main"))
+app_identifier(["com.TylerPavay.AscendApp.staging", "com.TylerPavay.AscendApp"])
+team_id("QWGVB7TN4T")


### PR DESCRIPTION
## Summary
- migrate iOS signing in deploy workflows from base64 cert/profile secrets to `fastlane match`
- add `fastlane/Matchfile` for shared match configuration
- update Fastlane build lanes to run `match` before `build_app`
- keep AGENTS.md and CLAUDE.md in sync with the new signing architecture

## What changed
- `.github/workflows/deploy-staging.yml`
  - removed manual certificate/provisioning import step
  - added SSH agent setup using `MATCH_GIT_PRIVATE_KEY`
  - added match secret validation (`MATCH_GIT_URL`, `MATCH_PASSWORD`)
  - build step now passes `MATCH_*` env vars and runs match in readonly mode
- `.github/workflows/deploy-production.yml`
  - same migration pattern as staging
- `fastlane/Fastfile`
  - added `match_readonly_enabled?` and `match_options_for(...)` helpers
  - `build_staging` and `build_production` lanes now call `match` before `build_app`
- `fastlane/Matchfile`
  - defines git-backed match storage, branch, app IDs, and team ID

## Required secrets
- `MATCH_GIT_URL`
- `MATCH_PASSWORD`
- `MATCH_GIT_PRIVATE_KEY`

## Notes
- legacy manual signing secrets (`BUILD_CERTIFICATE_BASE64`, `BUILD_PROVISION_PROFILE_BASE64`, `P12_PASSWORD`, `KEYCHAIN_PASSWORD`, and production variants) are now deprecated for deploy workflows.
- YAML parse check executed locally for both updated workflow files.
