### PR TITLE
Fix HealthKit entitlement missing on TestFlight builds

### DIFF
--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -295,7 +295,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.TylerPavay.AscendApp.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "AscendApp - Staging - AppStore";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.TylerPavay.AscendApp.staging";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
@@ -504,7 +504,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.TylerPavay.AscendApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "AscendApp - Production - AppStore";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AppStore com.TylerPavay.AscendApp";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;


### PR DESCRIPTION
## Summary
- Staging and Release build configs in the Xcode project referenced old manually-created provisioning profile names (`AscendApp - Staging - AppStore`, `AscendApp - Production - AppStore`) that either don't exist or predate HealthKit capability being added
- Updated to use the correct fastlane match-generated profile names (`match AppStore com.TylerPavay.AscendApp.staging`, `match AppStore com.TylerPavay.AscendApp`) which include HealthKit, In-App Purchase, and Sign In with Apple capabilities
- This was causing "Missing com.apple.developer.healthkit entitlement" error when tapping Connect on the Apple Health integration in TestFlight builds

## Test plan
- [ ] Deploy a new staging build to TestFlight
- [ ] Open Integrations → Apple Health → Connect
- [ ] Verify HealthKit permission prompt appears instead of the entitlement error

🤖 Generated with [Claude Code](https://claude.com/claude-code)