### PR TITLE
Optimize PR and percentile recalculation hot paths

### DIFF
--- a/AscendApp/Shared/Services/PercentileScoreService.swift
+++ b/AscendApp/Shared/Services/PercentileScoreService.swift
@@ -20,10 +20,18 @@ struct PercentileScoreService {
     static func calculatePercentileRank(value: Double, historicalValues: [Double]) -> Double {
         guard !historicalValues.isEmpty else { return 0.5 }
 
-        let countBelow = historicalValues.filter { $0 < value }.count
-        let countEqual = historicalValues.filter { abs($0 - value) < 0.0001 }.count
-        let totalCount = historicalValues.count
+        var countBelow = 0
+        var countEqual = 0
 
+        for historicalValue in historicalValues {
+            if historicalValue < value {
+                countBelow += 1
+            } else if abs(historicalValue - value) < 0.0001 {
+                countEqual += 1
+            }
+        }
+
+        let totalCount = historicalValues.count
         return (Double(countBelow) + 0.5 * Double(countEqual)) / Double(totalCount)
     }
 
@@ -59,14 +67,20 @@ struct PercentileScoreService {
         // Only consider workouts BEFORE this workout for percentile calculation
         let historicalWorkouts = existingWorkouts.filter { $0.date < workout.date }
         let workoutCount = historicalWorkouts.count
+        let workoutValues = metricValues(for: workout, preferredMetric: preferredMetric)
+        let historicalValuesByMetric = historicalValuesByMetric(
+            from: historicalWorkouts,
+            preferredMetric: preferredMetric
+        )
 
         var scores: [String: Double] = [:]
+        scores.reserveCapacity(HeatMapMetric.allCases.count)
 
         for metric in HeatMapMetric.allCases {
             let score = calculateScore(
-                for: workout,
                 metric: metric,
-                historicalWorkouts: historicalWorkouts,
+                value: workoutValues[metric],
+                historicalValues: historicalValuesByMetric[metric] ?? [],
                 workoutCount: workoutCount,
                 fitnessLevel: fitnessLevel,
                 preferredMetric: preferredMetric
@@ -80,17 +94,15 @@ struct PercentileScoreService {
     /// Calculate the score for a single metric
     @MainActor
     private static func calculateScore(
-        for workout: Workout,
         metric: HeatMapMetric,
-        historicalWorkouts: [Workout],
+        value: Double?,
+        historicalValues: [Double],
         workoutCount: Int,
         fitnessLevel: FitnessLevel,
         preferredMetric: WorkoutMetric
     ) -> Double {
-        let rawValue = getRawValue(for: workout, metric: metric, preferredMetric: preferredMetric)
-
         // If no value (e.g., no heart rate data), return 0
-        guard let value = rawValue else { return 0 }
+        guard let value = value else { return 0 }
 
         // Calculate fixed threshold score
         let threshold = fitnessLevel.threshold(for: metric, preferredMetric: preferredMetric)
@@ -99,11 +111,6 @@ struct PercentileScoreService {
         // If not enough workouts for percentile, use fixed score
         if workoutCount < 10 {
             return fixedScore
-        }
-
-        // Get historical values for this metric
-        let historicalValues = historicalWorkouts.compactMap { workout in
-            getRawValue(for: workout, metric: metric, preferredMetric: preferredMetric)
         }
 
         // If no historical data for this metric, use fixed score
@@ -118,6 +125,31 @@ struct PercentileScoreService {
             fixedScore: fixedScore,
             workoutCount: workoutCount
         )
+    }
+
+    @MainActor
+    private static func historicalValuesByMetric(
+        from workouts: [Workout],
+        preferredMetric: WorkoutMetric
+    ) -> [HeatMapMetric: [Double]] {
+        workouts.reduce(into: [:]) { result, workout in
+            for (metric, value) in metricValues(for: workout, preferredMetric: preferredMetric) {
+                result[metric, default: []].append(value)
+            }
+        }
+    }
+
+    @MainActor
+    private static func metricValues(
+        for workout: Workout,
+        preferredMetric: WorkoutMetric
+    ) -> [HeatMapMetric: Double] {
+        HeatMapMetric.allCases.reduce(into: [:]) { result, metric in
+            guard let value = getRawValue(for: workout, metric: metric, preferredMetric: preferredMetric) else {
+                return
+            }
+            result[metric] = value
+        }
     }
 
     // MARK: - Raw Value Extraction

--- a/AscendApp/Shared/Services/PersonalRecordService.swift
+++ b/AscendApp/Shared/Services/PersonalRecordService.swift
@@ -19,13 +19,14 @@ final class PersonalRecordService {
         measurementSystem: MeasurementSystem,
         stepHeight: Double
     ) -> [PersonalRecordResult] {
+        let currentRecordsByType = currentRecordsByType(from: allPersonalRecords)
         var results: [PersonalRecordResult] = []
         
         // Check steps PR
         let stepsResult = checkRecord(
             type: .mostSteps,
             newValue: Double(workout.steps),
-            currentRecords: allPersonalRecords
+            currentRecord: currentRecordsByType[.mostSteps]
         )
         results.append(stepsResult)
         
@@ -33,7 +34,7 @@ final class PersonalRecordService {
         let floorsResult = checkRecord(
             type: .mostFloors,
             newValue: Double(workout.floors),
-            currentRecords: allPersonalRecords
+            currentRecord: currentRecordsByType[.mostFloors]
         )
         results.append(floorsResult)
         
@@ -41,7 +42,7 @@ final class PersonalRecordService {
         let result = checkRecord(
             type: .longestDuration,
             newValue: workout.duration,
-            currentRecords: allPersonalRecords
+            currentRecord: currentRecordsByType[.longestDuration]
         )
         results.append(result)
         
@@ -50,7 +51,7 @@ final class PersonalRecordService {
             let result = checkRecord(
                 type: .highestAveragePace,
                 newValue: pace,
-                currentRecords: allPersonalRecords
+                currentRecord: currentRecordsByType[.highestAveragePace]
             )
             results.append(result)
         }
@@ -64,7 +65,7 @@ final class PersonalRecordService {
             let result = checkRecord(
                 type: .highestVerticalClimb,
                 newValue: verticalClimb,
-                currentRecords: allPersonalRecords
+                currentRecord: currentRecordsByType[.highestVerticalClimb]
             )
             results.append(result)
         }
@@ -74,7 +75,7 @@ final class PersonalRecordService {
             let result = checkRecord(
                 type: .highestAverageHeartRate,
                 newValue: Double(avgHR),
-                currentRecords: allPersonalRecords
+                currentRecord: currentRecordsByType[.highestAverageHeartRate]
             )
             results.append(result)
         }
@@ -84,7 +85,7 @@ final class PersonalRecordService {
             let result = checkRecord(
                 type: .highestMaxHeartRate,
                 newValue: Double(maxHR),
-                currentRecords: allPersonalRecords
+                currentRecord: currentRecordsByType[.highestMaxHeartRate]
             )
             results.append(result)
         }
@@ -94,7 +95,7 @@ final class PersonalRecordService {
             let result = checkRecord(
                 type: .mostCaloriesBurned,
                 newValue: Double(calories),
-                currentRecords: allPersonalRecords
+                currentRecord: currentRecordsByType[.mostCaloriesBurned]
             )
             results.append(result)
         }
@@ -109,20 +110,16 @@ final class PersonalRecordService {
         workout: Workout,
         modelContext: ModelContext
     ) throws {
+        let currentRecordsByID = try fetchCurrentRecordsByID(modelContext: modelContext)
+
         for result in results where result.isNewRecord {
-            // If there was a previous record, mark it as no longer current
-            if let previousId = result.previousRecordId {
-                let descriptor = FetchDescriptor<PersonalRecord>(
-                    predicate: #Predicate<PersonalRecord> { record in
-                        record.id == previousId
-                    }
-                )
-                if let previousRecord = try modelContext.fetch(descriptor).first {
-                    previousRecord.isCurrent = false
-                }
+            if let previousId = result.previousRecordId,
+               let previousRecord = currentRecordsByID[previousId] {
+                previousRecord.isCurrent = false
             }
-            
-            // Create the new personal record
+        }
+
+        for result in results where result.isNewRecord {
             let newRecord = PersonalRecord(
                 type: result.type,
                 value: result.newValue,
@@ -133,10 +130,10 @@ final class PersonalRecordService {
                 workoutName: workout.name,
                 workoutDate: workout.date
             )
-            
+
             modelContext.insert(newRecord)
         }
-        
+
         try modelContext.save()
     }
     
@@ -144,13 +141,8 @@ final class PersonalRecordService {
     private static func checkRecord(
         type: PersonalRecordType,
         newValue: Double,
-        currentRecords: [PersonalRecord]
+        currentRecord: PersonalRecord?
     ) -> PersonalRecordResult {
-        // Find the current record for this type
-        let currentRecord = currentRecords.first { record in
-            record.type == type && record.isCurrent
-        }
-        
         if let current = currentRecord {
             // Check if new value beats the current record
             let isNewRecord = newValue > current.value
@@ -220,7 +212,7 @@ final class PersonalRecordService {
         )
         let allWorkouts = try modelContext.fetch(workoutDescriptor)
         
-        // 2. Delete all existing PersonalRecord entries
+        // 2. Fetch all existing PersonalRecord entries and delete them
         let prDescriptor = FetchDescriptor<PersonalRecord>()
         let existingPRs = try modelContext.fetch(prDescriptor)
         for pr in existingPRs {
@@ -231,11 +223,9 @@ final class PersonalRecordService {
         for workout in allWorkouts {
             workout.personalRecordTypes = nil
         }
-        
-        try modelContext.save()
-        
+
         // 4. Process workouts chronologically, tracking the best values
-        var currentBests: [PersonalRecordType: (value: Double, recordId: UUID)] = [:]
+        var currentBests: [PersonalRecordType: (value: Double, record: PersonalRecord)] = [:]
         
         for workout in allWorkouts {
             var newPRTypes: [String] = []
@@ -268,13 +258,8 @@ final class PersonalRecordService {
                 
                 if isNewRecord {
                     // Mark previous record as no longer current
-                    if let prevId = previousBest?.recordId {
-                        let descriptor = FetchDescriptor<PersonalRecord>(
-                            predicate: #Predicate<PersonalRecord> { $0.id == prevId }
-                        )
-                        if let prevRecord = try modelContext.fetch(descriptor).first {
-                            prevRecord.isCurrent = false
-                        }
+                    if let prev = previousBest?.record {
+                        prev.isCurrent = false
                     }
                     
                     // Create new PR
@@ -284,14 +269,14 @@ final class PersonalRecordService {
                         workoutId: workout.id,
                         achievedAt: workout.date,
                         isCurrent: true,
-                        previousRecordId: previousBest?.recordId,
+                        previousRecordId: previousBest?.record.id,
                         workoutName: workout.name,
                         workoutDate: workout.date
                     )
                     modelContext.insert(newRecord)
                     
                     // Update tracking
-                    currentBests[type] = (value, newRecord.id)
+                    currentBests[type] = (value, newRecord)
                     newPRTypes.append(type.rawValue)
                 }
             }
@@ -310,5 +295,21 @@ final class PersonalRecordService {
             measurementSystem: measurementSystem
         )
     }
-}
 
+    private static func currentRecordsByType(
+        from records: [PersonalRecord]
+    ) -> [PersonalRecordType: PersonalRecord] {
+        records.reduce(into: [:]) { result, record in
+            guard record.isCurrent else { return }
+            result[record.type] = record
+        }
+    }
+
+    private static func fetchCurrentRecordsByID(
+        modelContext: ModelContext
+    ) throws -> [UUID: PersonalRecord] {
+        try fetchCurrentPersonalRecords(modelContext: modelContext).reduce(into: [:]) { result, record in
+            result[record.id] = record
+        }
+    }
+}

--- a/AscendApp/Shared/Services/WeightPersonalRecordService.swift
+++ b/AscendApp/Shared/Services/WeightPersonalRecordService.swift
@@ -23,6 +23,7 @@ final class WeightPersonalRecordService {
             return []
         }
 
+        let currentRecordsByLookup = currentWeightRecordsByLookup(from: allWeightRecords)
         var results: [WeightPersonalRecordResult] = []
 
         // For each enabled weight entry, check all 4 metrics
@@ -37,7 +38,7 @@ final class WeightPersonalRecordService {
                 type: .longestDuration,
                 comboKey: comboKey,
                 newValue: workout.duration,
-                currentRecords: allWeightRecords
+                currentRecord: currentRecordsByLookup[weightLookupKey(type: .longestDuration, comboKey: comboKey)]
             ))
 
             // Check steps PR
@@ -45,7 +46,7 @@ final class WeightPersonalRecordService {
                 type: .mostSteps,
                 comboKey: comboKey,
                 newValue: Double(workout.steps),
-                currentRecords: allWeightRecords
+                currentRecord: currentRecordsByLookup[weightLookupKey(type: .mostSteps, comboKey: comboKey)]
             ))
 
             // Check pace PR
@@ -54,7 +55,7 @@ final class WeightPersonalRecordService {
                     type: .bestPace,
                     comboKey: comboKey,
                     newValue: pace,
-                    currentRecords: allWeightRecords
+                    currentRecord: currentRecordsByLookup[weightLookupKey(type: .bestPace, comboKey: comboKey)]
                 ))
             }
 
@@ -63,7 +64,7 @@ final class WeightPersonalRecordService {
                 type: .mostFloors,
                 comboKey: comboKey,
                 newValue: Double(workout.floors),
-                currentRecords: allWeightRecords
+                currentRecord: currentRecordsByLookup[weightLookupKey(type: .mostFloors, comboKey: comboKey)]
             ))
         }
 
@@ -75,16 +76,8 @@ final class WeightPersonalRecordService {
         type: WeightRecordType,
         comboKey: WeightComboKey,
         newValue: Double,
-        currentRecords: [WeightPersonalRecord]
+        currentRecord: WeightPersonalRecord?
     ) -> WeightPersonalRecordResult {
-        let keyString = comboKey.keyString
-
-        let currentRecord = currentRecords.first { record in
-            record.recordType == type &&
-            record.weightComboKey == keyString &&
-            record.isCurrent
-        }
-
         if let current = currentRecord {
             let isNewRecord = newValue > current.value
             return WeightPersonalRecordResult(
@@ -120,6 +113,7 @@ final class WeightPersonalRecordService {
             return []
         }
 
+        let currentRecordsByType = currentAggregateRecordsByType(from: allAggregateRecords)
         var results: [AggregateWeightRecordResult] = []
 
         // Check heaviest for each equipment type used
@@ -128,7 +122,7 @@ final class WeightPersonalRecordService {
             results.append(checkAggregateRecord(
                 type: recordType,
                 newValue: entry.totalWeight,
-                currentRecords: allAggregateRecords
+                currentRecord: currentRecordsByType[recordType]
             ))
         }
 
@@ -136,7 +130,7 @@ final class WeightPersonalRecordService {
         results.append(checkAggregateRecord(
             type: .mostTotalWeight,
             newValue: config.totalWeight,
-            currentRecords: allAggregateRecords
+            currentRecord: currentRecordsByType[.mostTotalWeight]
         ))
 
         return results
@@ -145,10 +139,8 @@ final class WeightPersonalRecordService {
     private static func checkAggregateRecord(
         type: AggregateWeightRecordType,
         newValue: Double,
-        currentRecords: [AggregateWeightRecord]
+        currentRecord: AggregateWeightRecord?
     ) -> AggregateWeightRecordResult {
-        let currentRecord = currentRecords.first { $0.recordType == type && $0.isCurrent }
-
         if let current = currentRecord {
             let isNewRecord = newValue > current.value
             return AggregateWeightRecordResult(
@@ -180,15 +172,13 @@ final class WeightPersonalRecordService {
     ) throws {
         var newWeightPRTypes: [String] = []
 
+        let weightRecordById = try fetchCurrentWeightRecordsByID(modelContext: modelContext)
+        let aggregateRecordById = try fetchCurrentAggregateRecordsByID(modelContext: modelContext)
+
         // Save weight combo PRs
         for result in weightResults where result.isNewRecord {
             if let previousId = result.previousRecordId {
-                let descriptor = FetchDescriptor<WeightPersonalRecord>(
-                    predicate: #Predicate<WeightPersonalRecord> { $0.id == previousId }
-                )
-                if let previousRecord = try modelContext.fetch(descriptor).first {
-                    previousRecord.isCurrent = false
-                }
+                weightRecordById[previousId]?.isCurrent = false
             }
 
             let newRecord = WeightPersonalRecord(
@@ -204,7 +194,6 @@ final class WeightPersonalRecordService {
             )
             modelContext.insert(newRecord)
 
-            // Track for workout annotation
             let prKey = "\(result.weightComboKey.keyString)_\(result.recordType.rawValue)"
             newWeightPRTypes.append(prKey)
         }
@@ -212,12 +201,7 @@ final class WeightPersonalRecordService {
         // Save aggregate PRs
         for result in aggregateResults where result.isNewRecord {
             if let previousId = result.previousRecordId {
-                let descriptor = FetchDescriptor<AggregateWeightRecord>(
-                    predicate: #Predicate<AggregateWeightRecord> { $0.id == previousId }
-                )
-                if let previousRecord = try modelContext.fetch(descriptor).first {
-                    previousRecord.isCurrent = false
-                }
+                aggregateRecordById[previousId]?.isCurrent = false
             }
 
             let newRecord = AggregateWeightRecord(
@@ -274,12 +258,11 @@ final class WeightPersonalRecordService {
             workout.weightPersonalRecordTypes = nil
         }
 
-        try modelContext.save()
-
-        // 4. Process workouts chronologically
-        // Track best values per combo key per record type
-        var comboBests: [String: [WeightRecordType: (value: Double, recordId: UUID)]] = [:]
-        var aggregateBests: [AggregateWeightRecordType: (value: Double, recordId: UUID)] = [:]
+        // 4. Process workouts chronologically, tracking best values and their record objects.
+        // By keeping direct references to inserted objects, we avoid per-record
+        // SwiftData fetch queries inside the loop.
+        var comboBests: [String: [WeightRecordType: (value: Double, record: WeightPersonalRecord)]] = [:]
+        var aggregateBests: [AggregateWeightRecordType: (value: Double, record: AggregateWeightRecord)] = [:]
 
         for workout in allWorkouts {
             guard let config = workout.weightConfiguration, !config.isEmpty else {
@@ -296,12 +279,10 @@ final class WeightPersonalRecordService {
                 )
                 let keyString = comboKey.keyString
 
-                // Ensure we have a dictionary for this combo
                 if comboBests[keyString] == nil {
                     comboBests[keyString] = [:]
                 }
 
-                // Check each metric type
                 let metrics: [(WeightRecordType, Double?)] = [
                     (.longestDuration, workout.duration),
                     (.mostSteps, Double(workout.steps)),
@@ -316,17 +297,9 @@ final class WeightPersonalRecordService {
                     let isNewRecord = previousBest == nil || value > previousBest!.value
 
                     if isNewRecord {
-                        // Mark previous as non-current
-                        if let prevId = previousBest?.recordId {
-                            let descriptor = FetchDescriptor<WeightPersonalRecord>(
-                                predicate: #Predicate<WeightPersonalRecord> { $0.id == prevId }
-                            )
-                            if let prevRecord = try modelContext.fetch(descriptor).first {
-                                prevRecord.isCurrent = false
-                            }
-                        }
+                        // Mark previous record as non-current via direct object reference
+                        previousBest?.record.isCurrent = false
 
-                        // Create new record
                         let newRecord = WeightPersonalRecord(
                             recordType: recordType,
                             weightComboKey: comboKey,
@@ -334,13 +307,13 @@ final class WeightPersonalRecordService {
                             workoutId: workout.id,
                             achievedAt: workout.date,
                             isCurrent: true,
-                            previousRecordId: previousBest?.recordId,
+                            previousRecordId: previousBest?.record.id,
                             workoutName: workout.name,
                             workoutDate: workout.date
                         )
                         modelContext.insert(newRecord)
 
-                        comboBests[keyString]?[recordType] = (value, newRecord.id)
+                        comboBests[keyString]?[recordType] = (value, newRecord)
                         newWeightPRTypes.append("\(keyString)_\(recordType.rawValue)")
                     }
                 }
@@ -351,14 +324,8 @@ final class WeightPersonalRecordService {
                 let prevAggregate = aggregateBests[aggregateType]
 
                 if prevAggregate == nil || totalWeight > prevAggregate!.value {
-                    if let prevId = prevAggregate?.recordId {
-                        let descriptor = FetchDescriptor<AggregateWeightRecord>(
-                            predicate: #Predicate<AggregateWeightRecord> { $0.id == prevId }
-                        )
-                        if let prevRecord = try modelContext.fetch(descriptor).first {
-                            prevRecord.isCurrent = false
-                        }
-                    }
+                    // Mark previous record as non-current via direct object reference
+                    prevAggregate?.record.isCurrent = false
 
                     let newRecord = AggregateWeightRecord(
                         recordType: aggregateType,
@@ -366,13 +333,13 @@ final class WeightPersonalRecordService {
                         workoutId: workout.id,
                         achievedAt: workout.date,
                         isCurrent: true,
-                        previousRecordId: prevAggregate?.recordId,
+                        previousRecordId: prevAggregate?.record.id,
                         workoutName: workout.name,
                         workoutDate: workout.date
                     )
                     modelContext.insert(newRecord)
 
-                    aggregateBests[aggregateType] = (totalWeight, newRecord.id)
+                    aggregateBests[aggregateType] = (totalWeight, newRecord)
                     newWeightPRTypes.append(aggregateType.rawValue)
                 }
             }
@@ -382,14 +349,7 @@ final class WeightPersonalRecordService {
             let prevTotal = aggregateBests[.mostTotalWeight]
 
             if prevTotal == nil || totalWeight > prevTotal!.value {
-                if let prevId = prevTotal?.recordId {
-                    let descriptor = FetchDescriptor<AggregateWeightRecord>(
-                        predicate: #Predicate<AggregateWeightRecord> { $0.id == prevId }
-                    )
-                    if let prevRecord = try modelContext.fetch(descriptor).first {
-                        prevRecord.isCurrent = false
-                    }
-                }
+                prevTotal?.record.isCurrent = false
 
                 let newRecord = AggregateWeightRecord(
                     recordType: .mostTotalWeight,
@@ -397,13 +357,13 @@ final class WeightPersonalRecordService {
                     workoutId: workout.id,
                     achievedAt: workout.date,
                     isCurrent: true,
-                    previousRecordId: prevTotal?.recordId,
+                    previousRecordId: prevTotal?.record.id,
                     workoutName: workout.name,
                     workoutDate: workout.date
                 )
                 modelContext.insert(newRecord)
 
-                aggregateBests[.mostTotalWeight] = (totalWeight, newRecord.id)
+                aggregateBests[.mostTotalWeight] = (totalWeight, newRecord)
                 newWeightPRTypes.append(AggregateWeightRecordType.mostTotalWeight.rawValue)
             }
 
@@ -413,6 +373,7 @@ final class WeightPersonalRecordService {
             }
         }
 
+        // Single save for all deletions, insertions, and updates
         try modelContext.save()
     }
 
@@ -479,5 +440,47 @@ final class WeightPersonalRecordService {
             sortBy: [SortDescriptor(\.achievedAt, order: .forward)]
         )
         return try modelContext.fetch(descriptor)
+    }
+
+    private static func currentWeightRecordsByLookup(
+        from records: [WeightPersonalRecord]
+    ) -> [String: WeightPersonalRecord] {
+        records.reduce(into: [:]) { result, record in
+            guard record.isCurrent else { return }
+            result[weightLookupKey(type: record.recordType, comboKeyString: record.weightComboKey)] = record
+        }
+    }
+
+    private static func currentAggregateRecordsByType(
+        from records: [AggregateWeightRecord]
+    ) -> [AggregateWeightRecordType: AggregateWeightRecord] {
+        records.reduce(into: [:]) { result, record in
+            guard record.isCurrent else { return }
+            result[record.recordType] = record
+        }
+    }
+
+    private static func fetchCurrentWeightRecordsByID(
+        modelContext: ModelContext
+    ) throws -> [UUID: WeightPersonalRecord] {
+        try fetchCurrentWeightPersonalRecords(modelContext: modelContext).reduce(into: [:]) { result, record in
+            result[record.id] = record
+        }
+    }
+
+    private static func fetchCurrentAggregateRecordsByID(
+        modelContext: ModelContext
+    ) throws -> [UUID: AggregateWeightRecord] {
+        try fetchCurrentAggregateRecords(modelContext: modelContext).reduce(into: [:]) { result, record in
+            result[record.id] = record
+        }
+    }
+
+    private static func weightLookupKey(type: WeightRecordType, comboKey: WeightComboKey) -> String {
+        weightLookupKey(type: type, comboKeyString: comboKey.keyString)
+    }
+
+    private static func weightLookupKey(type: WeightRecordType, comboKeyString: String) -> String {
+        "\(comboKeyString)_\(type.rawValue)"
     }
 }


### PR DESCRIPTION
## Summary
- reduce repeated passes in percentile rank calculation and precompute grouped metric values for workout scoring
- replace repeated personal-record scans and fetch-by-ID updates with in-memory lookups
- avoid per-record SwiftData fetches during weight-personal-record recalculation by tracking direct record references

## Validation
- xcodebuild -project AscendApp.xcodeproj -scheme "AscendApp-Staging" -configuration Staging -sdk iphoneos -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build

Closes #81