### PR TITLE
Fix CI signing by avoiding setup_ci keychain override

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,8 +34,6 @@ end
 platform :ios do
   desc "Build a signed staging IPA"
   lane :build_staging do
-    setup_ci if ENV["CI"]
-
     staging_signing_identity = ENV.fetch("IOS_SIGNING_IDENTITY", "Apple Distribution")
     staging_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Staging - AppStore")
     staging_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
@@ -69,8 +67,6 @@ platform :ios do
 
   desc "Build a signed production IPA"
   lane :build_production do
-    setup_ci if ENV["CI"]
-
     production_signing_identity = ENV.fetch("IOS_SIGNING_IDENTITY", "Apple Distribution")
     production_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Production - AppStore")
     production_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")


### PR DESCRIPTION
## Summary
- remove setup_ci from build_staging lane
- remove setup_ci from build_production lane

## Why
match is successfully installing certs and provisioning profiles, but setup_ci can switch Fastlane into a temporary keychain context. This keeps signing in the same keychain context used by match.

## Validation
- ruby -c fastlane/Fastfile
