### PR TITLE
Add debug workout seeder and deterministic avatars

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,13 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 - Use server-side seeding (Admin SDK / Cloud Function / CI job) for deterministic multi-user leaderboard fixtures.
 - For local-only iteration, use Firestore emulator or seed only the authenticated user.
 
+### Workout Seeding Policy (Debug)
+- Debug Tools includes local SwiftData workout seeding presets for Simulator workflows (`App Store Screenshots`, `Quick Demo`).
+- Seeded workout metadata is stored in `Workout.sourceMetadata` with `isTestData=true`, `seedSource="debug-tools"`, and `preset` for targeted cleanup.
+- Workout seeding is idempotent for debug usage: seeding replaces existing debug-seeded workouts before inserting the new preset.
+- Clearing seeded workouts must recalculate personal records and local leaderboard aggregates to keep derived data consistent.
+- Weighted vest debug data should use an intended pounds range and convert to kilograms when measurement system is metric.
+
 ### Leaderboard UX Flow
 - The leaderboard tab root should be a category hub with per-metric preview cards (`Climb`, `Workouts`, `Duration`, `Pace`) and a `See all` action on each card.
 - `See all` opens a metric-specific leaderboard detail screen.

--- a/AscendApp/Features/Debug/Services/DebugToolsService.swift
+++ b/AscendApp/Features/Debug/Services/DebugToolsService.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftData
 
 #if DEBUG
 @MainActor
