### PR TITLE
Add admin email notification for feedback submissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -340,6 +340,7 @@ Website source lives in `web/` and is built to `web/dist/` before deploy.
 - Cloud Functions email provider config lives in the `TRANSACTIONAL_EMAIL_CONFIG` Secret Manager JSON secret, with `functions/.secret.local` used only for local emulator overrides.
 - `joinWaitlist` is idempotent by normalized email hash, enqueues the `waitlist_welcome` job into `email_jobs`, and rate limits public submissions using hashed requester IPs stored in `email_rate_limits`.
 - Transactional emails are delivered in the background by the scheduled `processEmailJobs` worker; retries and failure state live on `email_jobs`, not on `waitlist`.
+- In-app feedback submissions (`feedback` collection) trigger `onFeedbackCreated`, which sends an admin notification email directly via Resend (not queued). The recipient is `feedbackNotificationEmail` from the secret config (falls back to `replyTo` → `fromEmail`). Reply-to is set to the submitting user's email. Notification delivery metadata is written back onto the feedback document.
 
 ### Key Config Files
 - `.firebaserc` — project aliases (dev, staging, prod)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,7 @@ Website source lives in `web/` and is built to `web/dist/` before deploy.
 - Cloud Functions email provider config lives in the `TRANSACTIONAL_EMAIL_CONFIG` Secret Manager JSON secret, with `functions/.secret.local` used only for local emulator overrides.
 - `joinWaitlist` is idempotent by normalized email hash, enqueues the `waitlist_welcome` job into `email_jobs`, and rate limits public submissions using hashed requester IPs stored in `email_rate_limits`.
 - Transactional emails are delivered in the background by the scheduled `processEmailJobs` worker; retries and failure state live on `email_jobs`, not on `waitlist`.
+- In-app feedback submissions (`feedback` collection) trigger `onFeedbackCreated`, which sends an admin notification email directly via Resend (not queued). The recipient is `feedbackNotificationEmail` from the secret config (falls back to `replyTo` → `fromEmail`). Reply-to is set to the submitting user's email. Notification delivery metadata is written back onto the feedback document.
 
 ### Key Config Files
 - `.firebaserc` — project aliases (dev, staging, prod)

--- a/functions/EMAIL_SETUP.md
+++ b/functions/EMAIL_SETUP.md
@@ -9,6 +9,7 @@ Ascend's Cloud Functions use the `TRANSACTIONAL_EMAIL_CONFIG` JSON secret for ba
   "provider": "resend",
   "apiKey": "re_xxxxxxxxx",
   "betaInviteUrl": "https://testflight.apple.com/join/ZZ1zUmBf",
+  "feedbackNotificationEmail": "tyler@ascendstepper.com",
   "fromEmail": "hello@updates.ascendstepper.com",
   "fromName": "Ascend",
   "replyTo": "support@ascendstepper.com",
@@ -22,6 +23,7 @@ Ascend's Cloud Functions use the `TRANSACTIONAL_EMAIL_CONFIG` JSON secret for ba
 - Use a sender address from that verified domain for `fromEmail`.
 - Keep the API key only in Secret Manager or local emulator secret overrides.
 - `betaInviteUrl` is optional. If set, waitlist emails show a primary TestFlight CTA.
+- `feedbackNotificationEmail` is optional. Admin email for feedback notifications. Falls back to `replyTo`, then `fromEmail`.
 - `websiteUrl` is optional. If omitted, waitlist emails fall back to `https://ascendstepper.com`.
 
 ## Local emulator
@@ -53,3 +55,16 @@ npx firebase-tools deploy --only firestore:rules,firestore:indexes,functions
 - `email_jobs` stores queue state, attempts, retry timing, and provider metadata.
 - Retryable provider failures are requeued automatically; permanent failures are marked on the job.
 - Existing waitlist rows created before this system are not backfilled automatically.
