### PR TITLE
Replace xcargs with update_code_signing_settings

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -57,18 +57,22 @@ platform :ios do
     export_signing_cert = cert_name || staging_signing_identity
     UI.message("Using signing certificate for export: #{export_signing_cert}")
 
+    update_code_signing_settings(
+      path: "AscendApp.xcodeproj",
+      use_automatic_signing: false,
+      code_sign_identity: export_signing_cert,
+      team_id: staging_development_team,
+      profile_name: staging_profile_specifier,
+      bundle_identifier: staging_bundle_identifier,
+      targets: ["AscendApp"]
+    )
+
     build_app(
       project: "AscendApp.xcodeproj",
       scheme: "AscendApp-Staging",
       configuration: "Staging",
       clean: true,
       skip_profile_detection: true,
-      xcargs: [
-        "CODE_SIGN_STYLE=Manual",
-        "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
-        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
-      ].join(" "),
       export_xcargs: "-allowProvisioningUpdates",
       export_options: {
         signingStyle: "manual",
@@ -98,18 +102,22 @@ platform :ios do
     export_signing_cert = cert_name || production_signing_identity
     UI.message("Using signing certificate for export: #{export_signing_cert}")
 
+    update_code_signing_settings(
+      path: "AscendApp.xcodeproj",
+      use_automatic_signing: false,
+      code_sign_identity: export_signing_cert,
+      team_id: production_development_team,
+      profile_name: production_profile_specifier,
+      bundle_identifier: production_bundle_identifier,
+      targets: ["AscendApp"]
+    )
+
     build_app(
       project: "AscendApp.xcodeproj",
       scheme: "AscendApp",
       configuration: "Release",
       clean: true,
       skip_profile_detection: true,
-      xcargs: [
-        "CODE_SIGN_STYLE=Manual",
-        "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}",
-        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
-      ].join(" "),
       export_xcargs: "-allowProvisioningUpdates",
       export_options: {
         signingStyle: "manual",


### PR DESCRIPTION
## Summary
- Root cause: gym passes `xcargs` to both archive AND export `xcodebuild` commands — build settings like `CODE_SIGNING_ALLOWED` and `CODE_SIGN_IDENTITY` interfere with the export step
- Fix: use `update_code_signing_settings` to write signing config directly into the Xcode project file (targeting only the AscendApp target), then `build_app` without any xcargs
- Archive reads signing from project settings (SPM packages are untouched, won't try to sign)
- Export reads from the `export_options` plist only (no conflicting build settings)

## Test plan
- [ ] Merge and verify staging deploy pipeline passes both archive AND export steps
- [ ] Confirm no more "Missing private key" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)