@@ -13,6 +14,7 @@ final class DebugToolsService {
     static let shared = DebugToolsService()
     
     private let leaderboardSeeder = LeaderboardTestDataSeeder()
+    private let workoutSeeder = WorkoutTestDataSeeder()
     
     private init() {}
     
@@ -25,9 +27,24 @@ final class DebugToolsService {
     func clearLeaderboardData() async throws {
         try await leaderboardSeeder.clearTestData()
     }
+
+    // MARK: - Workout Operations
+
+    func seedWorkoutData(
+        preset: WorkoutSeedPreset,
+        modelContext: ModelContext
+    ) async throws -> Int {
+        try await workoutSeeder.seedWorkouts(
+            preset: preset,
+            modelContext: modelContext
+        )
+    }
+
+    func clearSeededWorkoutData(modelContext: ModelContext) async throws -> Int {
+        try workoutSeeder.clearSeededWorkouts(modelContext: modelContext)
+    }
     
     // MARK: - Future: Add more debug operations
-    // func seedWorkoutData() async throws { }
     // func clearAllData() async throws { }
     // func resetUserPreferences() async throws { }
 }

--- a/AscendApp/Features/Debug/Services/WorkoutTestDataSeeder.swift
+++ b/AscendApp/Features/Debug/Services/WorkoutTestDataSeeder.swift
@@ -1,0 +1,490 @@
+//
+//  WorkoutTestDataSeeder.swift
+//  AscendApp
+//
+//  Created by Codex on 3/10/26.
+//
+
+import Foundation
+import SwiftData
+@preconcurrency import FirebaseAuth
+
+#if DEBUG
+enum WorkoutSeedPreset: String, CaseIterable, Identifiable {
+    case appStoreScreenshots = "app_store_screenshots"
+    case quickDemo = "quick_demo"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .appStoreScreenshots:
+            return "App Store Screenshots"
+        case .quickDemo:
+            return "Quick Demo"
+        }
+    }
+
+    var pickerLabel: String {
+        switch self {
+        case .appStoreScreenshots:
+            return "Screenshots"
+        case .quickDemo:
+            return "Quick Demo"
+        }
+    }
+}
+
+@MainActor
+final class WorkoutTestDataSeeder {
+    private let settings = SettingsManager.shared
+    private let seedSource = "debug-tools"
+
+    func seedWorkouts(
+        preset: WorkoutSeedPreset,
+        modelContext: ModelContext
+    ) async throws -> Int {
+        try removeSeededWorkouts(modelContext: modelContext)
+
+        let generatedWorkouts = generateWorkouts(for: preset, referenceDate: Date())
+        for workout in generatedWorkouts {
+            modelContext.insert(workout)
+        }
+        try modelContext.save()
+
+        try rebuildDerivedData(modelContext: modelContext)
+        return generatedWorkouts.count
+    }
+
+    func clearSeededWorkouts(modelContext: ModelContext) throws -> Int {
+        let seededWorkouts = try fetchSeededWorkouts(modelContext: modelContext)
+        guard !seededWorkouts.isEmpty else { return 0 }
+
+        for workout in seededWorkouts {
+            modelContext.delete(workout)
+        }
+        try modelContext.save()
+
+        try rebuildDerivedData(modelContext: modelContext)
+        return seededWorkouts.count
+    }
+
+    // MARK: - Generators
+
+    private func generateWorkouts(
+        for preset: WorkoutSeedPreset,
+        referenceDate: Date
+    ) -> [Workout] {
+        switch preset {
+        case .appStoreScreenshots:
+            return generateScreenshotPreset(referenceDate: referenceDate)
+        case .quickDemo:
+            return generateQuickDemoPreset(referenceDate: referenceDate)
+        }
+    }
+
+    private func generateScreenshotPreset(referenceDate: Date) -> [Workout] {
+        let calendar = Calendar.current
+        let ninetyDaysAgo = calendar.date(byAdding: .day, value: -89, to: referenceDate) ?? referenceDate
+        let firstDay = calendar.startOfDay(for: ninetyDaysAgo)
+        var rng = SeededGenerator(seed: 78_000_026)
+        var workouts: [Workout] = []
+
+        for weekIndex in 0..<13 {
+            let phase = phaseProfile(forWeek: weekIndex)
+            guard let weekStart = calendar.date(byAdding: .day, value: weekIndex * 7, to: firstDay),
+                  let weekEndCandidate = calendar.date(byAdding: .day, value: 6, to: weekStart) else {
+                continue
+            }
+
+            let weekEnd = min(weekEndCandidate, referenceDate)
+            let maxOffset = max(
+                0,
+                calendar.dateComponents(
+                    [.day],
+                    from: calendar.startOfDay(for: weekStart),
+                    to: calendar.startOfDay(for: weekEnd)
+                ).day ?? 0
+            )
+
+            let desiredCount = Int.random(in: phase.workoutsPerWeek, using: &rng)
+            let workoutCount = min(desiredCount, maxOffset + 1)
+            guard workoutCount > 0 else { continue }
+
+            let dayOffsets = uniqueDayOffsets(maxOffset: maxOffset, count: workoutCount, rng: &rng)
+            for dayOffset in dayOffsets {
+                guard let day = calendar.date(byAdding: .day, value: dayOffset, to: weekStart),
+                      let timestamp = randomWorkoutTimestamp(on: day, referenceDate: referenceDate, rng: &rng) else {
+                    continue
+                }
+
+                workouts.append(
+                    buildWorkout(
+                        date: timestamp,
+                        phase: phase,
+                        preset: .appStoreScreenshots,
+                        rng: &rng
+                    )
+                )
+            }
+        }
+
+        return workouts.sorted { $0.date < $1.date }
+    }
+
+    private func generateQuickDemoPreset(referenceDate: Date) -> [Workout] {
+        let calendar = Calendar.current
+        let dayOffsets = [10, 8, 6, 3, 1]
+        var rng = SeededGenerator(seed: 78_000_101)
+        var workouts: [Workout] = []
+
+        for (index, daysAgo) in dayOffsets.enumerated() {
+            guard let day = calendar.date(byAdding: .day, value: -daysAgo, to: referenceDate),
+                  let timestamp = randomWorkoutTimestamp(on: day, referenceDate: referenceDate, rng: &rng) else {
+                continue
+            }
+
+            let phase = index < 2 ? WorkoutPhaseProfile.phaseTwo : WorkoutPhaseProfile.phaseThree
+            workouts.append(
+                buildWorkout(
+                    date: timestamp,
+                    phase: phase,
+                    preset: .quickDemo,
+                    rng: &rng
+                )
+            )
+        }
+
+        return workouts.sorted { $0.date < $1.date }
+    }
+
+    private func buildWorkout(
+        date: Date,
+        phase: WorkoutPhaseProfile,
+        preset: WorkoutSeedPreset,
+        rng: inout SeededGenerator
+    ) -> Workout {
+        let stepsPerFloor = max(settings.stepsPerFloor, 1)
+        let steps = Int.random(in: phase.stepRange, using: &rng)
+        let pace = Double.random(in: phase.paceRange, using: &rng)
+        let minutes = clamped(
+            Double(steps) / pace,
+            min: phase.durationMinutesRange.lowerBound,
+            max: phase.durationMinutesRange.upperBound
+        )
+        let duration = max(10 * 60, (minutes * 60).rounded())
+        let floors = Workout.stepsToFloors(steps, stepsPerFloor: stepsPerFloor)
+
+        let hasHeartRate = chance(0.70, rng: &rng)
+        let avgHeartRate = hasHeartRate ? Int.random(in: phase.avgHeartRateRange, using: &rng) : nil
+        let maxHeartRate = avgHeartRate.map { min($0 + Int.random(in: 10...30, using: &rng), 205) }
+        let heartRateTimeSeries = buildHeartRateSeries(
+            startDate: date,
+            duration: duration,
+            avgHeartRate: avgHeartRate,
+            maxHeartRate: maxHeartRate,
+            rng: &rng
+        )
+
+        let effortRating: Double?
+        if chance(0.60, rng: &rng) {
+            let rawEffort = Double.random(in: phase.effortRange, using: &rng)
+            effortRating = roundedToTenths(rawEffort)
+        } else {
+            effortRating = nil
+        }
+
+        let weightConfiguration = weightedVestConfigurationIfNeeded(
+            for: phase,
+            rng: &rng
+        )
+
+        let caloriesBurned = estimateCalories(
+            steps: steps,
+            durationMinutes: minutes,
+            pace: pace,
+            effortRating: effortRating,
+            hasWeights: weightConfiguration != nil,
+            phase: phase
+        )
+
+        return Workout(
+            name: Workout.generateDefaultName(for: date),
+            date: date,
+            duration: duration,
+            steps: steps,
+            floors: floors,
+            stepsPerFloor: stepsPerFloor,
+            avgHeartRate: avgHeartRate,
+            maxHeartRate: maxHeartRate,
+            caloriesBurned: caloriesBurned,
+            effortRating: effortRating,
+            heartRateTimeSeries: heartRateTimeSeries,
+            source: .manual,
+            deviceModel: "Ascend Debug Seeder",
+            sourceMetadata: metadataString(for: preset),
+            weightConfiguration: weightConfiguration
+        )
+    }
+
+    private func phaseProfile(forWeek weekIndex: Int) -> WorkoutPhaseProfile {
+        switch weekIndex {
+        case 0..<4:
+            return .phaseOne
+        case 4..<9:
+            return .phaseTwo
+        default:
+            return .phaseThree
+        }
+    }
+
+    private func randomWorkoutTimestamp(
+        on day: Date,
+        referenceDate: Date,
+        rng: inout SeededGenerator
+    ) -> Date? {
+        let calendar = Calendar.current
+        var components = calendar.dateComponents([.year, .month, .day], from: day)
+
+        let dayPartRoll = Double.random(in: 0...1, using: &rng)
+        let hourRange: ClosedRange<Int>
+        switch dayPartRoll {
+        case ..<0.65:
+            hourRange = 5...10
+        case ..<0.90:
+            hourRange = 12...17
+        default:
+            hourRange = 18...20
+        }
+
+        components.hour = Int.random(in: hourRange, using: &rng)
+        components.minute = Int.random(in: 0...5, using: &rng) * 10
+        components.second = 0
+
+        guard let candidate = calendar.date(from: components) else { return nil }
+        let latestAllowed = referenceDate.addingTimeInterval(-5 * 60)
+        return candidate > latestAllowed ? latestAllowed : candidate
+    }
+
+    private func buildHeartRateSeries(
+        startDate: Date,
+        duration: TimeInterval,
+        avgHeartRate: Int?,
+        maxHeartRate: Int?,
+        rng: inout SeededGenerator
+    ) -> [HeartRateDataPoint]? {
+        guard let avgHeartRate, let maxHeartRate else { return nil }
+
+        let pointCount = max(8, Int(duration / 120))
+        guard pointCount > 1 else { return nil }
+
+        let lowerBound = max(95, avgHeartRate - 15)
+        var dataPoints: [HeartRateDataPoint] = []
+        dataPoints.reserveCapacity(pointCount)
+
+        for index in 0..<pointCount {
+            let progress = Double(index) / Double(max(pointCount - 1, 1))
+            let wave = sin(progress * .pi * 2.5) * 8
+            let noise = Double(Int.random(in: -3...3, using: &rng))
+            let heartRate = Int((Double(avgHeartRate) + wave + noise).rounded())
+            let clampedHeartRate = Int(clamped(Double(heartRate), min: Double(lowerBound), max: Double(maxHeartRate)))
+            let timestamp = startDate.addingTimeInterval(progress * duration)
+            dataPoints.append(HeartRateDataPoint(timestamp: timestamp, heartRate: clampedHeartRate))
+        }
+
+        return dataPoints
+    }
+
+    private func weightedVestConfigurationIfNeeded(
+        for phase: WorkoutPhaseProfile,
+        rng: inout SeededGenerator
+    ) -> WeightConfiguration? {
+        guard phase.includesWeightedVest, chance(0.30, rng: &rng) else { return nil }
+
+        let intendedPounds = Double.random(in: 15...25, using: &rng)
+        let storedWeight: Double
+        switch settings.measurementSystem {
+        case .imperial:
+            storedWeight = intendedPounds
+        case .metric:
+            storedWeight = MeasurementSystem.imperial.convertWeight(intendedPounds, to: .metric)
+        }
+
+        let roundedWeight = roundedToTenths(storedWeight)
+        let entry = WeightEntry(
+            equipmentType: .weightedVest,
+            weightValue: max(roundedWeight, 0.5),
+            isEnabled: true
+        )
+        return WeightConfiguration(entries: [entry])
+    }
+
+    private func estimateCalories(
+        steps: Int,
+        durationMinutes: Double,
+        pace: Double,
+        effortRating: Double?,
+        hasWeights: Bool,
+        phase: WorkoutPhaseProfile
+    ) -> Int {
+        let paceSpan = phase.paceRange.upperBound - phase.paceRange.lowerBound
+        let paceRatio = paceSpan > 0
+            ? clamped((pace - phase.paceRange.lowerBound) / paceSpan, min: 0, max: 1)
+            : 0.5
+        let effort = effortRating ?? ((phase.effortRange.lowerBound + phase.effortRange.upperBound) / 2)
+        let effortBoost = max(0, effort - 1.0) * 0.7
+        let weightBoost = hasWeights ? 1.2 : 0
+        let burnPerMinute = 7.0 + (paceRatio * 3.0) + effortBoost + weightBoost
+        let stepsBoost = Double(steps) * 0.01
+
+        return max(60, Int((burnPerMinute * durationMinutes + stepsBoost).rounded()))
+    }
+
+    // MARK: - Cleanup + Rebuild
+
+    private func removeSeededWorkouts(modelContext: ModelContext) throws {
+        let existingSeededWorkouts = try fetchSeededWorkouts(modelContext: modelContext)
+        guard !existingSeededWorkouts.isEmpty else { return }
+
+        for workout in existingSeededWorkouts {
+            modelContext.delete(workout)
+        }
+        try modelContext.save()
+    }
+
+    private func fetchSeededWorkouts(modelContext: ModelContext) throws -> [Workout] {
+        let allWorkouts = try modelContext.fetch(FetchDescriptor<Workout>())
+        return allWorkouts.filter(isSeededWorkout)
+    }
+
+    private func isSeededWorkout(_ workout: Workout) -> Bool {
+        guard let metadata = metadata(from: workout) else { return false }
+        return metadata.isTestData && metadata.seedSource == seedSource
+    }
+
+    private func rebuildDerivedData(modelContext: ModelContext) throws {
+        try PersonalRecordService.recalculateAllPersonalRecords(
+            modelContext: modelContext,
+            measurementSystem: settings.measurementSystem,
+            stepHeight: settings.stepHeight
+        )
+
+        guard let userId = Auth.auth().currentUser?.uid else { return }
+
+        let leaderboardService = LeaderboardService.shared
+        leaderboardService.configure(modelContext: modelContext)
+        let allWorkouts = try modelContext.fetch(FetchDescriptor<Workout>())
+        try leaderboardService.updateAllTimeFrames(for: userId, workouts: allWorkouts)
+    }
+
+    // MARK: - Metadata
+
+    private func metadataString(for preset: WorkoutSeedPreset) -> String {
+        let metadata = SeededWorkoutMetadata(
+            isTestData: true,
+            seedSource: seedSource,
+            preset: preset.rawValue
+        )
+
+        if let data = try? JSONEncoder().encode(metadata),
+           let jsonString = String(data: data, encoding: .utf8) {
+            return jsonString
+        }
+
+        return "{\"isTestData\":true,\"seedSource\":\"\(seedSource)\",\"preset\":\"\(preset.rawValue)\"}"
+    }
+
+    private func metadata(from workout: Workout) -> SeededWorkoutMetadata? {
+        guard let sourceMetadata = workout.sourceMetadata,
+              let data = sourceMetadata.data(using: .utf8) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(SeededWorkoutMetadata.self, from: data)
+    }
+}
+
+private struct WorkoutPhaseProfile {
+    let stepRange: ClosedRange<Int>
+    let durationMinutesRange: ClosedRange<Double>
+    let avgHeartRateRange: ClosedRange<Int>
+    let effortRange: ClosedRange<Double>
+    let paceRange: ClosedRange<Double>
+    let workoutsPerWeek: ClosedRange<Int>
+    let includesWeightedVest: Bool
+
+    static let phaseOne = WorkoutPhaseProfile(
+        stepRange: 500...1_200,
+        durationMinutesRange: 15...25,
+        avgHeartRateRange: 120...140,
+        effortRange: 1.5...3.0,
+        paceRange: 35...55,
+        workoutsPerWeek: 2...3,
+        includesWeightedVest: false
+    )
+
+    static let phaseTwo = WorkoutPhaseProfile(
+        stepRange: 1_000...2_000,
+        durationMinutesRange: 20...35,
+        avgHeartRateRange: 130...150,
+        effortRange: 2.5...3.5,
+        paceRange: 45...65,
+        workoutsPerWeek: 2...3,
+        includesWeightedVest: false
+    )
+
+    static let phaseThree = WorkoutPhaseProfile(
+        stepRange: 1_500...2_800,
+        durationMinutesRange: 25...45,
+        avgHeartRateRange: 135...165,
+        effortRange: 3.0...4.5,
+        paceRange: 55...75,
+        workoutsPerWeek: 3...4,
+        includesWeightedVest: true
+    )
+}
+
+private struct SeededWorkoutMetadata: Codable {
+    let isTestData: Bool
+    let seedSource: String
+    let preset: String?
+}
+
+private struct SeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed == 0 ? 0xCAFE_BABE_F00D : seed
+    }
+
+    mutating func next() -> UInt64 {
+        state = state &* 6364136223846793005 &+ 1
+        return state
+    }
+}
+
+private func uniqueDayOffsets(
+    maxOffset: Int,
+    count: Int,
+    rng: inout SeededGenerator
+) -> [Int] {
+    guard maxOffset >= 0, count > 0 else { return [] }
+    var offsets = Array(0...maxOffset)
+    offsets.shuffle(using: &rng)
+    return Array(offsets.prefix(count)).sorted()
+}
+
+private func chance(
+    _ probability: Double,
+    rng: inout SeededGenerator
+) -> Bool {
+    Double.random(in: 0...1, using: &rng) <= clamped(probability, min: 0, max: 1)
+}
+
+private func roundedToTenths(_ value: Double) -> Double {
+    (value * 10).rounded() / 10
+}
+
+private func clamped<T: Comparable>(_ value: T, min lowerBound: T, max upperBound: T) -> T {
+    Swift.min(upperBound, Swift.max(lowerBound, value))
+}
+#endif

