### PR TITLE
Pass provisioning profile specifier during archive step

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -116,6 +116,7 @@ platform :ios do
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
+        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(staging_profile_specifier)}",
         "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" ")
     )
@@ -184,6 +185,7 @@ platform :ios do
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}",
+        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(production_profile_specifier)}",
         "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
       ].join(" ")
     )


### PR DESCRIPTION
## Summary
- The `build_app` xcargs in the Fastfile were missing `PROVISIONING_PROFILE_SPECIFIER`, so during the archive step xcodebuild couldn't resolve the correct provisioning profile
- Without it, the archive was signed with only bare minimum entitlements — no HealthKit, no Sign In with Apple — even though both the `.entitlements` file and the provisioning profile had them
- Added `PROVISIONING_PROFILE_SPECIFIER` to xcargs for both staging and production build lanes
- This is the actual fix for the "Missing com.apple.developer.healthkit entitlement" error on TestFlight builds (PR #90 fixed the profile names in pbxproj but this is where the archive signing actually happens)

## Test plan
- [ ] Merge to develop, let deploy-staging run
- [ ] Check build metadata in App Store Connect — Entitlements section should now include `com.apple.developer.healthkit`
- [ ] Install from TestFlight → Integrations → Apple Health → Connect should show the HealthKit permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)