### PR TITLE
Fix CI signing: use per-target settings instead of global xcargs

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -99,9 +99,18 @@ platform :ios do
     export_signing_cert = cert_name || staging_signing_identity
     UI.message("Using signing certificate: #{export_signing_cert}")
 
+    # Set signing identity on the app target only (not globally via xcargs,
+    # which would break SPM package targets that use automatic signing).
+    update_code_signing_settings(
+      path: "AscendApp.xcodeproj",
+      targets: ["AscendApp"],
+      build_configurations: ["Staging"],
+      code_sign_identity: export_signing_cert
+    )
+
     # Step 1: Archive only (skip IPA packaging).
-    # xcargs are needed for archive to find the cert in the temp keychain,
-    # but gym leaks them into the export command where they break signing.
+    # No signing xcargs — all signing settings come from the project file
+    # (set above and in the Xcode project's Staging build configuration).
     archive_path = File.join(Dir.tmpdir, "AscendApp-Staging.xcarchive")
 
     build_app(
@@ -111,11 +120,7 @@ platform :ios do
       clean: true,
       skip_profile_detection: true,
       skip_package_ipa: true,
-      archive_path: archive_path,
-      xcargs: [
-        "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(staging_development_team)}"
-      ].join(" ")
+      archive_path: archive_path
     )
 
     # Diagnostic: verify entitlements embedded in the archive
@@ -172,6 +177,14 @@ platform :ios do
     export_signing_cert = cert_name || production_signing_identity
     UI.message("Using signing certificate: #{export_signing_cert}")
 
+    # Set signing identity on the app target only (not globally via xcargs).
+    update_code_signing_settings(
+      path: "AscendApp.xcodeproj",
+      targets: ["AscendApp"],
+      build_configurations: ["Release"],
+      code_sign_identity: export_signing_cert
+    )
+
     # Step 1: Archive only
     archive_path = File.join(Dir.tmpdir, "AscendApp-Production.xcarchive")
 
@@ -182,11 +195,7 @@ platform :ios do
       clean: true,
       skip_profile_detection: true,
       skip_package_ipa: true,
-      archive_path: archive_path,
-      xcargs: [
-        "CODE_SIGN_IDENTITY=#{Shellwords.escape(export_signing_cert)}",
-        "DEVELOPMENT_TEAM=#{Shellwords.escape(production_development_team)}"
-      ].join(" ")
+      archive_path: archive_path
     )
 
     # Step 2: Export the archive to IPA


### PR DESCRIPTION
## Root cause (confirmed by diagnostics)
The archive binary was **completely unsigned** (`code object is not signed at all`). This was caused by `CODE_SIGNING_ALLOWED='$(CODE_SIGNING_ALLOWED_FOR_APPS)'` — a build setting that doesn't exist in Xcode 26.3, resolving to empty string and disabling signing.

But we can't just remove it — the deeper problem is that **all signing xcargs apply globally** to every target, including SPM packages. Each one causes a different failure:
- `CODE_SIGNING_ALLOWED_FOR_APPS` → not a real setting, disables signing
- `CODE_SIGN_STYLE=Manual` → SPM targets reject provisioning profiles  
- `PROVISIONING_PROFILE_SPECIFIER` → SPM targets don't support profiles
- `CODE_SIGN_IDENTITY=Apple Distribution` → conflicts with auto-signed SPM targets

## Fix
Replace all signing xcargs with `update_code_signing_settings`, which targets **only the AscendApp target** for the specific build configuration. All other signing settings (style, profile, entitlements, team) are already correctly configured per-target in the Xcode project.

## Test plan
- [ ] Merge to develop, let deploy-staging run
- [ ] Build should succeed (no SPM signing conflicts)
- [ ] Check CI logs for "DIAGNOSTIC: Archive entitlements" — should show HealthKit
- [ ] Check build metadata in App Store Connect for `com.apple.developer.healthkit`
- [ ] Install from TestFlight → Apple Health → Connect should show HealthKit permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)