### PR TITLE
Fix archive signing identity scope for iphoneos targets

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,6 +49,7 @@ platform :ios do
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(staging_signing_identity)}",
+        "CODE_SIGN_IDENTITY[sdk=iphoneos*]=#{Shellwords.escape(staging_signing_identity)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}"
       ].join(" "),
       export_options: {
@@ -82,6 +83,7 @@ platform :ios do
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(production_signing_identity)}",
+        "CODE_SIGN_IDENTITY[sdk=iphoneos*]=#{Shellwords.escape(production_signing_identity)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}"
       ].join(" "),
       export_options: {


### PR DESCRIPTION
## Summary
- add iphoneos-scoped CODE_SIGN_IDENTITY override to staging build lane
- add iphoneos-scoped CODE_SIGN_IDENTITY override to production build lane

## Why
Archive failures show package targets looking for `iOS Distribution` identity even though CI is configured for Apple Distribution. Adding sdk-scoped identity override ensures xcodebuild applies the intended distribution identity across iphoneos targets.

## Validation
- ruby -c fastlane/Fastfile
