### PR TITLE
Add Apple privacy manifest and maintenance rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,17 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 - When adding a new share card, prefer a new card type + preset + layout view instead of branching inside an existing card view so current card layouts stay isolated.
 - Do not reintroduce backend-driven workout share backgrounds or Firestore-configured stat layouts unless product explicitly chooses that direction again.
 
+### Privacy Manifest Maintenance Rule
+- `AscendApp/PrivacyInfo.xcprivacy` is a machine-readable Apple privacy manifest that ships inside the app bundle. It is REQUIRED for App Store submission and must stay in sync with reality.
+- Update `AscendApp/PrivacyInfo.xcprivacy` in the SAME PR whenever you:
+  1. **Collect a new data type** — any new field written to Firestore, Firebase Storage, Crashlytics, Analytics, a new HealthKit metric read, or a new profile/onboarding field captured from the user. Add or extend an entry under `NSPrivacyCollectedDataTypes` with the right Apple data type, `Linked` flag, and purpose(s).
+  2. **Call a new "required reason" API category** — `UserDefaults`, file timestamp APIs (`.contentModificationDateKey`, `stat`, `getattrlist`, etc.), system boot time (`mach_absolute_time`, `systemUptime`), disk space (`volumeAvailableCapacity`, `statfs`), or active keyboards (`UITextInputMode.activeInputModes`). Add an entry under `NSPrivacyAccessedAPITypes` with an Apple-approved reason code from https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api.
+  3. **Add or upgrade a third-party SDK** — open the SDK's bundled `PrivacyInfo.xcprivacy` and add any new data type / API reason it forces on the host app.
+  4. **Start performing tracking** in the ATT sense (cross-app or cross-site identifiers, ad networks, IDFA collection) — flip `NSPrivacyTracking` to `true`, populate `NSPrivacyTrackingDomains`, implement the ATT prompt via `ATTrackingManager`, and add `NSUserTrackingUsageDescription` to `Info.plist`.
+- The privacy manifest, the user-facing Privacy Policy at `ascendstepper.com/privacy`, the App Store Connect "App Privacy" questionnaire (nutrition labels), and the `NS*UsageDescription` strings in `Info.plist` must all describe the SAME set of data practices. If you change one, change all four.
+- The current manifest declares NO tracking and NO ads. Firebase Analytics is enabled in Release/TestFlight only, with `IS_ADS_ENABLED=false`. Do not enable ad SDKs or IDFA collection without flipping `NSPrivacyTracking` and adding ATT.
+- When in doubt about whether something needs to be declared, declare it. Under-declaring is a rejection risk; over-declaring is not.
+
 ### Firestore Schema-Change Rule
 - `firestore.rules` uses strict `hasOnly` + `hasAll` field validation on every collection. Adding, removing, or renaming a field in the app **requires a matching update to `firestore.rules`** — otherwise writes will be rejected at the server.
 - The same `firestore.rules` file must be deployed to all environments (dev, staging, production) to catch schema mismatches early. Never test against loose rules in dev while production has strict ones.
@@ -151,7 +162,7 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 
 ### Onboarding V2 (Issue #63)
 - Root routing uses onboarding completion before normal auth/home flow.
-- Onboarding sequence is: welcome, HealthKit permission, measurement system, base level, personal details (DOB + gender), body metrics (height + bodyweight), location permission, notifications permission, then mandatory auth.
+- Onboarding sequence is: welcome, HealthKit permission, measurement system, base level, personal details (DOB + gender), body metrics (height + bodyweight), notifications permission, then mandatory auth.
 - Auth is the final onboarding step with Apple/Google only (no "sign in later").
 - Onboarding draft/progress persists locally across app restarts; uninstall/reinstall resets via app data removal.
 - Bodyweight is a single profile-level value (set in onboarding, editable in settings) and is intended to be the app-wide source for body mass usage.

