### PR TITLE
Redesign workout detail screen and improve tab switching

### DIFF
--- a/AscendApp/Features/Workouts/Views/Components/EffortRatingCard.swift
+++ b/AscendApp/Features/Workouts/Views/Components/EffortRatingCard.swift
@@ -1,0 +1,70 @@
+//
+//  EffortRatingCard.swift
+//  AscendApp
+//
+//  Created by Tyler Pavay on 4/2/26.
+//
+
+import SwiftUI
+
+/// Displays the workout effort rating as a horizontal stat card.
+struct EffortRatingCard: View {
+    let rating: Double
+    let effectiveColorScheme: ColorScheme
+
+    private var description: String {
+        switch Int(rating) {
+        case 1: return "Minimal"
+        case 2: return "Light"
+        case 3: return "Moderate"
+        case 4: return "High"
+        case 5: return "Maximum"
+        default: return "Moderate"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "bolt.fill")
+                .font(.system(size: 20, weight: .medium))
+                .foregroundStyle(.orange)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Effort Rating")
+                    .font(.montserratMedium(size: 14))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
+
+                HStack(alignment: .firstTextBaseline, spacing: 6) {
+                    Text("\(Int(rating))/5")
+                        .font(.montserratBold(size: 20))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+
+                    Text(description)
+                        .font(.montserratRegular(size: 14))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15), lineWidth: 1)
+                )
+        )
+    }
+}
+
+#Preview {
+    VStack(spacing: 12) {
+        EffortRatingCard(rating: 4.0, effectiveColorScheme: .dark)
+        EffortRatingCard(rating: 2.0, effectiveColorScheme: .dark)
+    }
+    .padding(20)
+    .background(Color.black)
+}

--- a/AscendApp/Features/Workouts/Views/Components/HeroStatsPair.swift
+++ b/AscendApp/Features/Workouts/Views/Components/HeroStatsPair.swift
@@ -1,0 +1,97 @@
+//
+//  HeroStatsPair.swift
+//  AscendApp
+//
+//  Created by Tyler Pavay on 4/2/26.
+//
+
+import SwiftUI
+
+/// Large side-by-side hero stats (duration + steps/floors) with a vertical divider.
+/// Supports PR-aware accent border when either stat is a personal record.
+struct HeroStatsPair: View {
+    let leftLabel: String
+    let leftValue: String
+    let rightLabel: String
+    let rightValue: String
+    let leftIsPR: Bool
+    let rightIsPR: Bool
+    let effectiveColorScheme: ColorScheme
+
+    private var hasPR: Bool {
+        leftIsPR || rightIsPR
+    }
+
+    private var borderColor: Color {
+        hasPR
+            ? .accent.opacity(0.6)
+            : (effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15))
+    }
+
+    private var borderWidth: CGFloat {
+        hasPR ? 1.5 : 1
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            statColumn(label: leftLabel, value: leftValue)
+
+            // Vertical divider
+            Rectangle()
+                .fill(effectiveColorScheme == .dark ? .white.opacity(0.15) : .gray.opacity(0.3))
+                .frame(width: 1, height: 36)
+
+            statColumn(label: rightLabel, value: rightValue)
+        }
+        .padding(.vertical, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(borderColor, lineWidth: borderWidth)
+                )
+        )
+    }
+
+    private func statColumn(label: String, value: String) -> some View {
+        VStack(spacing: 4) {
+            Text(value)
+                .font(.montserratBold(size: 22))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+
+            Text(label.uppercased())
+                .font(.montserratMedium(size: 11))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        HeroStatsPair(
+            leftLabel: "Duration",
+            leftValue: "2:00:22",
+            rightLabel: "Steps",
+            rightValue: "10,849",
+            leftIsPR: false,
+            rightIsPR: true,
+            effectiveColorScheme: .dark
+        )
+
+        HeroStatsPair(
+            leftLabel: "Duration",
+            leftValue: "30:00",
+            rightLabel: "Floors",
+            rightValue: "156",
+            leftIsPR: false,
+            rightIsPR: false,
+            effectiveColorScheme: .dark
+        )
+    }
+    .padding(20)
+    .background(Color.black)
+}

--- a/AscendApp/Features/Workouts/Views/Components/NotesBlockquote.swift
+++ b/AscendApp/Features/Workouts/Views/Components/NotesBlockquote.swift
@@ -1,0 +1,68 @@
+//
+//  NotesBlockquote.swift
+//  AscendApp
+//
+//  Created by Tyler Pavay on 4/2/26.
+//
+
+import SwiftUI
+
+/// Displays workout notes in a blockquote style with a left accent border.
+/// Supports expand/collapse for long text.
+struct NotesBlockquote: View {
+    let text: String
+    let effectiveColorScheme: ColorScheme
+
+    @State private var isExpanded = false
+
+    private var needsTruncation: Bool {
+        text.count > 240 || text.components(separatedBy: "\n").count > 3
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Left accent border
+            RoundedRectangle(cornerRadius: 1.5)
+                .fill(.accent)
+                .frame(width: 3)
+
+            // Notes text
+            VStack(alignment: .leading, spacing: 6) {
+                Text(text)
+                    .font(.montserratRegular(size: 15))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.8) : .black.opacity(0.7))
+                    .lineLimit(isExpanded ? nil : 3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                if needsTruncation {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            isExpanded.toggle()
+                        }
+                    } label: {
+                        Text(isExpanded ? "Show less" : "Show more")
+                            .font(.montserratMedium(size: 13))
+                            .foregroundStyle(.accent)
+                    }
+                }
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+#Preview {
+    VStack(spacing: 24) {
+        NotesBlockquote(
+            text: "This is a note",
+            effectiveColorScheme: .dark
+        )
+
+        NotesBlockquote(
+            text: "Great morning workout! Felt really strong and maintained a good pace throughout the entire session. Pushed hard on the last 10 minutes and managed to hit a new personal record for steps.",
+            effectiveColorScheme: .dark
+        )
+    }
+    .padding(20)
+    .background(Color.black)
+}

--- a/AscendApp/Features/Workouts/Views/Components/PRTrophyBadge.swift
+++ b/AscendApp/Features/Workouts/Views/Components/PRTrophyBadge.swift
@@ -1,0 +1,90 @@
+//
+//  PRTrophyBadge.swift
+//  AscendApp
+//
+//  Created by Tyler Pavay on 4/2/26.
+//
+
+import SwiftUI
+
+/// A single PR entry for display in the trophy badge popover.
+struct PRDetail: Identifiable {
+    let id = UUID()
+    let emoji: String
+    let name: String
+    let isWeightPR: Bool
+}
+
+/// A compact trophy icon + PR count badge outlined in accent green.
+/// Tapping shows a popover listing all personal records.
+struct PRTrophyBadge: View {
+    let count: Int
+    let details: [PRDetail]
+
+    @State private var showingDetails = false
+
+    var body: some View {
+        if count > 0 {
+            Button {
+                showingDetails = true
+            } label: {
+                HStack(spacing: 4) {
+                    Image(systemName: "trophy.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                    Text("\(count)")
+                        .font(.montserratSemiBold(size: 13))
+                }
+                .foregroundStyle(.accent)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    Capsule()
+                        .stroke(.accent, lineWidth: 1.5)
+                )
+            }
+            .buttonStyle(.plain)
+            .popover(isPresented: $showingDetails) {
+                prDetailsPopover
+            }
+        }
+    }
+
+    private var prDetailsPopover: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Personal Records")
+                .font(.montserratSemiBold(size: 15))
+                .padding(.bottom, 4)
+
+            ForEach(details) { pr in
+                HStack(spacing: 8) {
+                    Text(pr.emoji)
+                        .font(.system(size: 14))
+                        .frame(width: 20)
+                    Text(pr.name)
+                        .font(.montserratRegular(size: 13))
+                    if pr.isWeightPR {
+                        Text("(weighted)")
+                            .font(.montserratRegular(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .presentationCompactAdaptation(.popover)
+    }
+}
+
+#Preview {
+    PRTrophyBadge(
+        count: 4,
+        details: [
+            PRDetail(emoji: "👟", name: "Most Steps", isWeightPR: false),
+            PRDetail(emoji: "⏱️", name: "Longest Workout", isWeightPR: false),
+            PRDetail(emoji: "🔥", name: "Most Calories Burned", isWeightPR: false),
+            PRDetail(emoji: "👟", name: "Most Steps", isWeightPR: true)
+        ]
+    )
+    .padding()
+    .preferredColorScheme(.dark)
+}

--- a/AscendApp/Features/Workouts/Views/Components/SecondaryStatsRow.swift
+++ b/AscendApp/Features/Workouts/Views/Components/SecondaryStatsRow.swift
@@ -1,0 +1,75 @@
+//
+//  SecondaryStatsRow.swift
+//  AscendApp
+//
+//  Created by Tyler Pavay on 4/2/26.
+//
+
+import SwiftUI
+
+/// A data item for the secondary stats row.
+struct SecondaryStatItem: Identifiable {
+    let id = UUID()
+    let label: String
+    let value: String
+    let isPR: Bool
+}
+
+/// Compact row of 1–3 secondary stat cards (pace, calories, METs).
+/// Each card supports PR-aware accent borders.
+struct SecondaryStatsRow: View {
+    let items: [SecondaryStatItem]
+    let effectiveColorScheme: ColorScheme
+
+    var body: some View {
+        HStack(spacing: 10) {
+            ForEach(items) { item in
+                secondaryStatCard(item: item)
+            }
+        }
+    }
+
+    private func secondaryStatCard(item: SecondaryStatItem) -> some View {
+        let borderColor: Color = item.isPR
+            ? .accent.opacity(0.6)
+            : (effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15))
+        let borderWidth: CGFloat = item.isPR ? 1.5 : 1
+
+        return VStack(spacing: 4) {
+            Text(item.value)
+                .font(.montserratBold(size: 18))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+
+            Text(item.label.uppercased())
+                .font(.montserratMedium(size: 10))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .padding(.horizontal, 8)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(borderColor, lineWidth: borderWidth)
+                )
+        )
+    }
+}
+
+#Preview {
+    SecondaryStatsRow(
+        items: [
+            SecondaryStatItem(label: "Steps/Min", value: "90.1", isPR: true),
+            SecondaryStatItem(label: "Calories", value: "1,692", isPR: false),
+            SecondaryStatItem(label: "METs", value: "10.3", isPR: false)
+        ],
+        effectiveColorScheme: .dark
+    )
+    .padding(20)
+    .background(Color.black)
+}

