### PR TITLE
Fix leaderboard hub timeframe picker and centralize mutation side effects

### DIFF
--- a/AscendApp/Features/Debug/Services/WorkoutTestDataSeeder.swift
+++ b/AscendApp/Features/Debug/Services/WorkoutTestDataSeeder.swift
@@ -363,18 +363,7 @@ final class WorkoutTestDataSeeder {
     }
 
     private func rebuildDerivedData(modelContext: ModelContext) throws {
-        try PersonalRecordService.recalculateAllPersonalRecords(
-            modelContext: modelContext,
-            measurementSystem: settings.measurementSystem,
-            stepHeight: settings.stepHeight
-        )
-
-        guard let userId = Auth.auth().currentUser?.uid else { return }
-
-        let leaderboardService = LeaderboardService.shared
-        leaderboardService.configure(modelContext: modelContext)
-        let allWorkouts = try modelContext.fetch(FetchDescriptor<Workout>())
-        try leaderboardService.updateAllTimeFrames(for: userId, workouts: allWorkouts)
+        try WorkoutMutationHandler.shared.workoutsDidChange(modelContext: modelContext)
     }
 
     // MARK: - Metadata

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardHubView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardHubView.swift
@@ -19,6 +19,7 @@ struct LeaderboardHubView: View {
     @Query private var workouts: [Workout]
     @State private var settingsManager = SettingsManager.shared
 
+    @State private var selectedTimeFrame: LeaderboardTimeFrame = .weekly
     @State private var previewEntries: [LeaderboardMetric: [LeaderboardEntry]] = [:]
     @State private var isLoading = false
     @State private var errorMessage: String?
@@ -42,7 +43,8 @@ struct LeaderboardHubView: View {
                         LeaderboardCategoryCard(
                             metric: metric,
                             entries: previewEntries[metric] ?? [],
-                            preferredMetric: preferredMetric
+                            preferredMetric: preferredMetric,
+                            selectedTimeFrame: selectedTimeFrame
                         )
                     }
                 } else if isLoading {
@@ -64,6 +66,9 @@ struct LeaderboardHubView: View {
         }
         .onChange(of: scenePhase) { _, newPhase in
             guard newPhase == .active, tabRouter.selectedTab == .leaderboard else { return }
+            Task { await loadPreviews(mode: .fast) }
+        }
+        .onChange(of: selectedTimeFrame) { _, _ in
             Task { await loadPreviews(mode: .fast) }
         }
         .refreshable {
@@ -123,7 +128,7 @@ struct LeaderboardHubView: View {
                     do {
                         let stats = try await repository.fetchLeaderboard(
                             metric: metric,
-                            timeFrame: .weekly,
+                            timeFrame: selectedTimeFrame,
                             limit: previewLimit,
                             preferredWorkoutMetric: preferredMetric,
                             source: mode == .fast ? .default : .server
@@ -134,7 +139,7 @@ struct LeaderboardHubView: View {
                             do {
                                 let cachedStats = try await repository.fetchLeaderboard(
                                     metric: metric,
-                                    timeFrame: .weekly,
+                                    timeFrame: selectedTimeFrame,
                                     limit: previewLimit,
                                     preferredWorkoutMetric: preferredMetric,
                                     source: .cache
@@ -212,15 +217,18 @@ struct LeaderboardHubView: View {
         }
     }
 
+    private let hubTimeFrames: [LeaderboardTimeFrame] = [.weekly, .monthly, .allTime]
+
     private var hubHeader: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 12) {
             Text("Leaderboards")
                 .font(.montserratBold(size: 34))
                 .foregroundStyle(.primary)
 
-            Text("Weekly")
-                .font(.montserratMedium(size: 16))
-                .foregroundStyle(.secondary)
+            LeaderboardPickerView(
+                selectedTimeFrame: $selectedTimeFrame,
+                timeFrames: hubTimeFrames
+            )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.bottom, 4)
@@ -279,6 +287,7 @@ private struct LeaderboardCategoryCard: View {
     let metric: LeaderboardMetric
     let entries: [LeaderboardEntry]
     let preferredMetric: WorkoutMetric
+    let selectedTimeFrame: LeaderboardTimeFrame
 
     private var title: String {
         metric.displayName(for: preferredMetric)
@@ -294,7 +303,7 @@ private struct LeaderboardCategoryCard: View {
                 Spacer()
 
                 NavigationLink {
-                    LeaderboardView(lockedMetric: metric)
+                    LeaderboardView(lockedMetric: metric, initialTimeFrame: selectedTimeFrame)
                 } label: {
                     Text("See all")
                         .font(.montserratSemiBold(size: 16))

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
@@ -29,14 +29,14 @@ struct LeaderboardView: View {
     }
 
     @MainActor
-    init(lockedMetric: LeaderboardMetric? = nil) {
+    init(lockedMetric: LeaderboardMetric? = nil, initialTimeFrame: LeaderboardTimeFrame = .weekly) {
         self.lockedMetric = lockedMetric
 
         let vm = LeaderboardViewModel()
         if let lockedMetric {
             vm.selectedMetric = lockedMetric
-            vm.selectedTimeFrame = .weekly
         }
+        vm.selectedTimeFrame = initialTimeFrame
         _viewModel = State(initialValue: vm)
     }
 

--- a/AscendApp/Features/Workouts/ViewModels/WorkoutFormViewModel.swift
+++ b/AscendApp/Features/Workouts/ViewModels/WorkoutFormViewModel.swift
@@ -149,10 +149,8 @@ class WorkoutFormViewModel {
             modelContext.insert(workout)
             try modelContext.save()
 
-            try WorkoutDerivedDataService.recalculateAll(
-                modelContext: modelContext,
-                settingsManager: settingsManager
-            )
+            // Recalculate PRs and leaderboard stats
+            try WorkoutMutationHandler.shared.workoutsDidChange(modelContext: modelContext)
 
             // Queue media uploads asynchronously (fire-and-forget)
             // This happens in background so form can close immediately

--- a/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
+++ b/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
@@ -780,11 +780,9 @@ struct EditWorkoutView: View {
             
             try modelContext.save()
             print("✅ Successfully updated workout with \(workout.photos.count) photos")
-            
-            try WorkoutDerivedDataService.recalculateAll(
-                modelContext: modelContext,
-                settingsManager: settingsManager
-            )
+
+            // Recalculate PRs and leaderboard stats after edit
+            try WorkoutMutationHandler.shared.workoutsDidChange(modelContext: modelContext)
             
             let photosToDelete = photosMarkedForDeletion
             if !photosToDelete.isEmpty {

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -1158,11 +1158,8 @@ struct WorkoutDetailView: View {
         do {
             try modelContext.save()
 
-            let settingsManager = SettingsManager.shared
-            try WorkoutDerivedDataService.recalculateAll(
-                modelContext: modelContext,
-                settingsManager: settingsManager
-            )
+            // Recalculate PRs and leaderboard stats after deletion
+            try WorkoutMutationHandler.shared.workoutsDidChange(modelContext: modelContext)
 
             await MainActor.run {
                 isDeleting = false

--- a/AscendApp/Features/Workouts/Views/WorkoutListView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutListView.swift
@@ -323,10 +323,8 @@ struct WorkoutListView: View {
             }
             try modelContext.save()
 
-            try WorkoutDerivedDataService.recalculateAll(
-                modelContext: modelContext,
-                settingsManager: settingsManager
-            )
+            // Recalculate PRs and leaderboard stats after deletion
+            try WorkoutMutationHandler.shared.workoutsDidChange(modelContext: modelContext)
 
             await MainActor.run {
                 isDeleting = false

--- a/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
@@ -867,9 +867,20 @@ final class WorkoutImportCoordinator {
     }
 
     private func recalculateDerivedData(modelContext: ModelContext) throws {
-        try WorkoutDerivedDataService.recalculateAll(
-            modelContext: modelContext,
-            settingsManager: .shared
-        )
+        let allWorkouts = try fetchAllWorkouts(from: modelContext)
+        let settings = SettingsManager.shared
+
+        for workout in allWorkouts {
+            workout.percentileScores = PercentileScoreService.calculateAllPercentiles(
+                for: workout,
+                existingWorkouts: allWorkouts,
+                preferredMetric: settings.preferredWorkoutMetric
+            )
+        }
+
+        // Recalculate PRs and leaderboard stats
+        try WorkoutMutationHandler.shared.workoutsDidChange(modelContext: modelContext)
+
+        try modelContext.save()
     }
 }

--- a/AscendApp/Shared/Services/WorkoutMutationHandler.swift
+++ b/AscendApp/Shared/Services/WorkoutMutationHandler.swift
@@ -1,0 +1,49 @@
+//
+//  WorkoutMutationHandler.swift
+//  AscendApp
+//
+
+import Foundation
+import SwiftData
+import FirebaseAuth
+
+/// Centralized handler for post-workout-mutation side effects.
+///
+/// Every code path that creates, edits, deletes, or imports workouts should call
+/// `workoutsDidChange(modelContext:)` after the mutation is persisted.
+/// This ensures PRs, leaderboard stats, and any future derived data stay in sync
+/// without requiring each call site to know about every side effect.
+@MainActor
+final class WorkoutMutationHandler {
+    static let shared = WorkoutMutationHandler()
+
+    private let settingsManager = SettingsManager.shared
+    private let leaderboardService = LeaderboardService.shared
+
+    private init() {}
+
+    /// Call after any workout create, edit, delete, or import has been saved to SwiftData.
+    ///
+    /// This method:
+    /// 1. Recalculates all personal records (synchronous — updates UI immediately)
+    /// 2. Recalculates local leaderboard stats for every time frame (skipped if not authenticated)
+    ///
+    /// - Parameter modelContext: The active SwiftData model context (must already have the mutation saved).
+    func workoutsDidChange(modelContext: ModelContext) throws {
+        // 1. Recalculate personal records
+        try PersonalRecordService.recalculateAllPersonalRecords(
+            modelContext: modelContext,
+            measurementSystem: settingsManager.measurementSystem,
+            stepHeight: settingsManager.stepHeight
+        )
+
+        // 2. Recalculate local leaderboard stats (fresh fetch avoids @Query staleness)
+        guard let userId = Auth.auth().currentUser?.uid else { return }
+
+        let allWorkouts = try modelContext.fetch(
+            FetchDescriptor<Workout>(sortBy: [SortDescriptor(\.date, order: .forward)])
+        )
+        leaderboardService.configure(modelContext: modelContext)
+        try leaderboardService.updateAllTimeFrames(for: userId, workouts: allWorkouts)
+    }
+}


### PR DESCRIPTION
## Summary
- **Hub timeframe picker**: Replaced the hardcoded "Weekly" subtitle with a reusable `LeaderboardPickerView` (Weekly / Monthly / All Time), so users can browse leaderboard data even when no workouts exist for the current week
- **Timeframe pass-through**: The selected hub timeframe carries into the detail view when tapping "See all" on any category card
- **Centralized `WorkoutMutationHandler`**: Single entry point for PR recalculation + leaderboard stat updates after any workout create/edit/delete/import — replaces scattered inline calls across 6 files

## Changes
| File | What changed |
|------|-------------|
| `WorkoutMutationHandler.swift` (new) | Centralized post-mutation handler (PRs + leaderboard) |
| `LeaderboardHubView.swift` | Added `selectedTimeFrame` state + picker, passes timeframe to cards |
| `LeaderboardView.swift` | Added `initialTimeFrame` parameter to init |
| `WorkoutFormViewModel.swift` | → `WorkoutMutationHandler` |
| `EditWorkoutView.swift` | → `WorkoutMutationHandler` |
| `WorkoutDetailView.swift` | → `WorkoutMutationHandler` |
| `WorkoutListView.swift` | → `WorkoutMutationHandler` |
| `WorkoutImportCoordinator.swift` | → `WorkoutMutationHandler` |
| `WorkoutTestDataSeeder.swift` | → `WorkoutMutationHandler` |

## Test plan
- [ ] Open Leaderboards tab — picker shows with Weekly selected by default
- [ ] Switch to Monthly/All Time — cards reload with correct data
- [ ] Verify empty weekly state still allows switching to Monthly/All Time (core bug fix)
- [ ] Tap "See all" with Monthly selected — detail view opens on Monthly
- [ ] Log a new workout → leaderboard stats update immediately
- [ ] Edit a workout → leaderboard stats reflect changes
- [ ] Delete a workout → leaderboard stats decrease
- [ ] Bulk delete from workout list → stats update
- [ ] Pull to refresh on hub still works
- [ ] Rapid timeframe switching doesn't crash or show stale data

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)