### PR TITLE
Add background waitlist email delivery

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -189,8 +189,8 @@ jobs:
       - name: Build web app
         run: npm --prefix web run build
 
-      - name: Deploy Functions, Rules, and Hosting
-        run: firebase deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,hosting --non-interactive
+      - name: Deploy Functions, Rules, Indexes, and Hosting
+        run: firebase deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,hosting --non-interactive
 
   upload-testflight:
     name: Upload to TestFlight (Production)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -159,8 +159,8 @@ jobs:
       - name: Build web app
         run: npm --prefix web run build
 
-      - name: Deploy Functions, Rules, and Hosting
-        run: firebase deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,hosting --non-interactive
+      - name: Deploy Functions, Rules, Indexes, and Hosting
+        run: firebase deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,hosting --non-interactive
 
   upload-testflight:
     name: Upload to TestFlight (Staging)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Ascend is a comprehensive stairstepper workout tracker for iOS. It serves the fu
 - **Data**: Local-first with cloud sync — SwiftData on device, Firebase Firestore for backup/sync/sharing
 - **Backend**: Firebase (Auth, Firestore, Storage, Cloud Functions, Hosting)
 - **Integrations**: Apple HealthKit, Strava, Hevy
-- **Cloud Functions** (TypeScript): Strava OAuth + sync, waitlist signup endpoint with dedupe
+- **Cloud Functions** (TypeScript): Strava OAuth + sync, waitlist signup endpoint with dedupe, transactional email job queue
 
 ---
 
@@ -278,13 +278,14 @@ If using CloudKit sync: never use `@Attribute(.unique)`, properties must have de
 
 ### Workflows
 - `.github/workflows/ci.yml` runs on PRs to `develop` and verifies the iOS app builds with the `AscendApp-Staging` scheme using `CODE_SIGNING_ALLOWED=NO`.
-- `.github/workflows/deploy-staging.yml` runs on manual dispatch only and executes sequential jobs (stop on failure):
+- `.github/workflows/deploy-staging.yml` runs on pushes to `develop` and manual dispatch, and executes sequential jobs (stop on failure):
   1. Build iOS app (Staging scheme, produce IPA)
   2. Deploy Firebase Functions
   3. Deploy Firestore Rules
-  4. Deploy Firebase Hosting
-  5. Upload to TestFlight (last — hardest to reverse)
-- `.github/workflows/deploy-production.yml` runs on pushes to `main` and manual dispatch. It mirrors the staging pipeline with Release configuration and remains gated behind `PRODUCTION_READY=true` plus GitHub `production` environment protection.
+  4. Deploy Firestore Indexes
+  5. Deploy Firebase Hosting
+  6. Upload to TestFlight (last — hardest to reverse)
+- `.github/workflows/deploy-production.yml` runs on pushes to `main` and manual dispatch. It mirrors the staging pipeline, including Firestore index deploys, with Release configuration and remains gated behind `PRODUCTION_READY=true` plus GitHub `production` environment protection.
 
 ### Deploy Authentication (OIDC)
 - GitHub Actions deploys to Firebase must use OIDC + GCP Workload Identity Federation.
@@ -318,6 +319,10 @@ If using CloudKit sync: never use `@Attribute(.unique)`, properties must have de
 ### Firebase Hosting
 Website source lives in `web/` and is built to `web/dist/` before deploy.
 - Waitlist form submissions must use `POST /api/join-waitlist` (Hosting rewrite to `joinWaitlist` Cloud Function), not direct Firestore client writes.
+- Transactional emails for waitlist and future product triggers must be sent server-side from Cloud Functions, never directly from the website or iOS client.
+- Cloud Functions email provider config lives in the `TRANSACTIONAL_EMAIL_CONFIG` Secret Manager JSON secret, with `functions/.secret.local` used only for local emulator overrides.
+- `joinWaitlist` is idempotent by normalized email hash, enqueues the `waitlist_welcome` job into `email_jobs`, and rate limits public submissions using hashed requester IPs stored in `email_rate_limits`.
+- Transactional emails are delivered in the background by the scheduled `processEmailJobs` worker; retries and failure state live on `email_jobs`, not on `waitlist`.
 
 ### Key Config Files
 - `.firebaserc` — project aliases (dev, staging, prod)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Ascend is a comprehensive stairstepper workout tracker for iOS. It serves the fu
 - **Data**: Local-first with cloud sync — SwiftData on device, Firebase Firestore for backup/sync/sharing
 - **Backend**: Firebase (Auth, Firestore, Storage, Cloud Functions, Hosting)
 - **Integrations**: Apple HealthKit, Strava, Hevy
-- **Cloud Functions** (TypeScript): Strava OAuth + sync, waitlist signup endpoint with dedupe
+- **Cloud Functions** (TypeScript): Strava OAuth + sync, waitlist signup endpoint with dedupe, transactional email job queue
 
 ---
 
@@ -278,13 +278,14 @@ If using CloudKit sync: never use `@Attribute(.unique)`, properties must have de
 
 ### Workflows
 - `.github/workflows/ci.yml` runs on PRs to `develop` and verifies the iOS app builds with the `AscendApp-Staging` scheme using `CODE_SIGNING_ALLOWED=NO`.
-- `.github/workflows/deploy-staging.yml` runs on manual dispatch only and executes sequential jobs (stop on failure):
+- `.github/workflows/deploy-staging.yml` runs on pushes to `develop` and manual dispatch, and executes sequential jobs (stop on failure):
   1. Build iOS app (Staging scheme, produce IPA)
   2. Deploy Firebase Functions
   3. Deploy Firestore Rules
-  4. Deploy Firebase Hosting
-  5. Upload to TestFlight (last — hardest to reverse)
-- `.github/workflows/deploy-production.yml` runs on pushes to `main` and manual dispatch. It mirrors the staging pipeline with Release configuration and remains gated behind `PRODUCTION_READY=true` plus GitHub `production` environment protection.
+  4. Deploy Firestore Indexes
+  5. Deploy Firebase Hosting
+  6. Upload to TestFlight (last — hardest to reverse)
+- `.github/workflows/deploy-production.yml` runs on pushes to `main` and manual dispatch. It mirrors the staging pipeline, including Firestore index deploys, with Release configuration and remains gated behind `PRODUCTION_READY=true` plus GitHub `production` environment protection.
 
 ### Deploy Authentication (OIDC)
 - GitHub Actions deploys to Firebase must use OIDC + GCP Workload Identity Federation.
@@ -318,6 +319,10 @@ If using CloudKit sync: never use `@Attribute(.unique)`, properties must have de
 ### Firebase Hosting
 Website source lives in `web/` and is built to `web/dist/` before deploy.
 - Waitlist form submissions must use `POST /api/join-waitlist` (Hosting rewrite to `joinWaitlist` Cloud Function), not direct Firestore client writes.
+- Transactional emails for waitlist and future product triggers must be sent server-side from Cloud Functions, never directly from the website or iOS client.
+- Cloud Functions email provider config lives in the `TRANSACTIONAL_EMAIL_CONFIG` Secret Manager JSON secret, with `functions/.secret.local` used only for local emulator overrides.
+- `joinWaitlist` is idempotent by normalized email hash, enqueues the `waitlist_welcome` job into `email_jobs`, and rate limits public submissions using hashed requester IPs stored in `email_rate_limits`.
+- Transactional emails are delivered in the background by the scheduled `processEmailJobs` worker; retries and failure state live on `email_jobs`, not on `waitlist`.
 
 ### Key Config Files
 - `.firebaserc` — project aliases (dev, staging, prod)