+
+## Feedback notifications
+
+- `onFeedbackCreated` fires on `feedback/{feedbackId}` document creation.
+- Sends an admin notification email directly via Resend (not queued).
+- Recipient is `feedbackNotificationEmail` from the secret (falls back to `replyTo`, then `fromEmail`).
+- `replyTo` on the notification email is set to the submitting user's email when present and valid, so replying goes directly to the user.
+- Notification delivery metadata is written back onto the feedback document:
+  - `adminNotificationStatus`: `"sent"` or `"failed"`
+  - `adminNotificationSentAt`: timestamp (on success)
+  - `adminNotificationLastAttemptAt`: timestamp
+  - `adminNotificationErrorCode`: error code string or `null`
+- Delivery failures are logged but do not throw — the feedback data is already persisted in Firestore.

--- a/functions/src/email/config.ts
+++ b/functions/src/email/config.ts
@@ -62,6 +62,7 @@ export function getTransactionalEmailConfig(): TransactionalEmailConfig {
     provider: config.provider,
     apiKey: config.apiKey,
     betaInviteUrl: config.betaInviteUrl,
+    feedbackNotificationEmail: config.feedbackNotificationEmail,
     fromEmail: config.fromEmail,
     fromName: config.fromName,
     replyTo: config.replyTo,
@@ -91,6 +92,16 @@ export function getMarketingWebsiteUrl(): string {
   }
 
   return DEFAULT_MARKETING_WEBSITE_URL;
+}
+
+/**
+ * Returns the admin email address for feedback notifications.
+ * Falls back to replyTo, then fromEmail.
+ * @return {string} Admin notification recipient
+ */
+export function getFeedbackNotificationEmail(): string {
+  const config = getTransactionalEmailConfig();
+  return config.feedbackNotificationEmail ?? config.replyTo ?? config.fromEmail;
 }
 
 /**

--- a/functions/src/email/templates.ts
+++ b/functions/src/email/templates.ts
@@ -1,6 +1,7 @@
 import {getBetaInviteUrl, getMarketingWebsiteUrl} from "./config";
 import type {
   EmailJobPayload,
+  FeedbackAdminNotifyPayload,
   TransactionalEmailRenderResult,
   WaitlistWelcomePayload,
 } from "./types";
@@ -156,4 +157,126 @@ export function renderWaitlistWelcomeEmailFromPayload(
   payload: EmailJobPayload
 ): TransactionalEmailRenderResult {
   return renderWaitlistWelcomeEmail(parseWaitlistWelcomePayload(payload));
+}
+
+// =============================================================================
+// Feedback Admin Notification
+// =============================================================================
+
+const FEEDBACK_TYPE_LABELS: Record<string, string> = {
+  bug_report: "Bug Report",
+  feature_request: "Feature Request",
+  get_help: "Help Request",
+};
+
+const FEEDBACK_TYPE_COLORS: Record<string, string> = {
+  bug_report: "#ef4444",
+  feature_request: "#b4cc00",
+  get_help: "#3b82f6",
+};
+
+/**
+ * Returns the human-readable label for a feedback type.
+ * @param {string} type - Raw feedback type value
+ * @return {string} Display label
+ */
+function feedbackTypeLabel(type: string): string {
+  return FEEDBACK_TYPE_LABELS[type] ?? type;
+}
+
+/**
+ * Returns the accent color for a feedback type.
+ * @param {string} type - Raw feedback type value
+ * @return {string} Hex color string
+ */
+function feedbackTypeColor(type: string): string {
+  return FEEDBACK_TYPE_COLORS[type] ?? "#6b7280";
+}
+
+/**
+ * Renders the admin notification email for a feedback submission.
+ * @param {FeedbackAdminNotifyPayload} payload - Feedback document data
+ * @return {TransactionalEmailRenderResult} Subject and rendered bodies
+ */
+export function renderFeedbackAdminNotifyEmail(
+  payload: FeedbackAdminNotifyPayload
+): TransactionalEmailRenderResult {
+  const label = feedbackTypeLabel(payload.type);
+  const color = feedbackTypeColor(payload.type);
+  const subject = `Ascend Feedback: ${label}`;
+
+  const escapedMessage = escapeHtml(payload.message);
+  const escapedEmail = escapeHtml(payload.userEmail);
+  const escapedUserId = escapeHtml(payload.userId);
+  const escapedDevice = escapeHtml(payload.deviceModel);
+  const escapedOs = escapeHtml(payload.osVersion);
+  const escapedAppVersion = escapeHtml(payload.appVersion);
+  const escapedBuild = escapeHtml(payload.buildNumber);
+  const escapedFeedbackId = escapeHtml(payload.feedbackId);
+  const escapedLabel = escapeHtml(label);
+
+  const text = [
+    `New ${label} from ${payload.userEmail}`,
+    "",
+    "Message:",
+    payload.message,
+    "",
+    "---",
+    `User: ${payload.userEmail} (${payload.userId})`,
+    `Device: ${payload.deviceModel}, iOS ${payload.osVersion}`,
+    `App: v${payload.appVersion} (${payload.buildNumber})`,
+    `Feedback ID: ${payload.feedbackId}`,
+  ].join("\n");
+
+  // eslint-disable-next-line max-len
+  const metaRow = (labelText: string, value: string): string => `<tr><td style="padding:6px 12px 6px 0;font-size:13px;color:#9ca3af;white-space:nowrap;vertical-align:top;">${labelText}</td><td style="padding:6px 0;font-size:13px;color:#374151;">${value}</td></tr>`;
+
+  const html = [
+    "<!doctype html>",
+    // eslint-disable-next-line max-len
+    "<html lang=\"en\"><body style=\"margin:0;padding:0;background:#f4f2eb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;color:#111111;\">",
+    // eslint-disable-next-line max-len
+    "<table role=\"presentation\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\" border=\"0\" style=\"background:#f4f2eb;padding:24px 12px;\"><tr><td align=\"center\">",
+    // eslint-disable-next-line max-len
+    "<table role=\"presentation\" width=\"100%\" cellspacing=\"0\" cellpadding=\"0\" border=\"0\" style=\"max-width:620px;background:#ffffff;border:1px solid rgba(17,17,17,0.08);border-radius:24px;overflow:hidden;\">",
+
+    // Header
+    // eslint-disable-next-line max-len
+    "<tr><td style=\"background:#111111;padding:20px 28px;\"><span style=\"font-size:14px;color:#ffffff;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;\">Ascend Feedback</span></td></tr>",
+
+    // Type badge + user
+    "<tr><td style=\"padding:28px 28px 0;\">",
+    // eslint-disable-next-line max-len
+    `<span style="display:inline-block;padding:6px 14px;border-radius:8px;background:${color};color:#ffffff;font-size:12px;font-weight:700;letter-spacing:0.06em;text-transform:uppercase;">${escapedLabel}</span>`,
+    // eslint-disable-next-line max-len
+    `<p style="margin:14px 0 0;font-size:14px;color:#6b7280;">From <strong style="color:#111111;">${escapedEmail}</strong></p>`,
+    "</td></tr>",
+
+    // Message
+    "<tr><td style=\"padding:20px 28px;\">",
+    // eslint-disable-next-line max-len
+    `<div style="padding:16px 20px;background:#f9fafb;border:1px solid #e5e7eb;border-radius:12px;font-size:15px;line-height:1.65;color:#374151;white-space:pre-wrap;">${escapedMessage}</div>`,
+    "</td></tr>",
+
+    // Metadata
+    "<tr><td style=\"padding:0 28px 28px;\">",
+    // eslint-disable-next-line max-len
+    "<table role=\"presentation\" cellspacing=\"0\" cellpadding=\"0\" border=\"0\" style=\"width:100%;\">",
+    metaRow("User ID", escapedUserId),
+    // eslint-disable-next-line max-len
+    metaRow("Device", `${escapedDevice}, iOS ${escapedOs}`),
+    // eslint-disable-next-line max-len
+    metaRow("App Version", `v${escapedAppVersion} (${escapedBuild})`),
+    metaRow("Feedback ID", escapedFeedbackId),
+    "</table>",
+    "</td></tr>",
+
+    // Footer
+    // eslint-disable-next-line max-len
+    "<tr><td style=\"padding:0 28px 24px;\"><div style=\"border-top:1px solid rgba(17,17,17,0.08);padding-top:16px;text-align:center;\"><p style=\"margin:0;font-size:12px;color:#9ca3af;\">Reply to this email to respond directly to the user.</p></div></td></tr>",
+
+    "</table></td></tr></table></body></html>",
+  ].join("");
+
+  return {html, subject, text};
 }

