### PR TITLE
Revert Ruby to 3.1 for CFPropertyList compatibility

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Configure SSH for match repository
@@ -207,7 +207,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Download production IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Configure SSH for match repository
@@ -185,7 +185,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Download staging IPA artifact


### PR DESCRIPTION
## Summary
- Revert Ruby from 3.2 to 3.1 in both deploy workflows

PR #41 was a no-op because the squash merge combined the 3.1→3.2 bump with the 3.2→3.1 revert, netting zero change. This is a clean branch with just the revert.

`CFPropertyList 3.0.9` (latest 3.x) requires Ruby < 3.2, and fastlane pins it to `< 4.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)