--- a/AscendApp/PrivacyInfo.xcprivacy
+++ b/AscendApp/PrivacyInfo.xcprivacy
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  PrivacyInfo.xcprivacy — Apple privacy manifest for AscendApp.
+
+  WHAT THIS IS
+  This file is the machine-readable declaration Apple uses at submission/upload
+  time to validate (a) what user data the app collects, (b) which "required
+  reason" APIs the app calls and why, and (c) whether the app performs
+  cross-app/cross-site tracking. It is REQUIRED for App Store submission.
+
+  EDIT THIS FILE WHENEVER YOU:
+    - Collect a new data type (any new field written to Firestore, Firebase
+      Storage, Crashlytics, Analytics, a new HealthKit metric read, a new
+      profile field captured in onboarding, etc.) → update
+      NSPrivacyCollectedDataTypes.
+    - Call a new "required reason" API category (UserDefaults, file timestamp
+      APIs, system boot time, disk space, active keyboards) → update
+      NSPrivacyAccessedAPITypes with an Apple-approved reason code.
+    - Add or upgrade a third-party SDK → check that SDK's bundled
+      PrivacyInfo.xcprivacy and add any new entries it forces on the host app.
+    - Start performing cross-app/cross-site tracking (ATT-defined) → flip
+      NSPrivacyTracking to true, populate NSPrivacyTrackingDomains, add the
+      ATT prompt, and add NSUserTrackingUsageDescription to Info.plist.
+
+  MUST STAY CONSISTENT WITH:
+    - ascendstepper.com/privacy (user-facing Privacy Policy)
+    - App Store Connect → App Privacy questionnaire (nutrition labels)
+    - Info.plist NS*UsageDescription strings
+
+  See CLAUDE.md / AGENTS.md → "Privacy Manifest Maintenance Rule" for the
+  full checklist tied to concrete code-change triggers.
+
+  Apple references:
+    - https://developer.apple.com/documentation/bundleresources/privacy_manifest_files
+    - https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests
+    - https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
+-->
+<plist version="1.0">
+<dict>
+    <!-- ============================================================ -->
+    <!-- TRACKING                                                     -->
+    <!-- ============================================================ -->
+    <!--
+      Ascend does not perform cross-app or cross-site tracking as defined by
+      App Tracking Transparency. Firebase Analytics is enabled in
+      Release/TestFlight builds but is configured without IDFA collection
+      (IS_ADS_ENABLED=false) and is used only for first-party app telemetry.
+      No ad networks are integrated.
+    -->
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+
+    <!-- ============================================================ -->
+    <!-- DATA TYPES COLLECTED                                         -->
+    <!-- ============================================================ -->
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+        <!-- Email Address — Sign in with Apple / Google, profile, feedback -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeEmailAddress</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+                <string>NSPrivacyCollectedDataTypePurposeCustomerSupport</string>
+            </array>
+        </dict>
+
+        <!-- Name — first name, last name, display name -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeName</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!-- Health & Fitness — HealthKit reads, workout metrics -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeHealth</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeFitness</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!-- Photos or Videos — workout media stored under users/{uid}/ -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePhotosorVideos</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!-- User ID — Firebase Auth UID -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeUserID</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!-- Other User Content — feedback submissions (free-text) -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeOtherUserContent</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeCustomerSupport</string>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!-- Product Interaction — first-party telemetry breadcrumbs (Release/TestFlight only) -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeProductInteraction</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!-- Crash Data — Firebase Crashlytics -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeCrashData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!-- Performance Data — non-fatal error logging via Crashlytics.recordError -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypePerformanceData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+
+        <!-- Other Diagnostic Data — feedback submission attaches device model, OS version, app/build version -->
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array>
+                <string>NSPrivacyCollectedDataTypePurposeCustomerSupport</string>
+                <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+            </array>
+        </dict>
+    </array>
+
+    <!-- ============================================================ -->
+    <!-- REQUIRED REASON API USAGE                                    -->
+    <!-- ============================================================ -->
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <!--
+          UserDefaults — pervasive use across SettingsManager, UserDataRepository,
+          StravaManager, FeedbackService for first-party preferences and caches.
+          Reason CA92.1: access info from same app, same group, or same App Clip.
+        -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+
+        <!--
+          File Timestamp — DiskAssetCache reads .contentModificationDateKey on
+          files inside the app's caches directory for cache eviction.
+          Reason C617.1: access timestamps for files inside the app container,
+          app group container, or the app's CloudKit container.
+        -->
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,17 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 - When adding a new share card, prefer a new card type + preset + layout view instead of branching inside an existing card view so current card layouts stay isolated.
 - Do not reintroduce backend-driven workout share backgrounds or Firestore-configured stat layouts unless product explicitly chooses that direction again.
 
