### PR TITLE
Add missing healthkit.access entitlement for manual signing

### DIFF
--- a/AscendApp/AscendApp.entitlements
+++ b/AscendApp/AscendApp.entitlements
@@ -8,5 +8,7 @@
 	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
+	<key>com.apple.developer.healthkit.access</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Adds `com.apple.developer.healthkit.access` (empty array) to `AscendApp.entitlements`
- This key is auto-injected by Xcode in **automatic signing** (dev builds) but NOT in **manual signing** (CI/staging)
- The provisioning profile requires this key — without it, codesign in manual mode may reject or skip the entire entitlements block, which explains why ALL custom entitlements (HealthKit + Sign In with Apple) are missing from the TestFlight binary
- Also includes the diagnostic and `-allowProvisioningUpdates` removal from PR #95

## The entitlements file now has:
```xml
<key>com.apple.developer.applesignin</key>
<array><string>Default</string></array>
<key>com.apple.developer.healthkit</key>
<true/>
<key>com.apple.developer.healthkit.access</key>
<array/>
```

## Test plan
- [ ] Merge to develop, let deploy-staging run
- [ ] Check CI logs for "DIAGNOSTIC: Archive entitlements" — should now show healthkit keys
- [ ] Check build metadata in App Store Connect — Entitlements should include `com.apple.developer.healthkit`
- [ ] Install from TestFlight → Integrations → Apple Health → Connect should show HealthKit permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)