--- a/AscendApp/Features/Workouts/Views/Components/VerticalClimbCard.swift
+++ b/AscendApp/Features/Workouts/Views/Components/VerticalClimbCard.swift
@@ -1,0 +1,70 @@
+//
+//  VerticalClimbCard.swift
+//  AscendApp
+//
+//  Created by Tyler Pavay on 4/2/26.
+//
+
+import SwiftUI
+
+/// Standalone horizontal card displaying vertical climb with a triangle icon.
+/// Supports PR-aware accent border.
+struct VerticalClimbCard: View {
+    let value: String
+    let unit: String
+    let isPR: Bool
+    let effectiveColorScheme: ColorScheme
+
+    private var borderColor: Color {
+        isPR
+            ? .accent.opacity(0.6)
+            : (effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15))
+    }
+
+    private var borderWidth: CGFloat {
+        isPR ? 1.5 : 1
+    }
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Image(systemName: "triangle.fill")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.accent)
+                .frame(width: 28)
+
+            Text("Vertical climb")
+                .font(.montserratMedium(size: 15))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
+
+            Spacer()
+
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(value)
+                    .font(.montserratBold(size: 20))
+                    .foregroundStyle(.accent)
+
+                Text(unit)
+                    .font(.montserratRegular(size: 14))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+            }
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(borderColor, lineWidth: borderWidth)
+                )
+        )
+    }
+}
+
+#Preview {
+    VStack(spacing: 12) {
+        VerticalClimbCard(value: "7,232.7", unit: "ft", isPR: true, effectiveColorScheme: .dark)
+        VerticalClimbCard(value: "1,204.5", unit: "m", isPR: false, effectiveColorScheme: .dark)
+    }
+    .padding(20)
+    .background(Color.black)
+}

--- a/AscendApp/Features/Workouts/Views/Components/WorkoutRowView.swift
+++ b/AscendApp/Features/Workouts/Views/Components/WorkoutRowView.swift
@@ -108,15 +108,6 @@ struct WorkoutRowView: View {
                     .font(.montserratMedium(size: 14))
                     .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
 
-                if let pace = paceText {
-                    Text("\u{2022}")
-                        .font(.system(size: 10))
-                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.4) : .gray.opacity(0.6))
-                    Text(pace)
-                        .font(.montserratMedium(size: 14))
-                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
-                }
-
                 Spacer()
 
                 if workout.hasWeights {

--- a/AscendApp/Features/Workouts/Views/Components/WorkoutTitleRow.swift
+++ b/AscendApp/Features/Workouts/Views/Components/WorkoutTitleRow.swift
@@ -1,0 +1,163 @@
+//
+//  WorkoutTitleRow.swift
+//  AscendApp
+//
+//  Created by Tyler Pavay on 4/2/26.
+//
+
+import SwiftUI
+
+/// Describes the weight summary for display in the title row subtitle.
+enum WeightSummary {
+    /// Single weight source (e.g. "20 lb vest")
+    case single(label: String)
+    /// Multiple weight sources with total and per-entry breakdown
+    case multiple(total: String, entries: [(name: String, weight: String)])
+    /// No weights used
+    case none
+}
+
+/// Workout title row with left-aligned name, date + weight subtitle, and trailing PR trophy badge.
+struct WorkoutTitleRow: View {
+    let workoutName: String
+    let dateText: String
+    let weightSummary: WeightSummary
+    let prCount: Int
+    let prDetails: [PRDetail]
+    let effectiveColorScheme: ColorScheme
+
+    @State private var showingWeightBreakdown = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Leading: name + subtitle
+            VStack(alignment: .leading, spacing: 4) {
+                Text(workoutName)
+                    .font(.montserratBold(size: 18))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                subtitleView
+            }
+
+            Spacer(minLength: 4)
+
+            // Trailing: PR trophy badge
+            if prCount > 0 {
+                PRTrophyBadge(count: prCount, details: prDetails)
+                    .padding(.top, 2)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var subtitleView: some View {
+        switch weightSummary {
+        case .none:
+            Text(dateText)
+                .font(.montserratRegular(size: 13))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+
+        case .single(let label):
+            Text("\(dateText) | \(label)")
+                .font(.montserratRegular(size: 13))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+
+        case .multiple(let total, _):
+            Button {
+                showingWeightBreakdown = true
+            } label: {
+                HStack(spacing: 2) {
+                    Text("\(dateText) | +\(total)")
+                        .font(.montserratRegular(size: 13))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 10))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.3) : .gray.opacity(0.5))
+                }
+            }
+            .buttonStyle(.plain)
+            .popover(isPresented: $showingWeightBreakdown) {
+                weightBreakdownPopover
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var weightBreakdownPopover: some View {
+        if case .multiple(let total, let entries) = weightSummary {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Weight Breakdown")
+                    .font(.montserratSemiBold(size: 15))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+
+                ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
+                    HStack {
+                        Text(entry.name)
+                            .font(.montserratRegular(size: 14))
+                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
+                        Spacer()
+                        Text(entry.weight)
+                            .font(.montserratMedium(size: 14))
+                            .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    }
+                }
+
+                Divider()
+
+                HStack {
+                    Text("Total")
+                        .font(.montserratMedium(size: 14))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
+                    Spacer()
+                    Text(total)
+                        .font(.montserratSemiBold(size: 14))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                }
+            }
+            .padding(16)
+            .frame(minWidth: 220)
+            .presentationCompactAdaptation(.popover)
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 24) {
+        WorkoutTitleRow(
+            workoutName: "Afternoon stair stepper",
+            dateText: "Mar 27 at 3:54 PM",
+            weightSummary: .single(label: "20 lb vest"),
+            prCount: 4,
+            prDetails: [],
+            effectiveColorScheme: .dark
+        )
+
+        WorkoutTitleRow(
+            workoutName: "Morning climb session",
+            dateText: "Today at 9:15 AM",
+            weightSummary: .multiple(
+                total: "30 lb",
+                entries: [
+                    (name: "Weighted Vest", weight: "20 lb"),
+                    (name: "Dumbbells", weight: "10 lb")
+                ]
+            ),
+            prCount: 2,
+            prDetails: [],
+            effectiveColorScheme: .dark
+        )
+
+        WorkoutTitleRow(
+            workoutName: "Evening session",
+            dateText: "Yesterday at 6:00 PM",
+            weightSummary: .none,
+            prCount: 0,
+            prDetails: [],
+            effectiveColorScheme: .dark
+        )
+    }
+    .padding(20)
+    .background(Color.black)
+}

--- a/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
+++ b/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
@@ -16,6 +16,7 @@ struct HeartRateChartView: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var themeManager = ThemeManager.shared
     @State private var rawSelectedTime: TimeInterval?
+    @State private var stickySelectedTime: TimeInterval?
     @State private var selectedPoint: HeartRateDataPoint?
     
     // Use actual heart rate data timespan instead of workout duration
@@ -42,15 +43,24 @@ struct HeartRateChartView: View {
         }
     }
     