--- a/AscendApp/Features/Debug/ViewModels/DebugToolsViewModel.swift
+++ b/AscendApp/Features/Debug/ViewModels/DebugToolsViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Observation
+import SwiftData
 
 #if DEBUG
 @MainActor
@@ -14,6 +15,14 @@ import Observation
 class DebugToolsViewModel {
     private let service = DebugToolsService.shared
 
+    private enum ActionTitle {
+        static let seedLeaderboard = "Seed Test Data"
+        static let clearLeaderboard = "Clear Test Data"
+        static let seedWorkouts = "Seed Workouts"
+        static let clearSeededWorkouts = "Clear Seeded Workouts"
+    }
+
+    var selectedWorkoutPreset: WorkoutSeedPreset = .appStoreScreenshots
     var executingActionId: UUID?  // Track which specific action is executing
     var errorMessage: String?
     var successMessage: String?
@@ -22,11 +31,33 @@ class DebugToolsViewModel {
 
     var sections: [DebugSection] {
         [
+            workoutsSection,
             leaderboardSection
-            // Easy to add more sections:
-            // workoutsSection,
-            // authSection,
         ]
+    }
+
+    // MARK: - Workouts Section
+
+    private var workoutsSection: DebugSection {
+        DebugSection(
+            title: "Workouts",
+            subtitle: "Seed local SwiftData workout history",
+            actions: [
+                DebugAction(
+                    title: ActionTitle.seedWorkouts,
+                    description: "Seeds realistic local workout history for Simulator testing and screenshots.",
+                    icon: "figure.stair.stepper",
+                    iconColor: .accent
+                ),
+                DebugAction(
+                    title: ActionTitle.clearSeededWorkouts,
+                    description: "Clears only workouts seeded by Debug Tools.",
+                    icon: "trash.fill",
+                    iconColor: .red,
+                    isDestructive: true
+                )
+            ]
+        )
     }
 
     // MARK: - Leaderboard Section
@@ -37,13 +68,13 @@ class DebugToolsViewModel {
             subtitle: "Manage test leaderboard data",
             actions: [
                 DebugAction(
-                    title: "Seed Test Data",
+                    title: ActionTitle.seedLeaderboard,
                     description: "Seeds leaderboard entries for YOUR account across all time frames. For multi-user data, run: node scripts/seed-leaderboard.mjs seed --project dev",
                     icon: "arrow.down.doc.fill",
                     iconColor: .accent
                 ),
                 DebugAction(
-                    title: "Clear Test Data",
+                    title: ActionTitle.clearLeaderboard,
                     description: "Clears YOUR seeded leaderboard entries.",
                     icon: "trash.fill",
                     iconColor: .red,
@@ -55,7 +86,7 @@ class DebugToolsViewModel {
 
     // MARK: - Action Execution
 
-    func executeAction(_ action: DebugAction) async {
+    func executeAction(_ action: DebugAction, modelContext: ModelContext) async {
         executingActionId = action.id  // Set the specific action being executed
         errorMessage = nil
         successMessage = nil
@@ -63,11 +94,22 @@ class DebugToolsViewModel {
         do {
             // Map action titles to service methods
             switch action.title {
-            case "Seed Test Data":
+            case ActionTitle.seedWorkouts:
+                let count = try await service.seedWorkoutData(
+                    preset: selectedWorkoutPreset,
+                    modelContext: modelContext
+                )
+                successMessage = "Seeded \(count) workout\(count == 1 ? "" : "s") using \(selectedWorkoutPreset.displayName)."
+
+            case ActionTitle.clearSeededWorkouts:
+                let count = try await service.clearSeededWorkoutData(modelContext: modelContext)
+                successMessage = "Cleared \(count) seeded workout\(count == 1 ? "" : "s")."
+
+            case ActionTitle.seedLeaderboard:
                 try await service.seedLeaderboardData()
                 successMessage = "Successfully seeded test data!"
 
-            case "Clear Test Data":
+            case ActionTitle.clearLeaderboard:
                 try await service.clearLeaderboardData()
                 successMessage = "Successfully cleared test data!"
 

--- a/AscendApp/Features/Debug/Views/DebugToolsView.swift
+++ b/AscendApp/Features/Debug/Views/DebugToolsView.swift
@@ -6,10 +6,12 @@
 //
 
 import SwiftUI
+import SwiftData
 
 #if DEBUG
 struct DebugToolsView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.modelContext) private var modelContext
     @State private var viewModel = DebugToolsViewModel()
     @State private var showSuccessAlert = false
     @State private var showErrorAlert = false
@@ -189,6 +191,11 @@ struct DebugToolsView: View {
             }
             .padding(.horizontal, 20)
 
+            if section.title == "Workouts" {
+                workoutPresetPicker
+                    .padding(.horizontal, 20)
+            }
+
             // Actions
             VStack(spacing: 12) {
                 ForEach(section.actions) { action in
@@ -197,13 +204,29 @@ struct DebugToolsView: View {
                         isExecuting: viewModel.isExecuting(action),  // Check if THIS specific action is executing
                         onExecute: {
                             Task {
-                                await viewModel.executeAction(action)
+                                await viewModel.executeAction(action, modelContext: modelContext)
                             }
                         }
                     )
                 }
             }
             .padding(.horizontal, 20)
+        }
+    }
+
+    private var workoutPresetPicker: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Preset")
+                .font(.montserratSemiBold(size: 13))
+                .foregroundStyle(colorScheme == .dark ? .white.opacity(0.8) : .black.opacity(0.7))
+
+            Picker("Workout Preset", selection: $viewModel.selectedWorkoutPreset) {
+                ForEach(WorkoutSeedPreset.allCases) { preset in
+                    Text(preset.pickerLabel)
+                        .tag(preset)
+                }
+            }
+            .pickerStyle(.segmented)
         }
     }
 
@@ -245,5 +268,6 @@ struct DebugToolsView: View {
     NavigationStack {
         DebugToolsView()
     }
+    .modelContainer(for: Workout.self, inMemory: true)
 }
 #endif

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,13 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 - Use server-side seeding (Admin SDK / Cloud Function / CI job) for deterministic multi-user leaderboard fixtures.
 - For local-only iteration, use Firestore emulator or seed only the authenticated user.
 
+### Workout Seeding Policy (Debug)
+- Debug Tools includes local SwiftData workout seeding presets for Simulator workflows (`App Store Screenshots`, `Quick Demo`).
+- Seeded workout metadata is stored in `Workout.sourceMetadata` with `isTestData=true`, `seedSource="debug-tools"`, and `preset` for targeted cleanup.
+- Workout seeding is idempotent for debug usage: seeding replaces existing debug-seeded workouts before inserting the new preset.
+- Clearing seeded workouts must recalculate personal records and local leaderboard aggregates to keep derived data consistent.
+- Weighted vest debug data should use an intended pounds range and convert to kilograms when measurement system is metric.
+
 ### Leaderboard UX Flow
 - The leaderboard tab root should be a category hub with per-metric preview cards (`Climb`, `Workouts`, `Duration`, `Pace`) and a `See all` action on each card.
 - `See all` opens a metric-specific leaderboard detail screen.

--- a/scripts/seed-leaderboard.mjs
+++ b/scripts/seed-leaderboard.mjs
@@ -79,6 +79,17 @@ const TIME_FRAMES = [
   { key: "all_time", multiplier: 100 },
 ];
 
+const AVATAR_BACKGROUNDS = [
+  "1D4ED8", // blue
+  "0F766E", // teal
+  "B45309", // amber
+  "7C3AED", // violet
+  "BE123C", // rose
+  "166534", // green
+  "0E7490", // cyan
+  "4338CA", // indigo
+];
+
 // ---------------------------------------------------------------------------
 // Period identifier logic — ported from LeaderboardTimeFrame.swift
 // ---------------------------------------------------------------------------
@@ -188,6 +199,29 @@ function randomDouble(min, max) {
   return Math.random() * (max - min) + min;
 }
 
+function hashString(value) {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+function avatarURL(name) {
+  const index = hashString(name) % AVATAR_BACKGROUNDS.length;
+  const background = AVATAR_BACKGROUNDS[index];
+  const params = new URLSearchParams({
+    name,
+    size: "200",
+    background,
+    color: "fff",
+    bold: "true",
+    format: "png",
+  });
+
+  return `https://ui-avatars.com/api/?${params.toString()}`;
+}
+
 function generateStats(multiplier) {
   const baseWorkouts = randomInt(3, 7);
   const baseStepsPerWorkout = randomInt(800, 2500);
@@ -292,7 +326,7 @@ async function seed(db, dryRun) {
         data: {
           userId: user.id,
           displayName: user.name,
-          photoURL: "",
+          photoURL: avatarURL(user.name),
           timeFrame: tf.key,
           periodIdentifier: period,
           totalSteps: stats.totalSteps,


### PR DESCRIPTION
## Summary
- add a debug workout seeder with reusable presets and cleanup hooks for simulator/screenshot workflows
- wire the new seeding actions into the Debug Tools view model and UI
- make leaderboard script avatar URLs deterministic and sync the project guide docs with the new debug seeding policy

## Validation
- xcodebuild -project AscendApp.xcodeproj -scheme "AscendApp" -configuration Debug -sdk iphoneos -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build

Closes #78