### PR TITLE
Add required NSHealthUpdateUsageDescription for TestFlight

### DIFF
--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -280,6 +280,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Ascend - STG";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Ascend needs access to your Health data to import your stair climbing workouts, including steps, heart rate, active energy, and resting energy.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Ascend needs access to your Health data to import your stair climbing workouts, including steps, heart rate, active energy, and resting energy.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Ascend saves your workout posters to your Photos library.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Ascend needs access to your photo library to attach photos and videos to workouts.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -447,6 +448,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Ascend - DEV";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Ascend needs access to your Health data to import your stair climbing workouts, including steps, heart rate, active energy, and resting energy.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Ascend needs access to your Health data to import your stair climbing workouts, including steps, heart rate, active energy, and resting energy.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Ascend saves your workout posters to your Photos library.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Ascend needs access to your photo library to attach photos and videos to workouts.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -489,6 +491,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Ascend;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.healthcare-fitness";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Ascend needs access to your Health data to import your stair climbing workouts, including steps, heart rate, active energy, and resting energy.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Ascend needs access to your Health data to import your stair climbing workouts, including steps, heart rate, active energy, and resting energy.";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Ascend saves your workout posters to your Photos library.";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Ascend needs access to your photo library to attach photos and videos to workouts.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/AscendApp/Info.plist
+++ b/AscendApp/Info.plist
@@ -36,6 +36,8 @@
 	<string>Ascend needs access to your photo library to attach photos and videos to workouts.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Ascend needs access to your Health data to import your stair climbing workouts, including steps, heart rate, active energy, and resting energy.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Ascend needs access to your Health data to import your stair climbing workouts, including steps, heart rate, active energy, and resting energy.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Montserrat-Regular.ttf</string>


### PR DESCRIPTION
## Summary
- Apple requires both `NSHealthShareUsageDescription` and `NSHealthUpdateUsageDescription` even when the app only reads HealthKit data
- Missing update key caused TestFlight error 90683 on builds 42 and 43
- Added `NSHealthUpdateUsageDescription` to all three build configs (Debug, Staging, Release) and Info.plist

## Test plan
- [ ] CI build passes
- [ ] Deploy staging and verify TestFlight build processes without error 90683

🤖 Generated with [Claude Code](https://claude.com/claude-code)