+### Privacy Manifest Maintenance Rule
+- `AscendApp/PrivacyInfo.xcprivacy` is a machine-readable Apple privacy manifest that ships inside the app bundle. It is REQUIRED for App Store submission and must stay in sync with reality.
+- Update `AscendApp/PrivacyInfo.xcprivacy` in the SAME PR whenever you:
+  1. **Collect a new data type** — any new field written to Firestore, Firebase Storage, Crashlytics, Analytics, a new HealthKit metric read, or a new profile/onboarding field captured from the user. Add or extend an entry under `NSPrivacyCollectedDataTypes` with the right Apple data type, `Linked` flag, and purpose(s).
+  2. **Call a new "required reason" API category** — `UserDefaults`, file timestamp APIs (`.contentModificationDateKey`, `stat`, `getattrlist`, etc.), system boot time (`mach_absolute_time`, `systemUptime`), disk space (`volumeAvailableCapacity`, `statfs`), or active keyboards (`UITextInputMode.activeInputModes`). Add an entry under `NSPrivacyAccessedAPITypes` with an Apple-approved reason code from https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api.
+  3. **Add or upgrade a third-party SDK** — open the SDK's bundled `PrivacyInfo.xcprivacy` and add any new data type / API reason it forces on the host app.
+  4. **Start performing tracking** in the ATT sense (cross-app or cross-site identifiers, ad networks, IDFA collection) — flip `NSPrivacyTracking` to `true`, populate `NSPrivacyTrackingDomains`, implement the ATT prompt via `ATTrackingManager`, and add `NSUserTrackingUsageDescription` to `Info.plist`.
+- The privacy manifest, the user-facing Privacy Policy at `ascendstepper.com/privacy`, the App Store Connect "App Privacy" questionnaire (nutrition labels), and the `NS*UsageDescription` strings in `Info.plist` must all describe the SAME set of data practices. If you change one, change all four.
+- The current manifest declares NO tracking and NO ads. Firebase Analytics is enabled in Release/TestFlight only, with `IS_ADS_ENABLED=false`. Do not enable ad SDKs or IDFA collection without flipping `NSPrivacyTracking` and adding ATT.
+- When in doubt about whether something needs to be declared, declare it. Under-declaring is a rejection risk; over-declaring is not.
+
 ### Firestore Schema-Change Rule
 - `firestore.rules` uses strict `hasOnly` + `hasAll` field validation on every collection. Adding, removing, or renaming a field in the app **requires a matching update to `firestore.rules`** — otherwise writes will be rejected at the server.
 - The same `firestore.rules` file must be deployed to all environments (dev, staging, production) to catch schema mismatches early. Never test against loose rules in dev while production has strict ones.
@@ -151,7 +162,7 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 
 ### Onboarding V2 (Issue #63)
 - Root routing uses onboarding completion before normal auth/home flow.
-- Onboarding sequence is: welcome, HealthKit permission, measurement system, base level, personal details (DOB + gender), body metrics (height + bodyweight), location permission, notifications permission, then mandatory auth.
+- Onboarding sequence is: welcome, HealthKit permission, measurement system, base level, personal details (DOB + gender), body metrics (height + bodyweight), notifications permission, then mandatory auth.
 - Auth is the final onboarding step with Apple/Google only (no "sign in later").
 - Onboarding draft/progress persists locally across app restarts; uninstall/reinstall resets via app data removal.
 - Bodyweight is a single profile-level value (set in onboarding, editable in settings) and is intended to be the app-wide source for body mass usage.

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -92,7 +92,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <div class="privacy-page">
     <main>
       <h1>Privacy Policy</h1>