-    // Computed property to find the selected point based on raw selected time
+    // Computed property to find the selected point — uses active touch or sticky (last-touched) time
     private var computedSelectedPoint: HeartRateDataPoint? {
-        guard let rawSelectedTime = rawSelectedTime else { return nil }
-        
+        guard let activeTime = rawSelectedTime ?? stickySelectedTime else { return nil }
+
         return heartRateData.min { point1, point2 in
-            let distance1 = abs(point1.timestamp.timeIntervalSince(actualStartTime) - rawSelectedTime)
-            let distance2 = abs(point2.timestamp.timeIntervalSince(actualStartTime) - rawSelectedTime)
+            let distance1 = abs(point1.timestamp.timeIntervalSince(actualStartTime) - activeTime)
+            let distance2 = abs(point2.timestamp.timeIntervalSince(actualStartTime) - activeTime)
             return distance1 < distance2
         }
+    }
+
+    private var averageHeartRate: Int {
+        guard !heartRateData.isEmpty else { return 0 }
+        return heartRateData.map(\.heartRate).reduce(0, +) / heartRateData.count
+    }
+
+    private var maxHeartRate: Int {
+        heartRateData.map(\.heartRate).max() ?? 0
     }
     
     // Heart rate range for Y-axis scaling
@@ -102,31 +112,49 @@ struct HeartRateChartView: View {
     }
     
     private var headerView: some View {
-        HStack {
-            Text("Heart Rate")
-                .font(.montserratSemiBold(size: 20))
-                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-            Spacer()
-            
-            VStack(alignment: .trailing, spacing: 2) {
-                if let selected = computedSelectedPoint {
+        VStack(spacing: 6) {
+            // Top row: "Heart Rate" title + always-visible avg/max
+            HStack {
+                Text("Heart Rate")
+                    .font(.montserratSemiBold(size: 20))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                Spacer()
+
+                HStack(spacing: 16) {
+                    HStack(spacing: 4) {
+                        Text("Avg")
+                            .font(.montserratRegular(size: 12))
+                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+                        Text("\(averageHeartRate)")
+                            .font(.montserratBold(size: 14))
+                            .foregroundStyle(.red)
+                    }
+                    HStack(spacing: 4) {
+                        Text("Max")
+                            .font(.montserratRegular(size: 12))
+                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+                        Text("\(maxHeartRate)")
+                            .font(.montserratBold(size: 14))
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+
+            // Selected point row (appears when user taps the graph)
+            if let selected = computedSelectedPoint {
+                HStack {
+                    Spacer()
                     Text("\(selected.heartRate) BPM")
                         .font(.montserratBold(size: 16))
                         .foregroundStyle(.red)
-                    Text(formatDuration(selected.timestamp.timeIntervalSince(actualStartTime)))
+                    Text("at \(formatDuration(selected.timestamp.timeIntervalSince(actualStartTime)))")
                         .font(.montserratRegular(size: 12))
                         .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
-                } else {
-                    // Invisible placeholder to maintain consistent height
-                    Text("000 BPM")
-                        .font(.montserratBold(size: 16))
-                        .opacity(0)
-                    Text("00:00")
-                        .font(.montserratRegular(size: 12))
-                        .opacity(0)
                 }
+                .transition(.opacity)
             }
         }
+        .animation(.easeInOut(duration: 0.15), value: computedSelectedPoint != nil)
     }
     
     private var emptyStateView: some View {
@@ -184,6 +212,11 @@ struct HeartRateChartView: View {
                 impactFeedback.impactOccurred()
             }
         }
+        .onChange(of: rawSelectedTime) { _, newValue in
+            if let newValue {
+                stickySelectedTime = newValue
+            }
+        }
         .chartBackground { _ in
             backgroundView
         }
@@ -195,7 +228,7 @@ struct HeartRateChartView: View {
             y: .value("Heart Rate", data.heartRate)
         )
         .foregroundStyle(.red)
-        .lineStyle(StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+        .lineStyle(StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
     }
     
     @ChartContentBuilder
@@ -221,14 +254,14 @@ struct HeartRateChartView: View {
                         .font(.montserratRegular(size: 10))
                         .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
                 }
-                AxisGridLine()
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.2))
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.15) : .gray.opacity(0.25))
                 AxisTick()
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.2))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.15) : .gray.opacity(0.25))
             }
         }
     }
-    
+
     private var yAxisMarks: some AxisContent {
         AxisMarks(position: .leading, values: heartRateTickValues) { value in
             if let heartRate = value.as(Int.self) {
@@ -237,10 +270,10 @@ struct HeartRateChartView: View {
                         .font(.montserratRegular(size: 10))
                         .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.6) : .gray)
                 }
-                AxisGridLine()
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.2))
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.15) : .gray.opacity(0.25))
                 AxisTick()
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.2))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.15) : .gray.opacity(0.25))
             }
         }
     }
@@ -254,7 +287,6 @@ struct HeartRateChartView: View {
             )
             .clipShape(RoundedRectangle(cornerRadius: 16))
     }
