### PR TITLE
Auto-increment build number on CI

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -138,6 +138,7 @@ jobs:
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
           IOS_PRODUCTION_BUNDLE_ID: com.TylerPavay.AscendApp
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
+          BUILD_NUMBER: ${{ github.run_number }}
         run: bundle exec fastlane build_production
 
       - name: Upload production IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -123,6 +123,7 @@ jobs:
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
           IOS_STAGING_BUNDLE_ID: com.TylerPavay.AscendApp.staging
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
+          BUILD_NUMBER: ${{ github.run_number }}
         run: bundle exec fastlane build_staging
 
       - name: Upload staging IPA artifact

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -84,6 +84,15 @@ platform :ios do
     staging_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
     staging_bundle_identifier = ENV.fetch("IOS_STAGING_BUNDLE_ID", "com.TylerPavay.AscendApp.staging")
 
+    # Auto-increment build number on CI using the workflow run number
+    build_number = ENV["BUILD_NUMBER"]
+    if build_number
+      increment_build_number(
+        build_number: build_number,
+        xcodeproj: "AscendApp.xcodeproj"
+      )
+    end
+
     match(**match_options_for(staging_bundle_identifier))
 
     cert_name = match_cert_name(staging_bundle_identifier)
@@ -144,6 +153,15 @@ platform :ios do
     production_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp")
     production_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
     production_bundle_identifier = ENV.fetch("IOS_PRODUCTION_BUNDLE_ID", "com.TylerPavay.AscendApp")
+
+    # Auto-increment build number on CI using the workflow run number
+    build_number = ENV["BUILD_NUMBER"]
+    if build_number
+      increment_build_number(
+        build_number: build_number,
+        xcodeproj: "AscendApp.xcodeproj"
+      )
+    end
 
     match(**match_options_for(production_bundle_identifier))
 


### PR DESCRIPTION
## Summary
- Use `github.run_number` as the build number for CI builds
- Fastlane's `increment_build_number` sets `CURRENT_PROJECT_VERSION` before archiving
- Only applies when `BUILD_NUMBER` env var is set, so local builds are unaffected
- Fixes: "The bundle version must be higher than the previously uploaded version: '2'"

## Test plan
- [ ] Merge and verify the staging pipeline uploads to TestFlight successfully
- [ ] Verify local Xcode builds still use the project's default build number

🤖 Generated with [Claude Code](https://claude.com/claude-code)