### PR TITLE
Build telemetry architecture and workout import analytics pilot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Organized by **features**, not file types. One type per file.
 AscendApp/
 ├── App/                        # App entry point, Firebase config
 │   ├── AscendApp.swift         # Firebase init, environment selection, deep links
-│   └── Firebase/               # GoogleService-Info-{Dev,Staging}.plist
+│   └── Firebase/               # Environment-specific GoogleService-Info plists
 ├── Features/
 │   ├── Workouts/               # Logging, detail, editing, sharing, import
 │   ├── Routines/               # Workout routines and folders
@@ -59,6 +59,8 @@ Three Firebase environments. App selects at compile time via `#if DEBUG / #elsei
 | Dev | `ascend-f2e4f` | Debug | `AscendApp` |
 | Staging | `ascend-staging-fa7d5` | Staging | `AscendApp-Staging` |
 | Production | `ascend-prod-9c8f2` | Release | `AscendApp` |
+
+Environment plists live in `AscendApp/App/Firebase`, but the build must copy the selected one into the built app bundle as `GoogleService-Info.plist`. App startup should use `FirebaseApp.configure()` with the bundled default plist, not runtime `FirebaseOptions(contentsOfFile:)`, so Firebase Analytics resolves the correct app ID reliably.
 
 **Environment-agnostic URLs**: Never hardcode Firebase project IDs. Derive from `FirebaseApp.app()?.options.projectID`:
 ```swift
@@ -99,6 +101,15 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.
 - Import architecture uses one canonical `Workout` plus local `WorkoutSourceLink` provenance records per provider. New import UI and state should flow through `WorkoutImportCoordinator`, not provider-specific views/services.
 - Apple Health is read-only. First connect may backfill historical workouts, but routine checks must stay incremental and sample-only until a workout is actually imported.
+
+### Analytics Architecture
+- `TelemetryManager` remains the app-facing facade, while reusable telemetry types and sinks live under `Shared/Services/Telemetry`.
+- Feature analytics definitions should live in feature-owned `Analytics/` folders (for example `Features/Workouts/Analytics`) as typed `TelemetryEvent` / `TelemetryScreen` definitions.
+- Feature code must not import Firebase directly for analytics or breadcrumbs. Route analytics through `TelemetryManager` and shared sinks only.
+- Log product events from the owning view model, coordinator, manager, or service instead of scattering calls through leaf views. The main exception is SwiftUI screen tracking, which should use the shared `.analyticsScreen(...)` modifier.
+- Keep analytics parameters low-cardinality and privacy-safe. Do not log raw user-entered text, email, DOB, exact location, exact health samples, or other high-sensitivity payloads.
+- New analytics work should include focused tests using `InMemoryTelemetrySink` so event contracts can be verified without a Firebase runtime.
+- DEBUG builds expose a Telemetry Console inside Debug Tools so recent events and screen views can be inspected locally when running with telemetry enabled.
 
 ### Climb Anything V1 Architecture
 - `Climb Anything` is a 3-screen loop:

--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -244,14 +244,15 @@
 				"$(SRCROOT)/AscendApp/App/Firebase/GoogleService-Info-Staging.plist",
 				"$(SRCROOT)/AscendApp/App/Firebase/GoogleService-Info-Production.plist",
 			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Ensure local Firebase config plists are linked into this worktree.\n\"${SRCROOT}/scripts/link-firebase-plists.sh\"\n\n# Determine which GoogleService-Info plist to use\ncase \"${CONFIGURATION}\" in\n    \"Debug\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Dev.plist\"\n        ;;\n    \"Staging\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Staging.plist\"\n        ;;\n    \"Release\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Production.plist\"\n        ;;\nesac\n\n# Run Crashlytics with the correct plist\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${GOOGLE_SERVICE_PLIST}\"\n";
-		};
+				outputFileListPaths = (
+				);
+				outputPaths = (
+					"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				);
+				runOnlyForDeploymentPostprocessing = 0;
+				shellPath = /bin/sh;
+				shellScript = "set -eu\n\n# Ensure local Firebase config plists are linked into this worktree.\n\"${SRCROOT}/scripts/link-firebase-plists.sh\"\n\n# Determine which GoogleService-Info plist to use\ncase \"${CONFIGURATION}\" in\n    \"Debug\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Dev.plist\"\n        ;;\n    \"Staging\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Staging.plist\"\n        ;;\n    \"Release\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Production.plist\"\n        ;;\nesac\n\n# Run Crashlytics with the correct plist\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${GOOGLE_SERVICE_PLIST}\"\n";
+			};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */

--- a/AscendApp/App/AscendApp.swift
+++ b/AscendApp/App/AscendApp.swift
@@ -22,19 +22,10 @@ struct AscendApp: App {
     }
 
     private static func configureFirebase() {
-        #if DEBUG
-        let configFile = "GoogleService-Info-Dev"
-        #elseif STAGING
-        let configFile = "GoogleService-Info-Staging"
-        #else
-        let configFile = "GoogleService-Info-Production"
-        #endif
-
-        guard let filePath = Bundle.main.path(forResource: configFile, ofType: "plist"),
-              let options = FirebaseOptions(contentsOfFile: filePath) else {
-            fatalError("Missing Firebase config: \(configFile).plist")
+        guard Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist") != nil else {
+            fatalError("Missing Firebase config: GoogleService-Info.plist")
         }
-        FirebaseApp.configure(options: options)
+        FirebaseApp.configure()
     }
 
     var body: some Scene {

--- a/AscendApp/Features/Debug/Views/DebugToolsView.swift
+++ b/AscendApp/Features/Debug/Views/DebugToolsView.swift
@@ -101,6 +101,18 @@ struct DebugToolsView: View {
                     )
                 }
                 .buttonStyle(.plain)
+
+                NavigationLink {
+                    TelemetryConsoleView()
+                } label: {
+                    inspectionRow(
+                        title: "Telemetry Console",
+                        description: "Inspect recent analytics events, screen views, and breadcrumbs",
+                        icon: "waveform.path.ecg.rectangle",
+                        iconColor: .mint
+                    )
+                }
+                .buttonStyle(.plain)
             }
             .padding(.horizontal, 20)
         }

--- a/AscendApp/Features/Debug/Views/TelemetryConsoleEntryInfoSheet.swift
+++ b/AscendApp/Features/Debug/Views/TelemetryConsoleEntryInfoSheet.swift
@@ -1,0 +1,129 @@
+#if DEBUG
+import SwiftUI
+
+struct TelemetryConsoleEntryInfoSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    let entry: DebugTelemetryConsoleEntry
+
+    private var foregroundColor: Color {
+        colorScheme == .dark ? .white : .black
+    }
+
+    var body: some View {
+        AppSheetScaffold(
+            title: entry.title,
+            message: "\(entry.kind.displayName) • \(entry.feature)",
+            headerAlignment: .leading,
+            contentAlignment: .leading
+        ) {
+            VStack(alignment: .leading, spacing: 16) {
+                infoSection(
+                    title: "What happened",
+                    body: entry.summary,
+                    icon: "text.bubble"
+                )
+
+                infoSection(
+                    title: "When this fires",
+                    body: entry.whenItFires,
+                    icon: "clock"
+                )
+
+                infoSection(
+                    title: "Why we track it",
+                    body: entry.whyTracked,
+                    icon: "chart.line.uptrend.xyaxis"
+                )
+
+                infoSection(
+                    title: "Destinations",
+                    body: entry.destinationsSummary,
+                    icon: "paperplane"
+                )
+
+                if !entry.parameters.isEmpty {
+                    parameterSection
+                }
+
+                infoSection(
+                    title: "Internal name",
+                    body: entry.rawName,
+                    icon: "curlybraces"
+                )
+            }
+        } footer: {
+            Button("Done") {
+                dismiss()
+            }
+            .appSheetButtonStyle(tone: .primary)
+        }
+    }
+
+    private var parameterSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Fields in this event")
+                .font(.montserratSemiBold(size: 14))
+                .foregroundStyle(foregroundColor)
+
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(entry.parameters) { parameter in
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack(alignment: .top, spacing: 12) {
+                            Text(parameter.key)
+                                .font(.montserratSemiBold(size: 13))
+                                .foregroundStyle(foregroundColor)
+
+                            Spacer()
+
+                            Text(parameter.value)
+                                .font(.system(size: 12, weight: .medium, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Text(
+                            parameter.helpText
+                                ?? "This field adds extra context to help interpret the event."
+                        )
+                        .font(.montserratRegular(size: 13))
+                        .foregroundStyle(.secondary)
+                    }
+
+                    if parameter.id != entry.parameters.last?.id {
+                        Divider()
+                            .overlay(Color.secondary.opacity(0.18))
+                    }
+                }
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(colorScheme == .dark ? Color.white.opacity(0.04) : Color.black.opacity(0.03))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(colorScheme == .dark ? Color.white.opacity(0.06) : Color.black.opacity(0.06), lineWidth: 1)
+            )
+        }
+    }
+
+    private func infoSection(title: String, body: String, icon: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: icon)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.accent)
+
+                Text(title)
+                    .font(.montserratSemiBold(size: 14))
+                    .foregroundStyle(foregroundColor)
+            }
+
+            Text(body)
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+#endif

