### PR TITLE
Fix CI signing: skip_profile_detection + remove bracket xcarg

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Configure SSH for match repository
@@ -207,7 +207,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Download production IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Configure SSH for match repository
@@ -185,7 +185,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: Download staging IPA artifact

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,6 +34,8 @@ end
 platform :ios do
   desc "Build a signed staging IPA"
   lane :build_staging do
+    setup_ci if ENV["CI"]
+
     staging_signing_identity = ENV.fetch("IOS_SIGNING_IDENTITY", "Apple Distribution")
     staging_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Staging - AppStore")
     staging_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
@@ -46,10 +48,10 @@ platform :ios do
       scheme: "AscendApp-Staging",
       configuration: "Staging",
       clean: true,
+      skip_profile_detection: true,
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(staging_signing_identity)}",
-        "CODE_SIGN_IDENTITY[sdk=iphoneos*]=#{Shellwords.escape(staging_signing_identity)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}"
       ].join(" "),
       export_options: {
@@ -68,6 +70,8 @@ platform :ios do
 
   desc "Build a signed production IPA"
   lane :build_production do
+    setup_ci if ENV["CI"]
+
     production_signing_identity = ENV.fetch("IOS_SIGNING_IDENTITY", "Apple Distribution")
     production_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Production - AppStore")
     production_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
@@ -80,10 +84,10 @@ platform :ios do
       scheme: "AscendApp",
       configuration: "Release",
       clean: true,
+      skip_profile_detection: true,
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(production_signing_identity)}",
-        "CODE_SIGN_IDENTITY[sdk=iphoneos*]=#{Shellwords.escape(production_signing_identity)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}"
       ].join(" "),
       export_options: {


### PR DESCRIPTION
## Summary
- Add `skip_profile_detection: true` to `build_app` in both staging and production lanes — prevents gym from auto-generating the broken `CODE_SIGN_IDENTITY[sdk=iphoneos*]=...` xcarg that Xcode 26 misparses
- Remove the explicit `CODE_SIGN_IDENTITY[sdk=iphoneos*]` xcarg (no longer needed with skip_profile_detection)
- Restore `setup_ci if ENV["CI"]` in both build lanes (creates temp keychain on CI for match)
- Bump Ruby from 3.1 to 3.2 in both deploy workflows

## Root Cause
Gym auto-generates `CODE_SIGN_IDENTITY[sdk=iphoneos*]=Apple\ Distribution` as an xcarg. Xcode 26 misparses the bracket syntax, reading the signing identity as `iphoneos*]=Apple Distribution` instead of `Apple Distribution`, causing "No certificate matching..." errors on every target.

## Test plan
- [ ] Trigger staging build via `workflow_dispatch` on this branch (or merge to develop)
- [ ] Verify match clones/decrypts/installs certs and profiles successfully
- [ ] Verify `skip_profile_detection: true` prevents the bracket xcarg from appearing in build logs
- [ ] Verify archive succeeds and IPA is produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)