### PR TITLE
Fix IPA artifact upload path

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -144,7 +144,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: AscendApp-Production-IPA
-          path: build/AscendApp-Production.ipa
+          path: fastlane/build/AscendApp-Production.ipa
           retention-days: 14
 
   deploy-firebase:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: AscendApp-Staging-IPA
-          path: build/AscendApp-Staging.ipa
+          path: fastlane/build/AscendApp-Staging.ipa
           retention-days: 14
 
   deploy-firebase:


### PR DESCRIPTION
## Summary
- IPA exports to `fastlane/build/` (Fastlane CWD is `fastlane/`), but the upload-artifact step was looking at `build/`
- Updated both staging and production workflows

## Test plan
- [ ] IPA artifact uploads successfully after build
- [ ] TestFlight upload job can download the artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)