### PR TITLE
Fix leaderboard empty-state sync and filter legacy zero rows

### DIFF
--- a/AscendApp/Features/Leaderboards/Repositories/LeaderboardRepository.swift
+++ b/AscendApp/Features/Leaderboards/Repositories/LeaderboardRepository.swift
@@ -53,7 +53,8 @@ final class LeaderboardRepository: Sendable {
         metric: LeaderboardMetric,
         timeFrame: LeaderboardTimeFrame,
         limit: Int = 100,
-        preferredWorkoutMetric: WorkoutMetric = .steps
+        preferredWorkoutMetric: WorkoutMetric = .steps,
+        source: FirestoreSource = .default
     ) async throws -> [FirestoreLeaderboardStats] {
         let (firstWeekday, timeZone): (Int, TimeZone) = await MainActor.run {
             (SettingsManager.shared.weekStartFirstWeekday, TimeZone.current)
@@ -67,7 +68,8 @@ final class LeaderboardRepository: Sendable {
             timeFrame: timeFrame,
             periodIdentifier: periodIdentifier,
             limit: limit,
-            preferredWorkoutMetric: preferredWorkoutMetric
+            preferredWorkoutMetric: preferredWorkoutMetric,
+            source: source
         )
     }
 
@@ -77,51 +79,60 @@ final class LeaderboardRepository: Sendable {
         timeFrame: LeaderboardTimeFrame,
         periodIdentifier: String,
         limit: Int = 100,
-        preferredWorkoutMetric: WorkoutMetric = .steps
+        preferredWorkoutMetric: WorkoutMetric = .steps,
+        source: FirestoreSource = .default
     ) async throws -> [FirestoreLeaderboardStats] {
         // Query Firestore for the specific time frame and period
         let query = db.collection("leaderboard_stats")
             .whereField("timeFrame", isEqualTo: timeFrame.rawValue)
             .whereField("periodIdentifier", isEqualTo: periodIdentifier)
-            .limit(to: limit)
 
-        let snapshot = try await query.getDocuments()
+        let snapshot = try await query.getDocuments(source: source)
 
         var stats: [FirestoreLeaderboardStats] = []
 
         for document in snapshot.documents {
             let data = document.data()
 
-            guard let userId = data["userId"] as? String,
-                  let displayName = data["displayName"] as? String,
-                  let timeFrame = data["timeFrame"] as? String,
-                  let periodIdentifier = data["periodIdentifier"] as? String,
-                  let totalSteps = data["totalSteps"] as? Int,
-                  let totalWorkouts = data["totalWorkouts"] as? Int,
-                  let totalDuration = data["totalDuration"] as? Double,
-                  let averageStepsPerMinute = data["averageStepsPerMinute"] as? Double,
-                  let timestamp = data["lastUpdated"] as? Timestamp else {
+            guard let userId = stringValue(for: "userId", in: data),
+                  let displayName = stringValue(for: "displayName", in: data),
+                  let timeFrameValue = stringValue(for: "timeFrame", in: data),
+                  let periodIdentifierValue = stringValue(for: "periodIdentifier", in: data) else {
                 continue
             }
 
             let photoURLString = data["photoURL"] as? String
-            // Handle missing floors data gracefully (for backwards compatibility)
-            let totalFloors = data["totalFloors"] as? Int ?? 0
-            let averageFloorsPerMinute = data["averageFloorsPerMinute"] as? Double ?? 0
+            // Handle older or partially populated documents gracefully.
+            let totalSteps = intValue(for: "totalSteps", in: data) ?? 0
+            let totalWorkouts = intValue(for: "totalWorkouts", in: data) ?? 0
+            let totalDuration = doubleValue(for: "totalDuration", in: data) ?? 0
+            let averageStepsPerMinute = doubleValue(for: "averageStepsPerMinute", in: data) ?? 0
+            let totalFloors = intValue(for: "totalFloors", in: data) ?? 0
+            let averageFloorsPerMinute = doubleValue(for: "averageFloorsPerMinute", in: data) ?? 0
+            let lastUpdated = timestampValue(for: "lastUpdated", in: data) ?? .distantPast
+            let hasActivity = totalWorkouts > 0 ||
+                totalSteps > 0 ||
+                totalFloors > 0 ||
+                totalDuration > 0 ||
+                averageStepsPerMinute > 0 ||
+                averageFloorsPerMinute > 0
+
+            // Filter legacy seeded documents that contain only zeros.
+            guard hasActivity else { continue }
 
             let stat = FirestoreLeaderboardStats(
                 userId: userId,
                 displayName: displayName,
                 photoURL: photoURLString,
-                timeFrame: timeFrame,
-                periodIdentifier: periodIdentifier,
+                timeFrame: timeFrameValue,
+                periodIdentifier: periodIdentifierValue,
                 totalSteps: totalSteps,
                 totalFloors: totalFloors,
                 totalWorkouts: totalWorkouts,
                 totalDuration: totalDuration,
                 averageStepsPerMinute: averageStepsPerMinute,
                 averageFloorsPerMinute: averageFloorsPerMinute,
-                lastUpdated: timestamp.dateValue()
+                lastUpdated: lastUpdated
             )
 
             stats.append(stat)
@@ -135,7 +146,9 @@ final class LeaderboardRepository: Sendable {
             return $0.userId < $1.userId
         }
 
-        return stats
+        let effectiveLimit = max(limit, 0)
+        guard effectiveLimit > 0 else { return [] }
+        return Array(stats.prefix(effectiveLimit))
     }
 
     // Get user's rank for a specific metric and time frame
@@ -191,5 +204,35 @@ final class LeaderboardRepository: Sendable {
                 "lastUpdated": FieldValue.serverTimestamp()
             ])
         }
+    }
+
+    private func stringValue(for key: String, in data: [String: Any]) -> String? {
+        data[key] as? String
+    }
+
+    private func intValue(for key: String, in data: [String: Any]) -> Int? {
+        if let value = data[key] as? Int { return value }
+        if let value = data[key] as? Int64 { return Int(value) }
+        if let value = data[key] as? Double { return Int(value) }
+        if let value = data[key] as? NSNumber { return value.intValue }
+        return nil
+    }
+
+    private func doubleValue(for key: String, in data: [String: Any]) -> Double? {
+        if let value = data[key] as? Double { return value }
+        if let value = data[key] as? Int { return Double(value) }
+        if let value = data[key] as? Int64 { return Double(value) }
+        if let value = data[key] as? NSNumber { return value.doubleValue }
+        return nil
+    }
+
+    private func timestampValue(for key: String, in data: [String: Any]) -> Date? {
+        if let timestamp = data[key] as? Timestamp {
+            return timestamp.dateValue()
+        }
+        if let date = data[key] as? Date {
+            return date
+        }
+        return nil
     }
 }