-    
     
     private func formatDuration(_ duration: TimeInterval) -> String {
         let totalSeconds = Int(duration)

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -28,19 +28,21 @@ struct WorkoutDetailView: View {
     @State private var isDeleting = false
     @State private var isCancelling = false
     @State private var deleteTask: Task<Void, Never>? = nil
-    @State private var isNotesExpanded = false
 
     // Strava-style layout state
     @State private var sheetPosition: SheetPosition = .middle
     @State private var currentPhotoIndex: Int = 0
     @State private var selectedPhoto: Photo? = nil
-    @State private var sheetOffset: CGFloat = 0  // For smooth hero animation during drag
+    @State private var sheetOffset: CGFloat = 0
+
+    // Scroll tracking for traditional layout nav bar title
+    @State private var scrolledPastTitle = false
+    @State private var scrollContentOffset: CGFloat = 0
 
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
     }
 
-    /// Whether the workout has media (photos or pending uploads)
     private var hasMedia: Bool {
         !orderedPhotos.isEmpty
     }
@@ -52,7 +54,6 @@ struct WorkoutDetailView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                // Background
                 (effectiveColorScheme == .dark ? Color.black : Color.white)
                     .ignoresSafeArea()
 
@@ -92,7 +93,6 @@ struct WorkoutDetailView: View {
                     isLoading: isDeleting,
                     isCancelling: isCancelling,
                     onConfirm: {
-                        // Guard against double-starting
                         guard deleteTask == nil else { return }
                         deleteTask = Task {
                             await deleteWorkout()
@@ -101,7 +101,6 @@ struct WorkoutDetailView: View {
                     },
                     onCancel: {
                         if isDeleting {
-                            // Cancel in-flight deletion
                             isCancelling = true
                             deleteTask?.cancel()
                             deleteTask = nil
@@ -125,20 +124,15 @@ struct WorkoutDetailView: View {
         }
     }
 
-    // MARK: - Strava-Style Layout
+    // MARK: - Strava-Style Layout (unchanged structure, new content)
 
     @ViewBuilder
     private var stravaStyleLayout: some View {
         GeometryReader { geometry in
             ZStack(alignment: .top) {
-                // Photo/Video Hero (behind sheet)
-                // Use sheetOffset for smooth height during drag, fall back to position-based height
-                // sheetOffset > 0 means we're actively dragging; use the live offset for immediate feedback
-                // sheetOffset == 0 means drag ended; use position-based height which animates via .animation modifier
                 let heroHeight = sheetOffset > 0 ? sheetOffset : sheetPosition.photoHeight(in: geometry)
                 let heroOpacity: Double = {
                     if sheetOffset > 0 {
-                        // During drag: fade based on how much hero is visible
                         return min(1.0, sheetOffset / (geometry.size.height * 0.1))
                     } else {
                         return sheetPosition.photoOpacity
@@ -158,7 +152,6 @@ struct WorkoutDetailView: View {
                 .opacity(heroOpacity)
                 .animation(.spring(response: 0.35, dampingFraction: 0.8), value: sheetPosition)
 
-                // Draggable Detail Sheet (overlays photo)
                 DraggableDetailSheet(position: $sheetPosition, currentOffset: $sheetOffset) {
                     sheetDetailContent(in: geometry)
                 }
@@ -169,7 +162,6 @@ struct WorkoutDetailView: View {
     private func sheetDetailContent(in geometry: GeometryProxy) -> some View {
         ScrollableDetailContent(sheetPosition: $sheetPosition) {
             VStack(spacing: 24) {
-                // Media upload status banner at top
                 MediaUploadBanner(workoutId: workout.id) {
                     Task {
                         await MediaUploadManager.shared.retryFailedUploads(
@@ -179,107 +171,10 @@ struct WorkoutDetailView: View {
                     }
                 }
 
-                // Header section (without top padding since sheet handles it)
-                sheetHeaderSection
-
-                // Notes (if available)
-                if !workout.notes.isEmpty {
-                    notesSection
-                }
-
-                // Workout Details
-                workoutDetailsSection
-
-                // Heart Rate Chart (if available)
-                if !workout.heartRateTimeSeries.isEmpty {
-                    HeartRateChartView(
-                        heartRateData: workout.heartRateTimeSeries,
-                        workoutStartTime: workout.date,
-                        workoutDuration: workout.duration
-                    )
-                }
-
-                // Additional metrics
-                if hasAdditionalMetrics {
-                    additionalMetricsSection
-                }
-
-                // Weights section
-                if workout.hasWeights {
-                    weightsUsedSection
-                }
-
-                Spacer(minLength: 40)
+                workoutContentSections
             }
             .padding(.horizontal, 20)
-            // Add top padding when expanded to account for header overlay
             .padding(.top, sheetPosition == .expanded ? 60 : 8)
-        }
-    }
-
-    /// Header section for sheet (without top padding)
-    private var sheetHeaderSection: some View {
-        VStack(spacing: 16) {
-            // Workout name
-            Text(workout.name)
-                .font(.montserratBold(size: 24))
-                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                .multilineTextAlignment(.center)
-                .lineLimit(nil)
-                .fixedSize(horizontal: false, vertical: true)
-
-            // Personal Records Badges
-            if workout.hasPersonalRecords {
-                PersonalRecordBadgeGroup(
-                    workout: workout,
-                    size: .medium,
-                    maxVisible: nil
-                )
-                .padding(.top, 4)
-            }
-
-            // Strava sync indicator
-            if FeatureFlags.isStravaEnabled && (isSyncingToStrava || workout.isSyncedToStrava) {
-                stravaSyncBadge
-            }
-
-            // Date & time
-            VStack(spacing: 4) {
-                Text(formatWorkoutDateTime())
-                    .font(.montserratRegular(size: 16))
-                    .foregroundStyle(.accent)
-            }
-        }
-    }
-
-    private var stravaSyncBadge: some View {
-        HStack(spacing: 6) {
-            Image("strava-icon")
-                .renderingMode(.template)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 12, height: 12)
-                .opacity(isSyncingToStrava ? syncingIconOpacity : 1.0)
-            Text(isSyncingToStrava ? "Syncing..." : "Synced to Strava")
-                .font(.montserratRegular(size: 12))
-        }
-        .foregroundStyle(Color(red: 252/255, green: 76/255, blue: 2/255)) // Strava orange
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(
-            Capsule()
-                .fill(Color(red: 252/255, green: 76/255, blue: 2/255).opacity(0.15))
-        )
-        .onChange(of: isSyncingToStrava) { _, syncing in
-            if syncing {
-                withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) {
-                    syncingIconOpacity = 0.3
-                }
-            } else {
-                withAnimation(.default) {
-                    syncingIconOpacity = 1.0
-                }
-            }
         }
     }
 
@@ -288,8 +183,21 @@ struct WorkoutDetailView: View {
     private var traditionalLayout: some View {
         ScrollView {
             VStack(spacing: 24) {
-                // Header with workout name and date
-                headerSection
+                // Title row — scrolls naturally behind the opaque nav bar
+                WorkoutTitleRow(
+                    workoutName: workout.name,
+                    dateText: formatWorkoutDateTime(),
+                    weightSummary: weightSummary,
+                    prCount: workout.totalPRCount,
+                    prDetails: prDetails,
+                    effectiveColorScheme: effectiveColorScheme
+                )
+                .padding(.top, 80) // Account for header overlay
+
+                // Strava sync indicator
+                if FeatureFlags.isStravaEnabled && (isSyncingToStrava || workout.isSyncedToStrava) {
+                    stravaSyncBadge
+                }
 
                 // Media upload status banner
                 MediaUploadBanner(workoutId: workout.id) {
@@ -301,42 +209,126 @@ struct WorkoutDetailView: View {
                     }
                 }
 
-                // Notes (if available)
-                if !workout.notes.isEmpty {
-                    notesSection
-                }
+                workoutContentSectionsWithoutTitle
 
-                // Workout Details
-                workoutDetailsSection
-
-                // Photos section - show if there are photos or pending uploads
+                // Photos section
                 WorkoutPhotosSection(workout: workout)
-
-                // Heart Rate Chart
-                if !workout.heartRateTimeSeries.isEmpty {
-                    HeartRateChartView(
-                        heartRateData: workout.heartRateTimeSeries,
-                        workoutStartTime: workout.date,
-                        workoutDuration: workout.duration
-                    )
-                }
-
-                // Additional metrics
-                if hasAdditionalMetrics {
-                    additionalMetricsSection
-                }
-
-                // Weights section
-                if workout.hasWeights {
-                    weightsUsedSection
-                }
 
                 Spacer(minLength: 20)
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 16)
+            .overlay(alignment: .top) {
+                // Scroll offset tracker — pinned to top of content
+                GeometryReader { geo in
+                    let minY = geo.frame(in: .global).minY
+                    Color.clear
+                        .onChange(of: minY) { _, newValue in
+                            scrollContentOffset = newValue
+                            // Title text is at ~96pt from content top (16pt padding + 80pt offset).
+                            // When the content top (minY) has scrolled so the title is behind the
+                            // nav bar, show the nav bar title. The safe area top + nav bar ≈ 100pt.
+                            let shouldShow = newValue < -40
+                            if shouldShow != scrolledPastTitle {
+                                scrolledPastTitle = shouldShow
+                            }
+                        }
+                }
+                .frame(height: 0)
+            }
         }
         .scrollIndicators(.hidden)
+    }
+
+    // MARK: - Shared Content Sections
+
+    /// All content sections (used in sheet detail for media layout)
+    private var workoutContentSections: some View {
+        Group {
+            // Hide inline title when sheet is expanded (nav bar shows it instead)
+            if sheetPosition != .expanded {
+                WorkoutTitleRow(
+                    workoutName: workout.name,
+                    dateText: formatWorkoutDateTime(),
+                    weightSummary: weightSummary,
+                    prCount: workout.totalPRCount,
+                    prDetails: prDetails,
+                    effectiveColorScheme: effectiveColorScheme
+                )
+
+                if FeatureFlags.isStravaEnabled && (isSyncingToStrava || workout.isSyncedToStrava) {
+                    stravaSyncBadge
+                }
+            }
+
+            workoutContentSectionsWithoutTitle
+
+            Spacer(minLength: 40)
+        }
+    }
+
+    /// Content sections after the title (shared between both layouts)
+    private var workoutContentSectionsWithoutTitle: some View {
+        Group {
+            // Notes (blockquote style)
+            if !workout.notes.isEmpty {
+                NotesBlockquote(
+                    text: workout.notes,
+                    effectiveColorScheme: effectiveColorScheme
+                )
+            }
+
+            // Hero stats: Duration + Steps/Floors
+            HeroStatsPair(
+                leftLabel: "Duration",
+                leftValue: workout.durationFormatted,
+                rightLabel: preferredMetric.displayName,
+                rightValue: formattedPrimaryMetric,
+                leftIsPR: isStatAPR(.duration),
+                rightIsPR: isStatAPR(preferredMetric == .steps ? .steps : .floors),
+                effectiveColorScheme: effectiveColorScheme
+            )
+
+            // Secondary stats row (pace, calories, METs)
+            if !secondaryStatItems.isEmpty {
+                SecondaryStatsRow(
+                    items: secondaryStatItems,
+                    effectiveColorScheme: effectiveColorScheme
+                )
+            }
+
+            // Heart Rate Chart
+            if !workout.heartRateTimeSeries.isEmpty {
+                HeartRateChartView(
+                    heartRateData: workout.heartRateTimeSeries,
+                    workoutStartTime: workout.date,
+                    workoutDuration: workout.duration
+                )
+            }
+
+            // Vertical Climb
+            if let verticalClimb = verticalClimbValue {
+                VerticalClimbCard(
+                    value: verticalClimb.formatted(.number.precision(.fractionLength(1))),
+                    unit: workout.verticalClimbUnit(measurementSystem: settingsManager.measurementSystem),
+                    isPR: isStatAPR(.verticalClimb),
+                    effectiveColorScheme: effectiveColorScheme
+                )
+            }
+
+            // Effort Rating
+            if let effortRating = workout.effortRating {
+                EffortRatingCard(
+                    rating: effortRating,
+                    effectiveColorScheme: effectiveColorScheme
+                )
+            }
+
+            // Weights section (unchanged)
+            if workout.hasWeights {
+                weightsUsedSection
+            }
+        }
     }
 
     // MARK: - Adaptive Header
@@ -358,11 +350,19 @@ struct WorkoutDetailView: View {
 
                 Spacer()
 
-                // Title (fades in as sheet expands)
-                Text("Workout Details")
-                    .font(.montserratSemiBold(size: 18))
-                    .foregroundStyle(headerForegroundColor)
-                    .opacity(hasMedia ? headerTitleOpacity : 1.0)
+                // Title + subtitle (fades in when scrolled past inline title)
+                VStack(spacing: 2) {
+                    Text(workout.name)
+                        .font(.montserratSemiBold(size: 16))
+                        .foregroundStyle(headerForegroundColor)
+                        .lineLimit(1)
+
+                    Text(headerSubtitleText)
+                        .font(.montserratRegular(size: 11))
+                        .foregroundStyle(headerForegroundColor.opacity(0.6))
+                        .lineLimit(1)
+                }
+                .opacity(headerTitleOpacity)
 
                 Spacer()
 
@@ -384,14 +384,17 @@ struct WorkoutDetailView: View {
             .padding(.top, 8)
             .padding(.bottom, hasMedia && sheetPosition != .expanded ? 8 : 16)
 
-            // Divider only when not over photo
             if !hasMedia || sheetPosition == .expanded {
                 Divider()
                     .background(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.2))
             }
         }
-        .background(headerBackground)
+        .background {
+            headerBackground
+                .ignoresSafeArea(edges: .top)
+        }
         .animation(.easeOut(duration: 0.2), value: sheetPosition)
+        .animation(.easeOut(duration: 0.2), value: scrolledPastTitle)
     }
 
     private var headerForegroundColor: Color {
@@ -409,9 +412,10 @@ struct WorkoutDetailView: View {
     }
 
     private var headerTitleOpacity: Double {
-        switch sheetPosition {
-        case .collapsed, .middle: return 0.0
-        case .expanded: return 1.0
+        if hasMedia {
+            return sheetPosition == .expanded ? 1.0 : 0.0
+        } else {
+            return scrolledPastTitle ? 1.0 : 0.0
         }
     }
 
@@ -424,6 +428,21 @@ struct WorkoutDetailView: View {
         }
     }
 
+    /// Compact subtitle text for the nav bar (date + optional weight)
+    private var headerSubtitleText: String {
+        let date = formatWorkoutDateTime()
+        switch weightSummary {
+        case .none:
+            return date
+        case .single(let label):
+            return "\(date) | \(label)"
+        case .multiple(let total, _):
+            return "\(date) | +\(total)"
+        }
+    }
+
+    // MARK: - Menu
+
     @ViewBuilder
     private var menuContent: some View {
         Button(action: {
@@ -432,7 +451,6 @@ struct WorkoutDetailView: View {
             Label("Share", systemImage: "square.and.arrow.up")
         }
 
-        // Strava sync option
         if FeatureFlags.isStravaEnabled && stravaManager.isConnected {
             if workout.isSyncedToStrava {
                 Label("Synced to Strava", systemImage: "checkmark.circle.fill")
@@ -468,320 +486,43 @@ struct WorkoutDetailView: View {
         }
     }
 
-    // MARK: - Original Custom Header (keeping for reference)
+    // MARK: - Strava Sync Badge
 
-    private var customHeader: some View {
-        VStack(spacing: 0) {
-            HStack {
-                Button(action: {
-                    dismiss()
-                }) {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 18, weight: .medium))
-                        .foregroundStyle(.accent)
-                }
-                
-                Spacer()
-                
-                Text("Workout Details")
-                    .font(.montserratSemiBold(size: 18))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                
-                Spacer()
-                
-                Menu {
-                    Button(action: {
-                        showingShareWorkoutView = true
-                    }) {
-                        Label("Share", systemImage: "square.and.arrow.up")
-                    }
-
-                    // Strava sync option
-                    if FeatureFlags.isStravaEnabled && stravaManager.isConnected {
-                        if workout.isSyncedToStrava {
-                            // Show synced state (non-actionable)
-                            Label("Synced to Strava", systemImage: "checkmark.circle.fill")
-                        } else {
-                            Button(action: shareToStrava) {
-                                if isSyncingToStrava {
-                                    Label("Syncing...", systemImage: "arrow.triangle.2.circlepath")
-                                } else {
-                                    HStack {
-                                        Image("strava-icon")
-                                            .renderingMode(.template)
-                                            .resizable()
-                                            .scaledToFit()
-                                            .frame(width: 13, height: 13)
-                                        Text("Sync to Strava")
-                                    }
-                                }
-                            }
-                            .disabled(isSyncingToStrava)
-                        }
-                    }
-
-                    Button(action: {
-                        showingEditWorkout = true
-                    }) {
-                        Label("Edit Workout", systemImage: "pencil")
-                    }
-
-                    Button(role: .destructive, action: {
-                        showingDeleteConfirmation = true
-                    }) {
-                        Label("Delete Workout", systemImage: "trash")
-                    }
-                } label: {
-                    Image(systemName: "ellipsis")
-                        .font(.system(size: 18, weight: .medium))
-                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                        .frame(width: 44, height: 44)
-                        .contentShape(Rectangle())
-                }
-            }
-            .padding(.horizontal, 20)
-            .padding(.top, 8)
-            .padding(.bottom, 16)
-            .background(effectiveColorScheme == .dark ? .black : .white)
-            
-            Divider()
-                .background(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.2))
+    private var stravaSyncBadge: some View {
+        HStack(spacing: 6) {
+            Image("strava-icon")
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 12, height: 12)
+                .opacity(isSyncingToStrava ? syncingIconOpacity : 1.0)
+            Text(isSyncingToStrava ? "Syncing..." : "Synced to Strava")
+                .font(.montserratRegular(size: 12))
         }
-        .background(effectiveColorScheme == .dark ? .black : .white)
-    }
-    
-    private var headerSection: some View {
-        VStack(spacing: 16) {
-            // Workout name
-            Text(workout.name)
-                .font(.montserratBold(size: 24))
-                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                .multilineTextAlignment(.center)
-                .lineLimit(nil)
-                .fixedSize(horizontal: false, vertical: true)
-            
-            // Personal Records Badges
-            if workout.hasPersonalRecords {
-                PersonalRecordBadgeGroup(
-                    workout: workout,
-                    size: .medium,
-                    maxVisible: nil
-                )
-                .padding(.top, 4)
-            }
-
-            // Strava sync indicator
-            if FeatureFlags.isStravaEnabled && (isSyncingToStrava || workout.isSyncedToStrava) {
-                HStack(spacing: 6) {
-                    Image("strava-icon")
-                        .renderingMode(.template)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 12, height: 12)
-                        .opacity(isSyncingToStrava ? syncingIconOpacity : 1.0)
-                    Text(isSyncingToStrava ? "Syncing..." : "Synced to Strava")
-                        .font(.montserratRegular(size: 12))
+        .foregroundStyle(Color(red: 252/255, green: 76/255, blue: 2/255))
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(
+            Capsule()
+                .fill(Color(red: 252/255, green: 76/255, blue: 2/255).opacity(0.15))
+        )
+        .onChange(of: isSyncingToStrava) { _, syncing in
+            if syncing {
+                withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) {
+                    syncingIconOpacity = 0.3
                 }
-                .foregroundStyle(Color(red: 252/255, green: 76/255, blue: 2/255)) // Strava orange
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(
-                    Capsule()
-                        .fill(Color(red: 252/255, green: 76/255, blue: 2/255).opacity(0.15))
-                )
-                .onChange(of: isSyncingToStrava) { _, syncing in
-                    if syncing {
-                        withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) {
-                            syncingIconOpacity = 0.3
-                        }
-                    } else {
-                        withAnimation(.default) {
-                            syncingIconOpacity = 1.0
-                        }
-                    }
-                }
-            }
-
-            // Date & time
-            VStack(spacing: 4) {
-                Text(formatWorkoutDateTime())
-                    .font(.montserratRegular(size: 16))
-                    .foregroundStyle(.accent)
-            }
-        }
-        .padding(.top, 80) // Account for custom header overlay
-    }
-
-    private var workoutDetailsSection: some View {
-        VStack(spacing: 16) {
-            // Section header
-            HStack {
-                Text("Workout Summary")
-                    .font(.montserratSemiBold(size: 20))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                Spacer()
-            }
-            
-            VStack(spacing: 16) {
-                // Square grid for main metrics
-                if workout.avgHeartRate != nil || workout.maxHeartRate != nil {
-                    // Show duration, steps/floors, avg HR, max HR in square
-                    squareMetricsGrid
-                    
-                    // Show pace below
-                    additionalMetrics
-                } else {
-                    // Show duration, steps/floors, pace in square
-                    fullWorkoutMetricsGrid
-                }
-                
-                // Effort rating (if available)
-                if let effortRating = workout.effortRating {
-                    statCard(
-                        icon: "bolt.fill",
-                        title: "Effort Rating",
-                        value: "\(Int(effortRating))/5",
-                        subtitle: effortDescription(for: effortRating),
-                        iconColor: .orange
-                    )
-                }
-            }
-        }
-    }
-    
-    private var preferredMetric: WorkoutMetric {
-        settingsManager.preferredWorkoutMetric
-    }
-    
-    private var squareMetricsGrid: some View {
-        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 2), spacing: 10) {
-            // Duration
-            gridStatCard(
-                icon: "stopwatch",
-                title: "Duration",
-                value: workout.durationFormatted
-            )
-            
-            // Primary metric based on user preference
-            gridStatCard(
-                icon: preferredMetric == .steps ? "figure.stairs" : "building.2",
-                title: preferredMetric.displayName,
-                value: "\(workout.metricValue(for: preferredMetric))"
-            )
-            
-            // Average Heart Rate
-            if let avgHR = workout.avgHeartRate {
-                gridStatCard(
-                    icon: "heart.fill",
-                    title: "Avg Heart Rate",
-                    value: "\(avgHR)",
-                    iconColor: .red
-                )
             } else {
-                gridStatCard(icon: "minus", title: "No Data", value: "—")
-            }
-            
-            // Max Heart Rate
-            if let maxHR = workout.maxHeartRate {
-                gridStatCard(
-                    icon: "heart.fill",
-                    title: "Max Heart Rate",
-                    value: "\(maxHR)",
-                    iconColor: .red
-                )
-            } else {
-                gridStatCard(icon: "minus", title: "No Data", value: "—")
+                withAnimation(.default) {
+                    syncingIconOpacity = 1.0
+                }
             }
         }
     }
-    
-    private var fullWorkoutMetricsGrid: some View {
-        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 2), spacing: 10) {
-            // Duration
-            gridStatCard(
-                icon: "stopwatch",
-                title: "Duration",
-                value: workout.durationFormatted
-            )
-            
-            // Primary metric based on user preference
-            gridStatCard(
-                icon: preferredMetric == .steps ? "figure.stairs" : "building.2",
-                title: preferredMetric.displayName,
-                value: "\(workout.metricValue(for: preferredMetric))"
-            )
-            
-            // Pace based on user preference
-            if let pace = workout.pace(for: preferredMetric) {
-                gridStatCard(
-                    icon: "speedometer",
-                    title: "Pace",
-                    value: pace.formatted(.number.precision(.fractionLength(1)))
-                )
-            } else {
-                gridStatCard(icon: "minus", title: "No Data", value: "—")
-            }
-        }
-    }
-    
-    private var additionalMetrics: some View {
-        VStack(spacing: 16) {
-            // Pace based on user preference
-            if let pace = workout.pace(for: preferredMetric) {
-                statCard(
-                    icon: "speedometer",
-                    title: "Pace",
-                    value: pace.formatted(.number.precision(.fractionLength(1))),
-                    subtitle: "\(preferredMetric.unit)/min"
-                )
-            }
-        }
-    }
-    
-    private var additionalMetricsSection: some View {
-        VStack(spacing: 16) {
-            // Section header
-            HStack {
-                Text("Additional Metrics")
-                    .font(.montserratSemiBold(size: 20))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                Spacer()
-            }
 
-            if let verticalClimb = verticalClimbValue {
-                statCard(
-                    icon: "arrow.up",
-                    title: "Vertical Climb",
-                    value: verticalClimb.formatted(.number.precision(.fractionLength(1))),
-                    subtitle: workout.verticalClimbUnit(measurementSystem: settingsManager.measurementSystem)
-                )
-            }
-
-            if let calories = workout.caloriesBurned {
-                statCard(
-                    icon: "flame.fill",
-                    title: "Calories Burned",
-                    value: "\(calories)",
-                    subtitle: "calories",
-                    iconColor: .orange
-                )
-            }
-
-            if let averageMETs = workout.averageMETs {
-                statCard(
-                    icon: "bolt.circle.fill",
-                    title: "Average METs",
-                    value: averageMETs.formatted(.number.precision(.fractionLength(1))),
-                    subtitle: "METs",
-                    iconColor: .green
-                )
-            }
-        }
-    }
+    // MARK: - Weights Section (unchanged)
 
     private var weightsUsedSection: some View {
         VStack(spacing: 16) {
-            // Section header
             HStack {
                 Text("Weights Used")
                     .font(.montserratSemiBold(size: 20))
@@ -796,11 +537,9 @@ struct WorkoutDetailView: View {
                             Divider()
                                 .padding(.leading, 48)
                         }
-
                         weightEntryRow(entry: entry)
                     }
 
-                    // Total weight footer
                     Divider()
                         .padding(.vertical, 8)
 
@@ -828,18 +567,15 @@ struct WorkoutDetailView: View {
 
     private func weightEntryRow(entry: WeightEntry) -> some View {
         HStack(spacing: 12) {
-            // Icon
             weightEquipmentIcon(for: entry.equipmentType)
                 .frame(width: 24, height: 24)
 
-            // Equipment name
             Text(entry.equipmentType.displayName)
                 .font(.montserratMedium(size: 15))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
 
             Spacer()
 
-            // Weight value
             VStack(alignment: .trailing, spacing: 2) {
                 Text(entry.formattedWeight(unit: settingsManager.measurementSystem.weightAbbreviation))
                     .font(.montserratSemiBold(size: 15))
@@ -857,14 +593,12 @@ struct WorkoutDetailView: View {
 
     @ViewBuilder
     private func weightEquipmentIcon(for type: WeightEquipmentType) -> some View {
-        // Try custom icon first, fall back to SF Symbol
         if let _ = UIImage(named: type.iconName) {
             Image(type.iconName)
                 .resizable()
                 .scaledToFit()
                 .frame(width: 20, height: 20)
         } else {
-            // Fallback SF Symbols
             Image(systemName: weightFallbackSFSymbol(for: type))
                 .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(.accent)
@@ -881,8 +615,15 @@ struct WorkoutDetailView: View {
         }
     }
 
-    private var hasAdditionalMetrics: Bool {
-        verticalClimbValue != nil || workout.caloriesBurned != nil || workout.averageMETs != nil
+    // MARK: - Data Helpers
+
+    private var preferredMetric: WorkoutMetric {
+        settingsManager.preferredWorkoutMetric
+    }
+
+    private var formattedPrimaryMetric: String {
+        let value = workout.metricValue(for: preferredMetric)
+        return value.formatted(.number)
     }
 
     private var verticalClimbValue: Double? {
@@ -891,190 +632,138 @@ struct WorkoutDetailView: View {
             measurementSystem: settingsManager.measurementSystem
         )
     }
-    
-    /// Check if notes need truncation (more than ~4 lines worth of text)
-    private var notesNeedsTruncation: Bool {
-        // Approximate check: ~60 chars per line at this font size, so ~240 for 4 lines
-        workout.notes.count > 240 || workout.notes.components(separatedBy: "\n").count > 4
+
+    /// Build secondary stat items from available data
+    private var secondaryStatItems: [SecondaryStatItem] {
+        var items: [SecondaryStatItem] = []
+
+        // Pace (steps/min or floors/min)
+        if let pace = workout.pace(for: preferredMetric) {
+            items.append(SecondaryStatItem(
+                label: "\(preferredMetric.unit)/Min",
+                value: pace.formatted(.number.precision(.fractionLength(1))),
+                isPR: isStatAPR(.pace)
+            ))
+        }
+
+        // Calories
+        if let calories = workout.caloriesBurned {
+            items.append(SecondaryStatItem(
+                label: "Calories",
+                value: "\(calories)",
+                isPR: isStatAPR(.calories)
+            ))
+        }
+
+        // METs
+        if let mets = workout.averageMETs {
+            items.append(SecondaryStatItem(
+                label: "METs",
+                value: mets.formatted(.number.precision(.fractionLength(1))),
+                isPR: false // No PR type for METs
+            ))
+        }
+
+        return items
     }
 
-    private var notesSection: some View {
-        VStack(spacing: 16) {
-            // Section header
-            HStack {
-                Text("Notes")
-                    .font(.montserratSemiBold(size: 20))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                Spacer()
-            }
+    /// Build weight summary for the title row subtitle
+    private var weightSummary: WeightSummary {
+        guard let config = workout.weightConfiguration, !config.isEmpty else {
+            return .none
+        }
 
-            Button {
-                if notesNeedsTruncation && !isNotesExpanded {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isNotesExpanded = true
-                    }
-                }
-            } label: {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(workout.notes)
-                        .font(.montserratRegular(size: 16))
-                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.9) : .black.opacity(0.8))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .lineLimit(isNotesExpanded ? nil : 4)
+        let enabledEntries = config.entries.filter { $0.isEnabled }
+        let ms = settingsManager.measurementSystem
 
-                    if isNotesExpanded {
-                        Button {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                isNotesExpanded = false
-                            }
-                        } label: {
-                            Text("Show less")
-                                .font(.montserratMedium(size: 14))
-                                .foregroundStyle(.accent)
-                        }
-                    }
-                }
-                .padding(20)
-                .contentShape(Rectangle())
+        if enabledEntries.count == 1, let entry = enabledEntries.first {
+            let weightStr = ms.formatWeight(entry.totalWeight)
+            let label = "\(weightStr) \(entry.equipmentType.displayName.lowercased())"
+            return .single(label: label)
+        } else {
+            let total = ms.formatWeight(config.totalWeight)
+            let entries = enabledEntries.map { entry in
+                (name: entry.equipmentType.displayName, weight: ms.formatWeight(entry.totalWeight))
             }
-            .buttonStyle(.plain)
-            .background(
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16)
-                            .stroke(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15), lineWidth: 1)
-                    )
-            )
+            return .multiple(total: total, entries: entries)
         }
     }
-    
-    private func statCard(
-        icon: String,
-        title: String,
-        value: String,
-        subtitle: String? = nil,
-        iconColor: Color = .accent,
-        isProminent: Bool = false
-    ) -> some View {
-        HStack(spacing: 16) {
-            // Icon
-            Image(systemName: icon)
-                .font(.system(size: isProminent ? 24 : 20, weight: .medium))
-                .foregroundStyle(iconColor)
-                .frame(width: isProminent ? 32 : 28)
-            
-            // Content
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(.montserratMedium(size: isProminent ? 16 : 14))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
-                
-                HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    Text(value)
-                        .font(.montserratBold(size: isProminent ? 28 : 20))
-                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                    
-                    if let subtitle = subtitle {
-                        Text(subtitle)
-                            .font(.montserratRegular(size: isProminent ? 16 : 14))
-                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
-                    }
+
+    /// Build the list of all PR details for the trophy badge popover
+    private var prDetails: [PRDetail] {
+        var details: [PRDetail] = []
+
+        // Standard PRs
+        for pr in workout.achievedPersonalRecords {
+            details.append(PRDetail(emoji: pr.emoji, name: pr.displayName, isWeightPR: false))
+        }
+
+        // Weight PRs (stored as raw string keys)
+        if let weightPRKeys = workout.weightPersonalRecordTypes {
+            for key in weightPRKeys {
+                // Try weight combo record types first
+                if let recordType = WeightRecordType(rawValue: key) {
+                    details.append(PRDetail(emoji: recordType.emoji, name: recordType.displayName, isWeightPR: true))
+                }
+                // Then aggregate weight record types
+                else if let aggType = AggregateWeightRecordType(rawValue: key) {
+                    details.append(PRDetail(emoji: aggType.emoji, name: aggType.displayName, isWeightPR: true))
+                }
+                // Unknown key — show generic
+                else {
+                    details.append(PRDetail(emoji: "🏋️", name: key, isWeightPR: true))
                 }
             }
-            
-            Spacer()
         }
-        .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 16)
-                        .stroke(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15), lineWidth: 1)
-                )
-        )
+
+        return details
     }
-    
-    private func gridStatCard(
-        icon: String,
-        title: String,
-        value: String,
-        iconColor: Color = .accent
-    ) -> some View {
-        VStack(spacing: 6) {
-            // Icon
-            Image(systemName: icon)
-                .font(.system(size: 18, weight: .medium))
-                .foregroundStyle(iconColor)
-                .frame(height: 20)
 
-            // Content
-            VStack(spacing: 2) {
-                Text(title)
-                    .font(.montserratMedium(size: 11))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(2)
+    // MARK: - PR Awareness
 
-                Text(value)
-                    .font(.montserratBold(size: 16))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                    .multilineTextAlignment(.center)
-            }
+    private enum StatIdentifier {
+        case duration, steps, floors, pace, avgHeartRate, maxHeartRate, verticalClimb, calories
+    }
+
+    private func isStatAPR(_ stat: StatIdentifier) -> Bool {
+        let prTypes = workout.achievedPersonalRecords
+        let metric = settingsManager.preferredWorkoutMetric
+        switch stat {
+        case .duration:       return prTypes.contains(.longestDuration)
+        case .steps:          return metric == .steps && prTypes.contains(.mostSteps)
+        case .floors:         return metric == .floors && prTypes.contains(.mostFloors)
+        case .pace:           return prTypes.contains(.highestAveragePace)
+        case .avgHeartRate:   return prTypes.contains(.highestAverageHeartRate)
+        case .maxHeartRate:   return prTypes.contains(.highestMaxHeartRate)
+        case .verticalClimb:  return prTypes.contains(.highestVerticalClimb)
+        case .calories:       return prTypes.contains(.mostCaloriesBurned)
         }
-        .frame(maxWidth: .infinity)
-        .frame(height: 80)
-        .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 14)
-                .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
-                .overlay(
-                    RoundedRectangle(cornerRadius: 14)
-                        .stroke(effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15), lineWidth: 1)
-                )
-        )
     }
-    
+
+    // MARK: - Formatting
+
     private func formatWorkoutDateTime() -> String {
         let calendar = Calendar.current
         let timeFormatter = DateFormatter()
         timeFormatter.dateFormat = "h:mm a"
-        
+
         if calendar.isDateInToday(workout.date) {
             return "Today at \(timeFormatter.string(from: workout.date))"
         } else if calendar.isDateInYesterday(workout.date) {
             return "Yesterday at \(timeFormatter.string(from: workout.date))"
         } else {
             let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = "MMM d"
-            // Check if it's from this year
             if calendar.component(.year, from: workout.date) == calendar.component(.year, from: Date()) {
-                return "\(dateFormatter.string(from: workout.date)) at \(timeFormatter.string(from: workout.date))"
+                dateFormatter.dateFormat = "MMM d"
             } else {
                 dateFormatter.dateFormat = "MMM d, yyyy"
-                return "\(dateFormatter.string(from: workout.date)) at \(timeFormatter.string(from: workout.date))"
             }
+            return "\(dateFormatter.string(from: workout.date)) at \(timeFormatter.string(from: workout.date))"
         }
     }
-    
-    private func effortDescription(for rating: Double) -> String {
-        switch Int(rating) {
-        case 1:
-            return "Minimal"
-        case 2:
-            return "Light"
-        case 3:
-            return "Moderate"
-        case 4:
-            return "High"
-        case 5:
-            return "Maximum"
-        default:
-            return "Moderate"
-        }
-    }
-    
+
+    // MARK: - Actions
+
     private func shareToStrava() {
         guard !workout.isSyncedToStrava else { return }
 
@@ -1088,7 +777,6 @@ struct WorkoutDetailView: View {
                     primaryMetric: settingsManager.preferredWorkoutMetric
                 )
 
-                // Update workout with sync metadata
                 let metadata = StravaSyncMetadata(stravaActivityId: activityId)
                 workout.setStravaSyncMetadata(metadata)
                 try? modelContext.save()
@@ -1096,7 +784,6 @@ struct WorkoutDetailView: View {
                 HapticsManager.shared.trigger(.success)
                 showingStravaSyncSuccess = true
 
-                // Auto-dismiss the success message after 2 seconds
                 try? await Task.sleep(for: .seconds(2))
                 showingStravaSyncSuccess = false
             } catch {
@@ -1113,10 +800,8 @@ struct WorkoutDetailView: View {
             isDeleting = true
         }
 
-        // Cancel any pending uploads first (deletes local files and records)
         await MediaUploadManager.shared.cancelUploads(for: workout.id, modelContext: modelContext)
 
-        // Delete uploaded photos from Firebase
         if !workout.photos.isEmpty {
             let photoService = PhotoService()
             do {
@@ -1137,7 +822,7 @@ struct WorkoutDetailView: View {
                     showingDeleteError = true
                     HapticsManager.shared.trigger(.error)
                 }
-                return // Don't delete the workout
+                return
             } catch {
                 print("❌ Failed to delete photos from Firebase: \(error)")
                 await MainActor.run {
@@ -1147,23 +832,20 @@ struct WorkoutDetailView: View {
                     showingDeleteError = true
                     HapticsManager.shared.trigger(.error)
                 }
-                return // Don't delete the workout
+                return
             }
         }
 
-        // Only delete workout if photo deletion succeeded
         modelContext.delete(workout)
         do {
             try modelContext.save()
-
-            // Recalculate PRs and leaderboard stats after deletion
             try WorkoutMutationHandler.shared.workoutsDidChange(modelContext: modelContext)
 
             await MainActor.run {
                 isDeleting = false
                 showingDeleteConfirmation = false
                 HapticsManager.shared.trigger(.success)
-                dismiss() // Navigate back to workout list
+                dismiss()
             }
         } catch {
             print("❌ Error deleting workout: \(error)")
@@ -1177,6 +859,8 @@ struct WorkoutDetailView: View {
         }
     }
 }
+
+// MARK: - Delete Confirmation
 
 struct SingleWorkoutDeleteConfirmationView: View {
     let workout: Workout
@@ -1205,7 +889,7 @@ struct SingleWorkoutDeleteConfirmationView: View {
     let sampleWorkout = Workout(
         name: "Morning Stair Climb",
         date: Date(),
-        duration: 1800, // 30 minutes
+        duration: 1800,
         steps: 2500,
         floors: 156,
         stepsPerFloor: 16,
@@ -1215,15 +899,15 @@ struct SingleWorkoutDeleteConfirmationView: View {
         caloriesBurned: 320,
         effortRating: 4.0
     )
-    
+
     WorkoutDetailView(workout: sampleWorkout)
 }
 
 #Preview("No Health Metrics") {
     let sampleWorkout = Workout(
         name: "Evening Floors Session",
-        date: Date().addingTimeInterval(-86400), // Yesterday
-        duration: 2400, // 40 minutes
+        date: Date().addingTimeInterval(-86400),
+        duration: 2400,
         steps: 1360,
         floors: 85,
         stepsPerFloor: 16,
@@ -1233,7 +917,7 @@ struct SingleWorkoutDeleteConfirmationView: View {
         caloriesBurned: nil,
         effortRating: 3.0
     )
-    
+
     WorkoutDetailView(workout: sampleWorkout)
         .preferredColorScheme(.dark)
 }

--- a/AscendApp/Shared/Views/MainTabView.swift
+++ b/AscendApp/Shared/Views/MainTabView.swift
@@ -25,40 +25,86 @@ struct MainTabView: View {
     }
 
     var body: some View {
-        TabView(selection: $tabRouter.selectedTab) {
+        ZStack {
             ForEach(tabs) { tab in
                 tab.view
-                    .tabItem {
-                        let isSelected = tabRouter.selectedTab == tab.identifier
-                        let iconToUse = iconToken(for: tab, isSelected: isSelected)
-                        tabBarIcon(for: iconToUse)
-                        Text(tab.title)
-                    }
-                    .tag(tab.identifier)
+                    .opacity(tabRouter.selectedTab == tab.identifier ? 1 : 0)
+                    .allowsHitTesting(tabRouter.selectedTab == tab.identifier)
             }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .animation(.smooth(duration: 0.25), value: tabRouter.selectedTab)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            tabBar
         }
         .accentColor(.accent)
         .environment(tabRouter)
         .onAppear {
-            setupTabBarAppearance()
             checkForRatingPromptOnLaunch()
             syncBaseLevelOnboardingPresentation()
         }
-        .onChange(of: effectiveColorScheme) { _, _ in
-            setupTabBarAppearance()
-        }
         .onChange(of: settingsManager.hasCompletedBaseLevelOnboarding) { _, _ in
             syncBaseLevelOnboardingPresentation()
-        }
-        .onChange(of: tabRouter.selectedTab) { _, _ in
-            let generator = UIImpactFeedbackGenerator(style: .heavy)
-            generator.impactOccurred()
         }
         .fullScreenCover(isPresented: $showingBaseLevelOnboarding) {
             BaseLevelOnboardingView()
         }
         .themeAware()
     }
+
+    // MARK: - Custom Tab Bar
+
+    private var tabBar: some View {
+        HStack(spacing: 0) {
+            ForEach(tabs) { tab in
+                tabBarButton(for: tab)
+            }
+        }
+        .padding(.top, 8)
+        .padding(.bottom, 2)
+        .background {
+            tabBarBackground
+                .ignoresSafeArea(edges: .bottom)
+        }
+    }
+
+    private func tabBarButton(for tab: TabItem) -> some View {
+        let isSelected = tabRouter.selectedTab == tab.identifier
+        return Button {
+            guard tabRouter.selectedTab != tab.identifier else { return }
+            let generator = UIImpactFeedbackGenerator(style: .light)
+            generator.impactOccurred()
+            tabRouter.selectedTab = tab.identifier
+        } label: {
+            VStack(spacing: 3) {
+                let iconToUse = iconToken(for: tab, isSelected: isSelected)
+                tabBarIcon(for: iconToUse)
+                    .frame(width: 24, height: 24)
+                Text(tab.title)
+                    .font(.system(size: 10, weight: isSelected ? .semibold : .regular))
+            }
+            .foregroundStyle(isSelected ? Color.accent : effectiveColorScheme == .dark ? .white.opacity(0.6) : Color.gray)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var tabBarBackground: some View {
+        if effectiveColorScheme == .dark {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+        } else {
+            VStack(spacing: 0) {
+                Divider()
+                Rectangle()
+                    .fill(Color(uiColor: .systemBackground))
+            }
+        }
+    }
+
+    // MARK: - Helpers
 
     private func checkForRatingPromptOnLaunch() {
         // Only check once per app session
@@ -78,7 +124,7 @@ struct MainTabView: View {
         settingsManager.resolveBaseLevelBootstrap(hasWorkoutHistory: workoutCount > 0)
         showingBaseLevelOnboarding = settingsManager.shouldPresentBaseLevelOnboarding
     }
-    
+
     private func iconToken(for tab: TabItem, isSelected: Bool) -> AppIconToken {
         if isSelected, let selectedIcon = tab.selectedIcon {
             return selectedIcon
@@ -110,51 +156,6 @@ struct MainTabView: View {
         }
 
         return rendered.withRenderingMode(.alwaysTemplate)
-    }
-    
-    private func setupTabBarAppearance() {
-        let appearance = UITabBarAppearance()
-        
-        if effectiveColorScheme == .dark {
-            // Dark mode styling - transparent to show gradient behind
-            appearance.configureWithTransparentBackground()
-            appearance.backgroundColor = UIColor.clear
-            
-            // Add subtle blur effect that works with gradient
-            appearance.backgroundEffect = UIBlurEffect(style: .systemUltraThinMaterialDark)
-            
-            // Normal state
-            appearance.stackedLayoutAppearance.normal.iconColor = UIColor.white.withAlphaComponent(0.6)
-            appearance.stackedLayoutAppearance.normal.titleTextAttributes = [
-                .foregroundColor: UIColor.white.withAlphaComponent(0.6)
-            ]
-            
-            // Selected state - using accent color
-            appearance.stackedLayoutAppearance.selected.iconColor = UIColor(Color.accent)
-            appearance.stackedLayoutAppearance.selected.titleTextAttributes = [
-                .foregroundColor: UIColor(Color.accent)
-            ]
-        } else {
-            // Light mode styling - clean white background
-            appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = UIColor.systemBackground
-            appearance.shadowColor = UIColor.systemGray4
-            
-            // Normal state
-            appearance.stackedLayoutAppearance.normal.iconColor = UIColor.systemGray
-            appearance.stackedLayoutAppearance.normal.titleTextAttributes = [
-                .foregroundColor: UIColor.systemGray
-            ]
-            
-            // Selected state - using accent color
-            appearance.stackedLayoutAppearance.selected.iconColor = UIColor(Color.accent)
-            appearance.stackedLayoutAppearance.selected.titleTextAttributes = [
-                .foregroundColor: UIColor(Color.accent)
-            ]
-        }
-        
-        UITabBar.appearance().standardAppearance = appearance
-        UITabBar.appearance().scrollEdgeAppearance = appearance
     }
 }
 


### PR DESCRIPTION
## Summary
- Redesign workout detail view with extracted reusable components, PR-aware stat borders, adaptive scroll-based nav bar, and weight summary in subtitle
- Replace standard TabView with custom crossfade tab bar for smoother switching
- Improve heart rate chart: sticky selection, always-visible avg/max, thicker lines, solid grid, removed zone bands
- Remove SPM from workout list cards

Closes #112

## Test plan
- [ ] Verify workout detail with media (Strava-style layout) — title hides when sheet expanded, nav bar shows title
- [ ] Verify workout detail without media — title fades into nav bar on scroll, content doesn't bleed through safe area
- [ ] Tap PR trophy badge — popover shows all standard + weight PRs
- [ ] Check weight subtitle: single weight shows item name, multiple shows collapsed total with tap-for-breakdown
- [ ] Notes blockquote: short notes show inline, long notes show 3-line limit with expand/collapse
- [ ] Tab switching: smooth crossfade between all tabs, light haptic
- [ ] Heart rate chart: tap and release — selection stays, avg/max always visible above
- [ ] Workout list cards: no SPM shown
- [ ] Light mode + dark mode for all new components

🤖 Generated with [Claude Code](https://claude.com/claude-code)