### PR TITLE
Harden Firebase security rules and migrate to user-scoped storage paths

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,6 +1,8 @@
 name: Deploy Staging
 
 on:
+  push:
+    branches: [develop]
   workflow_dispatch:
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,23 @@ let functionsURL = "https://\(region)-\(projectId).cloudfunctions.net"
 ### Data Models (SwiftData)
 Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightPersonalRecord, AggregateWeightRecord, PendingMediaUpload
 
+### Firebase Storage Pathing + Rules
+- User-generated media must be stored under user-scoped prefixes:
+  - `users/{uid}/photos/...`
+  - `users/{uid}/videos/...`
+  - `users/{uid}/profile_pictures/...`
+- Never write user media to shared root paths (`photos/`, `videos/`, `profile_pictures/`) in production.
+- Share card template assets live under `share-card-templates/...` and are read-only from client apps.
+- Account deletion and cleanup should target only the authenticated user's scoped prefix.
+
+### Firestore Schema-Change Rule
+- `firestore.rules` uses strict `hasOnly` + `hasAll` field validation on every collection. Adding, removing, or renaming a field in the app **requires a matching update to `firestore.rules`** — otherwise writes will be rejected at the server.
+- The same `firestore.rules` file must be deployed to all environments (dev, staging, production) to catch schema mismatches early. Never test against loose rules in dev while production has strict ones.
+- When changing Firestore document schemas, always update in this order:
+  1. Update `firestore.rules` to allow the new/changed fields
+  2. Update Swift model + write logic
+  3. Deploy rules to all environments before or alongside the app update
+
 ### Import UX
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.
 

