### PR TITLE
Fix staging Google sign-in crash

### DIFF
--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
 				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
 				"$(SRCROOT)/scripts/link-firebase-plists.sh",
+				"$(SRCROOT)/AscendApp/Info.plist",
 				"$(SRCROOT)/AscendApp/App/Firebase/GoogleService-Info-Dev.plist",
 				"$(SRCROOT)/AscendApp/App/Firebase/GoogleService-Info-Staging.plist",
 				"$(SRCROOT)/AscendApp/App/Firebase/GoogleService-Info-Production.plist",

--- a/AscendApp/Info.plist
+++ b/AscendApp/Info.plist
@@ -11,7 +11,7 @@
 			<array>
 				<string>com.googleusercontent.apps.808186881002-2nbeopa7sltss4mndm75s37o0var3c8n</string>
 				<string>com.googleusercontent.apps.761975761909-dibgspg10c56v2ipkm86a9jv6i51t2on</string>
-				<string>com.googleusercontent.apps.699362062754-btv2ounn0dvd3omgkjpfhcg3ppsclnh0</string>
+				<string>com.googleusercontent.apps.699362062754-od2ba0i13alcaqeplnrvh01p9vgj9hgi</string>
 			</array>
 		</dict>
 		<dict>

--- a/scripts/link-firebase-plists.sh
+++ b/scripts/link-firebase-plists.sh
@@ -154,5 +154,40 @@ MSG
   fi
 }
 
+validate_selected_plist_google_url_scheme() {
+  if [ -z "$required_plist" ] || [ -z "${INFOPLIST_FILE:-}" ]; then
+    return 0
+  fi
+
+  selected_plist="$TARGET_DIR/$required_plist"
+  if [ ! -f "$selected_plist" ]; then
+    echo "error: Selected Firebase plist not found: $selected_plist"
+    exit 1
+  fi
+
+  info_plist_path="${PROJECT_ROOT}/${INFOPLIST_FILE}"
+  if [ ! -f "$info_plist_path" ]; then
+    echo "error: App Info.plist not found: $info_plist_path"
+    exit 1
+  fi
+
+  reversed_client_id="$(/usr/libexec/PlistBuddy -c 'Print :REVERSED_CLIENT_ID' "$selected_plist" 2>/dev/null || true)"
+  if [ -z "$reversed_client_id" ]; then
+    echo "error: Could not read REVERSED_CLIENT_ID from Firebase plist: $selected_plist"
+    exit 1
+  fi
+
+  if ! /usr/libexec/PlistBuddy -c 'Print :CFBundleURLTypes' "$info_plist_path" 2>/dev/null | grep -Fq "$reversed_client_id"; then
+    cat <<MSG
+error: Missing Google Sign-In URL scheme for selected Firebase plist.
+  required scheme: $reversed_client_id
+  info plist:      $info_plist_path
+  firebase plist:  $selected_plist
+MSG
+    exit 1
+  fi
+}
+
 validate_selected_plist_bundle_id
+validate_selected_plist_google_url_scheme
 copy_selected_plist_into_bundle


### PR DESCRIPTION
## Summary
- fix the stale staging Google Sign-In callback URL scheme in the iOS app
- add a build-time validation that the selected Firebase plist's `REVERSED_CLIENT_ID` exists in the app URL schemes
- declare `AscendApp/Info.plist` as a run-script input so the new validation works inside Xcode's script sandbox

## Root Cause
The staging Firebase iOS app registration was corrected to `com.TylerPavay.AscendApp.staging`, which changed the staging plist's `REVERSED_CLIENT_ID`. The app still had the old staging Google callback scheme in `Info.plist`, so Google sign-in crashed immediately when the callback tried to return to the app.

The first pass at the safeguard also needed one follow-up: Xcode's user-script sandbox was blocking the run script from reading `Info.plist` because that file was not declared as a build-phase input.

## Validation
- `CONFIGURATION=Staging ... scripts/link-firebase-plists.sh`
- `xcodebuild build -project AscendApp.xcodeproj -scheme AscendApp-Staging -configuration Staging -destination 'platform=iOS Simulator,id=527ECF09-DFAB-4DAE-82F3-0B7D7E063869' CODE_SIGNING_ALLOWED=NO`

Closes #127