--- a/AscendApp/Features/Debug/Views/TelemetryConsoleView.swift
+++ b/AscendApp/Features/Debug/Views/TelemetryConsoleView.swift
@@ -1,0 +1,345 @@
+#if DEBUG
+import SwiftUI
+
+struct TelemetryConsoleView: View {
+    private enum Filter: String, CaseIterable, Identifiable {
+        case all
+        case analytics
+        case breadcrumb
+        case screen
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .all:
+                "All"
+            case .analytics:
+                "Analytics"
+            case .breadcrumb:
+                "Breadcrumbs"
+            case .screen:
+                "Screens"
+            }
+        }
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var store = DebugTelemetryConsoleStore.shared
+    @State private var selectedFilter: Filter = .all
+    @State private var selectedEntry: DebugTelemetryConsoleEntry?
+
+    private var foregroundColor: Color {
+        colorScheme == .dark ? .white : .black
+    }
+
+    private var filteredEntries: [DebugTelemetryConsoleEntry] {
+        switch selectedFilter {
+        case .all:
+            return store.entries
+        case .analytics:
+            return store.entries.filter { $0.kind == .analytics }
+        case .breadcrumb:
+            return store.entries.filter { $0.kind == .breadcrumb }
+        case .screen:
+            return store.entries.filter { $0.kind == .screen }
+        }
+    }
+
+    private var analyticsCount: Int {
+        store.entries.filter { $0.kind == .analytics }.count
+    }
+
+    private var breadcrumbCount: Int {
+        store.entries.filter { $0.kind == .breadcrumb }.count
+    }
+
+    private var screenCount: Int {
+        store.entries.filter { $0.kind == .screen }.count
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                statusCard
+                filterPicker
+
+                if filteredEntries.isEmpty {
+                    emptyState
+                } else {
+                    entriesSection
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 20)
+        }
+        .themedBackground()
+        .navigationTitle("Telemetry Console")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $selectedEntry) { entry in
+            TelemetryConsoleEntryInfoSheet(entry: entry)
+                .appSheetStyle(.fraction(0.68))
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Clear") {
+                    store.clear()
+                }
+                .font(.montserratMedium(size: 14))
+                .foregroundStyle(.accent)
+                .disabled(filteredEntries.isEmpty)
+            }
+        }
+    }
+
+    private var statusCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                statusPill(
+                    title: store.isCollectionEnabled ? "Telemetry On" : "Telemetry Off",
+                    color: store.isCollectionEnabled ? .green : .orange
+                )
+
+                Spacer()
+
+                Text("\(store.entries.count) entries")
+                    .font(.montserratSemiBold(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 8) {
+                countPill(title: "Analytics \(analyticsCount)", color: .accent)
+                countPill(title: "Breadcrumbs \(breadcrumbCount)", color: .orange)
+                countPill(title: "Screens \(screenCount)", color: .blue)
+            }
+
+            Text(
+                store.isCollectionEnabled
+                    ? "Analytics are product events, breadcrumbs are crash-tracing checkpoints, and screens are view opens. Tap the info icon on any row for a plain-English explanation."
+                    : "Telemetry is disabled for this run. Launch Debug with `-TelemetryEnabled` to populate this console."
+            )
+            .font(.montserratRegular(size: 14))
+            .foregroundStyle(.secondary)
+
+            if let userID = store.currentUserID, !userID.isEmpty {
+                Text("Current User ID: \(userID)")
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .foregroundStyle(foregroundColor.opacity(0.8))
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(colorScheme == .dark ? Color.white.opacity(0.05) : Color.black.opacity(0.03))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    private var filterPicker: some View {
+        Picker("Telemetry Type", selection: $selectedFilter) {
+            ForEach(Filter.allCases) { filter in
+                Text(filter.title).tag(filter)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, 2)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "waveform.path.ecg.rectangle")
+                .font(.system(size: 42))
+                .foregroundStyle(.accent)
+
+            Text(emptyStateTitle)
+                .font(.montserratBold(size: 20))
+                .foregroundStyle(foregroundColor)
+
+            Text(emptyStateMessage)
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 48)
+    }
+
+    private var emptyStateTitle: String {
+        switch selectedFilter {
+        case .all:
+            return "No Telemetry Yet"
+        case .analytics:
+            return "No Analytics Events Yet"
+        case .breadcrumb:
+            return "No Breadcrumbs Yet"
+        case .screen:
+            return "No Screen Views Yet"
+        }
+    }
+
+    private var emptyStateMessage: String {
+        if !store.isCollectionEnabled {
+            return "Launch Debug with `-TelemetryEnabled`, then come back here after using the app."
+        }
+
+        switch selectedFilter {
+        case .all:
+            return "Use the app for a moment, then come back here to inspect emitted telemetry."
+        case .analytics:
+            return "Open a flow that has product analytics wired up, like Workout Import, to see analytics events here."
+        case .breadcrumb:
+            return "Breadcrumbs appear for tracked app flows such as auth, Strava, and celebrations."
+        case .screen:
+            return "Open a screen with manual screen tracking, like Workout Import, to see screen views here."
+        }
+    }
+
+    private var entriesSection: some View {
+        LazyVStack(spacing: 12) {
+            ForEach(filteredEntries) { entry in
+                entryCard(entry)
+            }
+        }
+    }
+
+    private func entryCard(_ entry: DebugTelemetryConsoleEntry) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                statusPill(
+                    title: entry.kind.displayName,
+                    color: pillColor(for: entry.kind)
+                )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(entry.title)
+                        .font(.montserratSemiBold(size: 15))
+                        .foregroundStyle(foregroundColor)
+
+                    HStack(spacing: 8) {
+                        Text(entry.feature)
+                            .font(.montserratMedium(size: 12))
+                            .foregroundStyle(.secondary)
+
+                        Circle()
+                            .fill(Color.secondary.opacity(0.5))
+                            .frame(width: 4, height: 4)
+
+                        Text(entry.timestamp.formatted(date: .abbreviated, time: .standard))
+                            .font(.montserratRegular(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                Button {
+                    selectedEntry = entry
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundStyle(.accent.opacity(0.9))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Explain \(entry.title)")
+            }
+
+            Text(entry.summary)
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                detailChip(title: entry.destinationsSummary, color: .secondary)
+
+                if let environment = entry.environment {
+                    detailChip(title: environment, color: .accent)
+                }
+            }
+
+            if !entry.parameters.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Details")
+                        .font(.montserratSemiBold(size: 12))
+                        .foregroundStyle(.secondary)
+
+                    ForEach(entry.parameters) { parameter in
+                        HStack(alignment: .top, spacing: 10) {
+                            Text(parameter.key)
+                                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(foregroundColor.opacity(0.85))
+                                .frame(width: 160, alignment: .leading)
+
+                            Text(parameter.value)
+                                .font(.system(size: 12, weight: .regular, design: .monospaced))
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+                    }
+                }
+            }
+
+            Text("Internal name: \(entry.rawName)")
+                .font(.system(size: 11, weight: .regular, design: .monospaced))
+                .foregroundStyle(.secondary.opacity(0.8))
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(colorScheme == .dark ? Color.white.opacity(0.05) : Color.black.opacity(0.03))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(colorScheme == .dark ? Color.white.opacity(0.08) : Color.black.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    private func statusPill(title: String, color: Color) -> some View {
+        Text(title)
+            .font(.montserratSemiBold(size: 11))
+            .foregroundStyle(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(color.opacity(0.14))
+            )
+    }
+
+    private func countPill(title: String, color: Color) -> some View {
+        Text(title)
+            .font(.montserratSemiBold(size: 11))
+            .foregroundStyle(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(color.opacity(0.12))
+            )
+    }
+
+    private func detailChip(title: String, color: Color) -> some View {
+        Text(title)
+            .font(.montserratMedium(size: 11))
+            .foregroundStyle(color)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(color.opacity(0.12))
+            )
+    }
+
+    private func pillColor(for kind: DebugTelemetryConsoleEntry.Kind) -> Color {
+        switch kind {
+        case .analytics:
+            return .accent
+        case .breadcrumb:
+            return .orange
+        case .screen:
+            return .blue
+        }
+    }
+}
+#endif

--- a/AscendApp/Features/Workouts/Analytics/WorkoutImportAnalyticsEvent.swift
+++ b/AscendApp/Features/Workouts/Analytics/WorkoutImportAnalyticsEvent.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+enum WorkoutImportAnalyticsEvent: TelemetryEvent {
+    case importStarted(
+        mode: ImportMode,
+        candidateCount: Int,
+        sourceMix: SourceMix
+    )
+    case importFinished(
+        mode: ImportMode,
+        candidateCount: Int,
+        importedCount: Int,
+        updatedCount: Int,
+        failedCount: Int,
+        outcome: Outcome,
+        sourceMix: SourceMix
+    )
+
+    var record: TelemetryRecord {
+        switch self {
+        case .importStarted(let mode, let candidateCount, let sourceMix):
+            return TelemetryRecord(
+                name: "workout_import_started",
+                parameters: [
+                    "import_mode": .string(mode.rawValue),
+                    "candidate_count_bucket": .string(CountBucket(candidateCount).rawValue),
+                    "source_mix": .string(sourceMix.rawValue)
+                ],
+                destinations: [.analytics, .crashlytics]
+            )
+
+        case .importFinished(
+            let mode,
+            let candidateCount,
+            let importedCount,
+            let updatedCount,
+            let failedCount,
+            let outcome,
+            let sourceMix
+        ):
+            return TelemetryRecord(
+                name: "workout_import_finished",
+                parameters: [
+                    "import_mode": .string(mode.rawValue),
+                    "candidate_count_bucket": .string(CountBucket(candidateCount).rawValue),
+                    "imported_count_bucket": .string(CountBucket(importedCount).rawValue),
+                    "updated_count_bucket": .string(CountBucket(updatedCount).rawValue),
+                    "failed_count_bucket": .string(CountBucket(failedCount).rawValue),
+                    "outcome": .string(outcome.rawValue),
+                    "source_mix": .string(sourceMix.rawValue)
+                ],
+                destinations: [.analytics, .crashlytics]
+            )
+        }
+    }
+
+    static func started(mode: ImportMode, candidates: [ImportedWorkoutCandidate]) -> Self {
+        .importStarted(
+            mode: mode,
+            candidateCount: candidates.count,
+            sourceMix: SourceMix(candidates: candidates)
+        )
+    }
+
+    static func finished(
+        mode: ImportMode,
+        candidates: [ImportedWorkoutCandidate],
+        result: ImportBatchResult
+    ) -> Self {
+        .importFinished(
+            mode: mode,
+            candidateCount: candidates.count,
+            importedCount: result.importedWorkouts.count,
+            updatedCount: result.updatedWorkouts.count,
+            failedCount: result.failedCandidateIDs.count,
+            outcome: Outcome(result: result),
+            sourceMix: SourceMix(candidates: candidates)
+        )
+    }
+
+    static func finished(
+        mode: ImportMode,
+        candidate: ImportedWorkoutCandidate,
+        outcome: WorkoutImportCoordinator.ImportOutcome
+    ) -> Self {
+        let result = ImportBatchResult(
+            importedWorkouts: {
+                if case .imported(let workout) = outcome {
+                    return [workout]
+                }
+                return []
+            }(),
+            updatedWorkouts: {
+                if case .updatedExisting(let workout) = outcome {
+                    return [workout]
+                }
+                return []
+            }(),
+            failedCandidateIDs: {
+                if case .failed(let candidateID) = outcome {
+                    return [candidateID]
+                }
+                return []
+            }()
+        )
+
+        return finished(
+            mode: mode,
+            candidates: [candidate],
+            result: result
+        )
+    }
+}
+
+extension WorkoutImportAnalyticsEvent {
+    enum ImportMode: String {
+        case single
+        case selected
+        case all
+    }
+
+    enum Outcome: String {
+        case imported
+        case updatedExisting = "updated_existing"
+        case partialSuccess = "partial_success"
+        case mixedSuccess = "mixed_success"
+        case failed
+
+        init(result: ImportBatchResult) {
+            let hasImported = result.successCount > 0
+            let hasUpdated = result.updatedCount > 0
+            let hasFailures = result.failedCount > 0
+
+            switch (hasImported, hasUpdated, hasFailures) {
+            case (false, false, true):
+                self = .failed
+            case (true, false, false):
+                self = .imported
+            case (false, true, false):
+                self = .updatedExisting
+            case (_, _, true):
+                self = .partialSuccess
+            case (true, true, false):
+                self = .mixedSuccess
+            default:
+                self = .failed
+            }
+        }
+    }
+
+    enum CountBucket: String {
+        case zero
+        case one
+        case twoToFive = "2_5"
+        case sixToTen = "6_10"
+        case elevenPlus = "11_plus"
+
+        init(_ count: Int) {
+            switch count {
+            case ..<1:
+                self = .zero
+            case 1:
+                self = .one
+            case 2...5:
+                self = .twoToFive
+            case 6...10:
+                self = .sixToTen
+            default:
+                self = .elevenPlus
+            }
+        }
+    }
+
+    enum SourceMix: String {
+        case appleHealthOnly = "apple_health_only"
+        case hevyOnly = "hevy_only"
+        case linkedOnly = "linked_only"
+        case mixed
+
+        init(candidates: [ImportedWorkoutCandidate]) {
+            let kinds = Set(candidates.map(\.kind))
+
+            switch kinds {
+            case [.appleHealth]:
+                self = .appleHealthOnly
+            case [.hevy]:
+                self = .hevyOnly
+            case [.linkedHevyAppleHealth]:
+                self = .linkedOnly
+            default:
+                self = .mixed
+            }
+        }
+    }
+}

--- a/AscendApp/Features/Workouts/Analytics/WorkoutImportAnalyticsScreen.swift
+++ b/AscendApp/Features/Workouts/Analytics/WorkoutImportAnalyticsScreen.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum WorkoutImportAnalyticsScreen {
+    static func sheet(candidateCount: Int, hevyConnected: Bool) -> TelemetryScreen {
+        TelemetryScreen(
+            name: "workout_import_sheet",
+            screenClass: "WorkoutImportSheet",
+            parameters: [
+                "candidate_count_bucket": .string(candidateCountBucket(for: candidateCount)),
+                "hevy_connected": .bool(hevyConnected)
+            ]
+        )
+    }
+
+    private static func candidateCountBucket(for count: Int) -> String {
+        switch count {
+        case ..<1:
+            return "zero"
+        case 1:
+            return "one"
+        case 2...5:
+            return "2_5"
+        case 6...10:
+            return "6_10"
+        default:
+            return "11_plus"
+        }
+    }
+}

--- a/AscendApp/Features/Workouts/Views/WorkoutImportSheet.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutImportSheet.swift
@@ -83,6 +83,12 @@ struct WorkoutImportSheet: View {
             }
         }
         .themedBackground()
