### PR TITLE
Update provisioning profile names after match regeneration

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -134,7 +134,7 @@ jobs:
           MATCH_GIT_BRANCH: main
           MATCH_READONLY: "true"
           IOS_SIGNING_IDENTITY: Apple Distribution
-          IOS_PROVISIONING_PROFILE_SPECIFIER: AscendApp - Production - AppStore
+          IOS_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
           IOS_PRODUCTION_BUNDLE_ID: com.TylerPavay.AscendApp
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -119,7 +119,7 @@ jobs:
           MATCH_GIT_BRANCH: main
           MATCH_READONLY: "true"
           IOS_SIGNING_IDENTITY: Apple Distribution
-          IOS_PROVISIONING_PROFILE_SPECIFIER: AscendApp - Staging - AppStore
+          IOS_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.staging
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
           IOS_STAGING_BUNDLE_ID: com.TylerPavay.AscendApp.staging
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -80,7 +80,7 @@ platform :ios do
     setup_ci if ENV["CI"]
 
     staging_signing_identity = ENV.fetch("IOS_SIGNING_IDENTITY", "Apple Distribution")
-    staging_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Staging - AppStore")
+    staging_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp.staging")
     staging_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
     staging_bundle_identifier = ENV.fetch("IOS_STAGING_BUNDLE_ID", "com.TylerPavay.AscendApp.staging")
 
@@ -141,7 +141,7 @@ platform :ios do
     setup_ci if ENV["CI"]
 
     production_signing_identity = ENV.fetch("IOS_SIGNING_IDENTITY", "Apple Distribution")
-    production_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "AscendApp - Production - AppStore")
+    production_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp")
     production_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
     production_bundle_identifier = ENV.fetch("IOS_PRODUCTION_BUNDLE_ID", "com.TylerPavay.AscendApp")
 


### PR DESCRIPTION
## Summary
- After nuking and regenerating match certificates with proper private keys, the new provisioning profiles use match's default naming: `match AppStore <bundle_id>` instead of the old custom names
- Updated Fastfile defaults and workflow env vars to match

## Context
The root cause of the "Missing private key" export error was that the p12 in the match repo didn't have a valid private key. Certificates were nuked and regenerated locally via `match nuke distribution` + `match appstore`.

## Test plan
- [ ] Staging deploy: match imports cert, `set-key-partition-list` succeeds, archive + export both pass
- [ ] IPA artifact produced and uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)