### PR TITLE
Add bounded remote media loading for workout media

### DIFF
--- a/AscendApp/Features/Workouts/Views/Components/WorkoutCardMediaViews.swift
+++ b/AscendApp/Features/Workouts/Views/Components/WorkoutCardMediaViews.swift
@@ -20,42 +20,13 @@ func formatVideoDuration(_ duration: TimeInterval) -> String {
 /// Loads a remote photo with ImageCache support.
 /// Consolidates 3 duplicate `loadPhoto()` implementations.
 func loadCachedPhoto(from url: URL) async -> UIImage? {
-    if let cached = ImageCache.shared.image(for: url) {
-        return cached
-    }
-
-    do {
-        let (data, _) = try await URLSession.shared.data(from: url)
-        if let image = UIImage(data: data) {
-            ImageCache.shared.store(image, for: url)
-            return image
-        }
-    } catch {
-        // Caller handles nil return
-    }
-    return nil
+    await RemoteMediaLoader.shared.loadPhoto(from: url)
 }
 
 /// Generates a video thumbnail with ImageCache support.
 /// Consolidates 3 duplicate `loadVideoThumbnail()` implementations.
 func loadCachedVideoThumbnail(from url: URL) async -> UIImage? {
-    if let cached = ImageCache.shared.image(for: url) {
-        return cached
-    }
-
-    do {
-        let asset = AVURLAsset(url: url)
-        let imageGenerator = AVAssetImageGenerator(asset: asset)
-        imageGenerator.appliesPreferredTrackTransform = true
-
-        let cgImage = try await imageGenerator.image(at: .zero).image
-        let image = UIImage(cgImage: cgImage)
-        ImageCache.shared.store(image, for: url)
-        return image
-    } catch {
-        // Caller handles nil return
-    }
-    return nil
+    await RemoteMediaLoader.shared.loadVideoThumbnail(from: url)
 }
 
 // MARK: - WorkoutCardMediaSection
@@ -219,10 +190,8 @@ struct AutoPlayVideoView: View {
     }
 
     private func loadVideo() async {
-        // Load thumbnail first
-        thumbnail = await loadCachedVideoThumbnail(from: photo.url)
+        async let thumbnailLoad = loadCachedVideoThumbnail(from: photo.url)
 
-        // Then set up player
         let newPlayer = AVPlayer(url: photo.url)
         newPlayer.isMuted = true
         newPlayer.actionAtItemEnd = .none
@@ -244,6 +213,8 @@ struct AutoPlayVideoView: View {
                 newPlayer.play()
             }
         }
+
+        thumbnail = await thumbnailLoad
     }
 }
 

