### PR TITLE
Use full cert name in xcargs for archive and export

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,7 +65,7 @@ platform :ios do
       skip_profile_detection: true,
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
-        "CODE_SIGN_IDENTITY=#{Shellwords.escape(staging_signing_identity)}",
+        "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
         "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" "),
@@ -106,7 +106,7 @@ platform :ios do
       skip_profile_detection: true,
       xcargs: [
         "CODE_SIGN_STYLE=Manual",
-        "CODE_SIGN_IDENTITY=#{Shellwords.escape(production_signing_identity)}",
+        "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}",
         "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" "),

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,13 +33,12 @@ end
 
 # Build the full certificate common name from the short identity and team ID.
 # e.g. "Apple Distribution" + "QWGVB7TN4T" -> looks up the installed cert.
-# Match installs certs with common names like "Apple Distribution: Tyler Pavay (QWGVB7TN4T)".
+# After match runs, it sets an env var with the full certificate common name:
+#   sigh_<bundle_id>_appstore_certificate-name = "Apple Distribution: Tyler Pavay (QWGVB7TN4T)"
 # Using the full name in export options forces an exact keychain lookup and avoids
 # Xcode 26 mapping "Apple Distribution" to the legacy "iOS Distribution" type.
-def installed_cert_common_name(team_id)
-  output = `security find-identity -v -p codesigning 2>/dev/null`
-  match_data = output.match(/"(Apple Distribution: .+\(#{Regexp.escape(team_id)}\))"/)
-  match_data ? match_data[1] : nil
+def match_cert_name(bundle_identifier)
+  ENV["sigh_#{bundle_identifier}_appstore_certificate-name"]
 end
 
 platform :ios do
@@ -54,7 +53,7 @@ platform :ios do
 
     match(**match_options_for(staging_bundle_identifier))
 
-    cert_name = installed_cert_common_name(staging_development_team)
+    cert_name = match_cert_name(staging_bundle_identifier)
     export_signing_cert = cert_name || staging_signing_identity
     UI.message("Using signing certificate for export: #{export_signing_cert}")
 
@@ -95,7 +94,7 @@ platform :ios do
 
     match(**match_options_for(production_bundle_identifier))
 
-    cert_name = installed_cert_common_name(production_development_team)
+    cert_name = match_cert_name(production_bundle_identifier)
     export_signing_cert = cert_name || production_signing_identity
     UI.message("Using signing certificate for export: #{export_signing_cert}")
 


### PR DESCRIPTION
## Summary
- Gym passes `xcargs` to both archive AND export `xcodebuild` commands
- The short name `Apple Distribution` in `CODE_SIGN_IDENTITY` xcarg was overriding the full name in the export options plist
- This caused xcodebuild to match a system cert (without private key) instead of the one match installed in the temp keychain → "Missing private key for signing certificate"
- Now `CODE_SIGN_IDENTITY` in xcargs uses the full common name from match's env var (`Apple Distribution: Tyler Pavay (QWGVB7TN4T)`) — consistent with what's in the export options plist

## Test plan
- [ ] Merge and verify staging deploy pipeline passes the export step
- [ ] Confirm no more "Missing private key" or "iOS Distribution" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)