+        .analyticsScreen(
+            WorkoutImportAnalyticsScreen.sheet(
+                candidateCount: candidateCount,
+                hevyConnected: hevyManager.isConnected
+            )
+        )
         .interactiveDismissDisabled(importCoordinator.isImporting || showingCelebration)
         .safeAreaInset(edge: .bottom) {
             if isSelectionMode && candidateCount > 0 {

--- a/AscendApp/Shared/Managers/TelemetryManager.swift
+++ b/AscendApp/Shared/Managers/TelemetryManager.swift
@@ -5,28 +5,50 @@
 //  Created by Tyler Pavay on 12/16/25.
 //
 
-import FirebaseAnalytics
-import FirebaseCrashlytics
 import Foundation
 import os.lock
 
-/// Thread-safe telemetry manager for Crashlytics and Analytics.
-/// Call `configure()` once at app launch from the main thread.
+/// Thread-safe telemetry manager for shared app events and error reporting.
+/// Call `configure()` once at app launch, after Firebase is configured.
 final class TelemetryManager: @unchecked Sendable {
     static let shared = TelemetryManager()
 
     private let lock = OSAllocatedUnfairLock(initialState: State())
-
-    private struct State {
-        var isCollectionEnabled: Bool = false
-        var didConfigure: Bool = false
-    }
+    private let sinks: [any TelemetrySink]
+    private let crashlyticsReporter: any CrashlyticsReporting
+    private let collectionEnabledOverride: Bool?
 
     var isCollectionEnabled: Bool {
-        lock.withLock { $0.isCollectionEnabled }
+        lock.withLock(\.isCollectionEnabled)
     }
 
-    private init() {}
+    init(
+        sinks: [any TelemetrySink]? = nil,
+        crashlyticsReporter: (any CrashlyticsReporting)? = nil,
+        collectionEnabledOverride: Bool? = nil
+    ) {
+        let reporter = crashlyticsReporter ?? FirebaseCrashlyticsReporter()
+        self.crashlyticsReporter = reporter
+        self.collectionEnabledOverride = collectionEnabledOverride
+        if let sinks {
+            self.sinks = sinks
+        } else {
+            var defaultSinks: [any TelemetrySink] = [
+                FirebaseTelemetrySink(),
+                CrashlyticsBreadcrumbSink(reporter: reporter)
+            ]
+
+            #if DEBUG
+            defaultSinks.append(
+                DebugTelemetryConsoleSink {
+                    DebugTelemetryConsoleStore.shared
+                }
+            )
+            #endif
+
+            self.sinks = defaultSinks
+        }
+    }
 
     // MARK: - Collection Gating
 
@@ -40,22 +62,20 @@ final class TelemetryManager: @unchecked Sendable {
 
         guard shouldConfigure else { return }
 
-        let enabled = Self.shouldEnableCollection()
+        let enabled = collectionEnabledOverride ?? Self.shouldEnableCollection()
         lock.withLock { $0.isCollectionEnabled = enabled }
 
-        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(enabled)
-        Analytics.setAnalyticsCollectionEnabled(enabled)
+        crashlyticsReporter.setCollectionEnabled(enabled)
+        sinks.forEach { $0.setCollectionEnabled(enabled) }
     }
 
     private static func shouldEnableCollection() -> Bool {
         let args = ProcessInfo.processInfo.arguments
 
-        // -TelemetryDisabled wins (force off even in Release/TestFlight)
         if args.contains("-TelemetryDisabled") {
             return false
         }
 
-        // -TelemetryEnabled forces on (useful for testing in Debug)
         if args.contains("-TelemetryEnabled") {
             return true
         }
@@ -67,18 +87,72 @@ final class TelemetryManager: @unchecked Sendable {
         #endif
     }
 
+    private static var appEnvironmentName: String {
+        #if DEBUG
+        return "dev"
+        #elseif STAGING
+        return "staging"
+        #else
+        return "production"
+        #endif
+    }
+
     // MARK: - User Identity
 
     func setUserId(_ userId: String) {
         guard isCollectionEnabled else { return }
-        Crashlytics.crashlytics().setUserID(userId)
-        Analytics.setUserID(userId)
+        crashlyticsReporter.setUserID(userId)
+        sinks.forEach { $0.setUserID(userId) }
     }
 
     func clearUserId() {
         guard isCollectionEnabled else { return }
-        Crashlytics.crashlytics().setUserID("")
-        Analytics.setUserID(nil)
+        crashlyticsReporter.setUserID(nil)
+        sinks.forEach { $0.setUserID(nil) }
+    }
+
+    // MARK: - Event Tracking
+
+    func track(_ event: any TelemetryEvent) {
+        track(event.record)
+    }
+
+    func track(_ record: TelemetryRecord) {
+        guard isCollectionEnabled else { return }
+
+        let enrichedRecord = enrich(record)
+        sinks
+            .filter { !$0.supportedDestinations.isDisjoint(with: enrichedRecord.destinations) }
+            .forEach { $0.record(enrichedRecord) }
+    }
+
+    func track(screen: TelemetryScreen) {
+        guard isCollectionEnabled else { return }
+
+        let enrichedScreen = enrich(screen)
+        sinks
+            .filter { $0.supportedDestinations.contains(.analytics) }
+            .forEach { $0.record(screen: enrichedScreen) }
+    }
+
+    private func enrich(_ record: TelemetryRecord) -> TelemetryRecord {
+        var parameters = record.parameters
+        parameters["app_environment"] = .string(Self.appEnvironmentName)
+        return TelemetryRecord(
+            name: record.name,
+            parameters: parameters,
+            destinations: record.destinations
+        )
+    }
+
+    private func enrich(_ screen: TelemetryScreen) -> TelemetryScreen {
+        var parameters = screen.parameters
+        parameters["app_environment"] = .string(Self.appEnvironmentName)
+        return TelemetryScreen(
+            name: screen.name,
+            screenClass: screen.screenClass,
+            parameters: parameters
+        )
     }
 
     // MARK: - Custom Keys (Native Types)
@@ -93,17 +167,17 @@ final class TelemetryManager: @unchecked Sendable {
 
     func set(_ key: Key, value: Bool) {
         guard isCollectionEnabled else { return }
-        Crashlytics.crashlytics().setCustomValue(value, forKey: key.rawValue)
+        crashlyticsReporter.setCustomValue(value, forKey: key.rawValue)
     }
 
     func set(_ key: Key, value: Int) {
         guard isCollectionEnabled else { return }
-        Crashlytics.crashlytics().setCustomValue(value, forKey: key.rawValue)
+        crashlyticsReporter.setCustomValue(value, forKey: key.rawValue)
     }
 
     func set(_ key: Key, value: String) {
         guard isCollectionEnabled else { return }
-        Crashlytics.crashlytics().setCustomValue(value, forKey: key.rawValue)
+        crashlyticsReporter.setCustomValue(value, forKey: key.rawValue)
     }
 
     func setAppMetadata() {
@@ -111,6 +185,8 @@ final class TelemetryManager: @unchecked Sendable {
         let bundle = Bundle.main
         #if DEBUG
         set(.buildConfig, value: "debug")
+        #elseif STAGING
+        set(.buildConfig, value: "staging")
         #else
         set(.buildConfig, value: "release")
         #endif
@@ -121,37 +197,36 @@ final class TelemetryManager: @unchecked Sendable {
     // MARK: - Breadcrumbs (Structured Tokens)
 
     enum Breadcrumb: String {
-        // Auth
         case authSessionRestored = "auth:session_restored"
         case authInteractiveSignInSuccess = "auth:interactive_sign_in_success"
         case authSignInFailed = "auth:sign_in_failed"
         case authSignOut = "auth:sign_out"
         case authProfileLoaded = "auth:profile_loaded"
-
-        // Strava
         case stravaConnectStarted = "strava:connect_started"
         case stravaConnectSuccess = "strava:connect_success"
         case stravaConnectFailed = "strava:connect_failed"
         case stravaSyncStarted = "strava:sync_started"
         case stravaSyncCompleted = "strava:sync_completed"
         case stravaSyncFailed = "strava:sync_failed"
-
-        // Workouts
         case workoutImportStarted = "workout:import_started"
         case workoutImportCompleted = "workout:import_completed"
         case workoutImportFailed = "workout:import_failed"
-
-        // Celebration
         case celebrationShown = "celebration:shown"
         case celebrationScreen1Completed = "celebration:screen1_completed"
         case celebrationScreen2Completed = "celebration:screen2_completed"
         case celebrationDismissed = "celebration:dismissed"
         case celebrationGoalCompleted = "celebration:goal_completed"
+
+        var record: TelemetryRecord {
+            TelemetryRecord(
+                name: rawValue,
+                destinations: [.crashlytics]
+            )
+        }
     }
 
     func log(_ breadcrumb: Breadcrumb) {
-        guard isCollectionEnabled else { return }
-        Crashlytics.crashlytics().log(breadcrumb.rawValue)
+        track(breadcrumb.record)
     }
 
     // MARK: - Non-Fatal Errors (Normalized)
@@ -175,18 +250,18 @@ final class TelemetryManager: @unchecked Sendable {
         additionalInfo: [String: String]? = nil
     ) {
         guard isCollectionEnabled else { return }
+        crashlyticsReporter.record(
+            error: error,
+            context: context.rawValue,
+            code: code,
+            additionalInfo: additionalInfo
+        )
+    }
+}
 
-        var userInfo: [String: Any] = [
-            "context": context.rawValue,
-            "error_code": code
-        ]
-
-        if let additionalInfo {
-            for (key, value) in additionalInfo {
-                userInfo[key] = value
-            }
-        }
-
-        Crashlytics.crashlytics().record(error: error, userInfo: userInfo)
+private extension TelemetryManager {
+    struct State {
+        var isCollectionEnabled = false
+        var didConfigure = false
     }
 }

--- a/AscendApp/Shared/Services/Telemetry/AnalyticsScreenModifier.swift
+++ b/AscendApp/Shared/Services/Telemetry/AnalyticsScreenModifier.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct AnalyticsScreenModifier: ViewModifier {
+    let screen: TelemetryScreen
+
+    @State private var hasTracked = false
+
+    func body(content: Content) -> some View {
+        content.onAppear {
+            guard !hasTracked else { return }
+            hasTracked = true
+            TelemetryManager.shared.track(screen: screen)
+        }
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/CrashlyticsBreadcrumbSink.swift
+++ b/AscendApp/Shared/Services/Telemetry/CrashlyticsBreadcrumbSink.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+final class CrashlyticsBreadcrumbSink: TelemetrySink, @unchecked Sendable {
+    let supportedDestinations: Set<TelemetryDestination> = [.crashlytics]
+
+    private let reporter: any CrashlyticsReporting
+
+    init(reporter: any CrashlyticsReporting) {
+        self.reporter = reporter
+    }
+
+    func setCollectionEnabled(_ enabled: Bool) {}
+
+    func setUserID(_ userID: String?) {}
+
+    func record(_ record: TelemetryRecord) {
+        reporter.log(record.crashlyticsMessage)
+    }
+
+    func record(screen: TelemetryScreen) {}
+}

--- a/AscendApp/Shared/Services/Telemetry/CrashlyticsReporting.swift
+++ b/AscendApp/Shared/Services/Telemetry/CrashlyticsReporting.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+protocol CrashlyticsReporting: Sendable {
+    func setCollectionEnabled(_ enabled: Bool)
+    func setUserID(_ userID: String?)
+    func setCustomValue(_ value: Bool, forKey key: String)
+    func setCustomValue(_ value: Int, forKey key: String)
+    func setCustomValue(_ value: String, forKey key: String)
+    func log(_ message: String)
+    func record(error: Error, context: String, code: String, additionalInfo: [String: String]?)
+}

--- a/AscendApp/Shared/Services/Telemetry/DebugTelemetryConsoleEntry.swift
+++ b/AscendApp/Shared/Services/Telemetry/DebugTelemetryConsoleEntry.swift
@@ -1,0 +1,458 @@
+#if DEBUG
+import Foundation
+
+struct DebugTelemetryConsoleEntry: Identifiable, Hashable {
+    enum Kind: String {
+        case analytics
+        case breadcrumb
+        case screen
+
+        var displayName: String {
+            switch self {
+            case .analytics:
+                "Analytics"
+            case .breadcrumb:
+                "Breadcrumb"
+            case .screen:
+                "Screen"
+            }
+        }
+    }
+
+    struct Parameter: Identifiable, Hashable {
+        let rawKey: String
+        let key: String
+        let value: String
+        let helpText: String?
+
+        var id: String { rawKey }
+    }
+
+    let id = UUID()
+    let kind: Kind
+    let rawName: String
+    let title: String
+    let feature: String
+    let summary: String
+    let whenItFires: String
+    let whyTracked: String
+    let timestamp: Date
+    let parameters: [Parameter]
+    let environment: String?
+    let destinations: [String]
+    let destinationsSummary: String
+
+    init(record: TelemetryRecord, timestamp: Date = Date()) {
+        let kind: Kind = record.destinations.contains(.analytics) ? .analytics : .breadcrumb
+        let metadata = Self.metadata(for: record.name, kind: kind)
+        self.kind = kind
+        self.rawName = record.name
+        self.title = metadata.title
+        self.feature = metadata.feature
+        self.summary = metadata.summary
+        self.whenItFires = metadata.whenItFires
+        self.whyTracked = metadata.whyTracked
+        self.timestamp = timestamp
+        self.environment = Self.humanizedValue(for: "app_environment", value: record.parameters["app_environment"])
+        self.parameters = Self.displayParameters(from: record.parameters)
+        self.destinations = record.destinations
+            .map(\.displayName)
+            .sorted()
+        self.destinationsSummary = Self.destinationsSummary(for: self.destinations)
+    }
+
+    init(screen: TelemetryScreen, timestamp: Date = Date()) {
+        self.kind = .screen
+        let metadata = Self.metadata(for: screen.name, kind: .screen)
+        self.rawName = screen.name
+        self.title = metadata.title
+        self.feature = metadata.feature
+        self.summary = metadata.summary
+        self.whenItFires = metadata.whenItFires
+        self.whyTracked = metadata.whyTracked
+        self.timestamp = timestamp
+        self.environment = Self.humanizedValue(for: "app_environment", value: screen.parameters["app_environment"])
+        self.parameters = Self.displayParameters(from: screen.parameters)
+        self.destinations = [TelemetryDestination.analytics.displayName]
+        self.destinationsSummary = Self.destinationsSummary(for: self.destinations)
+    }
+}
+
+private extension DebugTelemetryConsoleEntry {
+    struct Metadata {
+        let title: String
+        let feature: String
+        let summary: String
+        let whenItFires: String
+        let whyTracked: String
+    }
+
+    static func metadata(for rawName: String, kind: Kind) -> Metadata {
+        if let known = knownMetadata[rawName] {
+            return known
+        }
+
+        return Metadata(
+            title: humanizedTitle(rawName),
+            feature: featureName(for: rawName),
+            summary: defaultSummary(for: kind),
+            whenItFires: defaultWhenItFires(for: kind),
+            whyTracked: defaultWhyTracked(for: kind)
+        )
+    }
+
+    static func displayParameters(from rawParameters: [String: TelemetryValue]) -> [Parameter] {
+        rawParameters
+            .filter { $0.key != "app_environment" }
+            .sorted { $0.key < $1.key }
+            .map {
+                Parameter(
+                    rawKey: $0.key,
+                    key: humanizedKey($0.key),
+                    value: humanizedValue(for: $0.key, value: $0.value) ?? $0.value.stringValue,
+                    helpText: parameterHelpText(for: $0.key)
+                )
+            }
+    }
+
+    static func destinationsSummary(for destinations: [String]) -> String {
+        if destinations.isEmpty {
+            return "Not sent anywhere"
+        }
+
+        if destinations.count == 1, let destination = destinations.first {
+            return "Sent to \(destination)"
+        }
+
+        let allButLast = destinations.dropLast().joined(separator: ", ")
+        let last = destinations.last ?? ""
+        return "Sent to \(allButLast), and \(last)"
+    }
+
+    static func featureName(for rawName: String) -> String {
+        if rawName.hasPrefix("auth:") {
+            return "Authentication"
+        }
+
+        if rawName.hasPrefix("strava:") {
+            return "Strava"
+        }
+
+        if rawName.hasPrefix("celebration:") {
+            return "Celebration"
+        }
+
+        if rawName.contains("workout") {
+            return "Workouts"
+        }
+
+        return "General"
+    }
+
+    static func humanizedTitle(_ rawName: String) -> String {
+        let trimmedName = rawName
+            .replacingOccurrences(of: "auth:", with: "")
+            .replacingOccurrences(of: "strava:", with: "")
+            .replacingOccurrences(of: "celebration:", with: "")
+            .replacingOccurrences(of: "workout_", with: "workout ")
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: ":", with: " ")
+
+        return trimmedName
+            .split(separator: " ")
+            .map { component in
+                switch component.lowercased() {
+                case "id":
+                    return "ID"
+                case "hevy":
+                    return "Hevy"
+                default:
+                    return component.capitalized
+                }
+            }
+            .joined(separator: " ")
+    }
+
+    static func humanizedKey(_ rawKey: String) -> String {
+        switch rawKey {
+        case "candidate_count_bucket":
+            return "Workout Count"
+        case "import_mode":
+            return "Import Mode"
+        case "source_mix":
+            return "Source Mix"
+        case "imported_count_bucket":
+            return "Imported"
+        case "updated_count_bucket":
+            return "Updated Existing"
+        case "failed_count_bucket":
+            return "Failed"
+        case "hevy_connected":
+            return "Hevy Connected"
+        case "app_environment":
+            return "Environment"
+        default:
+            return humanizedTitle(rawKey)
+        }
+    }
+
+    static func humanizedValue(for key: String, value: TelemetryValue?) -> String? {
+        guard let value else { return nil }
+
+        switch (key, value) {
+        case ("app_environment", .string(let raw)),
+             ("import_mode", .string(let raw)),
+             ("source_mix", .string(let raw)),
+             ("candidate_count_bucket", .string(let raw)),
+             ("imported_count_bucket", .string(let raw)),
+             ("updated_count_bucket", .string(let raw)),
+             ("failed_count_bucket", .string(let raw)),
+             ("outcome", .string(let raw)):
+            return humanizedBucketOrEnum(raw)
+
+        case (_, .bool(let boolean)):
+            return boolean ? "Yes" : "No"
+
+        default:
+            return value.stringValue
+        }
+    }
+
+    static func humanizedBucketOrEnum(_ raw: String) -> String {
+        switch raw {
+        case "dev":
+            return "Dev"
+        case "staging":
+            return "Staging"
+        case "production":
+            return "Production"
+        case "single":
+            return "Single workout"
+        case "selected":
+            return "Selected workouts"
+        case "all":
+            return "Import all"
+        case "apple_health_only":
+            return "Apple Health only"
+        case "hevy_only":
+            return "Hevy only"
+        case "linked_only":
+            return "Linked Hevy + Apple Health"
+        case "mixed":
+            return "Mixed sources"
+        case "updated_existing":
+            return "Updated existing workout"
+        case "partial_success":
+            return "Partial success"
+        case "mixed_success":
+            return "Imported and updated"
+        case "zero":
+            return "0"
+        case "one":
+            return "1"
+        case "2_5":
+            return "2-5"
+        case "6_10":
+            return "6-10"
+        case "11_plus":
+            return "11+"
+        default:
+            return raw
+                .replacingOccurrences(of: "_", with: " ")
+                .capitalized
+        }
+    }
+
+    static func defaultSummary(for kind: Kind) -> String {
+        switch kind {
+        case .analytics:
+            return "A product analytics event was emitted."
+        case .breadcrumb:
+            return "A crash breadcrumb was emitted to help explain what happened before an error."
+        case .screen:
+            return "A screen view was emitted for analytics."
+        }
+    }
+
+    static func defaultWhenItFires(for kind: Kind) -> String {
+        switch kind {
+        case .analytics:
+            return "This fires when a tracked product action or outcome happens in the app."
+        case .breadcrumb:
+            return "This fires when the app crosses a checkpoint that may help explain what happened before a crash."
+        case .screen:
+            return "This fires when a manually tracked screen appears on screen."
+        }
+    }
+
+    static func defaultWhyTracked(for kind: Kind) -> String {
+        switch kind {
+        case .analytics:
+            return "We track analytics to understand product usage, funnels, and outcomes."
+        case .breadcrumb:
+            return "We track breadcrumbs to reconstruct app state and user flow when something goes wrong."
+        case .screen:
+            return "We track screens to understand which surfaces are actually being opened."
+        }
+    }
+
+    static func parameterHelpText(for rawKey: String) -> String? {
+        switch rawKey {
+        case "candidate_count_bucket":
+            return "How many workout candidates were included in this import action."
+        case "import_mode":
+            return "Whether the user imported one workout, a selected set, or everything available."
+        case "source_mix":
+            return "Which source combination the imported workouts came from."
+        case "imported_count_bucket":
+            return "How many new workouts were created by this import."
+        case "updated_count_bucket":
+            return "How many existing workouts were matched and updated instead of creating duplicates."
+        case "failed_count_bucket":
+            return "How many candidate workouts failed to import."
+        case "outcome":
+            return "The final result of the import flow."
+        case "hevy_connected":
+            return "Whether the user currently had a Hevy account connected when the screen opened."
+        default:
+            return nil
+        }
+    }
+
+    static let knownMetadata: [String: Metadata] = [
+        "auth:session_restored": Metadata(
+            title: "Session Restored",
+            feature: "Authentication",
+            summary: "A previously signed-in user session was restored when the app launched.",
+            whenItFires: "This fires on launch when Firebase restores a saved sign-in session and the user does not need to log in again.",
+            whyTracked: "It confirms sign-in persistence is working and helps explain the app's auth state before a crash."
+        ),
+        "auth:profile_loaded": Metadata(
+            title: "Profile Loaded",
+            feature: "Authentication",
+            summary: "The signed-in user's profile finished loading.",
+            whenItFires: "This fires after auth is known and Ascend finishes loading the user's app profile data.",
+            whyTracked: "It marks the point where the app has enough user data to personalize the experience."
+        ),
+        "auth:interactive_sign_in_success": Metadata(
+            title: "Sign In Succeeded",
+            feature: "Authentication",
+            summary: "The user completed an Apple or Google sign-in flow.",
+            whenItFires: "This fires when an Apple or Google sign-in flow finishes successfully.",
+            whyTracked: "It helps measure sign-in success rate and diagnose auth funnel issues."
+        ),
+        "auth:sign_in_failed": Metadata(
+            title: "Sign In Failed",
+            feature: "Authentication",
+            summary: "An Apple or Google sign-in flow failed.",
+            whenItFires: "This fires when an Apple or Google sign-in attempt ends in failure.",
+            whyTracked: "It helps surface auth reliability problems and provider-specific friction."
+        ),
+        "auth:sign_out": Metadata(
+            title: "Signed Out",
+            feature: "Authentication",
+            summary: "The current user signed out.",
+            whenItFires: "This fires when the current user signs out of Ascend.",
+            whyTracked: "It helps distinguish intentional sign-out behavior from session loss or auth bugs."
+        ),
+        "strava:connect_started": Metadata(
+            title: "Strava Connect Started",
+            feature: "Strava",
+            summary: "The app started a Strava account connection flow.",
+            whenItFires: "This fires when the user begins connecting a Strava account.",
+            whyTracked: "It marks the top of the Strava connection funnel."
+        ),
+        "strava:connect_success": Metadata(
+            title: "Strava Connected",
+            feature: "Strava",
+            summary: "The user's Strava account connected successfully.",
+            whenItFires: "This fires after Strava OAuth succeeds and Ascend stores the connected account.",
+            whyTracked: "It measures successful Strava activation."
+        ),
+        "strava:connect_failed": Metadata(
+            title: "Strava Connect Failed",
+            feature: "Strava",
+            summary: "The Strava account connection flow failed.",
+            whenItFires: "This fires when the Strava connection flow fails or is rejected.",
+            whyTracked: "It helps debug where users are getting blocked while connecting Strava."
+        ),
+        "strava:sync_started": Metadata(
+            title: "Strava Sync Started",
+            feature: "Strava",
+            summary: "The app started syncing workouts from Strava.",
+            whenItFires: "This fires when the app begins a Strava sync attempt.",
+            whyTracked: "It marks the start of a sync job so failures and completions can be interpreted."
+        ),
+        "strava:sync_completed": Metadata(
+            title: "Strava Sync Completed",
+            feature: "Strava",
+            summary: "The app finished syncing workouts from Strava.",
+            whenItFires: "This fires when a Strava sync attempt completes.",
+            whyTracked: "It helps measure sync reliability and successful usage of the Strava integration."
+        ),
+        "strava:sync_failed": Metadata(
+            title: "Strava Sync Failed",
+            feature: "Strava",
+            summary: "The Strava sync attempt failed.",
+            whenItFires: "This fires when a Strava sync attempt fails.",
+            whyTracked: "It helps isolate sync errors and quantify integration reliability issues."
+        ),
+        "workout_import_started": Metadata(
+            title: "Workout Import Started",
+            feature: "Workouts",
+            summary: "The user started importing one or more workouts.",
+            whenItFires: "This fires the moment the user kicks off a workout import.",
+            whyTracked: "It marks the top of the import funnel and tells us which import modes people actually use."
+        ),
+        "workout_import_finished": Metadata(
+            title: "Workout Import Finished",
+            feature: "Workouts",
+            summary: "The workout import flow finished and reported its final outcome.",
+            whenItFires: "This fires when the import flow ends, whether it created workouts, updated existing ones, partially succeeded, or failed.",
+            whyTracked: "It tells us whether imports are succeeding, where users hit failures, and how much workout data is actually getting into the app."
+        ),
+        "workout_import_sheet": Metadata(
+            title: "Workout Import Sheet",
+            feature: "Workouts",
+            summary: "The workout import sheet appeared on screen.",
+            whenItFires: "This fires when the workout import sheet is opened.",
+            whyTracked: "It shows how often users reach the import surface, even if they do not finish an import."
+        ),
+        "celebration:shown": Metadata(
+            title: "Celebration Shown",
+            feature: "Celebration",
+            summary: "A celebration flow was presented to the user.",
+            whenItFires: "This fires when a celebration experience is shown.",
+            whyTracked: "It helps explain user state and progression around milestone moments."
+        ),
+        "celebration:screen1_completed": Metadata(
+            title: "Celebration Step Completed",
+            feature: "Celebration",
+            summary: "The first celebration step finished.",
+            whenItFires: "This fires when the first step of the celebration flow completes.",
+            whyTracked: "It helps measure whether users are moving through the celebration sequence."
+        ),
+        "celebration:screen2_completed": Metadata(
+            title: "Celebration Final Step Completed",
+            feature: "Celebration",
+            summary: "The final celebration step finished.",
+            whenItFires: "This fires when the final celebration step completes.",
+            whyTracked: "It helps measure whether users finish the celebration flow."
+        ),
+        "celebration:dismissed": Metadata(
+            title: "Celebration Dismissed",
+            feature: "Celebration",
+            summary: "The user dismissed a celebration flow.",
+            whenItFires: "This fires when the user exits the celebration flow.",
+            whyTracked: "It helps show whether users are engaging with or bailing out of celebration moments."
+        ),
+        "celebration:goal_completed": Metadata(
+            title: "Goal Celebration Recorded",
+            feature: "Celebration",
+            summary: "A goal-completion celebration event was recorded.",
+            whenItFires: "This fires when Ascend records a goal completion celebration.",
+            whyTracked: "It helps measure goal completions and milestone frequency."
+        )
+    ]
+}
+#endif

--- a/AscendApp/Shared/Services/Telemetry/DebugTelemetryConsoleSink.swift
+++ b/AscendApp/Shared/Services/Telemetry/DebugTelemetryConsoleSink.swift
@@ -1,0 +1,37 @@
+#if DEBUG
+import Foundation
+
+final class DebugTelemetryConsoleSink: TelemetrySink {
+    let supportedDestinations: Set<TelemetryDestination> = [.analytics, .crashlytics]
+
+    private let storeProvider: @Sendable @MainActor () -> DebugTelemetryConsoleStore
+
+    init(storeProvider: @escaping @Sendable @MainActor () -> DebugTelemetryConsoleStore) {
+        self.storeProvider = storeProvider
+    }
+
+    func setCollectionEnabled(_ enabled: Bool) {
+        Task { @MainActor in
+            storeProvider().setCollectionEnabled(enabled)
+        }
+    }
+
+    func setUserID(_ userID: String?) {
+        Task { @MainActor in
+            storeProvider().setUserID(userID)
+        }
+    }
+
+    func record(_ record: TelemetryRecord) {
+        Task { @MainActor in
+            storeProvider().record(record)
+        }
+    }
+
+    func record(screen: TelemetryScreen) {
+        Task { @MainActor in
+            storeProvider().record(screen: screen)
+        }
+    }
+}
+#endif

--- a/AscendApp/Shared/Services/Telemetry/DebugTelemetryConsoleStore.swift
+++ b/AscendApp/Shared/Services/Telemetry/DebugTelemetryConsoleStore.swift
@@ -1,0 +1,48 @@
+#if DEBUG
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class DebugTelemetryConsoleStore {
+    static let shared = DebugTelemetryConsoleStore()
+
+    var entries: [DebugTelemetryConsoleEntry] = []
+    var isCollectionEnabled = false
+    var currentUserID: String?
+
+    private let maxEntries: Int
+
+    init(maxEntries: Int = 200) {
+        self.maxEntries = maxEntries
+    }
+
+    func record(_ record: TelemetryRecord) {
+        insert(DebugTelemetryConsoleEntry(record: record))
+    }
+
+    func record(screen: TelemetryScreen) {
+        insert(DebugTelemetryConsoleEntry(screen: screen))
+    }
+
+    func setCollectionEnabled(_ enabled: Bool) {
+        isCollectionEnabled = enabled
+    }
+
+    func setUserID(_ userID: String?) {
+        currentUserID = userID
+    }
+
+    func clear() {
+        entries.removeAll()
+    }
+
+    private func insert(_ entry: DebugTelemetryConsoleEntry) {
+        entries.insert(entry, at: 0)
+
+        if entries.count > maxEntries {
+            entries.removeLast(entries.count - maxEntries)
+        }
+    }
+}
+#endif

--- a/AscendApp/Shared/Services/Telemetry/FirebaseCrashlyticsReporter.swift
+++ b/AscendApp/Shared/Services/Telemetry/FirebaseCrashlyticsReporter.swift
@@ -1,0 +1,43 @@
+import FirebaseCrashlytics
+import Foundation
+
+final class FirebaseCrashlyticsReporter: CrashlyticsReporting, @unchecked Sendable {
+    func setCollectionEnabled(_ enabled: Bool) {
+        Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(enabled)
+    }
+
+    func setUserID(_ userID: String?) {
+        Crashlytics.crashlytics().setUserID(userID ?? "")
+    }
+
+    func setCustomValue(_ value: Bool, forKey key: String) {
+        Crashlytics.crashlytics().setCustomValue(value, forKey: key)
+    }
+
+    func setCustomValue(_ value: Int, forKey key: String) {
+        Crashlytics.crashlytics().setCustomValue(value, forKey: key)
+    }
+
+    func setCustomValue(_ value: String, forKey key: String) {
+        Crashlytics.crashlytics().setCustomValue(value, forKey: key)
+    }
+
+    func log(_ message: String) {
+        Crashlytics.crashlytics().log(message)
+    }
+
+    func record(error: Error, context: String, code: String, additionalInfo: [String: String]?) {
+        var userInfo: [String: Any] = [
+            "context": context,
+            "error_code": code
+        ]
+
+        if let additionalInfo {
+            for (key, value) in additionalInfo {
+                userInfo[key] = value
+            }
+        }
+
+        Crashlytics.crashlytics().record(error: error, userInfo: userInfo)
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/FirebaseTelemetrySink.swift
+++ b/AscendApp/Shared/Services/Telemetry/FirebaseTelemetrySink.swift
@@ -1,0 +1,45 @@
+import FirebaseAnalytics
+import Foundation
+
+final class FirebaseTelemetrySink: TelemetrySink, @unchecked Sendable {
+    let supportedDestinations: Set<TelemetryDestination> = [.analytics]
+
+    func setCollectionEnabled(_ enabled: Bool) {
+        Analytics.setAnalyticsCollectionEnabled(enabled)
+    }
+
+    func setUserID(_ userID: String?) {
+        Analytics.setUserID(userID)
+    }
+
+    func record(_ record: TelemetryRecord) {
+        Analytics.logEvent(record.name, parameters: record.firebaseParameters)
+    }
+
+    func record(screen: TelemetryScreen) {
+        var parameters = screen.firebaseParameters
+        parameters[AnalyticsParameterScreenName] = screen.name
+        parameters[AnalyticsParameterScreenClass] = screen.screenClass
+        Analytics.logEvent(AnalyticsEventScreenView, parameters: parameters)
+    }
+}
+
+private extension Dictionary where Key == String, Value == TelemetryValue {
+    var firebaseParameters: [String: Any] {
+        reduce(into: [String: Any]()) { partialResult, entry in
+            partialResult[entry.key] = entry.value.firebaseValue
+        }
+    }
+}
+
+private extension TelemetryScreen {
+    var firebaseParameters: [String: Any] {
+        parameters.firebaseParameters
+    }
+}
+
+private extension TelemetryRecord {
+    var firebaseParameters: [String: Any] {
+        parameters.firebaseParameters
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/InMemoryTelemetrySink.swift
+++ b/AscendApp/Shared/Services/Telemetry/InMemoryTelemetrySink.swift
@@ -1,0 +1,53 @@
+import Foundation
+import os.lock
+
+final class InMemoryTelemetrySink: TelemetrySink, @unchecked Sendable {
+    let supportedDestinations: Set<TelemetryDestination>
+
+    private let lock = OSAllocatedUnfairLock(initialState: State())
+
+    init(destination: TelemetryDestination) {
+        self.supportedDestinations = [destination]
+    }
+
+    var collectionEnabledValues: [Bool] {
+        lock.withLock(\.collectionEnabledValues)
+    }
+
+    var userIDs: [String?] {
+        lock.withLock(\.userIDs)
+    }
+
+    var records: [TelemetryRecord] {
+        lock.withLock(\.records)
+    }
+
+    var screens: [TelemetryScreen] {
+        lock.withLock(\.screens)
+    }
+
+    func setCollectionEnabled(_ enabled: Bool) {
+        lock.withLock { $0.collectionEnabledValues.append(enabled) }
+    }
+
+    func setUserID(_ userID: String?) {
+        lock.withLock { $0.userIDs.append(userID) }
+    }
+
+    func record(_ record: TelemetryRecord) {
+        lock.withLock { $0.records.append(record) }
+    }
+
+    func record(screen: TelemetryScreen) {
+        lock.withLock { $0.screens.append(screen) }
+    }
+}
+
+private extension InMemoryTelemetrySink {
+    struct State {
+        var collectionEnabledValues: [Bool] = []
+        var userIDs: [String?] = []
+        var records: [TelemetryRecord] = []
+        var screens: [TelemetryScreen] = []
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/NoOpCrashlyticsReporter.swift
+++ b/AscendApp/Shared/Services/Telemetry/NoOpCrashlyticsReporter.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+final class NoOpCrashlyticsReporter: CrashlyticsReporting, @unchecked Sendable {
+    func setCollectionEnabled(_ enabled: Bool) {}
+    func setUserID(_ userID: String?) {}
+    func setCustomValue(_ value: Bool, forKey key: String) {}
+    func setCustomValue(_ value: Int, forKey key: String) {}
+    func setCustomValue(_ value: String, forKey key: String) {}
+    func log(_ message: String) {}
+    func record(error: Error, context: String, code: String, additionalInfo: [String: String]?) {}
+}

--- a/AscendApp/Shared/Services/Telemetry/TelemetryDestination.swift
+++ b/AscendApp/Shared/Services/Telemetry/TelemetryDestination.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum TelemetryDestination: Sendable, Hashable {
+    case analytics
+    case crashlytics
+
+    var displayName: String {
+        switch self {
+        case .analytics:
+            "Analytics"
+        case .crashlytics:
+            "Crashlytics"
+        }
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/TelemetryEvent.swift
+++ b/AscendApp/Shared/Services/Telemetry/TelemetryEvent.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol TelemetryEvent: Sendable {
+    var record: TelemetryRecord { get }
+}

--- a/AscendApp/Shared/Services/Telemetry/TelemetryRecord.swift
+++ b/AscendApp/Shared/Services/Telemetry/TelemetryRecord.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct TelemetryRecord: Sendable, Hashable, Equatable {
+    let name: String
+    let parameters: [String: TelemetryValue]
+    let destinations: Set<TelemetryDestination>
+
+    init(
+        name: String,
+        parameters: [String: TelemetryValue] = [:],
+        destinations: Set<TelemetryDestination> = [.analytics]
+    ) {
+        self.name = name
+        self.parameters = parameters
+        self.destinations = destinations
+    }
+
+    var crashlyticsMessage: String {
+        guard !parameters.isEmpty else {
+            return name
+        }
+
+        let serializedParameters = parameters
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value.stringValue)" }
+            .joined(separator: " ")
+
+        return "\(name) \(serializedParameters)"
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/TelemetryScreen.swift
+++ b/AscendApp/Shared/Services/Telemetry/TelemetryScreen.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct TelemetryScreen: Sendable, Hashable, Equatable {
+    let name: String
+    let screenClass: String
+    let parameters: [String: TelemetryValue]
+
+    init(
+        name: String,
+        screenClass: String,
+        parameters: [String: TelemetryValue] = [:]
+    ) {
+        self.name = name
+        self.screenClass = screenClass
+        self.parameters = parameters
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/TelemetrySink.swift
+++ b/AscendApp/Shared/Services/Telemetry/TelemetrySink.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol TelemetrySink: Sendable {
+    var supportedDestinations: Set<TelemetryDestination> { get }
+    func setCollectionEnabled(_ enabled: Bool)
+    func setUserID(_ userID: String?)
+    func record(_ record: TelemetryRecord)
+    func record(screen: TelemetryScreen)
+}

--- a/AscendApp/Shared/Services/Telemetry/TelemetryValue.swift
+++ b/AscendApp/Shared/Services/Telemetry/TelemetryValue.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum TelemetryValue: Sendable, Hashable, Equatable {
+    case string(String)
+    case int(Int)
+    case double(Double)
+    case bool(Bool)
+
+    var firebaseValue: Any {
+        switch self {
+        case .string(let value):
+            value
+        case .int(let value):
+            value
+        case .double(let value):
+            value
+        case .bool(let value):
+            value
+        }
+    }
+
+    var stringValue: String {
+        switch self {
+        case .string(let value):
+            value
+        case .int(let value):
+            String(value)
+        case .double(let value):
+            String(value)
+        case .bool(let value):
+            value ? "true" : "false"
+        }
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/View+AnalyticsScreen.swift
+++ b/AscendApp/Shared/Services/Telemetry/View+AnalyticsScreen.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+extension View {
+    func analyticsScreen(_ screen: TelemetryScreen) -> some View {
+        modifier(AnalyticsScreenModifier(screen: screen))
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
@@ -67,6 +67,7 @@ final class WorkoutImportCoordinator {
     private let workoutReader: any HealthKitWorkoutReading
     private let metricsReader: any HealthKitMetricsReading
     private let hevyManager: HevyManager
+    private let telemetry: TelemetryManager
     private let leaderboardService = LeaderboardService.shared
 
     private var modelContext: ModelContext?
@@ -76,12 +77,14 @@ final class WorkoutImportCoordinator {
         authorizationController: any HealthKitAuthorizationControlling = HealthKitAuthorizationClient.shared,
         workoutReader: any HealthKitWorkoutReading = HealthKitWorkoutReader.shared,
         metricsReader: any HealthKitMetricsReading = HealthKitMetricsReader.shared,
-        hevyManager: HevyManager = .shared
+        hevyManager: HevyManager = .shared,
+        telemetry: TelemetryManager = .shared
     ) {
         self.authorizationController = authorizationController
         self.workoutReader = workoutReader
         self.metricsReader = metricsReader
         self.hevyManager = hevyManager
+        self.telemetry = telemetry
         self.lastCheckAt = HealthKitSyncState.lastSuccessfulCheckAt
     }
 
@@ -190,6 +193,13 @@ final class WorkoutImportCoordinator {
             return .failed(candidateID: candidate.id)
         }
 
+        telemetry.track(
+            WorkoutImportAnalyticsEvent.started(
+                mode: .single,
+                candidates: [candidate]
+            )
+        )
+
         isImporting = true
         currentImportingCandidateID = candidate.id
         defer {
@@ -218,16 +228,30 @@ final class WorkoutImportCoordinator {
             break
         }
 
+        telemetry.track(
+            WorkoutImportAnalyticsEvent.finished(
+                mode: .single,
+                candidate: candidate,
+                outcome: outcome
+            )
+        )
+
         return outcome
     }
 
     func importCandidates(ids: Set<String>) async -> ImportBatchResult {
         let candidates = pendingCandidates.filter { ids.contains($0.id) }
-        return await importCandidatesInternal(candidates: candidates)
+        return await importCandidatesInternal(
+            candidates: candidates,
+            mode: .selected
+        )
     }
 
     func importAllCandidates() async -> ImportBatchResult {
-        await importCandidatesInternal(candidates: pendingCandidates)
+        await importCandidatesInternal(
+            candidates: pendingCandidates,
+            mode: .all
+        )
     }
 
     func isImported(_ candidate: ImportedWorkoutCandidate) -> Bool {
@@ -420,7 +444,10 @@ final class WorkoutImportCoordinator {
         return matches.first
     }
 
-    private func importCandidatesInternal(candidates: [ImportedWorkoutCandidate]) async -> ImportBatchResult {
+    private func importCandidatesInternal(
+        candidates: [ImportedWorkoutCandidate],
+        mode: WorkoutImportAnalyticsEvent.ImportMode
+    ) async -> ImportBatchResult {
         guard let modelContext else {
             return ImportBatchResult(importedWorkouts: [], updatedWorkouts: [], failedCandidateIDs: [])
         }
@@ -428,6 +455,13 @@ final class WorkoutImportCoordinator {
         guard !candidates.isEmpty else {
             return ImportBatchResult(importedWorkouts: [], updatedWorkouts: [], failedCandidateIDs: [])
         }
+
+        telemetry.track(
+            WorkoutImportAnalyticsEvent.started(
+                mode: mode,
+                candidates: candidates
+            )
+        )
 
         isImporting = true
         defer {
@@ -466,11 +500,21 @@ final class WorkoutImportCoordinator {
             }
         }
 
-        return ImportBatchResult(
+        let result = ImportBatchResult(
             importedWorkouts: importedWorkouts,
             updatedWorkouts: updatedWorkouts,
             failedCandidateIDs: failedCandidateIDs
         )
+
+        telemetry.track(
+            WorkoutImportAnalyticsEvent.finished(
+                mode: mode,
+                candidates: candidates,
+                result: result
+            )
+        )
+
+        return result
     }
 
     private func importCandidateInternal(

--- a/AscendAppTests/DebugTelemetryConsoleEntryTests.swift
+++ b/AscendAppTests/DebugTelemetryConsoleEntryTests.swift
@@ -1,0 +1,68 @@
+#if DEBUG
+//
+//  DebugTelemetryConsoleEntryTests.swift
+//  AscendAppTests
+//
+//  Created by Codex on 4/6/26.
+//
+
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct DebugTelemetryConsoleEntryTests {
+    @Test
+    func breadcrumbEntriesUseFriendlyLabels() {
+        let entry = DebugTelemetryConsoleEntry(
+            record: TelemetryRecord(
+                name: "auth:profile_loaded",
+                parameters: [
+                    "app_environment": .string("dev")
+                ],
+                destinations: [.crashlytics]
+            ),
+            timestamp: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(entry.kind == .breadcrumb)
+        #expect(entry.title == "Profile Loaded")
+        #expect(entry.feature == "Authentication")
+        #expect(entry.summary == "The signed-in user's profile finished loading.")
+        #expect(entry.whenItFires == "This fires after auth is known and Ascend finishes loading the user's app profile data.")
+        #expect(entry.whyTracked == "It marks the point where the app has enough user data to personalize the experience.")
+        #expect(entry.environment == "Dev")
+        #expect(entry.destinationsSummary == "Sent to Crashlytics")
+    }
+
+    @Test
+    func analyticsEntriesHumanizeParameters() {
+        let entry = DebugTelemetryConsoleEntry(
+            record: TelemetryRecord(
+                name: "workout_import_finished",
+                parameters: [
+                    "app_environment": .string("dev"),
+                    "import_mode": .string("selected"),
+                    "source_mix": .string("linked_only"),
+                    "candidate_count_bucket": .string("2_5"),
+                    "outcome": .string("partial_success")
+                ],
+                destinations: [.analytics, .crashlytics]
+            ),
+            timestamp: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(entry.kind == .analytics)
+        #expect(entry.title == "Workout Import Finished")
+        #expect(entry.feature == "Workouts")
+        #expect(entry.environment == "Dev")
+        #expect(entry.destinationsSummary == "Sent to Analytics, and Crashlytics")
+        #expect(entry.whenItFires == "This fires when the import flow ends, whether it created workouts, updated existing ones, partially succeeded, or failed.")
+        #expect(entry.whyTracked == "It tells us whether imports are succeeding, where users hit failures, and how much workout data is actually getting into the app.")
+        #expect(entry.parameters.contains(where: { $0.key == "Import Mode" && $0.value == "Selected workouts" }))
+        #expect(entry.parameters.contains(where: { $0.key == "Source Mix" && $0.value == "Linked Hevy + Apple Health" }))
+        #expect(entry.parameters.contains(where: { $0.key == "Workout Count" && $0.value == "2-5" }))
+        #expect(entry.parameters.contains(where: { $0.key == "Outcome" && $0.value == "Partial success" }))
+        #expect(entry.parameters.first(where: { $0.rawKey == "candidate_count_bucket" })?.helpText == "How many workout candidates were included in this import action.")
+    }
+}
+#endif

--- a/AscendAppTests/DebugTelemetryConsoleStoreTests.swift
+++ b/AscendAppTests/DebugTelemetryConsoleStoreTests.swift
@@ -1,0 +1,77 @@
+#if DEBUG
+//
+//  DebugTelemetryConsoleStoreTests.swift
+//  AscendAppTests
+//
+//  Created by Codex on 4/6/26.
+//
+
+import Foundation
+import Testing
+@testable import AscendApp
+
+@MainActor
+struct DebugTelemetryConsoleStoreTests {
+    @Test
+    func storeKeepsNewestEntriesAndCapsHistory() {
+        let store = DebugTelemetryConsoleStore(maxEntries: 2)
+
+        store.record(
+            TelemetryRecord(
+                name: "first_event",
+                destinations: [.analytics]
+            )
+        )
+        store.record(
+            screen: TelemetryScreen(
+                name: "import_screen",
+                screenClass: "WorkoutImportSheet"
+            )
+        )
+        store.record(
+            TelemetryRecord(
+                name: "second_event",
+                destinations: [.crashlytics]
+            )
+        )
+
+        #expect(store.entries.count == 2)
+        #expect(store.entries.map(\.rawName) == ["second_event", "import_screen"])
+        #expect(store.entries.first?.destinations == ["Crashlytics"])
+    }
+
+    @Test
+    func sinkMirrorsCollectionStateAndRecentTelemetry() async {
+        let store = DebugTelemetryConsoleStore(maxEntries: 10)
+        let sink = DebugTelemetryConsoleSink {
+            store
+        }
+
+        sink.setCollectionEnabled(true)
+        sink.setUserID("user_123")
+        sink.record(
+            TelemetryRecord(
+                name: "test_event",
+                parameters: ["result": .string("success")],
+                destinations: [.analytics, .crashlytics]
+            )
+        )
+        sink.record(
+            screen: TelemetryScreen(
+                name: "test_screen",
+                screenClass: "TelemetryConsoleView"
+            )
+        )
+
+        for _ in 0..<5 {
+            await Task.yield()
+        }
+
+        #expect(store.isCollectionEnabled)
+        #expect(store.currentUserID == "user_123")
+        #expect(store.entries.count == 2)
+        #expect(store.entries[0].kind == .screen)
+        #expect(store.entries[1].kind == .analytics)
+    }
+}
+#endif

--- a/AscendAppTests/TelemetryManagerTests.swift
+++ b/AscendAppTests/TelemetryManagerTests.swift
@@ -1,0 +1,63 @@
+//
+//  TelemetryManagerTests.swift
+//  AscendAppTests
+//
+//  Created by Codex on 4/6/26.
+//
+
+import Testing
+@testable import AscendApp
+
+struct TelemetryManagerTests {
+    @Test
+    func trackRoutesRecordsToMatchingDestinations() {
+        let analyticsSink = InMemoryTelemetrySink(destination: .analytics)
+        let crashlyticsSink = InMemoryTelemetrySink(destination: .crashlytics)
+        let telemetry = TelemetryManager(
+            sinks: [analyticsSink, crashlyticsSink],
+            crashlyticsReporter: NoOpCrashlyticsReporter(),
+            collectionEnabledOverride: true
+        )
+
+        telemetry.configure()
+        telemetry.track(
+            TelemetryRecord(
+                name: "test_event",
+                parameters: ["result": .string("success")],
+                destinations: [.analytics, .crashlytics]
+            )
+        )
+        telemetry.track(
+            screen: TelemetryScreen(
+                name: "test_screen",
+                screenClass: "TestScreen"
+            )
+        )
+
+        #expect(analyticsSink.collectionEnabledValues == [true])
+        #expect(crashlyticsSink.collectionEnabledValues == [true])
+        #expect(analyticsSink.records.count == 1)
+        #expect(crashlyticsSink.records.count == 1)
+        #expect(analyticsSink.screens.count == 1)
+        #expect(crashlyticsSink.screens.isEmpty)
+        #expect(analyticsSink.records.first?.parameters["app_environment"] != nil)
+    }
+
+    @Test
+    func disabledCollectionSuppressesRecordsAndScreens() {
+        let analyticsSink = InMemoryTelemetrySink(destination: .analytics)
+        let telemetry = TelemetryManager(
+            sinks: [analyticsSink],
+            crashlyticsReporter: NoOpCrashlyticsReporter(),
+            collectionEnabledOverride: false
+        )
+
+        telemetry.configure()
+        telemetry.track(TelemetryRecord(name: "suppressed_event"))
+        telemetry.track(screen: TelemetryScreen(name: "suppressed_screen", screenClass: "Screen"))
+
+        #expect(analyticsSink.collectionEnabledValues == [false])
+        #expect(analyticsSink.records.isEmpty)
+        #expect(analyticsSink.screens.isEmpty)
+    }
+}

--- a/AscendAppTests/WorkoutImportAnalyticsEventTests.swift
+++ b/AscendAppTests/WorkoutImportAnalyticsEventTests.swift
@@ -1,0 +1,95 @@
+//
+//  WorkoutImportAnalyticsEventTests.swift
+//  AscendAppTests
+//
+//  Created by Codex on 4/6/26.
+//
+
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct WorkoutImportAnalyticsEventTests {
+    @Test
+    func startedUsesLinkedOnlySourceMixForLinkedCandidate() {
+        let candidate = ImportedWorkoutCandidate.hevy(
+            workoutID: "hevy_123",
+            workoutTitle: "Morning Session",
+            startDate: Date(timeIntervalSince1970: 1_775_390_400),
+            endDate: Date(timeIntervalSince1970: 1_775_392_200),
+            duration: 1_800,
+            metricValue: 1_200,
+            metricType: .steps,
+            matchingAppleHealthSample: makeAppleHealthSample(id: "ah_123")
+        )
+
+        let record = WorkoutImportAnalyticsEvent
+            .started(mode: .single, candidates: [candidate])
+            .record
+
+        #expect(record.name == "workout_import_started")
+        #expect(record.parameters["import_mode"] == .string("single"))
+        #expect(record.parameters["candidate_count_bucket"] == .string("one"))
+        #expect(record.parameters["source_mix"] == .string("linked_only"))
+    }
+
+    @Test
+    func finishedUsesPartialSuccessForMixedBatch() {
+        let candidates = [
+            ImportedWorkoutCandidate.appleHealth(sample: makeAppleHealthSample(id: "ah_1")),
+            ImportedWorkoutCandidate.hevy(
+                workoutID: "hevy_1",
+                workoutTitle: "Evening Session",
+                startDate: Date(timeIntervalSince1970: 1_775_390_400),
+                endDate: Date(timeIntervalSince1970: 1_775_392_200),
+                duration: 1_800,
+                metricValue: 80,
+                metricType: .floors,
+                matchingAppleHealthSample: nil
+            )
+        ]
+
+        let result = ImportBatchResult(
+            importedWorkouts: [makeWorkout()],
+            updatedWorkouts: [],
+            failedCandidateIDs: ["hevy_1"]
+        )
+
+        let record = WorkoutImportAnalyticsEvent
+            .finished(mode: .all, candidates: candidates, result: result)
+            .record
+
+        #expect(record.name == "workout_import_finished")
+        #expect(record.parameters["import_mode"] == .string("all"))
+        #expect(record.parameters["candidate_count_bucket"] == .string("2_5"))
+        #expect(record.parameters["imported_count_bucket"] == .string("one"))
+        #expect(record.parameters["failed_count_bucket"] == .string("one"))
+        #expect(record.parameters["outcome"] == .string("partial_success"))
+        #expect(record.parameters["source_mix"] == .string("mixed"))
+    }
+
+    private func makeAppleHealthSample(id: String) -> HealthKitWorkoutSample {
+        let startDate = Date(timeIntervalSince1970: 1_775_390_400)
+        return HealthKitWorkoutSample(
+            externalRecordID: id,
+            startDate: startDate,
+            endDate: startDate.addingTimeInterval(1_800),
+            duration: 1_800,
+            sourceName: "Apple Watch",
+            sourceBundleIdentifier: "com.apple.health",
+            deviceModel: "Apple Watch"
+        )
+    }
+
+    private func makeWorkout() -> Workout {
+        Workout(
+            name: "Imported Workout",
+            date: Date(timeIntervalSince1970: 1_775_390_400),
+            duration: 1_800,
+            steps: 1_200,
+            floors: 75,
+            stepsPerFloor: 16,
+            source: .appleHealth
+        )
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Organized by **features**, not file types. One type per file.
 AscendApp/
 ├── App/                        # App entry point, Firebase config
 │   ├── AscendApp.swift         # Firebase init, environment selection, deep links
-│   └── Firebase/               # GoogleService-Info-{Dev,Staging}.plist
+│   └── Firebase/               # Environment-specific GoogleService-Info plists
 ├── Features/
 │   ├── Workouts/               # Logging, detail, editing, sharing, import
 │   ├── Routines/               # Workout routines and folders
@@ -59,6 +59,8 @@ Three Firebase environments. App selects at compile time via `#if DEBUG / #elsei
 | Dev | `ascend-f2e4f` | Debug | `AscendApp` |
 | Staging | `ascend-staging-fa7d5` | Staging | `AscendApp-Staging` |
 | Production | `ascend-prod-9c8f2` | Release | `AscendApp` |
+
+Environment plists live in `AscendApp/App/Firebase`, but the build must copy the selected one into the built app bundle as `GoogleService-Info.plist`. App startup should use `FirebaseApp.configure()` with the bundled default plist, not runtime `FirebaseOptions(contentsOfFile:)`, so Firebase Analytics resolves the correct app ID reliably.
 
 **Environment-agnostic URLs**: Never hardcode Firebase project IDs. Derive from `FirebaseApp.app()?.options.projectID`:
 ```swift
@@ -99,6 +101,15 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.
 - Import architecture uses one canonical `Workout` plus local `WorkoutSourceLink` provenance records per provider. New import UI and state should flow through `WorkoutImportCoordinator`, not provider-specific views/services.
 - Apple Health is read-only. First connect may backfill historical workouts, but routine checks must stay incremental and sample-only until a workout is actually imported.
+
+### Analytics Architecture
+- `TelemetryManager` remains the app-facing facade, while reusable telemetry types and sinks live under `Shared/Services/Telemetry`.
+- Feature analytics definitions should live in feature-owned `Analytics/` folders (for example `Features/Workouts/Analytics`) as typed `TelemetryEvent` / `TelemetryScreen` definitions.
+- Feature code must not import Firebase directly for analytics or breadcrumbs. Route analytics through `TelemetryManager` and shared sinks only.
+- Log product events from the owning view model, coordinator, manager, or service instead of scattering calls through leaf views. The main exception is SwiftUI screen tracking, which should use the shared `.analyticsScreen(...)` modifier.
+- Keep analytics parameters low-cardinality and privacy-safe. Do not log raw user-entered text, email, DOB, exact location, exact health samples, or other high-sensitivity payloads.
+- New analytics work should include focused tests using `InMemoryTelemetrySink` so event contracts can be verified without a Firebase runtime.
+- DEBUG builds expose a Telemetry Console inside Debug Tools so recent events and screen views can be inspected locally when running with telemetry enabled.
 
 ### Climb Anything V1 Architecture
 - `Climb Anything` is a 3-screen loop:

--- a/scripts/link-firebase-plists.sh
+++ b/scripts/link-firebase-plists.sh
@@ -20,9 +20,10 @@ case "${CONFIGURATION:-}" in
   Release) required_plist="GoogleService-Info-Production.plist" ;;
 esac
 
+skip_linking=0
 if [ -n "$required_plist" ] && [ -f "$TARGET_DIR/$required_plist" ]; then
   echo "Firebase plist already present at $TARGET_DIR/$required_plist — skipping link."
-  exit 0
+  skip_linking=1
 fi
 
 find_first_existing_source_dir() {
@@ -46,15 +47,18 @@ find_first_existing_source_dir() {
   return 1
 }
 
-if ! source_dir="$(find_first_existing_source_dir)"; then
-  cat <<MSG
+source_dir=""
+if [ "$skip_linking" != "1" ]; then
+  if ! source_dir="$(find_first_existing_source_dir)"; then
+    cat <<MSG
 error: Could not locate Firebase plist source directory.
 Set ASCEND_FIREBASE_PLISTS_DIR to a folder containing:
 - GoogleService-Info-Dev.plist
 - GoogleService-Info-Staging.plist
 - GoogleService-Info-Production.plist
 MSG
-  exit 1
+    exit 1
+  fi
 fi
 
 link_plist() {
@@ -91,8 +95,64 @@ case "${CONFIGURATION:-}" in
     ;;
 esac
 
-link_plist "GoogleService-Info-Dev.plist" "$required_dev"
-link_plist "GoogleService-Info-Staging.plist" "$required_staging"
-link_plist "GoogleService-Info-Production.plist" "$required_production"
+if [ "$skip_linking" != "1" ]; then
+  link_plist "GoogleService-Info-Dev.plist" "$required_dev"
+  link_plist "GoogleService-Info-Staging.plist" "$required_staging"
+  link_plist "GoogleService-Info-Production.plist" "$required_production"
 
-echo "Linked Firebase plists from: $source_dir"
+  echo "Linked Firebase plists from: $source_dir"
+fi
+
+copy_selected_plist_into_bundle() {
+  if [ -z "$required_plist" ]; then
+    return 0
+  fi
+
+  if [ -z "${TARGET_BUILD_DIR:-}" ] || [ -z "${UNLOCALIZED_RESOURCES_FOLDER_PATH:-}" ]; then
+    return 0
+  fi
+
+  selected_plist="$TARGET_DIR/$required_plist"
+  if [ ! -f "$selected_plist" ]; then
+    echo "error: Selected Firebase plist not found: $selected_plist"
+    exit 1
+  fi
+
+  bundle_resources_dir="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
+  bundle_plist="${bundle_resources_dir}/GoogleService-Info.plist"
+  mkdir -p "$bundle_resources_dir"
+  cp "$selected_plist" "$bundle_plist"
+
+  echo "Copied $required_plist to $bundle_plist"
+}
+
+validate_selected_plist_bundle_id() {
+  if [ -z "$required_plist" ] || [ -z "${PRODUCT_BUNDLE_IDENTIFIER:-}" ]; then
+    return 0
+  fi
+
+  selected_plist="$TARGET_DIR/$required_plist"
+  if [ ! -f "$selected_plist" ]; then
+    echo "error: Selected Firebase plist not found: $selected_plist"
+    exit 1
+  fi
+
+  plist_bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :BUNDLE_ID' "$selected_plist" 2>/dev/null || true)"
+  if [ -z "$plist_bundle_id" ]; then
+    echo "error: Could not read BUNDLE_ID from Firebase plist: $selected_plist"
+    exit 1
+  fi
+
+  if [ "$plist_bundle_id" != "$PRODUCT_BUNDLE_IDENTIFIER" ]; then
+    cat <<MSG
+error: Firebase plist bundle ID mismatch.
+  plist:   $plist_bundle_id
+  target:  $PRODUCT_BUNDLE_IDENTIFIER
+  file:    $selected_plist
+MSG
+    exit 1
+  fi
+}
+
+validate_selected_plist_bundle_id
+copy_selected_plist_into_bundle

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -168,7 +168,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <p>If you have questions about this Privacy Policy, please contact us at <a href="mailto:pavayt@gmail.com">pavayt@gmail.com</a>.</p>
 
       <hr class="divider" />
-      <p class="privacy-footer-note">Built by Tyler Pavay &middot; <a href="/">ascend-f2e4f.web.app</a></p>
+      <p class="privacy-footer-note">Built by Tyler Pavay &middot; <a href="https://ascendstepper.com">ascendstepper.com</a></p>
     </main>
   </div>
 


### PR DESCRIPTION
## Summary
- add a shared telemetry architecture with typed events, screens, sinks, and test infrastructure
- pilot the new analytics flow in Workout Import and add a debug telemetry console with human-readable descriptions
- fix iOS Firebase configuration to use the bundled `GoogleService-Info.plist` flow required by Firebase Analytics and clean the website privacy footer domain reference

## What Changed
- added `TelemetryManager`-backed analytics infrastructure under `AscendApp/Shared/Services/Telemetry`
- added Firebase Analytics, Crashlytics breadcrumb, debug console, and in-memory test sinks
- added Workout Import analytics events and screen tracking
- added a debug-only telemetry console in Debug Tools
- updated Firebase startup/build config to copy the selected env plist into the app bundle as `GoogleService-Info.plist`
- added a bundle ID validation guard for the selected Firebase plist during build
- updated `AGENTS.md` and `CLAUDE.md` with the telemetry and Firebase config rules
- updated the website privacy footer to use `ascendstepper.com`

## Validation
- `xcodebuild test -project AscendApp.xcodeproj -scheme AscendApp-Staging -destination 'platform=iOS Simulator,id=527ECF09-DFAB-4DAE-82F3-0B7D7E063869' -only-testing:AscendAppTests/TelemetryManagerTests -only-testing:AscendAppTests/WorkoutImportAnalyticsEventTests -only-testing:AscendAppTests/DebugTelemetryConsoleStoreTests -only-testing:AscendAppTests/DebugTelemetryConsoleEntryTests CODE_SIGNING_ALLOWED=NO`
- `npm --prefix web run build`

Closes #125
