### PR TITLE
Fix export: pass command as string to avoid escaping

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,15 +125,13 @@ platform :ios do
     output_dir = File.expand_path("build")
     FileUtils.mkdir_p(output_dir)
 
-    export_cmd = [
-      "xcodebuild", "-exportArchive",
-      "-archivePath", archive_path,
-      "-exportOptionsPlist", export_plist,
-      "-exportPath", output_dir,
-      "-allowProvisioningUpdates"
-    ]
-    export_cmd << "OTHER_CODE_SIGN_FLAGS=--keychain #{keychain_path}" if keychain_path
-    sh(*export_cmd)
+    export_cmd = "xcodebuild -exportArchive" \
+      " -archivePath #{archive_path.shellescape}" \
+      " -exportOptionsPlist #{export_plist.shellescape}" \
+      " -exportPath #{output_dir.shellescape}" \
+      " -allowProvisioningUpdates"
+    export_cmd += " OTHER_CODE_SIGN_FLAGS='--keychain #{keychain_path}'" if keychain_path
+    sh(export_cmd)
 
     # Rename exported IPA to expected name
     exported_ipa = Dir.glob(File.join(output_dir, "*.ipa")).first
@@ -188,15 +186,13 @@ platform :ios do
     output_dir = File.expand_path("build")
     FileUtils.mkdir_p(output_dir)
 
-    export_cmd = [
-      "xcodebuild", "-exportArchive",
-      "-archivePath", archive_path,
-      "-exportOptionsPlist", export_plist,
-      "-exportPath", output_dir,
-      "-allowProvisioningUpdates"
-    ]
-    export_cmd << "OTHER_CODE_SIGN_FLAGS=--keychain #{keychain_path}" if keychain_path
-    sh(*export_cmd)
+    export_cmd = "xcodebuild -exportArchive" \
+      " -archivePath #{archive_path.shellescape}" \
+      " -exportOptionsPlist #{export_plist.shellescape}" \
+      " -exportPath #{output_dir.shellescape}" \
+      " -allowProvisioningUpdates"
+    export_cmd += " OTHER_CODE_SIGN_FLAGS='--keychain #{keychain_path}'" if keychain_path
+    sh(export_cmd)
 
     # Rename exported IPA to expected name
     exported_ipa = Dir.glob(File.join(output_dir, "*.ipa")).first


### PR DESCRIPTION
## Summary
- Previous PR passed the export command as an array to `sh()`, which caused Fastlane to shell-escape each element
- `OTHER_CODE_SIGN_FLAGS=--keychain /path` became `OTHER_CODE_SIGN_FLAGS\=--keychain\ /path` — xcodebuild couldn't parse it
- Fix: build the command as a single string so the shell handles `=` and spaces correctly

## Test plan
- [ ] Verify `OTHER_CODE_SIGN_FLAGS` appears unescaped in the xcodebuild command
- [ ] Verify export passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)