### PR TITLE
Fix staging deploy: skip plist linking when plists already exist on CI

### DIFF
--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 			);
 			outputPaths = (
 			);
+			alwaysOutOfDate = 1;
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Ensure local Firebase config plists are linked into this worktree.\n\"${SRCROOT}/scripts/link-firebase-plists.sh\"\n\n# Determine which GoogleService-Info plist to use\ncase \"${CONFIGURATION}\" in\n    \"Debug\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Dev.plist\"\n        ;;\n    \"Staging\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Staging.plist\"\n        ;;\n    \"Release\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Production.plist\"\n        ;;\nesac\n\n# Run Crashlytics with the correct plist\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${GOOGLE_SERVICE_PLIST}\"\n";

--- a/scripts/link-firebase-plists.sh
+++ b/scripts/link-firebase-plists.sh
@@ -10,6 +10,21 @@ PROJECT_ROOT="${SRCROOT:-$(pwd)}"
 TARGET_DIR="${PROJECT_ROOT}/AscendApp/App/Firebase"
 mkdir -p "$TARGET_DIR"
 
+# On CI the decode step places real plist files directly into TARGET_DIR.
+# If the required plist for the current configuration already exists there,
+# skip the source-directory search entirely so CI archives succeed.
+required_plist=""
+case "${CONFIGURATION:-}" in
+  Debug)   required_plist="GoogleService-Info-Dev.plist" ;;
+  Staging) required_plist="GoogleService-Info-Staging.plist" ;;
+  Release) required_plist="GoogleService-Info-Production.plist" ;;
+esac
+
+if [ -n "$required_plist" ] && [ -f "$TARGET_DIR/$required_plist" ]; then
+  echo "Firebase plist already present at $TARGET_DIR/$required_plist — skipping link."
+  exit 0
+fi
+
 find_first_existing_source_dir() {
   if [ -n "$PLIST_SOURCE_DIR" ] && [ -d "$PLIST_SOURCE_DIR" ]; then
     echo "$PLIST_SOURCE_DIR"


### PR DESCRIPTION
## Summary
- Fix `link-firebase-plists.sh` to skip source directory search when the required plist already exists in the target directory (as it does on CI after the base64 decode step)
- Set `alwaysOutOfDate = 1` on the Crashlytics run script build phase to suppress the "does not specify any outputs" warning

## Root Cause
The `link-firebase-plists.sh` script was added to support local dev workflows (symlink plists from a shared secrets directory). On CI runners, the script fails because none of the expected source directories exist (`~/.config/ascend/firebase`, `~/.codex/worktrees`). The CI deploy workflow decodes plists directly into `AscendApp/App/Firebase/` from base64 secrets, so linking is unnecessary — but the script didn't check for this case.

## Test plan
- [ ] CI build passes on this PR
- [ ] Merge to develop triggers staging deploy — verify the `build_app` step succeeds
- [ ] Local Xcode build still works (link script finds plists via existing mechanism)
- [ ] No "Run Script will be run during every build" warning in Xcode build log

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)