### PR TITLE
Increase xcodebuild settings timeout for SPM packages

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -137,6 +137,7 @@ jobs:
           IOS_PROVISIONING_PROFILE_SPECIFIER: AscendApp - Production - AppStore
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
           IOS_PRODUCTION_BUNDLE_ID: com.TylerPavay.AscendApp
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
         run: bundle exec fastlane build_production
 
       - name: Upload production IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -122,6 +122,7 @@ jobs:
           IOS_PROVISIONING_PROFILE_SPECIFIER: AscendApp - Staging - AppStore
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
           IOS_STAGING_BUNDLE_ID: com.TylerPavay.AscendApp.staging
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
         run: bundle exec fastlane build_staging
 
       - name: Upload staging IPA artifact


### PR DESCRIPTION
## Summary
- Add `FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=120` to both deploy workflows

## Root Cause
Gym runs `xcodebuild -showBuildSettings` before building and has a 3-second base timeout with 4 retries (3, 6, 12, 24s). With many SPM packages to resolve, the command exceeds even the 24-second final retry. Setting the timeout to 120s gives it enough room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)