### PR TITLE
Fix CI signing: only pass cert identity and team as xcargs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -113,10 +113,8 @@ platform :ios do
       skip_package_ipa: true,
       archive_path: archive_path,
       xcargs: [
-        "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}",
-        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(staging_profile_specifier)}"
+        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}"
       ].join(" ")
     )
 
@@ -186,10 +184,8 @@ platform :ios do
       skip_package_ipa: true,
       archive_path: archive_path,
       xcargs: [
-        "CODE_SIGN_STYLE=Manual",
         "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}",
-        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(production_profile_specifier)}"
+        "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}"
       ].join(" ")
     )
 


### PR DESCRIPTION
## Problem
Removing `CODE_SIGNING_ALLOWED` fixed the app target not being signed, but exposed a second issue: `CODE_SIGN_STYLE=Manual` and `PROVISIONING_PROFILE_SPECIFIER` were also global xcargs, which SPM library targets reject ("does not support provisioning profiles").

This is the original problem that the invalid `CODE_SIGNING_ALLOWED_FOR_APPS` was masking — it disabled signing for everything, so SPM targets never tried to use the profile.

## Fix
Remove `CODE_SIGN_STYLE` and `PROVISIONING_PROFILE_SPECIFIER` from xcargs entirely. These are already set correctly **per-target** in the Xcode project:
- Staging config: `CODE_SIGN_STYLE = Manual`, `PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*] = "match AppStore com.TylerPavay.AscendApp.staging"`
- Release config: `CODE_SIGN_STYLE = Manual`, `PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*] = "match AppStore com.TylerPavay.AscendApp"`

Only `CODE_SIGN_IDENTITY` and `DEVELOPMENT_TEAM` remain as xcargs — CI needs these to find the cert in the temp keychain, and they don't cause issues for SPM targets.

## Test plan
- [ ] Merge to develop, let deploy-staging run  
- [ ] Check CI logs — diagnostic should show HealthKit in archive entitlements
- [ ] Check build metadata in App Store Connect for `com.apple.developer.healthkit`
- [ ] Install from TestFlight → Apple Health → Connect should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)