--- a/AscendApp/Features/Account/Services/AccountDeletionService.swift
+++ b/AscendApp/Features/Account/Services/AccountDeletionService.swift
@@ -238,12 +238,15 @@ final class AccountDeletionService {
 
     /// Deletes the user's profile picture from Firebase Storage
     private nonisolated func deleteProfilePicture(userId: String) async throws {
-        let profilePicRef = Storage.storage().reference().child("profile_pictures")
+        let profilePicRef = Storage.storage().reference()
+            .child("users")
+            .child(userId)
+            .child("profile_pictures")
 
         do {
             let result = try await profilePicRef.listAll()
 
-            for item in result.items where item.name.hasPrefix(userId) {
+            for item in result.items {
                 do {
                     try await item.delete()
                 } catch let error as NSError

--- a/AscendApp/Features/Authentication/AuthenticationViewModel.swift
+++ b/AscendApp/Features/Authentication/AuthenticationViewModel.swift
@@ -39,7 +39,6 @@ class AuthenticationViewModel {
     private(set) var isProfileLoaded: Bool = false
 
     private var authenticationService = AuthenticationService()
-    private var photoService = PhotoService()
 
     init() {
         // Load cached display name immediately for UI responsiveness
@@ -265,28 +264,28 @@ extension AuthenticationViewModel {
         }
         
         do {
-            // Upload the photo
-            let uploadedPhotos = try await photoService.uploadPhotos([photoPickerItem])
-            
-            guard let uploadedPhoto = uploadedPhotos.first else {
+            guard let imageData = try await photoPickerItem.loadTransferable(type: Data.self) else {
                 errorMessage = "Failed to upload photo"
                 return
             }
-            
-            // Save the URL to Firestore user document
+
+            let filename = "users/\(user.uid)/profile_pictures/\(UUID().uuidString).jpg"
+            let photoRepo = FirebasePhotoRepository()
+            let uploadedURL = try await photoRepo.upload(imageData, filename: filename)
+
             try await UserDataRepository.shared.updateProfilePictureURL(
                 userId: user.uid,
-                profilePictureURL: uploadedPhoto.url.absoluteString
+                profilePictureURL: uploadedURL.absoluteString
             )
             
             // Update the local state
-            customProfilePictureURL = uploadedPhoto.url
+            customProfilePictureURL = uploadedURL
             
             // Update all leaderboard entries with the new photo URL
             do {
                 try await LeaderboardService.shared.updateProfilePictureURL(
                     userId: user.uid,
-                    photoURL: uploadedPhoto.url
+                    photoURL: uploadedURL
                 )
             } catch {
                 // Don't fail the whole operation if leaderboard update fails
@@ -308,7 +307,7 @@ extension AuthenticationViewModel {
         
         do {
             // Upload the photo data directly
-            let filename = "profile_pictures/\(user.uid)_\(UUID().uuidString).jpg"
+            let filename = "users/\(user.uid)/profile_pictures/\(UUID().uuidString).jpg"
             let photoRepo = FirebasePhotoRepository()
             let uploadedURL = try await photoRepo.upload(imageData, filename: filename)
             

--- a/AscendApp/Info.plist
+++ b/AscendApp/Info.plist
@@ -11,6 +11,7 @@
 			<array>
 				<string>com.googleusercontent.apps.808186881002-ncqmrtrc05021fm2ekdlv2u6cjltbr14</string>
 				<string>com.googleusercontent.apps.699362062754-btv2ounn0dvd3omgkjpfhcg3ppsclnh0</string>
+				<string>com.googleusercontent.apps.761975761909-dibgspg10c56v2ipkm86a9jv6i51t2on</string>
 			</array>
 		</dict>
 		<dict>

--- a/AscendApp/Shared/Services/MediaUploadManager.swift
+++ b/AscendApp/Shared/Services/MediaUploadManager.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftData
 import PhotosUI
+import FirebaseAuth
 
 /// Status of media uploads for a workout
 enum MediaUploadStatus: Equatable {
@@ -19,11 +20,14 @@ enum MediaUploadStatus: Equatable {
 /// Errors that can occur during media upload
 enum UploadError: LocalizedError {
     case timeout
+    case notAuthenticated
 
     var errorDescription: String? {
         switch self {
         case .timeout:
             return "Upload timed out"
+        case .notAuthenticated:
+            return "You must be signed in to upload media."
         }
     }
 }
@@ -286,10 +290,16 @@ final class MediaUploadManager {
                 let data = try await LocalMediaStorage.readData(filename: upload.localFileName)
 
                 // Determine Firebase path
+                guard let userId = Auth.auth().currentUser?.uid else {
+                    throw UploadError.notAuthenticated
+                }
+
                 let fileExtension = upload.isVideo ?
                     (URL(fileURLWithPath: upload.localFileName).pathExtension.isEmpty ? "mov" : URL(fileURLWithPath: upload.localFileName).pathExtension) :
                     "jpg"
-                let path = upload.isVideo ? "videos/\(UUID().uuidString).\(fileExtension)" : "photos/\(UUID().uuidString).jpg"
+                let path = upload.isVideo ?
+                    "users/\(userId)/videos/\(UUID().uuidString).\(fileExtension)" :
+                    "users/\(userId)/photos/\(UUID().uuidString).jpg"
 
                 // Upload to Firebase with timeout
                 let remoteURL = try await withThrowingTaskGroup(of: URL.self) { group in

--- a/AscendApp/Shared/Services/PhotoService.swift
+++ b/AscendApp/Shared/Services/PhotoService.swift
@@ -9,6 +9,7 @@ import PhotosUI
 import SwiftUI
 import AVFoundation
 import UniformTypeIdentifiers
+import FirebaseAuth
 
 actor PhotoService {
     private let repo: any PhotoRepositoryProtocol
@@ -92,7 +93,7 @@ actor PhotoService {
     
     private func uploadPhoto(_ item: PhotosPickerItem, repo: any PhotoRepositoryProtocol) async throws -> Photo? {
         guard let data = try await item.loadTransferable(type: Data.self) else { return nil }
-        let filename = "photos/\(UUID().uuidString).jpg"
+        let filename = "users/\(try currentUserId())/photos/\(UUID().uuidString).jpg"
         let url = try await repo.upload(data, filename: filename)
         return Photo(url: url, type: .photo, duration: nil)
     }
@@ -111,7 +112,7 @@ actor PhotoService {
         
         // Upload with video extension
         let fileExtension = movie.url.pathExtension.isEmpty ? "mov" : movie.url.pathExtension
-        let filename = "videos/\(UUID().uuidString).\(fileExtension)"
+        let filename = "users/\(try currentUserId())/videos/\(UUID().uuidString).\(fileExtension)"
         let url = try await repo.upload(data, filename: filename)
         
         // Clean up temporary file
@@ -127,7 +128,7 @@ actor PhotoService {
         
         // Upload with video extension
         let fileExtension = videoURL.pathExtension.isEmpty ? "mov" : videoURL.pathExtension
-        let filename = "videos/\(UUID().uuidString).\(fileExtension)"
+        let filename = "users/\(try currentUserId())/videos/\(UUID().uuidString).\(fileExtension)"
         let url = try await repo.upload(data, filename: filename)
         
         // Don't clean up the temporary file here - PhotoGalleryView will handle cleanup
@@ -257,5 +258,16 @@ actor PhotoService {
                 throw error
             }
         }
+    }
+
+    private func currentUserId() throws -> String {
+        guard let userId = Auth.auth().currentUser?.uid else {
+            throw NSError(
+                domain: "PhotoService",
+                code: 401,
+                userInfo: [NSLocalizedDescriptionKey: "You must be signed in to upload media."]
+            )
+        }
+        return userId
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,23 @@ let functionsURL = "https://\(region)-\(projectId).cloudfunctions.net"
 ### Data Models (SwiftData)
 Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightPersonalRecord, AggregateWeightRecord, PendingMediaUpload
 
+### Firebase Storage Pathing + Rules
+- User-generated media must be stored under user-scoped prefixes:
+  - `users/{uid}/photos/...`
+  - `users/{uid}/videos/...`
+  - `users/{uid}/profile_pictures/...`
+- Never write user media to shared root paths (`photos/`, `videos/`, `profile_pictures/`) in production.
+- Share card template assets live under `share-card-templates/...` and are read-only from client apps.
+- Account deletion and cleanup should target only the authenticated user's scoped prefix.
+
+### Firestore Schema-Change Rule
+- `firestore.rules` uses strict `hasOnly` + `hasAll` field validation on every collection. Adding, removing, or renaming a field in the app **requires a matching update to `firestore.rules`** — otherwise writes will be rejected at the server.
+- The same `firestore.rules` file must be deployed to all environments (dev, staging, production) to catch schema mismatches early. Never test against loose rules in dev while production has strict ones.
+- When changing Firestore document schemas, always update in this order:
+  1. Update `firestore.rules` to allow the new/changed fields
+  2. Update Swift model + write logic
+  3. Deploy rules to all environments before or alongside the app update
+
 ### Import UX
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.
 

--- a/firebase.json
+++ b/firebase.json
@@ -2,6 +2,9 @@
   "firestore": {
     "rules": "firestore.rules"
   },
+  "storage": {
+    "rules": "storage.rules"
+  },
   "functions": [
     {
       "source": "functions",

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,50 +1,243 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-
-    // Users collection - users can only read/write their own document
-    match /users/{userId} {
-      allow read, write: if request.auth != null && request.auth.uid == userId;
+    function isSignedIn() {
+      return request.auth != null;
     }
 
-    // Leaderboard stats - authenticated users can read all, mutate only their own
-    match /leaderboard_stats/{docId} {
-      allow read: if request.auth != null;
-      allow create: if request.auth != null
-        && request.resource.data.userId == request.auth.uid;
-      allow update: if request.auth != null
-        && resource.data.userId == request.auth.uid
-        && request.resource.data.userId == request.auth.uid;
-      allow delete: if request.auth != null
-        && resource.data.userId == request.auth.uid;
+    function isOwner(userId) {
+      return isSignedIn() && request.auth.uid == userId;
     }
 
-    // Feedback collection - authenticated users can create, with rate limiting
-    match /feedback/{feedbackId} {
-      // Only authenticated users can create feedback
-      // userId in document must match authenticated user
-      allow create: if request.auth != null
-        && request.resource.data.userId == request.auth.uid
-        && (
-          // Allow if no rate limit doc exists
-          !exists(/databases/$(database)/documents/userRateLimits/$(request.auth.uid))
-          // Or if enough time has passed since last feedback
-          || request.time > get(/databases/$(database)/documents/userRateLimits/$(request.auth.uid)).data.lastFeedback + duration.value(60, 's')
+    function isNonNegativeNumber(value) {
+      return (value is int || value is float) && value >= 0;
+    }
+
+    function isValidTimeFrame(timeFrame) {
+      return timeFrame in ["weekly", "monthly", "yearly", "all_time"];
+    }
+
+    function isValidPeriodIdentifier(timeFrame, periodIdentifier) {
+      return
+        (timeFrame == "weekly" &&
+          periodIdentifier.matches("^\\d{4}-W(0[1-9]|[1-4][0-9]|5[0-3])$")) ||
+        (timeFrame == "monthly" &&
+          periodIdentifier.matches("^\\d{4}-M(0[1-9]|1[0-2])$")) ||
+        (timeFrame == "yearly" &&
+          periodIdentifier.matches("^\\d{4}$")) ||
+        (timeFrame == "all_time" && periodIdentifier == "all");
+    }
+
+    function isValidUserDocument() {
+      return request.resource.data.keys().hasOnly([
+          "email",
+          "firstName",
+          "lastName",
+          "displayName",
+          "profilePictureURL",
+          "createdAt",
+          "lastUpdated"
+        ]) &&
+        request.resource.data.keys().hasAll([
+          "email",
+          "firstName",
+          "lastName",
+          "displayName",
+          "createdAt",
+          "lastUpdated"
+        ]) &&
+        request.resource.data.email is string &&
+        request.resource.data.email.size() <= 320 &&
+        request.resource.data.firstName is string &&
+        request.resource.data.firstName.size() <= 80 &&
+        request.resource.data.lastName is string &&
+        request.resource.data.lastName.size() <= 80 &&
+        request.resource.data.displayName is string &&
+        request.resource.data.displayName.size() <= 80 &&
+        (!request.resource.data.keys().hasAny(["profilePictureURL"]) ||
+          (request.resource.data.profilePictureURL is string &&
+            request.resource.data.profilePictureURL.size() <= 2048)) &&
+        request.resource.data.createdAt is timestamp &&
+        request.resource.data.lastUpdated is timestamp;
+    }
+
+    function isValidLeaderboardDocument(docId) {
+      return request.resource.data.keys().hasOnly([
+          "userId",
+          "displayName",
+          "photoURL",
+          "timeFrame",
+          "periodIdentifier",
+          "totalSteps",
+          "totalFloors",
+          "totalWorkouts",
+          "totalDuration",
+          "averageStepsPerMinute",
+          "averageFloorsPerMinute",
+          "lastUpdated"
+        ]) &&
+        request.resource.data.keys().hasAll([
+          "userId",
+          "displayName",
+          "photoURL",
+          "timeFrame",
+          "periodIdentifier",
+          "totalSteps",
+          "totalFloors",
+          "totalWorkouts",
+          "totalDuration",
+          "averageStepsPerMinute",
+          "averageFloorsPerMinute",
+          "lastUpdated"
+        ]) &&
+        request.resource.data.userId == request.auth.uid &&
+        request.resource.data.displayName is string &&
+        request.resource.data.displayName.size() <= 80 &&
+        request.resource.data.photoURL is string &&
+        request.resource.data.photoURL.size() <= 2048 &&
+        request.resource.data.timeFrame is string &&
+        isValidTimeFrame(request.resource.data.timeFrame) &&
+        request.resource.data.periodIdentifier is string &&
+        isValidPeriodIdentifier(
+          request.resource.data.timeFrame,
+          request.resource.data.periodIdentifier
+        ) &&
+        docId ==
+          request.auth.uid + "_" +
+          request.resource.data.timeFrame + "_" +
+          request.resource.data.periodIdentifier &&
+        request.resource.data.totalSteps is int &&
+        request.resource.data.totalSteps >= 0 &&
+        request.resource.data.totalFloors is int &&
+        request.resource.data.totalFloors >= 0 &&
+        request.resource.data.totalWorkouts is int &&
+        request.resource.data.totalWorkouts >= 0 &&
+        isNonNegativeNumber(request.resource.data.totalDuration) &&
+        isNonNegativeNumber(request.resource.data.averageStepsPerMinute) &&
+        isNonNegativeNumber(request.resource.data.averageFloorsPerMinute) &&
+        request.resource.data.lastUpdated is timestamp;
+    }
+
+    function isValidFeedbackType(type) {
+      return type in ["feature_request", "bug_report", "get_help"];
+    }
+
+    function userRateLimitDocPath() {
+      return /databases/$(database)/documents/userRateLimits/$(request.auth.uid);
+    }
+
+    function feedbackCooldownPassed() {
+      return !exists(userRateLimitDocPath()) ||
+        (
+          get(userRateLimitDocPath()).data.lastFeedback is timestamp &&
+          request.time >
+            get(userRateLimitDocPath()).data.lastFeedback +
+              duration.value(60, "s")
         );
+    }
 
-      // Only admins can read/update/delete feedback (use Admin SDK server-side)
+    function isValidFeedbackDocument() {
+      return request.resource.data.keys().hasOnly([
+          "type",
+          "message",
+          "userId",
+          "userEmail",
+          "timestamp",
+          "appVersion",
+          "buildNumber",
+          "deviceModel",
+          "osVersion",
+          "status"
+        ]) &&
+        request.resource.data.keys().hasAll([
+          "type",
+          "message",
+          "userId",
+          "userEmail",
+          "timestamp",
+          "appVersion",
+          "buildNumber",
+          "deviceModel",
+          "osVersion",
+          "status"
+        ]) &&
+        request.resource.data.userId == request.auth.uid &&
+        request.resource.data.type is string &&
+        isValidFeedbackType(request.resource.data.type) &&
+        request.resource.data.message is string &&
+        request.resource.data.message.size() >= 10 &&
+        request.resource.data.message.size() <= 2000 &&
+        request.resource.data.userEmail is string &&
+        request.resource.data.userEmail.size() <= 320 &&
+        request.resource.data.timestamp is timestamp &&
+        request.resource.data.appVersion is string &&
+        request.resource.data.appVersion.size() <= 32 &&
+        request.resource.data.buildNumber is string &&
+        request.resource.data.buildNumber.size() <= 32 &&
+        request.resource.data.deviceModel is string &&
+        request.resource.data.deviceModel.size() <= 120 &&
+        request.resource.data.osVersion is string &&
+        request.resource.data.osVersion.size() <= 40 &&
+        request.resource.data.status == "new";
+    }
+
+    function isValidUserRateLimitDocument() {
+      return request.resource.data.keys().hasOnly(["lastFeedback"]) &&
+        request.resource.data.lastFeedback is timestamp;
+    }
+
+    match /users/{userId} {
+      allow read: if isOwner(userId);
+      allow create: if isOwner(userId) && isValidUserDocument();
+      allow update: if isOwner(userId) &&
+        isValidUserDocument() &&
+        request.resource.data.createdAt == resource.data.createdAt;
+      allow delete: if isOwner(userId);
+
+      // Strava and future integrations are written server-side; clients can only read their own.
+      match /integrations/{integrationId} {
+        allow read: if isOwner(userId);
+        allow write: if false;
+      }
+    }
+
+    match /leaderboard_stats/{docId} {
+      allow read: if isSignedIn();
+      allow create: if isSignedIn() && isValidLeaderboardDocument(docId);
+      allow update: if isSignedIn() &&
+        isValidLeaderboardDocument(docId) &&
+        request.resource.data.userId == resource.data.userId &&
+        request.resource.data.timeFrame == resource.data.timeFrame &&
+        request.resource.data.periodIdentifier == resource.data.periodIdentifier;
+      allow delete: if isSignedIn() && resource.data.userId == request.auth.uid;
+    }
+
+    match /feedback/{feedbackId} {
+      allow create: if isSignedIn() &&
+        isValidFeedbackDocument() &&
+        feedbackCooldownPassed();
       allow read, update, delete: if false;
     }
 
-    // User rate limits - users can only write their own rate limit doc
     match /userRateLimits/{userId} {
-      allow read: if request.auth != null && request.auth.uid == userId;
-      allow write: if request.auth != null && request.auth.uid == userId;
+      allow read: if isOwner(userId);
+      allow create, update: if isOwner(userId) && isValidUserRateLimitDocument();
+      allow delete: if isOwner(userId);
     }
 
-    // Waitlist - server-only writes via Cloud Functions
+    // Remote share-card template manifest is read-only for authenticated users.
+    match /config/{docId} {
+      allow read: if isSignedIn() && docId == "shareCardTemplates";
+      allow write: if false;
+    }
+
+    // Server-only collections managed by Cloud Functions / Admin SDK.
     match /waitlist/{docId} {
-      allow read, create, update, delete: if false;
+      allow read, write: if false;
+    }
+
+    match /oauthStates/{docId} {
+      allow read, write: if false;
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,63 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isOwner(userId) {
+      return isSignedIn() && request.auth.uid == userId;
+    }
+
+    function validFileName(fileName) {
+      return fileName.size() > 0 && fileName.size() <= 200;
+    }
+
+    function isImageUpload(maxBytes) {
+      return request.resource != null &&
+        request.resource.size > 0 &&
+        request.resource.size <= maxBytes &&
+        request.resource.contentType.matches("image/.*");
+    }
+
+    function isVideoUpload(maxBytes) {
+      return request.resource != null &&
+        request.resource.size > 0 &&
+        request.resource.size <= maxBytes &&
+        request.resource.contentType.matches("video/.*");
+    }
+
+    // User workout photos.
+    match /users/{userId}/photos/{fileName} {
+      allow read: if isOwner(userId) && validFileName(fileName);
+      allow create, update: if isOwner(userId) &&
+        validFileName(fileName) &&
+        isImageUpload(15 * 1024 * 1024);
+      allow delete: if isOwner(userId) && validFileName(fileName);
+    }
+
+    // User workout videos.
+    match /users/{userId}/videos/{fileName} {
+      allow read: if isOwner(userId) && validFileName(fileName);
+      allow create, update: if isOwner(userId) &&
+        validFileName(fileName) &&
+        isVideoUpload(200 * 1024 * 1024);
+      allow delete: if isOwner(userId) && validFileName(fileName);
+    }
+
+    // User profile pictures.
+    match /users/{userId}/profile_pictures/{fileName} {
+      allow read: if isOwner(userId) && validFileName(fileName);
+      allow create, update: if isOwner(userId) &&
+        validFileName(fileName) &&
+        isImageUpload(10 * 1024 * 1024);
+      allow delete: if isOwner(userId) && validFileName(fileName);
+    }
+
+    // Remote share-card template assets are read-only from the app.
+    match /share-card-templates/{allPaths=**} {
+      allow read: if isSignedIn();
+      allow write: if false;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Migrate all media uploads from flat paths (`photos/`, `videos/`, `profile_pictures/`) to user-scoped paths (`users/{uid}/photos/`, etc.)
- Rewrite `firestore.rules` with full schema validation (`hasOnly`/`hasAll`), type checking, string length limits, and immutable field protection
- Add new `storage.rules` with user-scoped access controls, content type validation, and file size limits
- Add auth guards before media uploads in `MediaUploadManager` and `PhotoService`
- Add production Google Sign-In URL scheme to `Info.plist`
- Document Firestore schema-change rule in `AGENTS.md` and `CLAUDE.md`
- Re-enable automatic staging deploy on push to `develop`

## Test plan
- [ ] Verify photo upload uses `users/{uid}/photos/` path in Firebase Storage
- [ ] Verify video upload uses `users/{uid}/videos/` path
- [ ] Verify profile picture upload uses `users/{uid}/profile_pictures/` path
- [ ] Verify account deletion cleans up user-scoped storage prefix
- [ ] Deploy `firestore.rules` to dev and confirm existing app operations still work
- [ ] Deploy `storage.rules` to dev and confirm uploads/reads still work
- [ ] Test unauthenticated upload is rejected with proper error message
- [ ] Verify Google Sign-In works with new production URL scheme in Info.plist

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)