### PR TITLE
Fix export: use app-store-connect and separate export xcargs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -55,8 +55,9 @@ platform :ios do
         "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
         "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" "),
+      export_xcargs: "-allowProvisioningUpdates",
       export_options: {
-        method: "app-store",
+        method: "app-store-connect",
         signingStyle: "manual",
         signingCertificate: staging_signing_identity,
         teamID: staging_development_team,
@@ -92,8 +93,9 @@ platform :ios do
         "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}",
         "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" "),
+      export_xcargs: "-allowProvisioningUpdates",
       export_options: {
-        method: "app-store",
+        method: "app-store-connect",
         signingStyle: "manual",
         signingCertificate: production_signing_identity,
         teamID: production_development_team,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,7 +52,8 @@ platform :ios do
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(staging_signing_identity)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}"
+        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
+        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" "),
       export_options: {
         method: "app-store",
@@ -88,7 +89,8 @@ platform :ios do
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(production_signing_identity)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}"
+        "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}",
+        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" "),
       export_options: {
         method: "app-store",


### PR DESCRIPTION
## Summary
- Change export method from deprecated `app-store` to `app-store-connect`
- Add `export_xcargs` to prevent `CODE_SIGNING_ALLOWED_FOR_APPS` from leaking into the export step
- Also includes the SPM signing fix from PR #43

## Context
Archive now succeeds (match works, skip_profile_detection works, SPM packages skip signing). But the export step fails with `No signing certificate "iOS Distribution" found`. Two likely causes:
1. The deprecated `app-store` method may trigger legacy certificate lookup in Xcode 26
2. `CODE_SIGNING_ALLOWED_FOR_APPS` being passed to the export command may confuse framework re-signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)