-      <p class="last-updated">Last updated: February 24, 2026</p>
+      <p class="last-updated">Last updated: April 6, 2026</p>
 
       <h2>Introduction</h2>
       <p>Ascend ("we", "our", or "us") is committed to protecting your privacy. This Privacy Policy explains how we collect, use, and safeguard your information when you use our stairstepper workout tracking application.</p>
@@ -104,7 +104,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <li><strong>Health Data:</strong> With your permission, we access HealthKit data including heart rate and workout information. This data is used solely to enhance your workout tracking experience and is never sold or shared with advertisers.</li>
         <li><strong>Account Information:</strong> Email address and display name when you create an account via Google or Apple Sign-In.</li>
         <li><strong>Photos and Videos:</strong> Media you optionally attach to your workouts, stored securely in the cloud.</li>
-        <li><strong>Device Information:</strong> Basic device identifiers for app functionality and crash reporting.</li>
+        <li><strong>Account Identifiers:</strong> A unique account ID assigned when you sign up. This ID is associated with crash reports and app usage diagnostics so we can investigate issues tied to a specific account if you contact support.</li>
+        <li><strong>Feedback Submissions:</strong> When you submit in-app feedback, we collect the text you write along with your email address, device model, operating system version, and app version to help us reproduce and respond to issues.</li>
+        <li><strong>Crash &amp; Diagnostic Data:</strong> We collect crash logs and non-fatal error reports through Firebase Crashlytics so we can find and fix bugs. These reports include device model, OS version, app version, and a stack trace of where the crash or error occurred. They are linked to your account identifier.</li>
+        <li><strong>Product Usage Analytics:</strong> In production builds we collect first-party analytics through Firebase Analytics — for example, which screens are visited and which features are used — to understand how the app is performing and where to improve it. This data is linked to your account identifier and is <strong>not</strong> shared with advertisers, ad networks, or data brokers, and is <strong>not</strong> used for cross-app or cross-site tracking. Ascend does not use the iOS advertising identifier (IDFA) and does not show the App Tracking Transparency prompt because we do not track you across other apps or websites.</li>
       </ul>
 
       <h2>How We Use Your Information</h2>


### PR DESCRIPTION
## Summary
- Ship `AscendApp/PrivacyInfo.xcprivacy` so production App Store submission can clear Apple's privacy manifest validation. Declares 10 collected data types (all Linked, none used for tracking), two required-reason API categories (`UserDefaults` CA92.1, `FileTimestamp` C617.1 from `DiskAssetCache`), and `NSPrivacyTracking: false`.
- Add a Privacy Manifest Maintenance Rule to `CLAUDE.md` and `AGENTS.md` so future feature PRs update the manifest whenever a new data type is collected, a new required-reason API category is called, an SDK is added/upgraded, or tracking is introduced.
- Update `web/src/pages/privacy.astro` to describe Crashlytics, first-party Firebase Analytics (Release/TestFlight only), feedback metadata, and the explicit no-IDFA / no-ATT / no-cross-app-tracking stance so the hosted Privacy Policy, the manifest, and the eventual App Store Connect App Privacy questionnaire all tell the same story. Bumped Last Updated date.
- Remove the stale `location permission` step from the documented onboarding sequence in both instruction files since onboarding does not actually request location.

## Environment impact
- Manifest ships inside the `.app` bundle and is environment-agnostic — Dev, Staging, and Production builds all get the same file.
- No Firestore rules, Storage rules, Cloud Functions, or indexes changed.
- Updated privacy policy deploys via Firebase Hosting on merge: staging now, production on the eventual `develop` → `main` merge.

## Test plan
- [ ] CI staging build passes on this PR (validates the manifest is well-formed and registered in the target)
- [ ] Local `⌘B` build succeeds — ✅ already verified in Xcode on `claude/charming-lamport`
- [ ] After merge to `develop`: verify staging Firebase Hosting serves the updated `/privacy` copy
- [ ] After merge to `main`: verify production Firebase Hosting at `ascendstepper.com/privacy` serves the updated copy before uploading any new production TestFlight/App Store build
- [ ] After production merge: update the App Store Connect "App Privacy" questionnaire to mirror the manifest's 10 declared data types

Closes #129