### PR TITLE
Fix archive signing: remove invalid CODE_SIGNING_ALLOWED_FOR_APPS xcarg

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -116,8 +116,7 @@ platform :ios do
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
-        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(staging_profile_specifier)}",
-        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
+        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(staging_profile_specifier)}"
       ].join(" ")
     )
 
@@ -190,8 +189,7 @@ platform :ios do
         "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
         "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}",
-        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(production_profile_specifier)}",
-        "CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'"
+        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(production_profile_specifier)}"
       ].join(" ")
     )
 


### PR DESCRIPTION
## Root cause
Diagnostic output revealed the archive binary was **completely unsigned** ("code object is not signed at all").

The xcarg `CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'` (added in PR #43 to prevent SPM packages from signing) used a build setting name that doesn't exist in Xcode. `$(CODE_SIGNING_ALLOWED_FOR_APPS)` resolved to empty string → `CODE_SIGNING_ALLOWED=` → signing disabled for ALL targets, including the app.

With no signing during archive, the export step signed from scratch using only the provisioning profile — but without the `.entitlements` file, so HealthKit and Sign In with Apple were never embedded.

## Fix
- Remove `CODE_SIGNING_ALLOWED` from xcargs entirely (default is YES)
- Keeps the diagnostic output so we can verify entitlements are now present in the archive

## Also included from previous commits
- `com.apple.developer.healthkit.access` added to entitlements file (needed for manual signing)
- `-allowProvisioningUpdates` removed from export (not needed for manual signing)
- Correct profile names in pbxproj and PROVISIONING_PROFILE_SPECIFIER in xcargs

## Test plan
- [ ] Merge to develop, let deploy-staging run
- [ ] Check CI logs — diagnostic should now show `com.apple.developer.healthkit` in archive entitlements
- [ ] Check build metadata in App Store Connect — Entitlements should include HealthKit
- [ ] Install from TestFlight → Integrations → Apple Health → Connect should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)