--- a/functions/src/email/types.ts
+++ b/functions/src/email/types.ts
@@ -8,6 +8,7 @@ export interface TransactionalEmailConfig {
   provider: TransactionalEmailProvider;
   apiKey: string;
   betaInviteUrl?: string;
+  feedbackNotificationEmail?: string;
   fromEmail: string;
   fromName: string;
   replyTo?: string;
@@ -59,6 +60,18 @@ export interface EmailJobDocument {
   status: EmailJobStatus;
   type: EmailType;
   updatedAt: admin.firestore.Timestamp;
+}
+
+export interface FeedbackAdminNotifyPayload {
+  appVersion: string;
+  buildNumber: string;
+  deviceModel: string;
+  feedbackId: string;
+  message: string;
+  osVersion: string;
+  type: string;
+  userEmail: string;
+  userId: string;
 }
 
 export interface EmailRateLimitDocument {

--- a/functions/src/feedback.ts
+++ b/functions/src/feedback.ts
@@ -1,0 +1,129 @@
+import {onDocumentCreated} from "firebase-functions/v2/firestore";
+import * as admin from "firebase-admin";
+import {
+  getFeedbackNotificationEmail,
+  transactionalEmailConfig,
+} from "./email/config";
+import {sendTransactionalEmail} from "./email/provider";
+import {renderFeedbackAdminNotifyEmail} from "./email/templates";
+import type {FeedbackAdminNotifyPayload} from "./email/types";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Validates that a feedback document has the required fields.
+ * @param {Record<string, unknown>} data - Raw Firestore document data
+ * @param {string} feedbackId - Firestore document ID
+ * @return {FeedbackAdminNotifyPayload | null} Validated payload or null
+ */
+function parseFeedbackDocument(
+  data: Record<string, unknown>,
+  feedbackId: string
+): FeedbackAdminNotifyPayload | null {
+  if (
+    typeof data.type !== "string" ||
+    typeof data.message !== "string" ||
+    typeof data.userId !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    appVersion: typeof data.appVersion === "string" ? data.appVersion : "",
+    buildNumber: typeof data.buildNumber === "string" ? data.buildNumber : "",
+    deviceModel: typeof data.deviceModel === "string" ? data.deviceModel : "",
+    feedbackId,
+    message: data.message,
+    osVersion: typeof data.osVersion === "string" ? data.osVersion : "",
+    type: data.type,
+    userEmail: typeof data.userEmail === "string" ? data.userEmail : "",
+    userId: data.userId,
+  };
+}
+
+/**
+ * Sends an admin notification email when a feedback document is created.
+ */
+export const onFeedbackCreated = onDocumentCreated(
+  {
+    document: "feedback/{feedbackId}",
+    secrets: [transactionalEmailConfig],
+  },
+  async (event) => {
+    const snapshot = event.data;
+    if (!snapshot) {
+      console.error("onFeedbackCreated: no document snapshot");
+      return;
+    }
+
+    const feedbackId = event.params.feedbackId;
+    const data = snapshot.data() as Record<string, unknown>;
+    const payload = parseFeedbackDocument(data, feedbackId);
+
+    if (!payload) {
+      console.error("onFeedbackCreated: invalid feedback document", {
+        feedbackId,
+      });
+      return;
+    }
+
+    const nowTimestamp = admin.firestore.Timestamp.now();
+    const feedbackRef = admin.firestore()
+      .collection("feedback")
+      .doc(feedbackId);
+
+    try {
+      const adminEmail = getFeedbackNotificationEmail();
+      const rendered = renderFeedbackAdminNotifyEmail(payload);
+
+      const replyTo = payload.userEmail &&
+        EMAIL_PATTERN.test(payload.userEmail) ?
+        payload.userEmail :
+        undefined;
+
+      await sendTransactionalEmail({
+        html: rendered.html,
+        idempotencyKey: `feedback:${feedbackId}`,
+        replyTo,
+        subject: rendered.subject,
+        text: rendered.text,
+        to: [adminEmail],
+      });
+
+      await feedbackRef.update({
+        adminNotificationErrorCode: null,
+        adminNotificationLastAttemptAt: nowTimestamp,
+        adminNotificationSentAt: nowTimestamp,
+        adminNotificationStatus: "sent",
+      });
+
+      console.log("onFeedbackCreated: notification sent", {
+        feedbackId,
+        type: payload.type,
+      });
+    } catch (error) {
+      const errorCode = error instanceof Error ? error.name : "unknown_error";
+      const errorMessage = error instanceof Error ?
+        error.message :
+        "unknown_error";
+
+      await feedbackRef.update({
+        adminNotificationErrorCode: errorCode,
+        adminNotificationLastAttemptAt: nowTimestamp,
+        adminNotificationSentAt: null,
+        adminNotificationStatus: "failed",
+      }).catch((updateError) => {
+        console.error(
+          "onFeedbackCreated: failed to update notification status",
+          {feedbackId, updateError}
+        );
+      });
+
+      console.error("onFeedbackCreated: notification failed", {
+        errorCode,
+        errorMessage,
+        feedbackId,
+      });
+    }
+  }
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,6 +11,7 @@ import * as admin from "firebase-admin";
 admin.initializeApp();
 
 export {processEmailJobs} from "./email/processor";
+export {onFeedbackCreated} from "./feedback";
 export {joinWaitlist} from "./waitlist";
 
 export {

--- a/functions/test/email-system.test.ts
+++ b/functions/test/email-system.test.ts
@@ -11,7 +11,10 @@ import {
   hashRateLimitIp,
 } from "../src/email/rateLimit";
 import {getNextRetryDelayMs} from "../src/email/retry";
-import {renderWaitlistWelcomeEmail} from "../src/email/templates";
+import {
+  renderFeedbackAdminNotifyEmail,
+  renderWaitlistWelcomeEmail,
+} from "../src/email/templates";
 
 test("waitlist dedupe keys and job ids are deterministic", () => {
   const recipientHash = "abc123";
@@ -147,4 +150,89 @@ test("waitlist template includes beta invite CTA when configured", () => {
       process.env.TRANSACTIONAL_EMAIL_CONFIG = originalConfig;
     }
   }
+});
+
+// =============================================================================
+// Feedback Admin Notification Template
+// =============================================================================
+
+const baseFeedbackPayload = {
+  appVersion: "1.2.0",
+  buildNumber: "42",
+  deviceModel: "iPhone",
+  feedbackId: "abc123",
+  message: "The app crashes when I tap the leaderboard tab.",
+  osVersion: "17.4",
+  type: "bug_report",
+  userEmail: "tester@example.com",
+  userId: "uid_xyz",
+};
+
+test("feedback template renders correct subject per type", () => {
+  const bugReport = renderFeedbackAdminNotifyEmail({
+    ...baseFeedbackPayload,
+    type: "bug_report",
+  });
+  assert.equal(bugReport.subject, "Ascend Feedback: Bug Report");
+
+  const featureRequest = renderFeedbackAdminNotifyEmail({
+    ...baseFeedbackPayload,
+    type: "feature_request",
+  });
+  assert.equal(featureRequest.subject, "Ascend Feedback: Feature Request");
+
+  const getHelp = renderFeedbackAdminNotifyEmail({
+    ...baseFeedbackPayload,
+    type: "get_help",
+  });
+  assert.equal(getHelp.subject, "Ascend Feedback: Help Request");
+});
+
+test("feedback template escapes html in user message and email", () => {
+  const rendered = renderFeedbackAdminNotifyEmail({
+    ...baseFeedbackPayload,
+    message: "<script>alert('xss')</script>",
+    userEmail: "user<evil>@test.com",
+  });
+
+  assert.doesNotMatch(rendered.html, /<script>/);
+  assert.match(rendered.html, /&lt;script&gt;/);
+  assert.doesNotMatch(rendered.html, /user<evil>/);
+  assert.match(rendered.html, /user&lt;evil&gt;@test\.com/);
+});
+
+test("feedback template includes all device metadata", () => {
+  const rendered = renderFeedbackAdminNotifyEmail(baseFeedbackPayload);
+
+  assert.match(rendered.html, /iPhone/);
+  assert.match(rendered.html, /17\.4/);
+  assert.match(rendered.html, /1\.2\.0/);
+  assert.match(rendered.html, /42/);
+  assert.match(rendered.html, /abc123/);
+  assert.match(rendered.html, /uid_xyz/);
+});
+
+test("feedback template plain text contains key fields", () => {
+  const rendered = renderFeedbackAdminNotifyEmail(baseFeedbackPayload);
+
+  assert.match(rendered.text, /Bug Report/);
+  assert.match(rendered.text, /tester@example\.com/);
+  assert.match(
+    rendered.text,
+    /The app crashes when I tap the leaderboard tab\./
+  );
+  assert.match(rendered.text, /iPhone/);
+  assert.match(rendered.text, /17\.4/);
+  assert.match(rendered.text, /1\.2\.0/);
+  assert.match(rendered.text, /abc123/);
+});
+
+test("feedback template handles unknown type gracefully", () => {
+  const rendered = renderFeedbackAdminNotifyEmail({
+    ...baseFeedbackPayload,
+    type: "unknown_type",
+  });
+
+  assert.equal(rendered.subject, "Ascend Feedback: unknown_type");
+  assert.match(rendered.text, /unknown_type/);
 });


### PR DESCRIPTION
## Summary
- Adds a Firestore `onDocumentCreated` trigger (`onFeedbackCreated`) that sends an admin notification email via Resend when users submit feedback through the in-app Contact Us form
- Configurable recipient via `feedbackNotificationEmail` in `TRANSACTIONAL_EMAIL_CONFIG` secret (falls back to `replyTo` → `fromEmail`)
- Reply-to set to the submitting user's email for direct responses
- Notification delivery metadata written back onto the feedback document (`adminNotificationStatus`, timestamps, error code)
- 5 new template render tests covering subject formatting, HTML escaping, metadata inclusion, and unknown type handling

## Test plan
- [ ] `npm run build` — TypeScript compiles cleanly
- [ ] `npm run lint` — no lint errors
- [ ] `npm test` — all 12 tests pass (7 existing + 5 new)
- [ ] Deploy functions to dev environment
- [ ] Submit a `feature_request` from the app → verify email arrives at pavayt@gmail.com
- [ ] Verify reply-to is set to the submitting user's email
- [ ] Verify feedback doc in Firestore has `adminNotificationStatus: "sent"`
- [ ] Spot check `bug_report` and `get_help` types

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)