### PR TITLE
Fix missing entitlements in staging/production archives

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -117,9 +117,20 @@ platform :ios do
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
         "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(staging_profile_specifier)}",
-        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
+        "CODE_SIGN_ENTITLEMENTS=AscendApp/AscendApp.entitlements",
+        "CODE_SIGNING_ALLOWED=YES"
       ].join(" ")
     )
+
+    # Diagnostic: verify entitlements in the archive before export
+    app_path = File.join(archive_path, "Products", "Applications", "AscendApp.app", "AscendApp")
+    if File.exist?(app_path)
+      UI.message("=== Archive binary entitlements ===")
+      sh("codesign -d --entitlements - '#{File.join(archive_path, "Products", "Applications", "AscendApp.app")}' 2>&1 || true")
+    else
+      UI.error("Archive binary not found at expected path — checking archive contents:")
+      sh("find '#{archive_path}' -name '*.app' 2>&1 || true")
+    end
 
     # Step 2: Export the archive to IPA.
     # Run xcodebuild directly so no stray xcargs leak into the export command.
@@ -186,7 +197,8 @@ platform :ios do
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}",
         "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(production_profile_specifier)}",
-        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
+        "CODE_SIGN_ENTITLEMENTS=AscendApp/AscendApp.entitlements",
+        "CODE_SIGNING_ALLOWED=YES"
       ].join(" ")
     )
 


### PR DESCRIPTION
## Summary
- Explicitly passes `CODE_SIGN_ENTITLEMENTS=AscendApp/AscendApp.entitlements` in the archive xcargs so xcodebuild is guaranteed to find and embed the entitlements file
- Replaces `CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'` with `CODE_SIGNING_ALLOWED=YES` to eliminate any ambiguity about whether signing is enabled
- Adds a diagnostic step that dumps `codesign -d --entitlements` on the archive binary, so we can see exactly what entitlements are embedded before the export step

## Context
Previous fixes (PRs #90, #92) corrected profile names and added `PROVISIONING_PROFILE_SPECIFIER`, but the TestFlight binary still shows zero custom entitlements. The entitlements file, provisioning profile, and project settings are all correct — the issue is that xcodebuild isn't picking up the entitlements during the archive step. This forces the path explicitly.

## Test plan
- [ ] Merge to develop, let deploy-staging run
- [ ] Check CI logs for the new "Archive binary entitlements" diagnostic output
- [ ] Check build metadata in App Store Connect — Entitlements should now include `com.apple.developer.healthkit` and `com.apple.developer.applesignin`
- [ ] Install from TestFlight → Integrations → Apple Health → Connect should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)