### PR TITLE
Disable code signing for SPM packages in CI builds

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,7 +52,8 @@ platform :ios do
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(staging_signing_identity)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}"
+        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
+        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" "),
       export_options: {
         method: "app-store",
@@ -88,7 +89,8 @@ platform :ios do
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(production_signing_identity)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}"
+        "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}",
+        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" "),
       export_options: {
         method: "app-store",


### PR DESCRIPTION
## Summary
- Add `CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'` to xcargs in both build lanes

## Root Cause
After the match signing fix landed, the build got past certificate setup but SPM package targets (gRPC, AppAuth, GoogleSignIn, GoogleUtilities) tried to code-sign with "iOS Distribution" and failed. These library/framework targets shouldn't sign at all.

`CODE_SIGNING_ALLOWED_FOR_APPS` is an Xcode build setting that evaluates to `YES` for app targets and `NO` for library/framework targets, so SPM packages skip signing entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)