--- a/AscendApp/Features/Leaderboards/Services/LeaderboardService.swift
+++ b/AscendApp/Features/Leaderboards/Services/LeaderboardService.swift
@@ -138,8 +138,18 @@ final class LeaderboardService {
             averageStepsPerMinute: Double,
             averageFloorsPerMinute: Double,
             lastUpdated: Date
-        )] = statsToSync.map { stats in
-            (
+        )] = statsToSync.compactMap { stats in
+            // Don't create empty remote leaderboard rows for users with no activity.
+            let hasActivity = stats.totalWorkouts > 0 ||
+                stats.totalSteps > 0 ||
+                stats.totalFloors > 0 ||
+                stats.totalDuration > 0 ||
+                stats.averageStepsPerMinute > 0 ||
+                stats.averageFloorsPerMinute > 0
+
+            guard hasActivity else { return nil }
+
+            return (
                 userId: stats.userId,
                 displayName: displayName,
                 photoURL: photoURL,

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardHubView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardHubView.swift
@@ -4,16 +4,28 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct LeaderboardHubView: View {
+    private enum LoadMode {
+        case fast
+        case refresh
+    }
+
+    @Environment(\.scenePhase) private var scenePhase
+    @Environment(TabRouter.self) private var tabRouter
     @Environment(AuthenticationViewModel.self) private var authVM
+    @Environment(\.modelContext) private var modelContext
+    @Query private var workouts: [Workout]
     @State private var settingsManager = SettingsManager.shared
 
     @State private var previewEntries: [LeaderboardMetric: [LeaderboardEntry]] = [:]
     @State private var isLoading = false
     @State private var errorMessage: String?
+    @State private var activeLoadID = UUID()
 
     private let repository = LeaderboardRepository.shared
+    private let leaderboardService = LeaderboardService.shared
     private let previewLimit = 3
 
     private var preferredMetric: WorkoutMetric {
@@ -22,74 +34,165 @@ struct LeaderboardHubView: View {
 
     var body: some View {
         ScrollView {
-            VStack(spacing: 14) {
-                ForEach(LeaderboardMetric.allCases) { metric in
-                    LeaderboardCategoryCard(
-                        metric: metric,
-                        entries: previewEntries[metric] ?? [],
-                        preferredMetric: preferredMetric,
-                        isLoading: isLoading,
-                        errorMessage: errorMessage
-                    )
+            VStack(spacing: 8) {
+                hubHeader
+
+                if hasAnyEntries {
+                    ForEach(LeaderboardMetric.allCases) { metric in
+                        LeaderboardCategoryCard(
+                            metric: metric,
+                            entries: previewEntries[metric] ?? [],
+                            preferredMetric: preferredMetric
+                        )
+                    }
+                } else if isLoading {
+                    loadingState
+                } else if let errorMessage {
+                    globalErrorState(message: errorMessage)
+                } else {
+                    globalEmptyState
                 }
             }
             .padding(.horizontal, 20)
-            .padding(.vertical, 16)
+            .padding(.vertical, 12)
         }
         .themedBackground()
-        .navigationTitle("Leaderboard")
-        .navigationBarTitleDisplayMode(.large)
-        .task {
-            await loadPreviews()
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            Task { await loadPreviews(mode: .fast) }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active, tabRouter.selectedTab == .leaderboard else { return }
+            Task { await loadPreviews(mode: .fast) }
         }
         .refreshable {
-            await loadPreviews()
+            await loadPreviews(mode: .refresh)
         }
     }
 
-    private func loadPreviews() async {
-        guard let userId = authVM.user?.uid else { return }
+    private var hasAnyEntries: Bool {
+        previewEntries.values.contains { !$0.isEmpty }
+    }
 
+    private func loadPreviews(mode: LoadMode) async {
+        let loadID = UUID()
+        activeLoadID = loadID
         isLoading = true
         errorMessage = nil
 
-        var fetchedEntries: [LeaderboardMetric: [LeaderboardEntry]] = [:]
-        var failedMetrics = 0
-
-        for metric in LeaderboardMetric.allCases {
-            do {
-                let stats = try await repository.fetchLeaderboard(
-                    metric: metric,
-                    timeFrame: .weekly,
-                    limit: previewLimit,
-                    preferredWorkoutMetric: preferredMetric
-                )
-
-                let entries = stats.enumerated().map { index, stat in
-                    let value = stat.value(for: metric, preferredWorkoutMetric: preferredMetric)
-                    return LeaderboardEntry(
-                        userId: stat.userId,
-                        displayName: stat.displayName,
-                        photoURL: stat.photoURL.flatMap { URL(string: $0) },
-                        rank: index + 1,
-                        value: value,
-                        formattedValue: formatValue(value, for: metric),
-                        isCurrentUser: stat.userId == userId
-                    )
-                }
-
-                fetchedEntries[metric] = entries
-            } catch {
-                failedMetrics += 1
-                fetchedEntries[metric] = []
+        defer {
+            if activeLoadID == loadID {
+                isLoading = false
             }
         }
 
+        guard let userId = authVM.user?.uid else {
+            if activeLoadID == loadID {
+                previewEntries = [:]
+                errorMessage = "Sign in to view leaderboard data."
+            }
+            return
+        }
+
+        if mode == .refresh {
+            do {
+                leaderboardService.configure(modelContext: modelContext)
+                try leaderboardService.updateAllTimeFrames(for: userId, workouts: workouts)
+                try await leaderboardService.syncToFirestore(
+                    userId: userId,
+                    displayName: authVM.displayName,
+                    photoURL: authVM.displayPhotoURL
+                )
+            } catch {
+                // Continue to fetch remote standings even if local sync fails.
+            }
+        }
+
+        var fetchedEntries: [LeaderboardMetric: [LeaderboardEntry]] = [:]
+        var failedMetrics = 0
+        let repository = self.repository
+        let previewLimit = self.previewLimit
+        let preferredMetric = self.preferredMetric
+        let metricResults = await withTaskGroup(
+            of: (LeaderboardMetric, [FirestoreLeaderboardStats]?, Bool).self,
+            returning: [(LeaderboardMetric, [FirestoreLeaderboardStats]?, Bool)].self
+        ) { group in
+            for metric in LeaderboardMetric.allCases {
+                group.addTask {
+                    do {
+                        let stats = try await repository.fetchLeaderboard(
+                            metric: metric,
+                            timeFrame: .weekly,
+                            limit: previewLimit,
+                            preferredWorkoutMetric: preferredMetric,
+                            source: mode == .fast ? .default : .server
+                        )
+                        return (metric, stats, false)
+                    } catch {
+                        if mode == .refresh {
+                            do {
+                                let cachedStats = try await repository.fetchLeaderboard(
+                                    metric: metric,
+                                    timeFrame: .weekly,
+                                    limit: previewLimit,
+                                    preferredWorkoutMetric: preferredMetric,
+                                    source: .cache
+                                )
+                                return (metric, cachedStats, false)
+                            } catch {
+                                // Fall through to failed metric accounting.
+                            }
+                        }
+
+                        return (metric, nil, true)
+                    }
+                }
+            }
+
+            var results: [(LeaderboardMetric, [FirestoreLeaderboardStats]?, Bool)] = []
+            for await result in group {
+                results.append(result)
+            }
+            return results
+        }
+
+        for (metric, stats, didFail) in metricResults {
+            if let stats {
+                fetchedEntries[metric] = makePreviewEntries(from: stats, metric: metric, userId: userId)
+            } else {
+                fetchedEntries[metric] = []
+            }
+
+            if didFail {
+                failedMetrics += 1
+            }
+        }
+
+        guard activeLoadID == loadID else { return }
         previewEntries = fetchedEntries
         if failedMetrics == LeaderboardMetric.allCases.count {
             errorMessage = "Couldn’t load leaderboard previews right now."
         }
-        isLoading = false
+    }
+
+    private func makePreviewEntries(
+        from stats: [FirestoreLeaderboardStats],
+        metric: LeaderboardMetric,
+        userId: String
+    ) -> [LeaderboardEntry] {
+        stats.enumerated().map { index, stat in
+            let value = stat.value(for: metric, preferredWorkoutMetric: preferredMetric)
+            return LeaderboardEntry(
+                userId: stat.userId,
+                displayName: stat.displayName,
+                photoURL: stat.photoURL.flatMap { URL(string: $0) },
+                rank: index + 1,
+                value: value,
+                formattedValue: formatValue(value, for: metric),
+                isCurrentUser: stat.userId == userId
+            )
+        }
     }
 
     private func formatValue(_ value: Double, for metric: LeaderboardMetric) -> String {
@@ -108,6 +211,66 @@ struct LeaderboardHubView: View {
             return value.formatted(.number.precision(.fractionLength(1)))
         }
     }
+
+    private var hubHeader: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Leaderboards")
+                .font(.montserratBold(size: 34))
+                .foregroundStyle(.primary)
+
+            Text("Weekly")
+                .font(.montserratMedium(size: 16))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.bottom, 4)
+    }
+
+    private var globalEmptyState: some View {
+        VStack(spacing: 10) {
+            Image(systemName: "person.3.fill")
+                .font(.system(size: 34))
+                .foregroundStyle(.secondary)
+
+            Text("No leaderboard data yet")
+                .font(.montserratSemiBold(size: 20))
+                .foregroundStyle(.primary)
+
+            Text("Complete a workout and pull to refresh to populate weekly standings.")
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 12)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 48)
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: 0) {
+            Text("Loading leaderboard…")
+                .font(.montserratSemiBold(size: 18))
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 48)
+    }
+
+    private func globalErrorState(message: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: "wifi.exclamationmark")
+                .font(.system(size: 30))
+                .foregroundStyle(.secondary)
+
+            Text(message)
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 12)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 48)
+    }
 }
 
 private struct LeaderboardCategoryCard: View {
@@ -116,39 +279,17 @@ private struct LeaderboardCategoryCard: View {
     let metric: LeaderboardMetric
     let entries: [LeaderboardEntry]
     let preferredMetric: WorkoutMetric
-    let isLoading: Bool
-    let errorMessage: String?
 
     private var title: String {
         metric.displayName(for: preferredMetric)
     }
 
-    private var subtitle: String {
-        "Weekly standings"
-    }
-
-    private var emptyStateText: String {
-        if let errorMessage {
-            return errorMessage
-        }
-        if isLoading {
-            return "Loading..."
-        }
-        return "No data yet"
-    }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(title)
-                        .font(.montserratSemiBold(size: 18))
-                        .foregroundStyle(colorScheme == .dark ? .white : .black)
-
-                    Text(subtitle)
-                        .font(.montserratRegular(size: 12))
-                        .foregroundStyle(.secondary)
-                }
+            HStack(alignment: .center) {
+                Text(title)
+                    .font(.montserratSemiBold(size: 18))
+                    .foregroundStyle(colorScheme == .dark ? .white : .black)
 
                 Spacer()
 
@@ -156,17 +297,12 @@ private struct LeaderboardCategoryCard: View {
                     LeaderboardView(lockedMetric: metric)
                 } label: {
                     Text("See all")
-                        .font(.montserratMedium(size: 13))
-                        .foregroundStyle(.accent)
+                        .font(.montserratSemiBold(size: 16))
+                        .foregroundStyle(colorScheme == .dark ? .white.opacity(0.6) : .gray)
                 }
             }
 
-            if entries.isEmpty {
-                Text(emptyStateText)
-                    .font(.montserratRegular(size: 13))
-                    .foregroundStyle(.secondary)
-                    .padding(.vertical, 18)
-            } else {
+            if !entries.isEmpty {
                 VStack(spacing: 10) {
                     ForEach(entries) { entry in
                         LeaderboardCategoryRow(
@@ -178,8 +314,8 @@ private struct LeaderboardCategoryCard: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity, minHeight: 300, alignment: .topLeading)
-        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(.vertical, 4)
     }
 }
 
@@ -194,18 +330,68 @@ private struct LeaderboardCategoryRow: View {
         metric.unit(for: preferredMetric)
     }
 
+    private var medalRingGradient: AngularGradient? {
+        switch entry.rank {
+        case 1:
+            return AngularGradient(
+                colors: [
+                    Color(red: 1.0, green: 0.94, blue: 0.62),
+                    Color(red: 0.95, green: 0.76, blue: 0.24),
+                    Color(red: 0.68, green: 0.50, blue: 0.09),
+                    Color(red: 1.0, green: 0.94, blue: 0.62)
+                ],
+                center: .center
+            )
+        case 2:
+            return AngularGradient(
+                colors: [
+                    Color(red: 0.98, green: 0.99, blue: 1.0),
+                    Color(red: 0.74, green: 0.78, blue: 0.86),
+                    Color(red: 0.55, green: 0.60, blue: 0.68),
+                    Color(red: 0.98, green: 0.99, blue: 1.0)
+                ],
+                center: .center
+            )
+        case 3:
+            return AngularGradient(
+                colors: [
+                    Color(red: 0.93, green: 0.71, blue: 0.48),
+                    Color(red: 0.72, green: 0.45, blue: 0.24),
+                    Color(red: 0.49, green: 0.30, blue: 0.16),
+                    Color(red: 0.93, green: 0.71, blue: 0.48)
+                ],
+                center: .center
+            )
+        default:
+            return nil
+        }
+    }
+
+    private var medalRingGlow: Color {
+        switch entry.rank {
+        case 1:
+            return Color(red: 0.96, green: 0.78, blue: 0.25)
+        case 2:
+            return Color(red: 0.79, green: 0.83, blue: 0.92)
+        case 3:
+            return Color(red: 0.79, green: 0.50, blue: 0.28)
+        default:
+            return .clear
+        }
+    }
+
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 12) {
             Text("\(entry.rank)")
-                .font(.montserratBold(size: 13))
+                .font(.montserratBold(size: 16))
                 .foregroundStyle(colorScheme == .dark ? .white.opacity(0.8) : .black.opacity(0.7))
-                .frame(width: 14, alignment: .leading)
+                .frame(width: 18, alignment: .leading)
 
             avatar
-                .frame(width: 40, height: 40)
+                .frame(width: 46, height: 46)
 
             Text(entry.displayName)
-                .font(.montserratMedium(size: 14))
+                .font(.montserratSemiBold(size: 16))
                 .foregroundStyle(entry.isCurrentUser ? .accent : (colorScheme == .dark ? .white : .black))
                 .lineLimit(1)
 
@@ -213,26 +399,28 @@ private struct LeaderboardCategoryRow: View {
 
             VStack(alignment: .trailing, spacing: 1) {
                 Text(entry.formattedValue)
-                    .font(.montserratSemiBold(size: 14))
+                    .font(.montserratBold(size: 17))
                     .foregroundStyle(entry.isCurrentUser ? .accent : (colorScheme == .dark ? .white : .black))
 
                 if !unitLabel.isEmpty {
                     Text(unitLabel)
-                        .font(.montserratRegular(size: 10))
+                        .font(.montserratRegular(size: 11))
                         .foregroundStyle(.secondary)
                 }
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 12)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 14)
         .background(
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: 14)
                 .fill(colorScheme == .dark ? Color.white.opacity(0.05) : Color.gray.opacity(0.06))
         )
     }
 
     @ViewBuilder
     private var avatar: some View {
+        let ringGradient = medalRingGradient
+
         if let photoURL = entry.photoURL {
             AsyncImage(url: photoURL) { phase in
                 switch phase {
@@ -245,9 +433,59 @@ private struct LeaderboardCategoryRow: View {
                     placeholderAvatar
                 }
             }
+            .ifLet(ringGradient) { view, gradient in
+                view
+                    .overlay(
+                        Circle()
+                            .stroke(gradient, lineWidth: 3)
+                    )
+                    .overlay {
+                        Circle()
+                            .stroke(
+                                AngularGradient(
+                                    colors: [
+                                        .white.opacity(0.5),
+                                        .clear,
+                                        .white.opacity(0.28),
+                                        .clear,
+                                        .white.opacity(0.5)
+                                    ],
+                                    center: .center
+                                ),
+                                lineWidth: 1.2
+                            )
+                            .padding(1.5)
+                    }
+                    .shadow(color: medalRingGlow.opacity(colorScheme == .dark ? 0.54 : 0.3), radius: 8, x: 0, y: 2)
+            }
             .id(photoURL)
         } else {
             placeholderAvatar
+                .ifLet(ringGradient) { view, gradient in
+                    view
+                        .overlay(
+                            Circle()
+                                .stroke(gradient, lineWidth: 3)
+                        )
+                        .overlay {
+                            Circle()
+                                .stroke(
+                                    AngularGradient(
+                                        colors: [
+                                            .white.opacity(0.5),
+                                            .clear,
+                                            .white.opacity(0.28),
+                                            .clear,
+                                            .white.opacity(0.5)
+                                        ],
+                                        center: .center
+                                    ),
+                                    lineWidth: 1.2
+                                )
+                                .padding(1.5)
+                        }
+                        .shadow(color: medalRingGlow.opacity(colorScheme == .dark ? 0.54 : 0.3), radius: 8, x: 0, y: 2)
+                }
         }
     }
 
@@ -262,9 +500,21 @@ private struct LeaderboardCategoryRow: View {
     }
 }
 
+private extension View {
+    @ViewBuilder
+    func ifLet<T, Content: View>(_ value: T?, transform: (Self, T) -> Content) -> some View {
+        if let value {
+            transform(self, value)
+        } else {
+            self
+        }
+    }
+}
+
 #Preview {
     NavigationStack {
         LeaderboardHubView()
             .environment(AuthenticationViewModel())
+            .environment(TabRouter())
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes the leaderboard empty-state issue where users with no workouts could still see leaderboard rows with `0` stats.

## Problem

In dev, `leaderboard_stats` documents were being created/synced even when a user had no workout activity.  
Those zero-value docs were then fetched and rendered, which made leaderboards look populated even though there was no real data.

## What changed

### 1) Prevent syncing empty leaderboard rows
- Updated `LeaderboardService.syncToFirestore(...)` to skip stats with no activity.
- A row is now synced only if at least one of these is > 0:
  - `totalWorkouts`
  - `totalSteps`
  - `totalFloors`
  - `totalDuration`
  - `averageStepsPerMinute`
  - `averageFloorsPerMinute`

### 2) Filter legacy zero rows on fetch
- Updated `LeaderboardRepository.fetchLeaderboard(...)` to ignore legacy all-zero docs during read.
- This prevents existing zero docs from appearing in leaderboard UI.

### 3) Leaderboard hub loading + state handling improvements
- `LeaderboardHubView` now supports:
  - fast/default-source loading on appear/active
  - server-backed refresh on pull-to-refresh (with cache fallback)
  - clearer global empty/loading/error states
- Added load de-duping/guarding to avoid stale async state updates.

### 4) Firestore parsing resilience
- Added typed helper parsing in repository for `String`, numeric, and timestamp fields to handle older/partial docs more safely.

## Validation

- Build passed:
  - `xcodebuild -project AscendApp.xcodeproj -scheme AscendApp -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- Existing legacy zero docs can be manually deleted (small volume), but they are now filtered client-side and no longer displayed.
