### PR TITLE
Deploy Firebase Storage rules in staging and production workflows

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,6 +14,7 @@ on:
       - "web/**"
       - "firebase.json"
       - "firestore.rules"
+      - "storage.rules"
       - ".firebaserc"
       - ".github/workflows/deploy-production.yml"
 
@@ -189,8 +190,8 @@ jobs:
       - name: Build web app
         run: npm --prefix web run build
 
-      - name: Deploy Functions, Rules, Indexes, and Hosting
-        run: firebase deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,hosting --non-interactive
+      - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
+        run: firebase deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive
 
   upload-testflight:
     name: Upload to TestFlight (Production)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -159,8 +159,8 @@ jobs:
       - name: Build web app
         run: npm --prefix web run build
 
-      - name: Deploy Functions, Rules, Indexes, and Hosting
-        run: firebase deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,hosting --non-interactive
+      - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
+        run: firebase deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive
 
   upload-testflight:
     name: Upload to TestFlight (Staging)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -299,8 +299,9 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
   2. Deploy Firebase Functions
   3. Deploy Firestore Rules
   4. Deploy Firestore Indexes
-  5. Deploy Firebase Hosting
-  6. Upload to TestFlight (last — hardest to reverse)
+  5. Deploy Storage Rules
+  6. Deploy Firebase Hosting
+  7. Upload to TestFlight (last — hardest to reverse)
 - `.github/workflows/deploy-production.yml` runs on pushes to `main` and manual dispatch. It mirrors the staging pipeline, including Firestore index deploys, with Release configuration and remains gated behind `PRODUCTION_READY=true` plus GitHub `production` environment protection.
 
 ### Deploy Authentication (OIDC)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,8 +299,9 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
   2. Deploy Firebase Functions
   3. Deploy Firestore Rules
   4. Deploy Firestore Indexes
-  5. Deploy Firebase Hosting
-  6. Upload to TestFlight (last — hardest to reverse)
+  5. Deploy Storage Rules
+  6. Deploy Firebase Hosting
+  7. Upload to TestFlight (last — hardest to reverse)
 - `.github/workflows/deploy-production.yml` runs on pushes to `main` and manual dispatch. It mirrors the staging pipeline, including Firestore index deploys, with Release configuration and remains gated behind `PRODUCTION_READY=true` plus GitHub `production` environment protection.
 
 ### Deploy Authentication (OIDC)


### PR DESCRIPTION
## Summary
Update the staging and production deploy workflows so Firebase Storage rules are deployed alongside Functions, Firestore rules/indexes, and Hosting.

## What changed
- Added `storage` to the Firebase deploy command in staging
- Added `storage` to the Firebase deploy command in production
- Added `storage.rules` to the production workflow path filters
- Updated `AGENTS.md` and `CLAUDE.md` so the documented deploy sequence matches the workflows

## Why
- Climb artwork is now remote-only and governed by `storage.rules`
- The repo should not rely on manual storage-rules deploys to stay correct

## Notes
- This does not automate binary climb-image uploads to Firebase Storage; that remains a separate content-pipeline concern

Closes #118
