### PR TITLE
Fix export_method: set as top-level build_app param

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -49,6 +49,7 @@ platform :ios do
       configuration: "Staging",
       clean: true,
       skip_profile_detection: true,
+      export_method: "app-store-connect",
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(staging_signing_identity)}",
@@ -87,6 +88,7 @@ platform :ios do
       configuration: "Release",
       clean: true,
       skip_profile_detection: true,
+      export_method: "app-store-connect",
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(production_signing_identity)}",


### PR DESCRIPTION
## Summary
- Add `export_method: "app-store-connect"` as a top-level `build_app` parameter

## Root Cause
Gym ignores the `method` key inside the `export_options` hash and uses its own `export_method` parameter (which defaults to `app-store`). The generated plist was still writing `"method": "app-store"` despite our export_options saying `"app-store-connect"`. The deprecated `app-store` method triggers Xcode 26 to look for legacy "iOS Distribution" certificates instead of "Apple Distribution".

🤖 Generated with [Claude Code](https://claude.com/claude-code)