--- a/firebase.json
+++ b/firebase.json
@@ -1,6 +1,7 @@
 {
   "firestore": {
-    "rules": "firestore.rules"
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
   },
   "storage": {
     "rules": "storage.rules"

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,20 @@
 {
   "indexes": [
     {
+      "collectionGroup": "leaderboard_stats",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "timeFrame",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "periodIdentifier",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "email_jobs",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,33 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "email_jobs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "readyAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "email_jobs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "processingStartedAt",
+          "order": "ASCENDING"
+        }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -232,6 +232,14 @@ service cloud.firestore {
     }
 
     // Server-only collections managed by Cloud Functions / Admin SDK.
+    match /email_jobs/{docId} {
+      allow read, write: if false;
+    }
+
+    match /email_rate_limits/{docId} {
+      allow read, write: if false;
+    }
+
     match /waitlist/{docId} {
       allow read, write: if false;
     }

--- a/functions/EMAIL_SETUP.md
+++ b/functions/EMAIL_SETUP.md
@@ -1,0 +1,55 @@
+# Transactional Email Setup
+
+Ascend's Cloud Functions use the `TRANSACTIONAL_EMAIL_CONFIG` JSON secret for background transactional email delivery.
+
+## Secret shape
+
+```json
+{
+  "provider": "resend",
+  "apiKey": "re_xxxxxxxxx",
+  "betaInviteUrl": "https://testflight.apple.com/join/ZZ1zUmBf",
+  "fromEmail": "hello@updates.ascendstepper.com",
+  "fromName": "Ascend",
+  "replyTo": "support@ascendstepper.com",
+  "websiteUrl": "https://ascendstepper.com"
+}
+```
+
+## Resend prerequisites
+
+- Verify the sending domain in Resend before deploying.
+- Use a sender address from that verified domain for `fromEmail`.
+- Keep the API key only in Secret Manager or local emulator secret overrides.
+- `betaInviteUrl` is optional. If set, waitlist emails show a primary TestFlight CTA.
+- `websiteUrl` is optional. If omitted, waitlist emails fall back to `https://ascendstepper.com`.
+
+## Local emulator
+
+Firebase's Cloud Functions emulator can override secret values with `functions/.secret.local`.
+
+```dotenv
+TRANSACTIONAL_EMAIL_CONFIG={"provider":"resend","apiKey":"re_xxxxxxxxx","betaInviteUrl":"https://testflight.apple.com/join/ZZ1zUmBf","fromEmail":"hello@updates.ascendstepper.com","fromName":"Ascend","replyTo":"support@ascendstepper.com","websiteUrl":"https://ascendstepper.com"}
+```
+
+## Deploying the secret
+
+Create a local JSON file with the secret payload above, then load it into Secret Manager:
+
+```bash
+npx firebase-tools functions:secrets:set TRANSACTIONAL_EMAIL_CONFIG --data-file /absolute/path/to/transactional-email-config.json --format=json
+```
+
+Deploy the Firestore rules, indexes, and Cloud Functions after setting or rotating the secret:
+
+```bash
+npx firebase-tools deploy --only firestore:rules,firestore:indexes,functions
+```
+
+## Current behavior
+
+- `joinWaitlist` validates email input, rate limits by hashed requester IP, and enqueues a deterministic `waitlist_welcome` job.
+- The welcome email is sent in the background by the scheduled `processEmailJobs` worker.
+- `email_jobs` stores queue state, attempts, retry timing, and provider metadata.
+- Retryable provider failures are requeued automatically; permanent failures are marked on the job.
+- Existing waitlist rows created before this system are not backfilled automatically.

--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,8 @@
   "name": "functions",
   "scripts": {
     "lint": "eslint --ext .js,.ts .",
-    "build": "tsc",
+    "build": "node -e \"require('fs').rmSync('lib', { recursive: true, force: true })\" && tsc",
+    "test": "npm run build && node --test lib/test/*.test.js",
     "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
@@ -13,7 +14,7 @@
   "engines": {
     "node": "24"
   },
-  "main": "lib/index.js",
+  "main": "lib/src/index.js",
   "dependencies": {
     "firebase-admin": "^13.6.0",
     "firebase-functions": "^7.0.0"

--- a/functions/src/email/catalog.ts
+++ b/functions/src/email/catalog.ts
@@ -1,0 +1,39 @@
+import {
+  renderWaitlistWelcomeEmailFromPayload,
+} from "./templates";
+import type {
+  EmailJobDocument,
+  EmailJobPayload,
+  EmailType,
+  TransactionalEmailRenderResult,
+} from "./types";
+
+export interface EmailTypeDefinition {
+  render: (payload: EmailJobPayload) => TransactionalEmailRenderResult;
+  retryDelaysMs: number[];
+  sendPolicy: "send_now";
+}
+
+export const emailTypeConfigs: Record<EmailType, EmailTypeDefinition> = {
+  waitlist_welcome: {
+    render: renderWaitlistWelcomeEmailFromPayload,
+    retryDelaysMs: [
+      5 * 60 * 1000,
+      30 * 60 * 1000,
+      2 * 60 * 60 * 1000,
+      12 * 60 * 60 * 1000,
+    ],
+    sendPolicy: "send_now",
+  },
+};
+
+/**
+ * Renders email content for a queued job using the type config map.
+ * @param {EmailJobDocument} job - Queued email job
+ * @return {TransactionalEmailRenderResult} Subject and rendered bodies
+ */
+export function renderEmailContentForJob(
+  job: EmailJobDocument
+): TransactionalEmailRenderResult {
+  return emailTypeConfigs[job.type].render(job.payload);
+}

--- a/functions/src/email/config.ts
+++ b/functions/src/email/config.ts
@@ -1,0 +1,110 @@
+import {defineSecret} from "firebase-functions/params";
+import type {TransactionalEmailConfig} from "./types";
+
+export const transactionalEmailConfig =
+  defineSecret("TRANSACTIONAL_EMAIL_CONFIG");
+export const DEFAULT_MARKETING_WEBSITE_URL = "https://ascendstepper.com";
+
+/**
+ * Normalizes a public-facing HTTPS URL from config.
+ * @param {string | undefined} value - Raw configured URL
+ * @return {string | null} Normalized URL or null if invalid
+ */
+function normalizePublicUrl(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "https:") {
+      return null;
+    }
+
+    url.hash = "";
+    return url.toString().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Parses and validates the transactional email secret payload.
+ * @return {TransactionalEmailConfig} Provider config for email delivery
+ */
+export function getTransactionalEmailConfig(): TransactionalEmailConfig {
+  const rawConfig = transactionalEmailConfig.value();
+  let parsedConfig: unknown;
+
+  try {
+    parsedConfig = JSON.parse(rawConfig) as unknown;
+  } catch {
+    throw new Error("TRANSACTIONAL_EMAIL_CONFIG must be valid JSON");
+  }
+
+  if (!parsedConfig || typeof parsedConfig !== "object") {
+    throw new Error("TRANSACTIONAL_EMAIL_CONFIG is missing or invalid");
+  }
+
+  const config = parsedConfig as Partial<TransactionalEmailConfig>;
+
+  if (config.provider !== "resend") {
+    throw new Error("TRANSACTIONAL_EMAIL_CONFIG.provider must be 'resend'");
+  }
+
+  if (!config.apiKey || !config.fromEmail || !config.fromName) {
+    throw new Error(
+      "TRANSACTIONAL_EMAIL_CONFIG must include apiKey, fromEmail, and fromName"
+    );
+  }
+
+  return {
+    provider: config.provider,
+    apiKey: config.apiKey,
+    betaInviteUrl: config.betaInviteUrl,
+    fromEmail: config.fromEmail,
+    fromName: config.fromName,
+    replyTo: config.replyTo,
+    websiteUrl: config.websiteUrl,
+  };
+}
+
+/**
+ * Returns the public marketing website used in customer-facing email copy.
+ * Falls back to the primary marketing site when the secret is unavailable.
+ * @return {string} Normalized website URL
+ */
+export function getMarketingWebsiteUrl(): string {
+  if (!process.env.TRANSACTIONAL_EMAIL_CONFIG) {
+    return DEFAULT_MARKETING_WEBSITE_URL;
+  }
+
+  try {
+    const configuredUrl = normalizePublicUrl(
+      getTransactionalEmailConfig().websiteUrl
+    );
+    if (configuredUrl) {
+      return configuredUrl;
+    }
+  } catch {
+    // Ignore missing secret access in test-only render paths.
+  }
+
+  return DEFAULT_MARKETING_WEBSITE_URL;
+}
+
+/**
+ * Returns the TestFlight or beta invite URL when configured.
+ * @return {string | null} Normalized beta invite URL
+ */
+export function getBetaInviteUrl(): string | null {
+  if (!process.env.TRANSACTIONAL_EMAIL_CONFIG) {
+    return null;
+  }
+
+  try {
+    return normalizePublicUrl(getTransactionalEmailConfig().betaInviteUrl);
+  } catch {
+    return null;
+  }
+}

--- a/functions/src/email/crypto.ts
+++ b/functions/src/email/crypto.ts
@@ -1,0 +1,19 @@
+import {createHash} from "crypto";
+
+/**
+ * Normalizes an email for deduplication comparisons.
+ * @param {string} value - Raw email input
+ * @return {string} Trimmed lowercase email
+ */
+export function normalizeEmail(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+/**
+ * Creates a stable SHA-256 hash for a string value.
+ * @param {string} value - Raw string value
+ * @return {string} Hex-encoded hash
+ */
+export function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/functions/src/email/processor.ts
+++ b/functions/src/email/processor.ts
@@ -1,0 +1,343 @@
+import * as admin from "firebase-admin";
+import {onSchedule} from "firebase-functions/v2/scheduler";
+import {transactionalEmailConfig} from "./config";
+import {renderEmailContentForJob} from "./catalog";
+import {sendTransactionalEmail, EmailDeliveryError} from "./provider";
+import {getNextRetryDelayMs} from "./retry";
+import type {EmailJobDocument} from "./types";
+
+const JOB_BATCH_SIZE = 25;
+const STALE_PROCESSING_MS = 15 * 60 * 1000;
+
+/**
+ * Creates a Firestore timestamp from a Date instance.
+ * @param {Date} value - Date value
+ * @return {Timestamp} Firestore timestamp
+ */
+function toTimestamp(value: Date): admin.firestore.Timestamp {
+  return admin.firestore.Timestamp.fromDate(value);
+}
+
+/**
+ * Serializes an unknown error into a stable message.
+ * @param {unknown} error - Unknown error value
+ * @return {string} Safe error message
+ */
+function serializeErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return "unknown_error";
+}
+
+/**
+ * Requeues stale processing jobs so they are not stuck forever.
+ * @param {Timestamp} nowTimestamp - Current timestamp
+ * @return {Promise<number>} Number of jobs reclaimed
+ */
+async function reclaimStaleJobs(
+  nowTimestamp: admin.firestore.Timestamp
+): Promise<number> {
+  const staleThreshold = admin.firestore.Timestamp.fromMillis(
+    nowTimestamp.toMillis() - STALE_PROCESSING_MS
+  );
+  const staleSnapshot = await admin.firestore()
+    .collection("email_jobs")
+    .where("status", "==", "processing")
+    .where("processingStartedAt", "<=", staleThreshold)
+    .limit(JOB_BATCH_SIZE)
+    .get();
+
+  let reclaimedCount = 0;
+
+  for (const document of staleSnapshot.docs) {
+    const didReclaim = await admin.firestore().runTransaction(
+      async (transaction) => {
+        const snapshot = await transaction.get(document.ref);
+        if (!snapshot.exists) {
+          return false;
+        }
+
+        const data = snapshot.data() as EmailJobDocument;
+        const startedAt = data.processingStartedAt?.toMillis() ?? 0;
+        if (
+          data.status !== "processing" ||
+          startedAt > staleThreshold.toMillis()
+        ) {
+          return false;
+        }
+
+        transaction.update(document.ref, {
+          processingStartedAt: null,
+          readyAt: nowTimestamp,
+          status: "queued",
+          updatedAt: nowTimestamp,
+        });
+        return true;
+      }
+    );
+
+    if (didReclaim) {
+      reclaimedCount += 1;
+    }
+  }
+
+  return reclaimedCount;
+}
+
+/**
+ * Claims a queued email job for processing.
+ * @param {DocumentReference} jobRef - Email job document reference
+ * @param {Timestamp} nowTimestamp - Current timestamp
+ * @return {Promise<EmailJobDocument | null>} Claimed job or null
+ */
+async function claimEmailJob(
+  jobRef: admin.firestore.DocumentReference,
+  nowTimestamp: admin.firestore.Timestamp
+): Promise<EmailJobDocument | null> {
+  return admin.firestore().runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(jobRef);
+    if (!snapshot.exists) {
+      return null;
+    }
+
+    const data = snapshot.data() as EmailJobDocument;
+    if (data.status !== "queued" ||
+      data.readyAt.toMillis() > nowTimestamp.toMillis()) {
+      return null;
+    }
+
+    transaction.update(jobRef, {
+      processingStartedAt: nowTimestamp,
+      status: "processing",
+      updatedAt: nowTimestamp,
+    });
+
+    return {
+      ...data,
+      processingStartedAt: nowTimestamp,
+      status: "processing",
+      updatedAt: nowTimestamp,
+    };
+  });
+}
+
+/**
+ * Marks an email job as permanently failed.
+ * @param {DocumentReference} jobRef - Email job document reference
+ * @param {Timestamp} nowTimestamp - Current timestamp
+ * @param {number} attemptCount - Attempt count after the failed attempt
+ * @param {string} errorCode - Stable error code
+ * @param {string} errorMessage - Human-readable error message
+ * @param {string | null} provider - Delivery provider name
+ * @return {Promise<void>}
+ */
+async function markJobFailed(
+  jobRef: admin.firestore.DocumentReference,
+  nowTimestamp: admin.firestore.Timestamp,
+  attemptCount: number,
+  errorCode: string,
+  errorMessage: string,
+  provider: string | null
+): Promise<void> {
+  await jobRef.update({
+    attemptCount,
+    lastErrorCode: errorCode,
+    lastErrorMessage: errorMessage,
+    processingStartedAt: null,
+    provider,
+    providerMessageId: null,
+    status: "failed",
+    updatedAt: nowTimestamp,
+  });
+}
+
+/**
+ * Requeues an email job after a retryable failure.
+ * @param {DocumentReference} jobRef - Email job document reference
+ * @param {Timestamp} nowTimestamp - Current timestamp
+ * @param {number} attemptCount - Attempt count after the failed attempt
+ * @param {number} delayMs - Delay until next retry
+ * @param {string} errorCode - Stable error code
+ * @param {string} errorMessage - Human-readable error message
+ * @param {string | null} provider - Delivery provider name
+ * @return {Promise<void>}
+ */
+async function requeueEmailJob(
+  jobRef: admin.firestore.DocumentReference,
+  nowTimestamp: admin.firestore.Timestamp,
+  attemptCount: number,
+  delayMs: number,
+  errorCode: string,
+  errorMessage: string,
+  provider: string | null
+): Promise<void> {
+  await jobRef.update({
+    attemptCount,
+    lastErrorCode: errorCode,
+    lastErrorMessage: errorMessage,
+    processingStartedAt: null,
+    provider,
+    providerMessageId: null,
+    readyAt: admin.firestore.Timestamp.fromMillis(
+      nowTimestamp.toMillis() + delayMs
+    ),
+    status: "queued",
+    updatedAt: nowTimestamp,
+  });
+}
+
+/**
+ * Processes a claimed email job.
+ * @param {DocumentReference} jobRef - Email job document reference
+ * @param {EmailJobDocument} job - Claimed email job
+ * @param {Timestamp} nowTimestamp - Current timestamp
+ * @return {Promise<"sent" | "retried" | "failed">} Processing outcome
+ */
+async function processClaimedJob(
+  jobRef: admin.firestore.DocumentReference,
+  job: EmailJobDocument,
+  nowTimestamp: admin.firestore.Timestamp
+): Promise<"sent" | "retried" | "failed"> {
+  const nextAttemptCount = job.attemptCount + 1;
+  let renderedEmail;
+
+  try {
+    renderedEmail = renderEmailContentForJob(job);
+  } catch (error) {
+    await markJobFailed(
+      jobRef,
+      nowTimestamp,
+      nextAttemptCount,
+      "invalid_payload",
+      serializeErrorMessage(error),
+      null
+    );
+    console.error("processEmailJobs invalid payload", {
+      errorCode: "invalid_payload",
+      jobId: jobRef.id,
+    });
+    return "failed";
+  }
+
+  try {
+    const delivery = await sendTransactionalEmail({
+      idempotencyKey: job.dedupeKey,
+      html: renderedEmail.html,
+      subject: renderedEmail.subject,
+      text: renderedEmail.text,
+      to: [job.recipientEmail],
+    });
+
+    await jobRef.update({
+      attemptCount: nextAttemptCount,
+      lastErrorCode: null,
+      lastErrorMessage: null,
+      processingStartedAt: null,
+      provider: delivery.provider,
+      providerMessageId: delivery.messageId,
+      sentAt: nowTimestamp,
+      status: "sent",
+      updatedAt: nowTimestamp,
+    });
+
+    return "sent";
+  } catch (error) {
+    const errorCode = error instanceof EmailDeliveryError ?
+      error.code :
+      "unexpected_provider_error";
+    const errorMessage = serializeErrorMessage(error);
+    const provider = error instanceof EmailDeliveryError ?
+      error.provider :
+      null;
+
+    if (error instanceof EmailDeliveryError && error.retryable) {
+      const nextRetryDelay = getNextRetryDelayMs(job.type, nextAttemptCount);
+      if (nextRetryDelay !== null) {
+        await requeueEmailJob(
+          jobRef,
+          nowTimestamp,
+          nextAttemptCount,
+          nextRetryDelay,
+          errorCode,
+          errorMessage,
+          provider
+        );
+        console.error("processEmailJobs retrying job", {
+          errorCode,
+          jobId: jobRef.id,
+        });
+        return "retried";
+      }
+    }
+
+    await markJobFailed(
+      jobRef,
+      nowTimestamp,
+      nextAttemptCount,
+      errorCode,
+      errorMessage,
+      provider
+    );
+    console.error("processEmailJobs failed job", {
+      errorCode,
+      jobId: jobRef.id,
+    });
+    return "failed";
+  }
+}
+
+/**
+ * Processes queued transactional email jobs on a fixed schedule.
+ */
+export const processEmailJobs = onSchedule(
+  {
+    schedule: "* * * * *",
+    secrets: [transactionalEmailConfig],
+    timeZone: "Etc/UTC",
+  },
+  async () => {
+    const startedAt = new Date();
+    const startedAtTimestamp = toTimestamp(startedAt);
+    const reclaimedCount = await reclaimStaleJobs(startedAtTimestamp);
+    const dueJobsSnapshot = await admin.firestore()
+      .collection("email_jobs")
+      .where("status", "==", "queued")
+      .where("readyAt", "<=", startedAtTimestamp)
+      .limit(JOB_BATCH_SIZE)
+      .get();
+
+    let sentCount = 0;
+    let retriedCount = 0;
+    let failedCount = 0;
+
+    for (const document of dueJobsSnapshot.docs) {
+      const claimedJob = await claimEmailJob(document.ref, startedAtTimestamp);
+      if (!claimedJob) {
+        continue;
+      }
+
+      const outcome = await processClaimedJob(
+        document.ref,
+        claimedJob,
+        startedAtTimestamp
+      );
+      if (outcome === "sent") {
+        sentCount += 1;
+      } else if (outcome === "retried") {
+        retriedCount += 1;
+      } else {
+        failedCount += 1;
+      }
+    }
+
+    console.log("processEmailJobs summary", {
+      failedCount,
+      queuedCount: dueJobsSnapshot.size,
+      reclaimedCount,
+      retriedCount,
+      sentCount,
+    });
+  }
+);

--- a/functions/src/email/provider.ts
+++ b/functions/src/email/provider.ts
@@ -1,0 +1,167 @@
+import {getTransactionalEmailConfig} from "./config";
+import type {
+  TransactionalEmailDelivery,
+  TransactionalEmailMessage,
+  TransactionalEmailProvider,
+} from "./types";
+
+interface ResendEmailResponse {
+  error?: string;
+  id?: string;
+  message?: string;
+}
+
+interface ResendStatusClassification {
+  code: string;
+  retryable: boolean;
+}
+
+/**
+ * Wraps provider delivery failures with retry metadata.
+ */
+export class EmailDeliveryError extends Error {
+  code: string;
+  provider: TransactionalEmailProvider;
+  retryable: boolean;
+
+  /**
+   * Creates a stable provider error used by the job processor.
+   * @param {string} message - Human-readable error message
+   * @param {string} code - Stable error code
+   * @param {boolean} retryable - Whether the job should be retried
+   * @param {TransactionalEmailProvider} provider - Delivery provider name
+   */
+  constructor(
+    message: string,
+    code: string,
+    retryable: boolean,
+    provider: TransactionalEmailProvider
+  ) {
+    super(message);
+    this.code = code;
+    this.provider = provider;
+    this.retryable = retryable;
+  }
+}
+
+/**
+ * Formats the sender field expected by Resend.
+ * @param {string} fromName - Sender display name
+ * @param {string} fromEmail - Sender email
+ * @return {string} RFC-friendly sender string
+ */
+function formatSender(fromName: string, fromEmail: string): string {
+  return `${fromName} <${fromEmail}>`;
+}
+
+/**
+ * Classifies a Resend HTTP status code for retry behavior.
+ * @param {number} status - HTTP status code
+ * @return {ResendStatusClassification} Retry classification
+ */
+export function classifyResendStatus(
+  status: number
+): ResendStatusClassification {
+  if (status === 429) {
+    return {
+      code: "resend_rate_limited",
+      retryable: true,
+    };
+  }
+
+  if (status >= 500) {
+    return {
+      code: "resend_server_error",
+      retryable: true,
+    };
+  }
+
+  return {
+    code: `resend_client_error_${status}`,
+    retryable: false,
+  };
+}
+
+/**
+ * Safely parses a JSON HTTP response body.
+ * @param {Response} response - Fetch response
+ * @return {Promise<ResendEmailResponse | null>} Parsed JSON or null
+ */
+async function parseJsonResponse(
+  response: Response
+): Promise<ResendEmailResponse | null> {
+  try {
+    return await response.json() as ResendEmailResponse;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sends a transactional email through Resend.
+ * @param {TransactionalEmailMessage} message - Message payload
+ * @return {Promise<TransactionalEmailDelivery>} Delivery result
+ */
+export async function sendTransactionalEmail(
+  message: TransactionalEmailMessage
+): Promise<TransactionalEmailDelivery> {
+  const config = getTransactionalEmailConfig();
+
+  try {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${config.apiKey}`,
+        "Content-Type": "application/json",
+        "Idempotency-Key": message.idempotencyKey,
+      },
+      body: JSON.stringify({
+        from: formatSender(config.fromName, config.fromEmail),
+        html: message.html,
+        reply_to: message.replyTo ?? config.replyTo,
+        subject: message.subject,
+        text: message.text,
+        to: message.to,
+      }),
+    });
+
+    const payload = await parseJsonResponse(response);
+
+    if (!response.ok) {
+      const classification = classifyResendStatus(response.status);
+      const responseMessage = payload?.message ?? payload?.error ??
+        `HTTP ${response.status}`;
+      throw new EmailDeliveryError(
+        `Resend send failed: ${responseMessage}`,
+        classification.code,
+        classification.retryable,
+        "resend"
+      );
+    }
+
+    if (!payload?.id) {
+      throw new EmailDeliveryError(
+        "Resend response missing message id",
+        "resend_invalid_response",
+        false,
+        "resend"
+      );
+    }
+
+    return {
+      provider: "resend",
+      messageId: payload.id,
+    };
+  } catch (error) {
+    if (error instanceof EmailDeliveryError) {
+      throw error;
+    }
+
+    throw new EmailDeliveryError(
+      "Resend network request failed",
+      "resend_network_error",
+      true,
+      "resend"
+    );
+  }
+}

--- a/functions/src/email/queue.ts
+++ b/functions/src/email/queue.ts
@@ -1,0 +1,67 @@
+import * as admin from "firebase-admin";
+import {sha256Hex} from "./crypto";
+import type {
+  EmailJobDocument,
+  EmailJobPayload,
+  EmailType,
+} from "./types";
+
+/**
+ * Builds the deterministic dedupe key for a waitlist welcome email.
+ * @param {string} recipientHash - Normalized recipient hash
+ * @return {string} Stable dedupe key
+ */
+export function buildWaitlistWelcomeDedupeKey(recipientHash: string): string {
+  return `waitlist-welcome:${recipientHash}`;
+}
+
+/**
+ * Builds the deterministic Firestore job ID for an email dedupe key.
+ * @param {string} dedupeKey - Stable dedupe key
+ * @return {string} Stable Firestore document ID
+ */
+export function buildEmailJobId(dedupeKey: string): string {
+  return sha256Hex(dedupeKey);
+}
+
+/**
+ * Creates a queued email job document.
+ * @param {EmailType} type - Email type
+ * @param {string} recipientEmail - Recipient email address
+ * @param {string} recipientHash - Stable recipient hash
+ * @param {string} dedupeKey - Stable dedupe key
+ * @param {EmailJobPayload} payload - Template payload
+ * @param {Timestamp} scheduledFor - Scheduled send time
+ * @param {string | null} sourceRef - Source Firestore reference string
+ * @return {EmailJobDocument} Firestore-ready queued job
+ */
+export function createQueuedEmailJob(
+  type: EmailType,
+  recipientEmail: string,
+  recipientHash: string,
+  dedupeKey: string,
+  payload: EmailJobPayload,
+  scheduledFor: admin.firestore.Timestamp,
+  sourceRef: string | null
+): EmailJobDocument {
+  return {
+    attemptCount: 0,
+    createdAt: scheduledFor,
+    dedupeKey,
+    lastErrorCode: null,
+    lastErrorMessage: null,
+    payload,
+    processingStartedAt: null,
+    provider: null,
+    providerMessageId: null,
+    readyAt: scheduledFor,
+    recipientEmail,
+    recipientHash,
+    scheduledFor,
+    sentAt: null,
+    sourceRef,
+    status: "queued",
+    type,
+    updatedAt: scheduledFor,
+  };
+}

--- a/functions/src/email/rateLimit.ts
+++ b/functions/src/email/rateLimit.ts
@@ -1,0 +1,156 @@
+import * as admin from "firebase-admin";
+import {sha256Hex} from "./crypto";
+import type {
+  EmailRateLimitDocument,
+  EmailRateLimitState,
+} from "./types";
+
+const SHORT_WINDOW_LIMIT = 10;
+const SHORT_WINDOW_MS = 10 * 60 * 1000;
+const LONG_WINDOW_LIMIT = 50;
+const LONG_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+export type WaitlistRateLimitReason = "short_window" | "long_window";
+
+export interface WaitlistRateLimitEvaluation {
+  allowed: boolean;
+  reason: WaitlistRateLimitReason | null;
+  state: EmailRateLimitState;
+}
+
+/**
+ * Extracts the best-effort requester IP for abuse protection.
+ * @param {string | undefined} forwardedFor - x-forwarded-for header value
+ * @param {string | undefined} fallback - Fallback socket or framework IP
+ * @return {string} Requester IP string, or "unknown"
+ */
+export function extractRequesterIp(
+  forwardedFor: string | undefined,
+  fallback: string | undefined
+): string {
+  if (forwardedFor) {
+    const firstForwardedIp = forwardedFor.split(",")[0]?.trim();
+    if (firstForwardedIp) {
+      return firstForwardedIp;
+    }
+  }
+
+  if (fallback && fallback.trim().length > 0) {
+    return fallback.trim();
+  }
+
+  return "unknown";
+}
+
+/**
+ * Hashes a requester IP before persistence.
+ * @param {string} ipAddress - Raw requester IP
+ * @return {string} SHA-256 hash of the IP
+ */
+export function hashRateLimitIp(ipAddress: string): string {
+  return sha256Hex(ipAddress);
+}
+
+/**
+ * Converts a stored Firestore rate-limit document into pure state.
+ * @param {EmailRateLimitDocument | null} document - Stored Firestore doc
+ * @return {EmailRateLimitState | null} Pure state for calculations
+ */
+export function toEmailRateLimitState(
+  document: EmailRateLimitDocument | null
+): EmailRateLimitState | null {
+  if (!document) {
+    return null;
+  }
+
+  return {
+    ipHash: document.ipHash,
+    shortWindowCount: document.shortWindowCount,
+    shortWindowStartedAtMs: document.shortWindowStartedAt.toMillis(),
+    longWindowCount: document.longWindowCount,
+    longWindowStartedAtMs: document.longWindowStartedAt.toMillis(),
+  };
+}
+
+/**
+ * Evaluates the waitlist endpoint rate limit for a single request.
+ * @param {EmailRateLimitState | null} state - Existing rate-limit state
+ * @param {number} nowMs - Current time in milliseconds
+ * @param {string} ipHash - Hashed requester IP
+ * @return {WaitlistRateLimitEvaluation} Evaluation result and next state
+ */
+export function evaluateWaitlistRateLimit(
+  state: EmailRateLimitState | null,
+  nowMs: number,
+  ipHash: string
+): WaitlistRateLimitEvaluation {
+  const shortWindowExpired = !state ||
+    nowMs - state.shortWindowStartedAtMs >= SHORT_WINDOW_MS;
+  const longWindowExpired = !state ||
+    nowMs - state.longWindowStartedAtMs >= LONG_WINDOW_MS;
+
+  const nextState: EmailRateLimitState = {
+    ipHash,
+    shortWindowCount: shortWindowExpired ? 0 : state.shortWindowCount,
+    shortWindowStartedAtMs: shortWindowExpired ?
+      nowMs :
+      state.shortWindowStartedAtMs,
+    longWindowCount: longWindowExpired ? 0 : state.longWindowCount,
+    longWindowStartedAtMs: longWindowExpired ?
+      nowMs :
+      state.longWindowStartedAtMs,
+  };
+
+  if (nextState.shortWindowCount >= SHORT_WINDOW_LIMIT) {
+    return {
+      allowed: false,
+      reason: "short_window",
+      state: nextState,
+    };
+  }
+
+  if (nextState.longWindowCount >= LONG_WINDOW_LIMIT) {
+    return {
+      allowed: false,
+      reason: "long_window",
+      state: nextState,
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: null,
+    state: {
+      ...nextState,
+      shortWindowCount: nextState.shortWindowCount + 1,
+      longWindowCount: nextState.longWindowCount + 1,
+    },
+  };
+}
+
+/**
+ * Converts pure rate-limit state back into a Firestore document.
+ * @param {EmailRateLimitState} state - Pure state
+ * @param {Timestamp} nowTimestamp - Current timestamp
+ * @param {Timestamp | null} createdAt - Existing createdAt if present
+ * @return {EmailRateLimitDocument} Firestore-ready document
+ */
+export function toEmailRateLimitDocument(
+  state: EmailRateLimitState,
+  nowTimestamp: admin.firestore.Timestamp,
+  createdAt: admin.firestore.Timestamp | null
+): EmailRateLimitDocument {
+  return {
+    createdAt: createdAt ?? nowTimestamp,
+    ipHash: state.ipHash,
+    shortWindowCount: state.shortWindowCount,
+    shortWindowStartedAt: admin.firestore.Timestamp.fromMillis(
+      state.shortWindowStartedAtMs
+    ),
+    longWindowCount: state.longWindowCount,
+    longWindowStartedAt: admin.firestore.Timestamp.fromMillis(
+      state.longWindowStartedAtMs
+    ),
+    updatedAt: nowTimestamp,
+  };
+}

--- a/functions/src/email/retry.ts
+++ b/functions/src/email/retry.ts
@@ -1,0 +1,15 @@
+import {emailTypeConfigs} from "./catalog";
+import type {EmailType} from "./types";
+
+/**
+ * Returns the next retry delay after a failed send attempt.
+ * @param {EmailType} type - Email type
+ * @param {number} attemptCount - Total attempts made so far
+ * @return {number | null} Delay in milliseconds, or null if exhausted
+ */
+export function getNextRetryDelayMs(
+  type: EmailType,
+  attemptCount: number
+): number | null {
+  return emailTypeConfigs[type].retryDelaysMs[attemptCount - 1] ?? null;
+}

--- a/functions/src/email/templates.ts
+++ b/functions/src/email/templates.ts
@@ -1,0 +1,159 @@
+import {getBetaInviteUrl, getMarketingWebsiteUrl} from "./config";
+import type {
+  EmailJobPayload,
+  TransactionalEmailRenderResult,
+  WaitlistWelcomePayload,
+} from "./types";
+
+/**
+ * Escapes untrusted HTML content for safe email rendering.
+ * @param {string} value - Raw user-provided content
+ * @return {string} Escaped HTML string
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Validates the payload for a waitlist welcome email.
+ * @param {EmailJobPayload} payload - Stored job payload
+ * @return {WaitlistWelcomePayload} Validated payload
+ */
+function parseWaitlistWelcomePayload(
+  payload: EmailJobPayload
+): WaitlistWelcomePayload {
+  if (
+    !payload ||
+    typeof payload !== "object" ||
+    typeof payload.source !== "string"
+  ) {
+    throw new Error("invalid_waitlist_welcome_payload");
+  }
+
+  return {
+    source: payload.source,
+  };
+}
+
+/**
+ * Renders the waitlist welcome email content.
+ * @param {WaitlistWelcomePayload} payload - Template payload
+ * @return {TransactionalEmailRenderResult} Subject and rendered bodies
+ */
+export function renderWaitlistWelcomeEmail(
+  payload: WaitlistWelcomePayload
+): TransactionalEmailRenderResult {
+  void payload;
+
+  const betaInviteUrl = getBetaInviteUrl();
+  const websiteUrl = getMarketingWebsiteUrl();
+  const iconUrl = `${websiteUrl}/images/StairmasterIconAccent.png`;
+  const privacyPolicyUrl = `${websiteUrl}/privacy`;
+  const primaryCtaUrl = betaInviteUrl ?? websiteUrl;
+  const primaryCtaLabel = betaInviteUrl ?
+    "Join the beta on TestFlight" :
+    "Visit ascendstepper.com";
+  const subject = betaInviteUrl ?
+    "You're in. Start testing Ascend on TestFlight" :
+    "You're on the Ascend waitlist";
+  const eyebrow = betaInviteUrl ? "Signup Confirmed" : "Waitlist Confirmed";
+  const headlineLeading = betaInviteUrl ? "START TESTING" : "YOU'RE ON";
+  const headlineAccent = betaInviteUrl ? "TODAY." : "THE LIST.";
+  const bodyCopy = betaInviteUrl ?
+    [
+      "Thanks for signing up for Ascend. We're currently in beta,",
+      "so you can start testing right away. No waiting required.",
+    ].join(" ") :
+    [
+      "Thanks for signing up for Ascend.",
+      "We'll email you when early access and launch details are ready.",
+    ].join(" ");
+  const helperCopy = betaInviteUrl ?
+    "You'll need Apple's TestFlight app installed." :
+    "We'll keep you posted when beta access opens.";
+  const escapedBetaInviteUrl = betaInviteUrl ? escapeHtml(betaInviteUrl) : null;
+  const escapedIconUrl = escapeHtml(iconUrl);
+  const escapedPrimaryCtaUrl = escapeHtml(primaryCtaUrl);
+  const escapedPrivacyPolicyUrl = escapeHtml(privacyPolicyUrl);
+
+  return {
+    subject,
+    text: [
+      betaInviteUrl ? "Start testing today." : "You're on the list.",
+      "",
+      bodyCopy,
+      helperCopy,
+      "",
+      `${primaryCtaLabel}: ${primaryCtaUrl}`,
+      "",
+      "Talk soon,",
+      "Tyler",
+      "Ascend",
+      "",
+      "Need help? Reply to this email.",
+      `Privacy Policy: ${privacyPolicyUrl}`,
+    ].join("\n"),
+    html: [
+      "<!doctype html>",
+      // eslint-disable-next-line max-len
+      "<html lang=\"en\" xmlns=\"http://www.w3.org/1999/xhtml\"><body style=\"margin:0;padding:0;background:#f4f2eb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;color:#111111;\">",
+      // eslint-disable-next-line max-len
+      "<table role=\"presentation\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\" border=\"0\" style=\"background:#f4f2eb;padding:24px 12px;\"><tr><td align=\"center\">",
+      // eslint-disable-next-line max-len
+      "<table role=\"presentation\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\" border=\"0\" style=\"max-width:620px;background:#ffffff;border:1px solid rgba(17,17,17,0.08);border-radius:32px;overflow:hidden;\">",
+      // eslint-disable-next-line max-len
+      "<tr><td style=\"background:#111111;padding:28px 32px;\"><table role=\"presentation\" cellspacing=\"0\" cellpadding=\"0\" border=\"0\"><tr><td valign=\"middle\" style=\"padding-right:14px;\"><img src=\"",
+      escapedIconUrl,
+      // eslint-disable-next-line max-len
+      "\" width=\"42\" height=\"42\" alt=\"Ascend icon\" style=\"display:block;width:42px;height:42px;border:0;border-radius:10px;\" /></td><td valign=\"middle\" style=\"font-size:16px;line-height:1;color:#ffffff;font-weight:800;letter-spacing:0.08em;text-transform:uppercase;\">Ascend</td></tr></table></td></tr>",
+      // eslint-disable-next-line max-len
+      "<tr><td style=\"padding:40px 32px 24px;\"><p style=\"margin:0 0 18px;font-size:12px;line-height:1.3;color:#b4cc00;font-weight:700;letter-spacing:0.28em;text-transform:uppercase;\">",
+      eyebrow,
+      "</p>",
+      // eslint-disable-next-line max-len
+      "<h1 style=\"margin:0 0 20px;font-size:58px;line-height:0.94;font-weight:900;letter-spacing:-0.04em;color:#111111;\">",
+      headlineLeading,
+      "<br /><span style=\"color:#b4cc00;\">",
+      headlineAccent,
+      "</span></h1>",
+      // eslint-disable-next-line max-len
+      "<p style=\"margin:0 0 28px;font-size:18px;line-height:1.65;color:#4b5563;max-width:470px;\">",
+      bodyCopy.replace(/'/g, "&#39;").replace(/—/g, "&mdash;"),
+      "</p>",
+      // eslint-disable-next-line max-len
+      "<p style=\"margin:0 0 28px;font-size:15px;line-height:1.6;color:#9ca3af;text-align:center;\">",
+      helperCopy.replace(/'/g, "&#39;"),
+      "</p>",
+      "<div style=\"text-align:center;\">",
+      // eslint-disable-next-line max-len
+      "<a href=\"",
+      betaInviteUrl ? escapedBetaInviteUrl : escapedPrimaryCtaUrl,
+      // eslint-disable-next-line max-len
+      "\" style=\"display:inline-block;padding:20px 28px;border-radius:18px;background:#b4cc00;color:#111111;font-size:18px;line-height:1;font-weight:800;text-decoration:none;text-transform:uppercase;letter-spacing:0.04em;\">",
+      primaryCtaLabel,
+      "</a></div></td></tr>",
+      // eslint-disable-next-line max-len
+      "<tr><td style=\"padding:0 32px 36px;\"><div style=\"border-top:1px solid rgba(17,17,17,0.08);padding-top:24px;text-align:center;\"><p style=\"margin:0 0 10px;font-size:14px;line-height:1.6;color:#9ca3af;\">You received this because you signed up at ascendstepper.com.</p><p style=\"margin:0 0 10px;font-size:14px;line-height:1.6;color:#9ca3af;\">Need help? Reply to this email.</p><p style=\"margin:0;font-size:14px;line-height:1.6;\"><a href=\"",
+      escapedPrivacyPolicyUrl,
+      // eslint-disable-next-line max-len
+      "\" style=\"color:#6b7280;text-decoration:underline;\">Privacy Policy</a></p></div></td></tr>",
+      "</table></td></tr></table></body></html>",
+    ].join(""),
+  };
+}
+
+/**
+ * Validates and renders a waitlist welcome email from a generic payload.
+ * @param {EmailJobPayload} payload - Stored job payload
+ * @return {TransactionalEmailRenderResult} Subject and rendered bodies
+ */
+export function renderWaitlistWelcomeEmailFromPayload(
+  payload: EmailJobPayload
+): TransactionalEmailRenderResult {
+  return renderWaitlistWelcomeEmail(parseWaitlistWelcomePayload(payload));
+}

--- a/functions/src/email/types.ts
+++ b/functions/src/email/types.ts
@@ -1,0 +1,80 @@
+import * as admin from "firebase-admin";
+
+export type TransactionalEmailProvider = "resend";
+export type EmailType = "waitlist_welcome";
+export type EmailJobStatus = "queued" | "processing" | "sent" | "failed";
+
+export interface TransactionalEmailConfig {
+  provider: TransactionalEmailProvider;
+  apiKey: string;
+  betaInviteUrl?: string;
+  fromEmail: string;
+  fromName: string;
+  replyTo?: string;
+  websiteUrl?: string;
+}
+
+export interface TransactionalEmailMessage {
+  idempotencyKey: string;
+  html: string;
+  replyTo?: string;
+  subject: string;
+  text: string;
+  to: string[];
+}
+
+export interface TransactionalEmailDelivery {
+  provider: TransactionalEmailProvider;
+  messageId: string;
+}
+
+export interface TransactionalEmailRenderResult {
+  html: string;
+  subject: string;
+  text: string;
+}
+
+export interface WaitlistWelcomePayload {
+  source: string;
+}
+
+export type EmailJobPayload = WaitlistWelcomePayload;
+
+export interface EmailJobDocument {
+  attemptCount: number;
+  createdAt: admin.firestore.Timestamp;
+  dedupeKey: string;
+  lastErrorCode: string | null;
+  lastErrorMessage: string | null;
+  payload: EmailJobPayload;
+  processingStartedAt: admin.firestore.Timestamp | null;
+  provider: TransactionalEmailProvider | null;
+  providerMessageId: string | null;
+  readyAt: admin.firestore.Timestamp;
+  recipientEmail: string;
+  recipientHash: string;
+  scheduledFor: admin.firestore.Timestamp;
+  sentAt: admin.firestore.Timestamp | null;
+  sourceRef: string | null;
+  status: EmailJobStatus;
+  type: EmailType;
+  updatedAt: admin.firestore.Timestamp;
+}
+
+export interface EmailRateLimitDocument {
+  createdAt: admin.firestore.Timestamp;
+  ipHash: string;
+  longWindowCount: number;
+  longWindowStartedAt: admin.firestore.Timestamp;
+  shortWindowCount: number;
+  shortWindowStartedAt: admin.firestore.Timestamp;
+  updatedAt: admin.firestore.Timestamp;
+}
+
+export interface EmailRateLimitState {
+  ipHash: string;
+  longWindowCount: number;
+  longWindowStartedAtMs: number;
+  shortWindowCount: number;
+  shortWindowStartedAtMs: number;
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,128 +2,16 @@
  * Cloud Functions for AscendApp
  *
  * - Strava: OAuth and activity sync integration
+ * - Email: Background transactional waitlist email processing
  */
 
 import {setGlobalOptions} from "firebase-functions/v2";
-import {onRequest} from "firebase-functions/v2/https";
 import * as admin from "firebase-admin";
-import {createHash} from "crypto";
 
-// Initialize Firebase Admin (only once)
 admin.initializeApp();
 
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-/**
- * Normalizes an email for deduplication comparisons.
- * @param {string} value - Raw email input
- * @return {string} Trimmed lowercase email
- */
-function normalizeEmail(value: string): string {
-  return value.trim().toLowerCase();
-}
-
-/**
- * Creates a stable SHA-256 hash for an email.
- * @param {string} value - Normalized email value
- * @return {string} Hex-encoded hash
- */
-function hashEmail(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-/**
- * Checks if a Firestore write failed due to an existing document.
- * @param {unknown} error - Error thrown by Firestore Admin SDK
- * @return {boolean} True if the error indicates an existing doc
- */
-function isAlreadyExistsError(error: unknown): boolean {
-  if (!error || typeof error !== "object") {
-    return false;
-  }
-
-  const code = "code" in error ? String(error.code) : "";
-  if (code === "6" || code === "already-exists") {
-    return true;
-  }
-
-  const message = "message" in error ? String(error.message) : "";
-  return message.includes("Already exists");
-}
-
-// ============================================
-// HTTP: Waitlist Signup (deduplicated)
-// ============================================
-
-export const joinWaitlist = onRequest(async (req, res) => {
-  if (req.method !== "POST") {
-    res.status(405).json({error: "method_not_allowed"});
-    return;
-  }
-
-  let body: Record<string, unknown> | null = null;
-  if (typeof req.body === "string") {
-    try {
-      body = JSON.parse(req.body) as Record<string, unknown>;
-    } catch {
-      body = null;
-    }
-  } else if (req.body && typeof req.body === "object") {
-    body = req.body as Record<string, unknown>;
-  }
-
-  const emailInput = body?.email;
-  const email = typeof emailInput === "string" ?
-    normalizeEmail(emailInput) :
-    "";
-  if (!email || email.length > 255 || !EMAIL_PATTERN.test(email)) {
-    res.status(400).json({error: "invalid_email"});
-    return;
-  }
-
-  const sourceInput = body?.source;
-  const source = typeof sourceInput === "string" &&
-    sourceInput.trim().length > 0 &&
-    sourceInput.length < 100 ?
-    sourceInput.trim() :
-    "landing_page";
-
-  try {
-    const waitlistCollection = admin.firestore().collection("waitlist");
-    const existingByEmail = await waitlistCollection
-      .where("email", "==", email)
-      .limit(1)
-      .get();
-
-    if (!existingByEmail.empty) {
-      res.status(200).json({status: "already_subscribed"});
-      return;
-    }
-
-    const emailHash = hashEmail(email);
-    const waitlistRef = waitlistCollection.doc(emailHash);
-
-    await waitlistRef.create({
-      email,
-      emailHash,
-      source,
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-    });
-    res.status(200).json({status: "subscribed"});
-  } catch (error) {
-    if (isAlreadyExistsError(error)) {
-      res.status(200).json({status: "already_subscribed"});
-      return;
-    }
-
-    console.error("joinWaitlist failed:", error);
-    res.status(500).json({error: "internal"});
-  }
-});
-
-// ============================================
-// RE-EXPORT STRAVA FUNCTIONS
-// ============================================
+export {processEmailJobs} from "./email/processor";
+export {joinWaitlist} from "./waitlist";
 
 export {
   stravaCallback,
@@ -132,5 +20,4 @@ export {
   stravaDisconnect,
 } from "./strava";
 
-// Global options for cost control
 setGlobalOptions({maxInstances: 10});

--- a/functions/src/waitlist.ts
+++ b/functions/src/waitlist.ts
@@ -1,0 +1,213 @@
+import {onRequest} from "firebase-functions/v2/https";
+import * as admin from "firebase-admin";
+import {
+  buildEmailJobId,
+  buildWaitlistWelcomeDedupeKey,
+  createQueuedEmailJob,
+} from "./email/queue";
+import {
+  extractRequesterIp,
+  evaluateWaitlistRateLimit,
+  hashRateLimitIp,
+  toEmailRateLimitDocument,
+  toEmailRateLimitState,
+  type WaitlistRateLimitReason,
+} from "./email/rateLimit";
+import {normalizeEmail, sha256Hex} from "./email/crypto";
+import type {EmailRateLimitDocument} from "./email/types";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Signals that the public waitlist endpoint hit an abuse limit.
+ */
+class RateLimitExceededError extends Error {
+  reason: WaitlistRateLimitReason;
+
+  /**
+   * Creates a stable rate-limit error for HTTP response handling.
+   * @param {WaitlistRateLimitReason} reason - Window that blocked the request
+   */
+  constructor(reason: WaitlistRateLimitReason) {
+    super(reason);
+    this.reason = reason;
+  }
+}
+
+/**
+ * Checks if a Firestore write failed due to an existing document.
+ * @param {unknown} error - Error thrown by Firestore Admin SDK
+ * @return {boolean} True if the error indicates an existing doc
+ */
+function isAlreadyExistsError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = "code" in error ? String(error.code) : "";
+  if (code === "6" || code === "already-exists") {
+    return true;
+  }
+
+  const message = "message" in error ? String(error.message) : "";
+  return message.includes("Already exists");
+}
+
+/**
+ * Parses the HTTP request body into a plain object.
+ * @param {unknown} body - Raw request body
+ * @return {Record<string, unknown> | null} Parsed body or null
+ */
+function parseBody(body: unknown): Record<string, unknown> | null {
+  if (typeof body === "string") {
+    try {
+      return JSON.parse(body) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  if (body && typeof body === "object") {
+    return body as Record<string, unknown>;
+  }
+
+  return null;
+}
+
+/**
+ * Normalizes and validates a waitlist signup source label.
+ * @param {unknown} value - Raw source value
+ * @return {string} Validated source label
+ */
+function parseSource(value: unknown): string {
+  if (typeof value !== "string") {
+    return "landing_page";
+  }
+
+  const trimmedValue = value.trim();
+  if (trimmedValue.length === 0 || trimmedValue.length >= 100) {
+    return "landing_page";
+  }
+
+  return trimmedValue;
+}
+
+/**
+ * Handles public waitlist signups and enqueues the welcome email job.
+ */
+export const joinWaitlist = onRequest(async (req, res) => {
+  if (req.method !== "POST") {
+    res.status(405).json({error: "method_not_allowed"});
+    return;
+  }
+
+  const body = parseBody(req.body);
+  const emailInput = body?.email;
+  const email = typeof emailInput === "string" ?
+    normalizeEmail(emailInput) :
+    "";
+
+  if (!email || email.length > 255 || !EMAIL_PATTERN.test(email)) {
+    res.status(400).json({error: "invalid_email"});
+    return;
+  }
+
+  const source = parseSource(body?.source);
+  const emailHash = sha256Hex(email);
+  const dedupeKey = buildWaitlistWelcomeDedupeKey(emailHash);
+  const emailJobId = buildEmailJobId(dedupeKey);
+  const requesterIp = extractRequesterIp(
+    req.get("x-forwarded-for") ?? undefined,
+    req.ip ?? req.socket.remoteAddress ?? undefined
+  );
+  const ipHash = hashRateLimitIp(requesterIp);
+  const now = new Date();
+  const nowTimestamp = admin.firestore.Timestamp.fromDate(now);
+  const waitlistRef = admin.firestore().collection("waitlist").doc(emailHash);
+  const emailJobRef = admin.firestore()
+    .collection("email_jobs")
+    .doc(emailJobId);
+  const rateLimitRef = admin.firestore()
+    .collection("email_rate_limits")
+    .doc(ipHash);
+
+  try {
+    const responseStatus = await admin.firestore().runTransaction(
+      async (transaction) => {
+        const rateLimitSnapshot = await transaction.get(rateLimitRef);
+        const waitlistSnapshot = await transaction.get(waitlistRef);
+        const emailJobSnapshot = await transaction.get(emailJobRef);
+        const rateLimitDocument = rateLimitSnapshot.exists ?
+          rateLimitSnapshot.data() as EmailRateLimitDocument :
+          null;
+        const rateLimitEvaluation = evaluateWaitlistRateLimit(
+          toEmailRateLimitState(rateLimitDocument),
+          now.getTime(),
+          ipHash
+        );
+
+        if (!rateLimitEvaluation.allowed) {
+          throw new RateLimitExceededError(
+            rateLimitEvaluation.reason ?? "short_window"
+          );
+        }
+
+        transaction.set(
+          rateLimitRef,
+          toEmailRateLimitDocument(
+            rateLimitEvaluation.state,
+            nowTimestamp,
+            rateLimitDocument?.createdAt ?? null
+          )
+        );
+
+        if (waitlistSnapshot.exists) {
+          return "already_subscribed";
+        }
+
+        transaction.create(waitlistRef, {
+          createdAt: nowTimestamp,
+          email,
+          emailHash,
+          source,
+          welcomeEmailJobId: emailJobId,
+        });
+
+        if (!emailJobSnapshot.exists) {
+          transaction.create(
+            emailJobRef,
+            createQueuedEmailJob(
+              "waitlist_welcome",
+              email,
+              emailHash,
+              dedupeKey,
+              {source},
+              nowTimestamp,
+              `waitlist/${emailHash}`
+            )
+          );
+        }
+
+        return "subscribed";
+      }
+    );
+
+    res.status(200).json({status: responseStatus});
+  } catch (error) {
+    if (error instanceof RateLimitExceededError) {
+      res.status(429).json({error: "rate_limited"});
+      return;
+    }
+
+    if (isAlreadyExistsError(error)) {
+      res.status(200).json({status: "already_subscribed"});
+      return;
+    }
+
+    console.error("joinWaitlist failed", {
+      errorCode: error instanceof Error ? error.name : "unknown_error",
+      message: error instanceof Error ? error.message : "unknown_error",
+    });
+    res.status(500).json({error: "internal"});
+  }
+});

--- a/functions/test/email-system.test.ts
+++ b/functions/test/email-system.test.ts
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildEmailJobId,
+  buildWaitlistWelcomeDedupeKey,
+} from "../src/email/queue";
+import {classifyResendStatus} from "../src/email/provider";
+import {
+  evaluateWaitlistRateLimit,
+  extractRequesterIp,
+  hashRateLimitIp,
+} from "../src/email/rateLimit";
+import {getNextRetryDelayMs} from "../src/email/retry";
+import {renderWaitlistWelcomeEmail} from "../src/email/templates";
+
+test("waitlist dedupe keys and job ids are deterministic", () => {
+  const recipientHash = "abc123";
+  const dedupeKey = buildWaitlistWelcomeDedupeKey(recipientHash);
+  const jobId = buildEmailJobId(dedupeKey);
+
+  assert.equal(dedupeKey, "waitlist-welcome:abc123");
+  assert.equal(jobId, buildEmailJobId(dedupeKey));
+});
+
+test("retry schedule matches the waitlist welcome backoff policy", () => {
+  assert.equal(getNextRetryDelayMs("waitlist_welcome", 1), 5 * 60 * 1000);
+  assert.equal(getNextRetryDelayMs("waitlist_welcome", 2), 30 * 60 * 1000);
+  assert.equal(getNextRetryDelayMs("waitlist_welcome", 3), 2 * 60 * 60 * 1000);
+  assert.equal(
+    getNextRetryDelayMs("waitlist_welcome", 4),
+    12 * 60 * 60 * 1000
+  );
+  assert.equal(getNextRetryDelayMs("waitlist_welcome", 5), null);
+});
+
+test("resend status classification distinguishes retryable failures", () => {
+  assert.deepEqual(classifyResendStatus(429), {
+    code: "resend_rate_limited",
+    retryable: true,
+  });
+  assert.deepEqual(classifyResendStatus(503), {
+    code: "resend_server_error",
+    retryable: true,
+  });
+  assert.deepEqual(classifyResendStatus(400), {
+    code: "resend_client_error_400",
+    retryable: false,
+  });
+});
+
+test("rate limit helpers extract and hash requester IPs", () => {
+  const requesterIp = extractRequesterIp(
+    "203.0.113.1, 70.41.3.18",
+    "10.0.0.1"
+  );
+  const hashedIp = hashRateLimitIp(requesterIp);
+
+  assert.equal(requesterIp, "203.0.113.1");
+  assert.equal(hashedIp.length, 64);
+  assert.notEqual(hashedIp, requesterIp);
+});
+
+test("waitlist rate limit blocks the eleventh request in ten minutes", () => {
+  let state = null;
+  const nowMs = Date.parse("2026-03-24T12:00:00.000Z");
+
+  for (let requestCount = 0; requestCount < 10; requestCount += 1) {
+    const evaluation = evaluateWaitlistRateLimit(state, nowMs, "hash");
+    assert.equal(evaluation.allowed, true);
+    state = evaluation.state;
+  }
+
+  const blockedEvaluation = evaluateWaitlistRateLimit(state, nowMs, "hash");
+  assert.equal(blockedEvaluation.allowed, false);
+  assert.equal(blockedEvaluation.reason, "short_window");
+});
+
+test("waitlist template renders escaped html and text output", () => {
+  const rendered = renderWaitlistWelcomeEmail({
+    source: "<script>alert('xss')</script>",
+  });
+
+  assert.equal(rendered.subject, "You're on the Ascend waitlist");
+  assert.match(rendered.html, /Visit ascendstepper\.com/);
+  assert.match(
+    rendered.html,
+    /https:\/\/ascendstepper\.com\/images\/StairmasterIconAccent\.png/
+  );
+  assert.match(rendered.html, /https:\/\/ascendstepper\.com\/privacy/);
+  assert.match(
+    rendered.text,
+    /Visit ascendstepper\.com: https:\/\/ascendstepper\.com/
+  );
+  assert.match(
+    rendered.text,
+    /Privacy Policy: https:\/\/ascendstepper\.com\/privacy/
+  );
+  assert.doesNotMatch(rendered.html, /landing_page|script/i);
+  assert.doesNotMatch(rendered.text, /Signup source:/);
+  assert.doesNotMatch(rendered.html, /Beta Open/);
+});
+
+test("waitlist template includes beta invite CTA when configured", () => {
+  const originalConfig = process.env.TRANSACTIONAL_EMAIL_CONFIG;
+  process.env.TRANSACTIONAL_EMAIL_CONFIG = JSON.stringify({
+    provider: "resend",
+    apiKey: "re_test",
+    fromEmail: "hello@updates.ascendstepper.com",
+    fromName: "Ascend",
+    replyTo: "support@ascendstepper.com",
+    websiteUrl: "https://ascendstepper.com",
+    betaInviteUrl: "https://testflight.apple.com/join/ZZ1zUmBf",
+  });
+
+  try {
+    const rendered = renderWaitlistWelcomeEmail({
+      source: "landing_page",
+    });
+
+    assert.equal(
+      rendered.subject,
+      "You're in. Start testing Ascend on TestFlight"
+    );
+    assert.match(
+      rendered.html,
+      /START TESTING[\s\S]*TODAY\./
+    );
+    assert.match(
+      rendered.html,
+      /https:\/\/ascendstepper\.com\/images\/StairmasterIconAccent\.png/
+    );
+    assert.match(
+      rendered.html,
+      /https:\/\/testflight\.apple\.com\/join\/ZZ1zUmBf/
+    );
+    assert.doesNotMatch(rendered.html, /Beta Open/);
+    assert.ok(
+      rendered.text.includes(
+        "Join the beta on TestFlight: " +
+          "https://testflight.apple.com/join/ZZ1zUmBf"
+      )
+    );
+  } finally {
+    if (originalConfig === undefined) {
+      delete process.env.TRANSACTIONAL_EMAIL_CONFIG;
+    } else {
+      process.env.TRANSACTIONAL_EMAIL_CONFIG = originalConfig;
+    }
+  }
+});

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -12,6 +12,7 @@
   },
   "compileOnSave": true,
   "include": [
-    "src"
+    "src",
+    "test"
   ]
 }

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -845,7 +845,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       const isExisting = status === 'already_subscribed';
       successEl.textContent = isExisting
         ? "You're already on the list. We'll be in touch."
-        : "You're in! We'll let you know when Ascend is live.";
+        : "You're in. We'll send a confirmation email shortly.";
 
       successEl.classList.remove('show', 'is-subscribed', 'is-existing');
       void successEl.offsetWidth;
@@ -917,6 +917,12 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         if (!response.ok) {
           if (payload?.error === 'invalid_email') {
             showError('Please enter a valid email address.', true);
+            button.disabled = false;
+            button.textContent = 'Join Waitlist';
+            return;
+          }
+          if (payload?.error === 'rate_limited') {
+            showError("You've reached the signup limit for now. Please try again later.");
             button.disabled = false;
             button.textContent = 'Join Waitlist';
             return;


### PR DESCRIPTION
Closes #104

## Summary
- add a reusable background transactional email system for waitlist signups using Resend
- enqueue waitlist emails into `email_jobs` with retries, dedupe, and public endpoint rate limiting
- redesign the signup email as a beta-open TestFlight invite with configurable public links
- add Firestore indexes for email job processing and include Firestore index deploys in staging/production workflows
- document the email architecture and setup flow in `AGENTS.md`, `CLAUDE.md`, and `functions/EMAIL_SETUP.md`

## Validation
- `PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npm --prefix functions run lint`
- `PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npm --prefix functions run build`
- `PATH="$HOME/.nvm/versions/node/v22.16.0/bin:$PATH" npm --prefix functions run test`
- manual dev verification: waitlist signup created the queued job and delivered the email through Resend