--- a/AscendApp/Features/Workouts/Views/Components/WorkoutDetailHeroView.swift
+++ b/AscendApp/Features/Workouts/Views/Components/WorkoutDetailHeroView.swift
@@ -189,8 +189,9 @@ private struct HeroMediaItem: View {
 
     private func loadMedia() async {
         if photo.isVideo {
-            loadedImage = await loadCachedVideoThumbnail(from: photo.url)
+            async let thumbnailLoad = loadCachedVideoThumbnail(from: photo.url)
             await configureVideoPlayer()
+            loadedImage = await thumbnailLoad
         } else {
             loadedImage = await loadCachedPhoto(from: photo.url)
             isLoading = false

--- a/AscendApp/Shared/Components/FullScreenPhotoView.swift
+++ b/AscendApp/Shared/Components/FullScreenPhotoView.swift
@@ -14,7 +14,6 @@ struct FullScreenPhotoView: View {
 
     @State private var loadedImage: UIImage?
     @State private var isLoading = true
-    @State private var loadError: Error?
     @State private var scale: CGFloat = 1.0
     @State private var offset: CGSize = .zero
     @State private var dragOffset: CGSize = .zero
@@ -203,45 +202,23 @@ struct FullScreenPhotoView: View {
     }
     
     private func loadVideo() async {
-        let asset = AVURLAsset(url: photo.url)
-        // Preload to avoid main thread blocking
-        _ = try? await asset.load(.isPlayable)
-
-        let playerItem = AVPlayerItem(asset: asset)
+        let canPrepareVideo = await RemoteMediaLoader.shared.canPrepareVideo(from: photo.url)
 
         await MainActor.run {
-            self.player = AVPlayer(playerItem: playerItem)
+            if canPrepareVideo {
+                self.player = AVPlayer(url: photo.url)
+            } else {
+                self.player = nil
+            }
             self.isLoading = false
         }
     }
 
     private func loadPhoto() async {
-        // Check cache first
-        if let cached = ImageCache.shared.image(for: photo.url) {
-            await MainActor.run {
-                self.loadedImage = cached
-                self.isLoading = false
-            }
-            return
-        }
-
-        do {
-            let (data, _) = try await URLSession.shared.data(from: photo.url)
-
-            await MainActor.run {
-                if let image = UIImage(data: data) {
-                    ImageCache.shared.store(image, for: photo.url)
-                    self.loadedImage = image
-                } else {
-                    self.loadError = PhotoLoadError.invalidImageData
-                }
-                self.isLoading = false
-            }
-        } catch {
-            await MainActor.run {
-                self.loadError = error
-                self.isLoading = false
-            }
+        let image = await RemoteMediaLoader.shared.loadPhoto(from: photo.url)
+        await MainActor.run {
+            self.loadedImage = image
+            self.isLoading = false
         }
     }
 

--- a/AscendApp/Shared/Components/LoadablePhotoView.swift
+++ b/AscendApp/Shared/Components/LoadablePhotoView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import AVFoundation
 
 struct LoadablePhotoView: View {
     let photo: Photo
@@ -16,7 +15,6 @@ struct LoadablePhotoView: View {
 
     @State private var loadedImage: UIImage?
     @State private var isLoading = true
-    @State private var loadError: Error?
 
     init(
         photo: Photo,
@@ -106,66 +104,18 @@ struct LoadablePhotoView: View {
     }
     
     private func loadPhoto() async {
-        // Check cache first
-        if let cached = ImageCache.shared.image(for: photo.url) {
-            await MainActor.run {
-                self.loadedImage = cached
-                self.isLoading = false
-            }
-            return
-        }
-
-        do {
-            let (data, _) = try await URLSession.shared.data(from: photo.url)
-
-            await MainActor.run {
-                if let image = UIImage(data: data) {
-                    ImageCache.shared.store(image, for: photo.url)
-                    self.loadedImage = image
-                } else {
-                    self.loadError = PhotoLoadError.invalidImageData
-                }
-                self.isLoading = false
-            }
-        } catch {
-            await MainActor.run {
-                self.loadError = error
-                self.isLoading = false
-            }
+        let image = await RemoteMediaLoader.shared.loadPhoto(from: photo.url)
+        await MainActor.run {
+            self.loadedImage = image
+            self.isLoading = false
         }
     }
 
     private func loadVideoThumbnail() async {
-        // Check cache first
-        if let cached = ImageCache.shared.image(for: photo.url) {
-            await MainActor.run {
-                self.loadedImage = cached
-                self.isLoading = false
-            }
-            return
-        }
-
-        do {
-            let asset = AVURLAsset(url: photo.url)
-            // Preload to ensure asset is ready for thumbnail generation
-            try await asset.load(.isReadable, .tracks)
-
-            let imageGenerator = AVAssetImageGenerator(asset: asset)
-            imageGenerator.appliesPreferredTrackTransform = true
-
-            let cgImage = try await imageGenerator.image(at: .zero).image
-            let image = UIImage(cgImage: cgImage)
-
-            await MainActor.run {
-                ImageCache.shared.store(image, for: photo.url)
-                self.loadedImage = image
-                self.isLoading = false
-            }
-        } catch {
-            await MainActor.run {
-                self.loadError = error
-                self.isLoading = false
-            }
+        let image = await RemoteMediaLoader.shared.loadVideoThumbnail(from: photo.url)
+        await MainActor.run {
+            self.loadedImage = image
+            self.isLoading = false
         }
     }
     
@@ -175,17 +125,6 @@ struct LoadablePhotoView: View {
         let seconds = totalSeconds % 60
         
         return "\(minutes):\(seconds < 10 ? "0" : "")\(seconds)"
-    }
-}
-
-enum PhotoLoadError: LocalizedError {
-    case invalidImageData
-
-    var errorDescription: String? {
-        switch self {
-        case .invalidImageData:
-            return "Invalid image data"
-        }
     }
 }
 

--- a/AscendApp/Shared/Services/RemoteMediaLoader.swift
+++ b/AscendApp/Shared/Services/RemoteMediaLoader.swift
@@ -1,0 +1,187 @@
+//
+//  RemoteMediaLoader.swift
+//  AscendApp
+//
+//  Created by Codex on 3/30/26.
+//
+
+import AVFoundation
+import UIKit
+
+struct RemoteMediaLoader: Sendable {
+    enum LoaderError: LocalizedError {
+        case timedOut(kind: MediaKind)
+        case invalidResponse(statusCode: Int?)
+        case invalidImageData
+        case videoNotPlayable
+
+        enum MediaKind: String {
+            case photo
+            case video
+            case videoThumbnail
+        }
+
+        var errorDescription: String? {
+            switch self {
+            case .timedOut(let kind):
+                return "\(kind.rawValue.capitalized) load timed out."
+            case .invalidResponse(let statusCode):
+                if let statusCode {
+                    return "Received an invalid media response (\(statusCode))."
+                }
+                return "Received an invalid media response."
+            case .invalidImageData:
+                return "Received invalid image data."
+            case .videoNotPlayable:
+                return "Video is not currently playable."
+            }
+        }
+    }
+
+    typealias PhotoRequest = @Sendable (URLRequest) async throws -> (Data, URLResponse)
+    typealias VideoPlayableRequest = @Sendable (URL) async throws -> Void
+
+    static let shared = RemoteMediaLoader()
+
+    private let imageCache: ImageCache
+    private let photoRequest: PhotoRequest
+    private let videoPlayableRequest: VideoPlayableRequest
+    private let requestTimeoutSeconds: Double
+    private let errorRecorder: @Sendable (Error, LoaderError.MediaKind) -> Void
+
+    init(
+        imageCache: ImageCache = .shared,
+        requestTimeoutSeconds: Double = 15.0,
+        photoRequest: PhotoRequest? = nil,
+        videoPlayableRequest: VideoPlayableRequest? = nil,
+        errorRecorder: @escaping @Sendable (Error, LoaderError.MediaKind) -> Void = Self.recordError(_:kind:)
+    ) {
+        self.imageCache = imageCache
+        self.requestTimeoutSeconds = requestTimeoutSeconds
+        self.photoRequest = photoRequest ?? Self.defaultPhotoRequest(timeoutSeconds: requestTimeoutSeconds)
+        self.videoPlayableRequest = videoPlayableRequest ?? Self.defaultVideoPlayableRequest
+        self.errorRecorder = errorRecorder
+    }
+
+    func loadPhoto(from url: URL) async -> UIImage? {
+        if let cached = imageCache.image(for: url) {
+            return cached
+        }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = requestTimeoutSeconds
+
+        do {
+            let (data, response) = try await photoRequest(request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw LoaderError.invalidResponse(statusCode: nil)
+            }
+            guard (200..<300).contains(httpResponse.statusCode) else {
+                throw LoaderError.invalidResponse(statusCode: httpResponse.statusCode)
+            }
+            guard let image = UIImage(data: data) else {
+                throw LoaderError.invalidImageData
+            }
+
+            imageCache.store(image, for: url)
+            return image
+        } catch is CancellationError {
+            return nil
+        } catch {
+            errorRecorder(error, .photo)
+            return nil
+        }
+    }
+
+    func loadVideoThumbnail(from url: URL) async -> UIImage? {
+        if let cached = imageCache.image(for: url) {
+            return cached
+        }
+
+        guard await canPrepareVideo(from: url) else {
+            return nil
+        }
+
+        let asset = AVURLAsset(url: url)
+        let imageGenerator = AVAssetImageGenerator(asset: asset)
+        imageGenerator.appliesPreferredTrackTransform = true
+
+        do {
+            let cgImage = try await imageGenerator.image(at: .zero).image
+            let image = UIImage(cgImage: cgImage)
+            imageCache.store(image, for: url)
+            return image
+        } catch is CancellationError {
+            return nil
+        } catch {
+            errorRecorder(error, .videoThumbnail)
+            return nil
+        }
+    }
+
+    func canPrepareVideo(from url: URL) async -> Bool {
+        do {
+            try await Self.runWithTimeout(seconds: requestTimeoutSeconds) {
+                try await videoPlayableRequest(url)
+            }
+            return true
+        } catch is CancellationError {
+            return false
+        } catch {
+            errorRecorder(error, .video)
+            return false
+        }
+    }
+
+    private static func defaultPhotoRequest(timeoutSeconds: Double) -> PhotoRequest {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = timeoutSeconds
+        configuration.timeoutIntervalForResource = timeoutSeconds
+        configuration.waitsForConnectivity = false
+        let session = URLSession(configuration: configuration)
+
+        return { request in
+            try await session.data(for: request)
+        }
+    }
+
+    private static func defaultVideoPlayableRequest(_ url: URL) async throws {
+        let asset = AVURLAsset(url: url)
+        let isPlayable = try await asset.load(.isPlayable)
+        guard isPlayable else {
+            throw LoaderError.videoNotPlayable
+        }
+    }
+
+    private static func runWithTimeout(
+        seconds: Double,
+        operation: @escaping @Sendable () async throws -> Void
+    ) async throws {
+        try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                try await operation()
+                return true
+            }
+            group.addTask {
+                try await Task.sleep(for: .seconds(seconds))
+                return false
+            }
+
+            let result = try await group.next()!
+            group.cancelAll()
+
+            if !result {
+                throw LoaderError.timedOut(kind: .video)
+            }
+        }
+    }
+
+    private static func recordError(_ error: Error, kind: LoaderError.MediaKind) {
+        TelemetryManager.shared.recordError(
+            error,
+            context: .network,
+            code: "remote_media_load_failed",
+            additionalInfo: ["media_kind": kind.rawValue]
+        )
+    }
+}

--- a/AscendAppTests/RemoteMediaLoaderTests.swift
+++ b/AscendAppTests/RemoteMediaLoaderTests.swift
@@ -1,0 +1,103 @@
+//
+//  RemoteMediaLoaderTests.swift
+//  AscendAppTests
+//
+//  Created by Codex on 3/30/26.
+//
+
+import Foundation
+import Testing
+import UIKit
+@testable import AscendApp
+
+struct RemoteMediaLoaderTests {
+    @Test
+    func loadPhotoCachesSuccessfulResponses() async throws {
+        ImageCache.shared.clearAll()
+
+        let url = URL(string: "https://example.com/cache-photo.jpg")!
+        let callCounter = RequestCounter()
+        let imageData = try #require(makeImageData())
+
+        let loader = RemoteMediaLoader(
+            requestTimeoutSeconds: 1.0,
+            photoRequest: { request in
+                #expect(request.timeoutInterval == 1.0)
+                await callCounter.increment()
+
+                let response = try #require(
+                    HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+                )
+                return (imageData, response)
+            },
+            videoPlayableRequest: { _ in },
+            errorRecorder: { _, _ in }
+        )
+
+        let firstImage = await loader.loadPhoto(from: url)
+        let secondImage = await loader.loadPhoto(from: url)
+
+        #expect(firstImage != nil)
+        #expect(secondImage != nil)
+        #expect(await callCounter.value == 1)
+    }
+
+    @Test
+    func loadPhotoRejectsInvalidResponses() async throws {
+        ImageCache.shared.clearAll()
+
+        let url = URL(string: "https://example.com/forbidden-photo.jpg")!
+        let imageData = try #require(makeImageData())
+
+        let loader = RemoteMediaLoader(
+            requestTimeoutSeconds: 1.0,
+            photoRequest: { _ in
+                let response = try #require(
+                    HTTPURLResponse(url: url, statusCode: 403, httpVersion: nil, headerFields: nil)
+                )
+                return (imageData, response)
+            },
+            videoPlayableRequest: { _ in },
+            errorRecorder: { _, _ in }
+        )
+
+        let image = await loader.loadPhoto(from: url)
+        #expect(image == nil)
+    }
+
+    @Test
+    func canPrepareVideoTimesOutWhenReadinessNeverFinishes() async {
+        let url = URL(string: "https://example.com/hanging-video.mov")!
+
+        let loader = RemoteMediaLoader(
+            requestTimeoutSeconds: 0.05,
+            photoRequest: { _ in
+                throw URLError(.badServerResponse)
+            },
+            videoPlayableRequest: { _ in
+                try await Task.sleep(for: .seconds(5))
+            },
+            errorRecorder: { _, _ in }
+        )
+
+        let canPrepare = await loader.canPrepareVideo(from: url)
+        #expect(canPrepare == false)
+    }
+
+    private func makeImageData() -> Data? {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 4, height: 4))
+        let image = renderer.image { context in
+            UIColor.systemGreen.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+        }
+        return image.pngData()
+    }
+}
+
+private actor RequestCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared `RemoteMediaLoader` for workout photos and video thumbnails
- bound remote media loading with explicit timeouts, connectivity behavior, and response validation
- stop hero/video loading states from waiting indefinitely on thumbnail generation
- add focused tests covering successful image caching, invalid responses, and video readiness timeout

## Why
PR #107 was already merged into `develop`, but the remote media loading fix landed afterward on the old feature branch. This follow-up PR carries only that bounded media loading work on top of current `develop`.

## Testing
- `xcodebuild -project /private/tmp/ascendapp-issue-106-media-loading/AscendApp.xcodeproj -scheme AscendApp -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16' build`
- `xcodebuild -project /private/tmp/ascendapp-issue-106-media-loading/AscendApp.xcodeproj -scheme AscendApp -destination 'platform=iOS Simulator,OS=18.5,name=iPhone 16' -only-testing:AscendAppTests test`

## Notes
- Follow-up to #107
- This does not change the share-card UI work already merged into `develop`
