### PR TITLE
Implement workout durability sync and QA auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,15 @@ let hostingURL = "https://\(projectId).web.app"
 let functionsURL = "https://\(region)-\(projectId).cloudfunctions.net"
 ```
 
+### Internal QA Sign-In
+- Internal QA sign-in exists only for **dev** and **staging** builds and must stay unavailable in production.
+- Internal QA sign-in must create a real Firebase-authenticated user session (email/password in dev/staging), not a fake authenticated client state.
+- Gate the feature by both build configuration and Firebase project ID so the UI only appears for `ascend-f2e4f` and `ascend-staging-fa7d5`.
+- Local simulator/automation credentials should come from user-local scheme environment variables or other non-committed secrets sources such as `ASC_INTERNAL_QA_EMAIL` and `ASC_INTERNAL_QA_PASSWORD`.
+- XcodeBuildMCP simulator automation should inject `ASC_INTERNAL_QA_EMAIL` and `ASC_INTERNAL_QA_PASSWORD` through `session_set_defaults(env: ...)` or `launch_app_sim(env: ...)` instead of relying on user-local Xcode scheme environment inheritance.
+- Do not persist Internal QA credentials in repo-local `.xcodebuildmcp/config.yaml`; keep them in user-local scheme settings or pass them into the MCP session at runtime.
+- Never commit QA credentials, never bundle them into production builds, and never use the internal QA path to bypass Firestore/Storage/Auth server enforcement.
+
 ### Data Models (SwiftData)
 Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightPersonalRecord, AggregateWeightRecord, PendingMediaUpload
 
@@ -76,9 +85,24 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
   - `users/{uid}/photos/...`
   - `users/{uid}/videos/...`
   - `users/{uid}/profile_pictures/...`
+  - `users/{uid}/workout_heart_rate/...`
 - Never write user media to shared root paths (`photos/`, `videos/`, `profile_pictures/`) in production.
 - Legacy share card template assets may still live under `share-card-templates/...`, but workout share cards in v1 must not fetch their backgrounds or layout config from Firebase.
-- Account deletion and cleanup should target only the authenticated user's scoped prefix.
+- Account deletion and cleanup should target only the authenticated user's scoped prefixes, including durable workout heart-rate sidecars and private workout backup documents.
+
+### Workout Durability Architecture
+- Canonical private workout backups live at `users/{uid}/workouts/{workoutId}`. These documents are the durable backend record for private workout metadata, while `Workout` in SwiftData remains the local-first cache and editing surface.
+- Workout document IDs should use the workout's stable UUID string. Heart-rate sidecars must use the matching Storage path `users/{uid}/workout_heart_rate/{workoutId}.json.gz` so cleanup and repair flows can derive both resources from the same identity.
+- `WorkoutRemoteRepository` owns Firestore upserts/deletes for the canonical workout document, and `WorkoutHeartRateStorageRepository` owns the gzip-compressed heart-rate sidecar upload/delete path.
+- Full heart-rate chart samples should not be embedded directly in Firestore workout documents. Store the full series as a Storage sidecar and keep only pointer/metadata fields in Firestore, alongside summary values like average and max heart rate.
+- A workout that includes heart-rate series data is not fully synced until both the Storage sidecar upload and Firestore workout document upsert succeed.
+- Local workout sync state lives on `Workout` itself (`ownerUserId`, last-modified timestamp, last-remote-sync timestamp, last remote heart-rate sidecar path, sync status, and last sync error) so the app can track pending remote backup work without changing the current local-first UX.
+- Existing on-device workouts are backfilled once per signed-in user into that sync model. Phase 1 explicitly assumes one account per install for this backfill, so shared local workout history is not a supported multi-account scenario yet.
+- Pending remote deletes are tracked locally in `PendingWorkoutDeletion` so delete/retry flows can become durable without overloading the canonical workout record.
+- Workout backup is mutation-driven for create/edit/import flows. `WorkoutMutationHandler` persists the local sync-state changes and immediately kicks the remote coordinator after successful mutations instead of waiting for the user to relaunch the app.
+- Background media uploads are part of the same durability contract. When `Workout.photos` or `highlightedPhotoId` changes after upload completion, the app should mark that workout pending and republish the private workout backup immediately.
+- `WorkoutSyncCoordinator` is the single orchestrator for pending workout backup work. It currently runs both during authenticated bootstrap/foreground repair and from mutation-triggered flushes, processes pending workout deletions before pending upserts, uploads any required heart-rate sidecar before the Firestore upsert, and coalesces overlapping process requests so launch/auth/lifecycle hooks do not issue duplicate remote work for the same workout.
+- Future public sharing or social features must not read directly from the private workout backup collection. Public posts/comments/likes should use separate public models.
 
 ### Workout Share Card Architecture
 - Workout share cards in v1 use bundled poster background assets so the share surface renders instantly and offline.
@@ -96,6 +120,13 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
   1. Update `firestore.rules` to allow the new/changed fields
   2. Update Swift model + write logic
   3. Deploy rules to all environments before or alongside the app update
+
+### Connectivity UX
+- `NetworkConnectivityService` is the app-wide source of truth for immediate connected-vs-offline UX using `NWPathMonitor`.
+- App-wide offline and back-online messaging should be owned by `MainTabView` as a slim conditional status row inside the custom tab bar chrome, so connectivity state appears in one consistent bottom-of-screen location without covering feature content.
+- When connectivity drops, the custom tab bar should briefly emphasize the offline transition by tinting the full tab-bar chrome blue before settling back to the normal tab-bar background with the compact offline status text still visible.
+- Use connectivity state to fail fast for user-initiated refreshes or uploads when there is no network path, instead of waiting for request timeouts to tell the user they are offline.
+- Request-level failures and timeouts are still a separate concern. Features should keep their own timeout/error handling for slow connections, backend failures, or partial cached-data fallbacks.
 
 ### Import UX
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.

--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -244,15 +244,15 @@
 				"$(SRCROOT)/AscendApp/App/Firebase/GoogleService-Info-Staging.plist",
 				"$(SRCROOT)/AscendApp/App/Firebase/GoogleService-Info-Production.plist",
 			);
-				outputFileListPaths = (
-				);
-				outputPaths = (
-					"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
-				);
-				runOnlyForDeploymentPostprocessing = 0;
-				shellPath = /bin/sh;
-				shellScript = "set -eu\n\n# Ensure local Firebase config plists are linked into this worktree.\n\"${SRCROOT}/scripts/link-firebase-plists.sh\"\n\n# Determine which GoogleService-Info plist to use\ncase \"${CONFIGURATION}\" in\n    \"Debug\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Dev.plist\"\n        ;;\n    \"Staging\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Staging.plist\"\n        ;;\n    \"Release\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Production.plist\"\n        ;;\nesac\n\n# Run Crashlytics with the correct plist\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${GOOGLE_SERVICE_PLIST}\"\n";
-			};
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -eu\n\n# Ensure local Firebase config plists are linked into this worktree.\n\"${SRCROOT}/scripts/link-firebase-plists.sh\"\n\n# Determine which GoogleService-Info plist to use\ncase \"${CONFIGURATION}\" in\n    \"Debug\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Dev.plist\"\n        ;;\n    \"Staging\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Staging.plist\"\n        ;;\n    \"Release\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Production.plist\"\n        ;;\nesac\n\n# Run Crashlytics with the correct plist\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${GOOGLE_SERVICE_PLIST}\"\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */

--- a/AscendApp/App/AscendApp.swift
+++ b/AscendApp/App/AscendApp.swift
@@ -38,6 +38,7 @@ struct AscendApp: App {
             }
         }
         .environment(authVM)
+        .environment(NetworkConnectivityService.shared)
         .environment(MediaUploadManager.shared)  // For async media upload status observation
         .modelContainer(createModelContainer())
     }
@@ -69,10 +70,11 @@ struct AscendApp: App {
                 ClimbAttempt.self,
                 WeightPersonalRecord.self,
                 AggregateWeightRecord.self,
-                PendingMediaUpload.self
+                PendingMediaUpload.self,
+                PendingWorkoutDeletion.self
             ]))
             return try ModelContainer(
-                for: Workout.self, WorkoutSourceLink.self, LeaderboardStats.self, PersonalRecord.self, Goal.self, Routine.self, RoutineFolder.self, ClimbAttempt.self, WeightPersonalRecord.self, AggregateWeightRecord.self, PendingMediaUpload.self,
+                for: Workout.self, WorkoutSourceLink.self, LeaderboardStats.self, PersonalRecord.self, Goal.self, Routine.self, RoutineFolder.self, ClimbAttempt.self, WeightPersonalRecord.self, AggregateWeightRecord.self, PendingMediaUpload.self, PendingWorkoutDeletion.self,
                 configurations: config
             )
         } catch {
@@ -103,10 +105,11 @@ struct AscendApp: App {
                     ClimbAttempt.self,
                     WeightPersonalRecord.self,
                     AggregateWeightRecord.self,
-                    PendingMediaUpload.self
+                    PendingMediaUpload.self,
+                    PendingWorkoutDeletion.self
                 ]))
                 return try ModelContainer(
-                    for: Workout.self, WorkoutSourceLink.self, LeaderboardStats.self, PersonalRecord.self, Goal.self, Routine.self, RoutineFolder.self, ClimbAttempt.self, WeightPersonalRecord.self, AggregateWeightRecord.self, PendingMediaUpload.self,
+                    for: Workout.self, WorkoutSourceLink.self, LeaderboardStats.self, PersonalRecord.self, Goal.self, Routine.self, RoutineFolder.self, ClimbAttempt.self, WeightPersonalRecord.self, AggregateWeightRecord.self, PendingMediaUpload.self, PendingWorkoutDeletion.self,
                     configurations: config
                 )
             } catch {

--- a/AscendApp/App/RootView.swift
+++ b/AscendApp/App/RootView.swift
@@ -19,7 +19,8 @@ struct RootView: View {
             case .authenticated, .restoringSession:
                 MainTabView()
             case .authenticatingWithApple,
-                 .authenticatingWithGoogle:
+                 .authenticatingWithGoogle,
+                 .authenticatingWithInternalQA:
                 ProgressView("Signing In...")
                     .themedBackground()
             case .unauthenticated:
@@ -31,27 +32,37 @@ struct RootView: View {
         .task {
             // Resume any pending uploads from previous session
             await uploadManager.processPendingUploads(modelContext: modelContext)
-            await bootstrapLeaderboardState()
+            await bootstrapAuthenticatedLocalState()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             // Retry pending uploads when app comes to foreground (network may have restored)
             Task {
                 await uploadManager.processPendingUploads(modelContext: modelContext)
-                await bootstrapLeaderboardState()
+                await bootstrapAuthenticatedLocalState()
             }
         }
         .onChange(of: authVM.user?.uid) { _, _ in
             Task {
-                await bootstrapLeaderboardState()
+                await bootstrapAuthenticatedLocalState()
             }
         }
     }
 
     @MainActor
-    private func bootstrapLeaderboardState() async {
+    private func bootstrapAuthenticatedLocalState() async {
         guard let user = authVM.user else { return }
 
         do {
+            try WorkoutRemoteSyncMigrationService.runIfNeeded(
+                modelContext: modelContext,
+                currentUserId: user.uid
+            )
+
+            await WorkoutSyncCoordinator.shared.processPendingWorkouts(
+                modelContext: modelContext,
+                currentUserId: user.uid
+            )
+
             let goalService = GoalService(modelContext: modelContext)
             try goalService.migrateActiveGoalToMondayIfNeeded()
 
@@ -81,7 +92,7 @@ struct RootView: View {
                 photoURL: photoURL
             )
         } catch {
-            print("Leaderboard bootstrap failed: \(error)")
+            print("Authenticated bootstrap failed: \(error)")
         }
     }
 }

--- a/AscendApp/Features/Account/Services/AccountDeletionService.swift
+++ b/AscendApp/Features/Account/Services/AccountDeletionService.swift
@@ -77,7 +77,7 @@ final class AccountDeletionService {
         }
 
         let userId = user.uid
-        let totalSteps = 10
+        let totalSteps = 11
         var completedSteps = 0
         var hasStagedLocalDeletion = false
         var hasCommittedLocalDeletion = false
@@ -115,9 +115,9 @@ final class AccountDeletionService {
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 3: Delete all user media from Firebase Storage (storage-level sweep)
-        updateProgress("Deleting workout media...")
-        try await deleteAllUserMedia(userId: userId)
+        // Step 3: Delete all user-scoped Storage data (storage-level sweep)
+        updateProgress("Deleting stored files...")
+        try await deleteAllUserStorage(userId: userId)
         completedSteps += 1
         try Task.checkCancellation()
 
@@ -139,26 +139,32 @@ final class AccountDeletionService {
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 7: Delete Firestore user document
+        // Step 7: Delete Firestore workout backup documents
+        updateProgress("Deleting workout backups...")
+        try await deleteWorkoutBackups(userId: userId)
+        completedSteps += 1
+        try Task.checkCancellation()
+
+        // Step 8: Delete Firestore user document
         updateProgress("Deleting user profile...")
         try await deleteUserDocument(userId: userId)
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 8: Stage local deletion (rollback if auth deletion fails)
+        // Step 9: Stage local deletion (rollback if auth deletion fails)
         updateProgress("Preparing local data cleanup...")
         try stageLocalDataDeletion(modelContext: modelContext)
         hasStagedLocalDeletion = true
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 9: Delete Firebase Auth account (credentials already fresh from Step 1)
+        // Step 10: Delete Firebase Auth account (credentials already fresh from Step 1)
         updateProgress("Deleting account...")
         try await deleteAuthAccount()
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 10: Commit local deletion and clear caches
+        // Step 11: Commit local deletion and clear caches
         updateProgress("Finalizing local cleanup...")
         try commitStagedLocalDeletion(modelContext: modelContext)
         hasCommittedLocalDeletion = true
@@ -210,7 +216,6 @@ final class AccountDeletionService {
             if error.code == AuthErrorCode.requiresRecentLogin.rawValue {
                 // This shouldn't happen since we reauthenticated upfront,
                 // but handle it gracefully rather than losing data.
-                let providerIDs = user.providerData.map { $0.providerID }
                 try await ensureFreshAuthentication(
                     user: user
                 )
@@ -226,7 +231,7 @@ final class AccountDeletionService {
 
     /// Sweeps all user-scoped Storage prefixes and deletes every file.
     /// This is independent of SwiftData — it catches orphaned files too.
-    private nonisolated func deleteAllUserMedia(userId: String) async throws {
+    private nonisolated func deleteAllUserStorage(userId: String) async throws {
         let userRoot = Storage.storage().reference()
             .child("users")
             .child(userId)
@@ -235,6 +240,7 @@ final class AccountDeletionService {
             userRoot.child("photos"),
             userRoot.child("videos"),
             userRoot.child("profile_pictures"),
+            userRoot.child("workout_heart_rate"),
         ]
 
         for prefix in prefixes {
@@ -333,6 +339,38 @@ final class AccountDeletionService {
         }
     }
 
+    /// Deletes all private workout backup documents stored under the user's Firestore subcollection.
+    private func deleteWorkoutBackups(userId: String) async throws {
+        do {
+            let snapshot = try await db.collection("users")
+                .document(userId)
+                .collection("workouts")
+                .getDocuments()
+
+            guard !snapshot.documents.isEmpty else { return }
+
+            var batch = db.batch()
+            var operationsInBatch = 0
+
+            for document in snapshot.documents {
+                batch.deleteDocument(document.reference)
+                operationsInBatch += 1
+
+                if operationsInBatch == 500 {
+                    try await batch.commit()
+                    batch = db.batch()
+                    operationsInBatch = 0
+                }
+            }
+
+            if operationsInBatch > 0 {
+                try await batch.commit()
+            }
+        } catch {
+            throw DeletionError.firestoreDeletionFailed(error.localizedDescription)
+        }
+    }
+
     /// Disconnects cloud integrations before auth account deletion
     private func disconnectCloudIntegrations() async throws {
         do {
@@ -408,6 +446,12 @@ final class AccountDeletionService {
             let pendingUploads = try modelContext.fetch(pendingUploadDescriptor)
             for upload in pendingUploads {
                 modelContext.delete(upload)
+            }
+
+            let pendingWorkoutDeletionDescriptor = FetchDescriptor<PendingWorkoutDeletion>()
+            let pendingWorkoutDeletions = try modelContext.fetch(pendingWorkoutDeletionDescriptor)
+            for pendingDeletion in pendingWorkoutDeletions {
+                modelContext.delete(pendingDeletion)
             }
         } catch {
             throw DeletionError.localDataDeletionFailed(error.localizedDescription)

--- a/AscendApp/Features/Authentication/AuthenticationService.swift
+++ b/AscendApp/Features/Authentication/AuthenticationService.swift
@@ -17,6 +17,7 @@ enum AuthenticationError: LocalizedError {
     case noRootViewController
     case noIDToken
     case signInFailed(String)
+    case emailPasswordSignInFailed(String)
     case signOutFailed(String)
     case appleSignInFailed(String)
     case invalidAppleCredential
@@ -28,7 +29,7 @@ extension AuthenticationError {
         switch self {
         case .noClientID, .noRootViewController, .noIDToken, .invalidAppleCredential:
             return "Something went wrong. Please try again."
-        case .signInFailed, .appleSignInFailed:
+        case .signInFailed, .emailPasswordSignInFailed, .appleSignInFailed:
             return "Unable to sign in. Please check your connection and try again."
         case .signOutFailed:
             return "Unable to sign out. Please try again."
@@ -46,6 +47,8 @@ extension AuthenticationError {
             return "ID token is missing from Google Sign-In"
         case .signInFailed(let error):
             return "Sign-in failed: \(error)"
+        case .emailPasswordSignInFailed(let error):
+            return "Email/password sign-in failed: \(error)"
         case .signOutFailed(let error):
             return "Sign-out failed: \(error)"
         case .appleSignInFailed(let error):
@@ -118,6 +121,17 @@ class AuthenticationService: NSObject, ASAuthorizationControllerDelegate {
             }
             
             throw AuthenticationError.signInFailed(error.localizedDescription)
+        }
+    }
+
+    func signInWithEmail(email: String, password: String) async throws -> User {
+        do {
+            let result = try await Auth.auth().signIn(withEmail: email, password: password)
+            let firebaseUser = result.user
+            print("User \(firebaseUser.uid) signed in with email \(firebaseUser.email ?? "unknown")")
+            return firebaseUser
+        } catch {
+            throw AuthenticationError.emailPasswordSignInFailed(error.localizedDescription)
         }
     }
 
@@ -281,7 +295,7 @@ extension AuthenticationService {
                 errorToThrow = AuthenticationError.appleSignInFailed("Apple Sign-in failed")
             case .notInteractive:
                 errorToThrow = AuthenticationError.appleSignInFailed("Apple Sign-in requires user interaction")
-            @unknown default:
+            default:
                 errorToThrow = AuthenticationError.appleSignInFailed("Apple Sign-in failed with unknown error")
             }
         } else {

--- a/AscendApp/Features/Authentication/AuthenticationViewModel.swift
+++ b/AscendApp/Features/Authentication/AuthenticationViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import FirebaseAuth
+import FirebaseCore
 import Observation
 import PhotosUI
 import SwiftUI
@@ -15,10 +16,20 @@ enum AuthenticationState {
     case authenticated
     case authenticatingWithApple
     case authenticatingWithGoogle
+    case authenticatingWithInternalQA
     case unauthenticated
 
     /// Shown while restoring a session on app launch (waiting for profile fetch)
     case restoringSession
+
+    var isAuthenticating: Bool {
+        switch self {
+        case .authenticatingWithApple, .authenticatingWithGoogle, .authenticatingWithInternalQA:
+            return true
+        case .authenticated, .unauthenticated, .restoringSession:
+            return false
+        }
+    }
 }
 
 
@@ -66,7 +77,8 @@ class AuthenticationViewModel {
 
                     // Check if we're in an interactive sign-in flow (already showing progress)
                     let isInteractiveSignIn = self.authenticationState == .authenticatingWithGoogle ||
-                                               self.authenticationState == .authenticatingWithApple
+                                               self.authenticationState == .authenticatingWithApple ||
+                                               self.authenticationState == .authenticatingWithInternalQA
 
                     // Load cached display name immediately
                     let cachedDisplayName = UserDataRepository.shared.getCachedDisplayName() ?? user.displayName ?? ""
@@ -163,6 +175,46 @@ extension AuthenticationViewModel {
                 errorMessage = error.localizedDescription
                 authenticationState = .unauthenticated
             }
+        }
+    }
+
+    func signInWithInternalQA(email: String, password: String) async {
+        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard InternalQASignInAvailability.isEnabled(projectID: FirebaseApp.app()?.options.projectID) else {
+            errorMessage = "Internal QA sign-in is unavailable in this build."
+            authenticationState = .unauthenticated
+            return
+        }
+
+        guard !trimmedEmail.isEmpty else {
+            errorMessage = "Enter the internal QA email address."
+            authenticationState = .unauthenticated
+            return
+        }
+
+        guard !password.isEmpty else {
+            errorMessage = "Enter the internal QA password."
+            authenticationState = .unauthenticated
+            return
+        }
+
+        authenticationState = .authenticatingWithInternalQA
+        errorMessage = nil
+
+        do {
+            _ = try await authenticationService.signInWithEmail(email: trimmedEmail, password: password)
+            TelemetryManager.shared.log(.authInteractiveSignInSuccess)
+        } catch {
+            TelemetryManager.shared.log(.authSignInFailed)
+            TelemetryManager.shared.recordError(
+                error,
+                context: .auth,
+                code: "internal_qa_sign_in_failed",
+                additionalInfo: ["provider": "internal_qa"]
+            )
+            errorMessage = error.localizedDescription
+            authenticationState = .unauthenticated
         }
     }
     

--- a/AscendApp/Features/Authentication/InternalQALocalCredentials.swift
+++ b/AscendApp/Features/Authentication/InternalQALocalCredentials.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct InternalQALocalCredentials: Equatable {
+    let email: String
+    let password: String
+}

--- a/AscendApp/Features/Authentication/InternalQALocalCredentialsLoader.swift
+++ b/AscendApp/Features/Authentication/InternalQALocalCredentialsLoader.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct InternalQALocalCredentialsLoader {
+    static let emailEnvironmentKey = "ASC_INTERNAL_QA_EMAIL"
+    static let passwordEnvironmentKey = "ASC_INTERNAL_QA_PASSWORD"
+
+    private let environment: [String: String]
+
+    init(environment: [String: String] = ProcessInfo.processInfo.environment) {
+        self.environment = environment
+    }
+
+    func load() -> InternalQALocalCredentials? {
+        let email = (environment[Self.emailEnvironmentKey] ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let password = environment[Self.passwordEnvironmentKey] ?? ""
+
+        guard !email.isEmpty else { return nil }
+        guard !password.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+
+        return InternalQALocalCredentials(
+            email: email,
+            password: password
+        )
+    }
+}

--- a/AscendApp/Features/Authentication/InternalQASignInAvailability.swift
+++ b/AscendApp/Features/Authentication/InternalQASignInAvailability.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct InternalQASignInAvailability {
+    private static let allowedProjectIDs: Set<String> = [
+        "ascend-f2e4f",
+        "ascend-staging-fa7d5"
+    ]
+
+    static var isBuildEnabled: Bool {
+        #if DEBUG
+        return true
+        #elseif STAGING
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static var supportsEnvironmentCredentials: Bool {
+        #if targetEnvironment(simulator)
+        return true
+        #else
+        return false
+        #endif
+    }
+
+    static func isEnabled(projectID: String?) -> Bool {
+        guard isBuildEnabled else { return false }
+        return isAllowedProjectID(projectID)
+    }
+
+    static func isAllowedProjectID(_ projectID: String?) -> Bool {
+        guard let projectID else { return false }
+        return allowedProjectIDs.contains(projectID)
+    }
+}

--- a/AscendApp/Features/Authentication/Views/InternalQASignInView.swift
+++ b/AscendApp/Features/Authentication/Views/InternalQASignInView.swift
@@ -1,0 +1,250 @@
+import SwiftUI
+
+struct InternalQASignInView: View {
+    @Environment(AuthenticationViewModel.self) private var authVM
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var localCredentials: InternalQALocalCredentials?
+    @State private var didLoadLocalCredentials = false
+
+    @FocusState private var isEmailFocused: Bool
+    @FocusState private var isPasswordFocused: Bool
+
+    private var isSigningIn: Bool {
+        authVM.authenticationState == .authenticatingWithInternalQA
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                headerSection
+
+                if let localCredentials {
+                    localCredentialsSection(credentials: localCredentials)
+                }
+
+                manualCredentialsSection
+
+                if let errorMessage = authVM.errorMessage {
+                    Text(errorMessage)
+                        .font(.montserratRegular(size: 14))
+                        .foregroundStyle(.red)
+                        .multilineTextAlignment(.leading)
+                }
+
+                signInButton
+
+                guidanceSection
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 24)
+            .padding(.bottom, 40)
+        }
+        .themedBackground()
+        .navigationTitle("Internal QA")
+        .navigationBarTitleDisplayMode(.inline)
+        .keyboardDoneToolbar {
+            isEmailFocused = false
+            isPasswordFocused = false
+        }
+        .task {
+            authVM.errorMessage = nil
+            loadLocalCredentialsIfNeeded()
+        }
+    }
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Internal QA Sign-In")
+                .font(.montserratBold(size: 28))
+                .foregroundStyle(colorScheme == .dark ? .white : .black)
+
+            Text("Use a dedicated dev or staging Firebase email/password account. This path is excluded from production builds.")
+                .font(.montserratRegular(size: 15))
+                .foregroundStyle(colorScheme == .dark ? .white.opacity(0.72) : .gray.opacity(0.9))
+        }
+    }
+
+    private func localCredentialsSection(credentials: InternalQALocalCredentials) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Local Credentials Detected")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(colorScheme == .dark ? .white : .black)
+
+            Text(credentials.email)
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(colorScheme == .dark ? .white.opacity(0.72) : .gray.opacity(0.9))
+                .privacySensitive()
+
+            Button {
+                Task {
+                    await signIn(email: credentials.email, password: credentials.password)
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "bolt.horizontal.circle.fill")
+                        .font(.system(size: 18, weight: .semibold))
+                    Text(isSigningIn ? "Signing In..." : "Use Local QA Credentials")
+                        .font(.montserratSemiBold)
+                    Spacer()
+                }
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+                .padding(.horizontal, 16)
+                .background(
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(Color.orange)
+                )
+            }
+            .disabled(isSigningIn)
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 18)
+                .fill(colorScheme == .dark ? Color.orange.opacity(0.12) : Color.orange.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(Color.orange.opacity(colorScheme == .dark ? 0.4 : 0.28), lineWidth: 1)
+        )
+    }
+
+    private var manualCredentialsSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text(localCredentials == nil ? "Credentials" : "Use Another QA Account")
+                .font(.montserratSemiBold(size: 16))
+                .foregroundStyle(colorScheme == .dark ? .white : .black)
+
+            HStack(spacing: 12) {
+                Image(systemName: "envelope")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(.gray)
+                    .frame(width: 24)
+
+                TextField("qa@example.com", text: $email)
+                    .font(.montserratRegular(size: 16))
+                    .focused($isEmailFocused)
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .textContentType(.username)
+                    .onSubmit {
+                        isPasswordFocused = true
+                    }
+            }
+            .padding(16)
+            .background(fieldBackground)
+
+            HStack(spacing: 12) {
+                Image(systemName: "lock")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(.gray)
+                    .frame(width: 24)
+
+                SecureField("Password", text: $password)
+                    .font(.montserratRegular(size: 16))
+                    .focused($isPasswordFocused)
+                    .textContentType(.password)
+                    .onSubmit {
+                        Task {
+                            await signIn(email: email, password: password)
+                        }
+                    }
+            }
+            .padding(16)
+            .background(fieldBackground)
+        }
+    }
+
+    private var signInButton: some View {
+        Button {
+            Task {
+                await signIn(email: email, password: password)
+            }
+        } label: {
+            HStack {
+                Spacer()
+                if isSigningIn {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        .scaleEffect(0.85)
+                }
+                Text(isSigningIn ? "Signing In..." : "Sign In")
+                    .font(.montserratSemiBold)
+                Spacer()
+            }
+            .foregroundStyle(.white)
+            .frame(height: 55)
+            .background(
+                RoundedRectangle(cornerRadius: 14)
+                    .fill(canSubmit ? .accent : .gray.opacity(0.45))
+            )
+        }
+        .disabled(!canSubmit || isSigningIn)
+    }
+
+    private var guidanceSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Local setup")
+                .font(.montserratSemiBold(size: 14))
+                .foregroundStyle(colorScheme == .dark ? .white.opacity(0.72) : .black.opacity(0.85))
+
+            Text(guidanceText)
+                .font(.montserratRegular(size: 13))
+                .foregroundStyle(colorScheme == .dark ? .white.opacity(0.58) : .gray.opacity(0.9))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var guidanceText: String {
+        if InternalQASignInAvailability.supportsEnvironmentCredentials {
+            return "For one-tap simulator testing, set ASC_INTERNAL_QA_EMAIL and ASC_INTERNAL_QA_PASSWORD in your personal Xcode scheme or automation environment."
+        }
+
+        return "Use a dedicated dev or staging QA email/password account. Do not ship QA credentials in production builds."
+    }
+
+    private var canSubmit: Bool {
+        !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !password.isEmpty
+    }
+
+    private var fieldBackground: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(colorScheme == .dark ? .white.opacity(0.05) : .gray.opacity(0.06))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(colorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15), lineWidth: 1)
+            )
+    }
+
+    private func loadLocalCredentialsIfNeeded() {
+        guard !didLoadLocalCredentials else { return }
+        didLoadLocalCredentials = true
+
+        let credentials = InternalQALocalCredentialsLoader().load()
+        localCredentials = credentials
+
+        guard let credentials else { return }
+        email = credentials.email
+        password = credentials.password
+    }
+
+    private func signIn(email: String, password: String) async {
+        await authVM.signInWithInternalQA(email: email, password: password)
+
+        if authVM.authenticationState == .authenticated {
+            dismiss()
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        InternalQASignInView()
+            .environment(AuthenticationViewModel())
+    }
+}

--- a/AscendApp/Features/Authentication/Views/SignUpView.swift
+++ b/AscendApp/Features/Authentication/Views/SignUpView.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import FirebaseCore
 import SwiftUI
 
 struct SignUpView: View {
@@ -83,8 +84,7 @@ struct SignUpView: View {
                                 .stroke(.accent, lineWidth: 1)
                         )
                     }
-                    .disabled(authVM.authenticationState == .authenticatingWithApple ||
-                              authVM.authenticationState ==  .authenticatingWithGoogle)
+                    .disabled(authVM.authenticationState.isAuthenticating)
 
                     // Google Sign In Button with secondary styling
                     Button(action: { Task {
@@ -120,8 +120,49 @@ struct SignUpView: View {
                                 .stroke(colorScheme == .dark ? .white.opacity(0.3) : .gray.opacity(0.3), lineWidth: 1)
                         )
                     }
-                    .disabled(authVM.authenticationState == .authenticatingWithApple ||
-                              authVM.authenticationState == .authenticatingWithGoogle)
+                    .disabled(authVM.authenticationState.isAuthenticating)
+
+                    if canShowInternalQASignIn {
+                        NavigationLink(destination: InternalQASignInView()) {
+                            HStack(spacing: 12) {
+                                Image(systemName: "person.badge.key")
+                                    .font(.system(size: 18, weight: .semibold))
+
+                                Text("Internal QA Sign In")
+                                    .font(.montserratSemiBold)
+
+                                Spacer()
+
+                                Text("Dev/Staging")
+                                    .font(.montserratSemiBold(size: 12))
+                                    .padding(.horizontal, 10)
+                                    .padding(.vertical, 6)
+                                    .background(
+                                        Capsule()
+                                            .fill(Color.orange.opacity(colorScheme == .dark ? 0.22 : 0.14))
+                                    )
+                            }
+                            .foregroundStyle(colorScheme == .dark ? .white : .black)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 55)
+                            .padding(.horizontal, 14)
+                            .background(
+                                RoundedRectangle(cornerRadius: 14)
+                                    .fill(colorScheme == .dark ? Color.orange.opacity(0.12) : Color.orange.opacity(0.08))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 14)
+                                    .stroke(Color.orange.opacity(colorScheme == .dark ? 0.45 : 0.35), lineWidth: 1)
+                            )
+                        }
+                        .disabled(authVM.authenticationState.isAuthenticating)
+
+                        Text("Internal QA sign-in uses a real Firebase account and is only available in dev and staging builds.")
+                            .font(.montserratRegular(size: 12))
+                            .foregroundStyle(colorScheme == .dark ? .white.opacity(0.6) : .gray.opacity(0.85))
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 8)
+                    }
                 }
                 .padding(.horizontal, 24)
 
@@ -136,6 +177,12 @@ struct SignUpView: View {
                     .padding(.bottom, 40)
         }
         .themedBackground()
+    }
+
+    private var canShowInternalQASignIn: Bool {
+        InternalQASignInAvailability.isEnabled(
+            projectID: FirebaseApp.app()?.options.projectID
+        )
     }
 }
 

--- a/AscendApp/Features/Leaderboards/Services/LeaderboardCurrentUserReconciler.swift
+++ b/AscendApp/Features/Leaderboards/Services/LeaderboardCurrentUserReconciler.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+enum LeaderboardCurrentUserReconciler {
+    static func reconcilePreviewStats(
+        _ statsByMetric: [LeaderboardMetric: [FirestoreLeaderboardStats]],
+        userId: String,
+        localStats: LeaderboardStats,
+        displayName: String,
+        photoURL: URL?
+    ) -> [LeaderboardMetric: [FirestoreLeaderboardStats]] {
+        var resolved = statsByMetric
+
+        for metric in LeaderboardMetric.allCases {
+            resolved[metric] = reconcileStats(
+                resolved[metric] ?? [],
+                metric: metric,
+                userId: userId,
+                localStats: localStats,
+                displayName: displayName,
+                photoURL: photoURL
+            )
+        }
+
+        return resolved
+    }
+
+    static func reconcileDetailStats(
+        _ stats: [FirestoreLeaderboardStats],
+        metric: LeaderboardMetric,
+        userId: String,
+        localStats: LeaderboardStats,
+        displayName: String,
+        photoURL: URL?
+    ) -> [FirestoreLeaderboardStats] {
+        reconcileStats(
+            stats,
+            metric: metric,
+            userId: userId,
+            localStats: localStats,
+            displayName: displayName,
+            photoURL: photoURL
+        )
+    }
+
+    private static func reconcileStats(
+        _ stats: [FirestoreLeaderboardStats],
+        metric: LeaderboardMetric,
+        userId: String,
+        localStats: LeaderboardStats,
+        displayName: String,
+        photoURL: URL?
+    ) -> [FirestoreLeaderboardStats] {
+        var resolved = stats
+        if localStats.hasActivity == false {
+            resolved.removeAll { $0.userId == userId }
+            return resolved
+        }
+
+        if let currentIndex = resolved.firstIndex(where: { $0.userId == userId }) {
+            let existing = resolved[currentIndex]
+            resolved[currentIndex] = FirestoreLeaderboardStats(
+                userId: existing.userId,
+                displayName: displayName.isEmpty ? existing.displayName : displayName,
+                photoURL: photoURL?.absoluteString ?? existing.photoURL,
+                timeFrame: existing.timeFrame,
+                schemaVersion: existing.schemaVersion,
+                periodKey: existing.periodKey,
+                periodStartAt: existing.periodStartAt,
+                totalSteps: localStats.totalSteps,
+                totalFloors: localStats.totalFloors,
+                totalWorkouts: localStats.totalWorkouts,
+                totalDuration: localStats.totalDuration,
+                stepsPerMinute: localStats.stepsPerMinute,
+                lastUpdated: max(existing.lastUpdated, localStats.lastUpdated)
+            )
+        } else {
+            resolved.append(
+                FirestoreLeaderboardStats(
+                    userId: userId,
+                    displayName: displayName.isEmpty ? "You" : displayName,
+                    photoURL: photoURL?.absoluteString,
+                    timeFrame: localStats.timeFrameEnum.rawValue,
+                    schemaVersion: localStats.schemaVersion,
+                    periodKey: localStats.periodKey,
+                    periodStartAt: localStats.periodStartAt,
+                    totalSteps: localStats.totalSteps,
+                    totalFloors: localStats.totalFloors,
+                    totalWorkouts: localStats.totalWorkouts,
+                    totalDuration: localStats.totalDuration,
+                    stepsPerMinute: localStats.stepsPerMinute,
+                    lastUpdated: localStats.lastUpdated
+                )
+            )
+        }
+
+        resolved.sort { lhs, rhs in
+            let lhsValue = lhs.value(for: metric)
+            let rhsValue = rhs.value(for: metric)
+            if lhsValue != rhsValue {
+                return lhsValue > rhsValue
+            }
+            return lhs.userId < rhs.userId
+        }
+
+        return resolved
+    }
+}

--- a/AscendApp/Features/Leaderboards/Services/LeaderboardTimeout.swift
+++ b/AscendApp/Features/Leaderboards/Services/LeaderboardTimeout.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+enum LeaderboardRefreshPolicy {
+    static let networkTimeoutSeconds = 10.0
+}
+
 enum LeaderboardTimeoutError: LocalizedError {
     case operationTimedOut
 
@@ -49,18 +53,43 @@ func withLeaderboardTimeout<T: Sendable>(
     seconds: Double,
     operation: @escaping @Sendable () async throws -> T
 ) async throws -> T {
-    try await withThrowingTaskGroup(of: T.self) { group in
-        group.addTask {
-            try await operation()
+    try await withCheckedThrowingContinuation { continuation in
+        let state = LeaderboardTimeoutContinuationState(continuation: continuation)
+
+        let operationTask = Task {
+            do {
+                let value = try await operation()
+                await state.resume(with: .success(value))
+            } catch {
+                await state.resume(with: .failure(error))
+            }
         }
 
-        group.addTask {
-            try await Task.sleep(for: .seconds(seconds))
-            throw LeaderboardTimeoutError.operationTimedOut
-        }
+        Task {
+            do {
+                try await Task.sleep(for: .seconds(seconds))
+            } catch {
+                return
+            }
 
-        let result = try await group.next()!
-        group.cancelAll()
-        return result
+            operationTask.cancel()
+            await state.resume(with: .failure(LeaderboardTimeoutError.operationTimedOut))
+        }
+    }
+}
+
+private actor LeaderboardTimeoutContinuationState<T: Sendable> {
+    private var continuation: CheckedContinuation<T, Error>?
+    private var hasResumed = false
+
+    init(continuation: CheckedContinuation<T, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(with result: Result<T, Error>) {
+        guard hasResumed == false, let continuation else { return }
+        hasResumed = true
+        self.continuation = nil
+        continuation.resume(with: result)
     }
 }

--- a/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
+++ b/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
@@ -24,7 +24,7 @@ final class LeaderboardViewModel {
     private let service = LeaderboardService.shared
     private let repository = LeaderboardRepository.shared
     private let pageSize = 25
-    private let networkTimeoutSeconds = 15.0
+    private let networkTimeoutSeconds = LeaderboardRefreshPolicy.networkTimeoutSeconds
     private(set) var visibleEntryLimit = 25
     private var currentUserId: String?
 
@@ -50,37 +50,55 @@ final class LeaderboardViewModel {
     func refreshLeaderboard(
         userId: String,
         displayName: String,
-        photoURL: URL?
+        photoURL: URL?,
+        isNetworkConnected: Bool
     ) async {
         isLoading = true
         errorMessage = nil
         isOffline = false
         var syncError: Error?
 
-        do {
-            try await withLeaderboardTimeout(seconds: networkTimeoutSeconds) {
-                try await LeaderboardSyncCoordinator.shared.flushNow(
-                    userId: userId,
-                    displayName: displayName,
-                    photoURL: photoURL
-                )
+        if isNetworkConnected == false {
+            syncError = URLError(.notConnectedToInternet)
+        } else {
+            do {
+                try await withLeaderboardTimeout(seconds: networkTimeoutSeconds) {
+                    try await LeaderboardSyncCoordinator.shared.flushNow(
+                        userId: userId,
+                        displayName: displayName,
+                        photoURL: photoURL
+                    )
+                }
+            } catch {
+                syncError = error
             }
-        } catch {
-            syncError = error
         }
 
-        await loadLeaderboard(userId: userId, forceRefresh: true)
+        let refreshIssue = syncError.map(LeaderboardNetworkIssue.classify)
+        let shouldForceRemoteRefresh: Bool = {
+            guard let refreshIssue else { return true }
+            switch refreshIssue {
+            case .offline, .slowConnection:
+                return false
+            case .other:
+                return true
+            }
+        }()
+
+        await loadLeaderboard(
+            userId: userId,
+            forceRefresh: shouldForceRemoteRefresh,
+            isNetworkConnected: isNetworkConnected
+        )
 
         guard let syncError else { return }
         switch LeaderboardNetworkIssue.classify(syncError) {
         case .offline:
             isOffline = true
-            errorMessage = "You're offline. Pull to retry."
+            errorMessage = nil
         case .slowConnection:
             isOffline = false
-            errorMessage = leaderboardEntries.isEmpty
-                ? "Leaderboard sync is still timing out."
-                : "Latest changes may take a moment to appear."
+            errorMessage = "Latest changes may take a moment to appear."
         case .other:
             isOffline = false
             errorMessage = leaderboardEntries.isEmpty
@@ -89,7 +107,11 @@ final class LeaderboardViewModel {
         }
     }
 
-    func loadLeaderboard(userId: String, forceRefresh: Bool = false) async {
+    func loadLeaderboard(
+        userId: String,
+        forceRefresh: Bool = false,
+        isNetworkConnected: Bool? = nil
+    ) async {
         isLoading = leaderboardEntries.isEmpty
         if forceRefresh {
             errorMessage = nil
@@ -101,11 +123,44 @@ final class LeaderboardViewModel {
                 for: selectedMetric,
                 timeFrame: selectedTimeFrame
            ) {
-            apply(stats: cachedStats, userId: userId)
+            apply(stats: reconcileCurrentUserStats(cachedStats, userId: userId), userId: userId)
             errorMessage = nil
             isOffline = false
             isLoading = false
             return
+        }
+
+        if isNetworkConnected == false {
+            do {
+                let cacheStats = try await repository.fetchLeaderboard(
+                    metric: selectedMetric,
+                    timeFrame: selectedTimeFrame,
+                    limit: 100,
+                    source: .cache
+                )
+                let reconciledStats = reconcileCurrentUserStats(cacheStats, userId: userId)
+                await LeaderboardSessionCache.shared.setDetailEntries(
+                    reconciledStats,
+                    for: selectedMetric,
+                    timeFrame: selectedTimeFrame
+                )
+                if cacheStats.isEmpty {
+                    leaderboardEntries = []
+                    userEntry = try? placeholderEntry(for: userId)
+                    handleError(URLError(.notConnectedToInternet), context: "load")
+                } else {
+                    apply(stats: reconciledStats, userId: userId)
+                    handleCachedFallbackError(URLError(.notConnectedToInternet))
+                }
+                isLoading = false
+                return
+            } catch {
+                leaderboardEntries = []
+                userEntry = try? placeholderEntry(for: userId)
+                handleError(URLError(.notConnectedToInternet), context: "load")
+                isLoading = false
+                return
+            }
         }
 
         do {
@@ -118,12 +173,13 @@ final class LeaderboardViewModel {
                     source: source
                 )
             }
+            let reconciledStats = reconcileCurrentUserStats(stats, userId: userId)
             await LeaderboardSessionCache.shared.setDetailEntries(
-                stats,
+                reconciledStats,
                 for: selectedMetric,
                 timeFrame: selectedTimeFrame
             )
-            apply(stats: stats, userId: userId)
+            apply(stats: reconciledStats, userId: userId)
             errorMessage = nil
             isOffline = false
         } catch {
@@ -131,12 +187,13 @@ final class LeaderboardViewModel {
                 for: selectedMetric,
                 timeFrame: selectedTimeFrame
             ) {
+                let reconciledStats = reconcileCurrentUserStats(cachedStats, userId: userId)
                 if cachedStats.isEmpty {
                     leaderboardEntries = []
                     userEntry = try? placeholderEntry(for: userId)
                     handleError(error, context: "load")
                 } else {
-                    apply(stats: cachedStats, userId: userId)
+                    apply(stats: reconciledStats, userId: userId)
                     handleCachedFallbackError(error)
                 }
                 isLoading = false
@@ -150,8 +207,9 @@ final class LeaderboardViewModel {
                     limit: 100,
                     source: .cache
                 )
+                let reconciledStats = reconcileCurrentUserStats(cacheStats, userId: userId)
                 await LeaderboardSessionCache.shared.setDetailEntries(
-                    cacheStats,
+                    reconciledStats,
                     for: selectedMetric,
                     timeFrame: selectedTimeFrame
                 )
@@ -160,7 +218,7 @@ final class LeaderboardViewModel {
                     userEntry = try? placeholderEntry(for: userId)
                     handleError(error, context: "load")
                 } else {
-                    apply(stats: cacheStats, userId: userId)
+                    apply(stats: reconciledStats, userId: userId)
                     handleCachedFallbackError(error)
                 }
             } catch {
@@ -271,6 +329,24 @@ final class LeaderboardViewModel {
         visibleEntryLimit = min(pageSize, filteredEntries.count)
     }
 
+    private func reconcileCurrentUserStats(
+        _ stats: [FirestoreLeaderboardStats],
+        userId: String
+    ) -> [FirestoreLeaderboardStats] {
+        guard let localStats = try? service.getLocalStats(for: userId, timeFrame: selectedTimeFrame) else {
+            return stats
+        }
+
+        return LeaderboardCurrentUserReconciler.reconcileDetailStats(
+            stats,
+            metric: selectedMetric,
+            userId: userId,
+            localStats: localStats,
+            displayName: userEntry?.displayName ?? "You",
+            photoURL: userEntry?.photoURL
+        )
+    }
+
     private func formatValue(_ value: Double, for metric: LeaderboardMetric) -> String {
         switch metric {
         case .climb, .workouts:
@@ -292,10 +368,10 @@ final class LeaderboardViewModel {
         switch LeaderboardNetworkIssue.classify(error) {
         case .offline:
             isOffline = true
-            errorMessage = "Offline - showing cached data"
+            errorMessage = nil
         case .slowConnection:
             isOffline = false
-            errorMessage = "Connection is slow - showing cached data"
+            errorMessage = "Latest changes may take a moment to appear."
         case .other:
             isOffline = false
             errorMessage = "Showing cached data. Latest refresh failed."

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardHubView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardHubView.swift
@@ -12,9 +12,11 @@ struct LeaderboardHubView: View {
         case refresh
     }
 
+    @Environment(\.modelContext) private var modelContext
     @Environment(\.scenePhase) private var scenePhase
     @Environment(TabRouter.self) private var tabRouter
     @Environment(AuthenticationViewModel.self) private var authVM
+    @Environment(NetworkConnectivityService.self) private var connectivityService
     @State private var settingsManager = SettingsManager.shared
 
     @State private var selectedTimeFrame: LeaderboardTimeFrame = .weekly
@@ -25,7 +27,7 @@ struct LeaderboardHubView: View {
 
     private let repository = LeaderboardRepository.shared
     private let previewLimit = 3
-    private let networkTimeoutSeconds = 15.0
+    private let networkTimeoutSeconds = LeaderboardRefreshPolicy.networkTimeoutSeconds
 
     private var preferredMetric: WorkoutMetric {
         settingsManager.preferredWorkoutMetric
@@ -43,6 +45,13 @@ struct LeaderboardHubView: View {
                 } else if hasAnyEntries == false {
                     globalEmptyState
                 } else {
+                    if let errorMessage {
+                        StatusBannerView(
+                            message: errorMessage,
+                            style: .warning
+                        )
+                    }
+
                     ForEach(LeaderboardMetric.allCases) { metric in
                         LeaderboardCategoryCard(
                             metric: metric,
@@ -99,7 +108,9 @@ struct LeaderboardHubView: View {
             return
         }
 
-        if mode == .refresh {
+        if mode == .refresh, connectivityService.isConnected == false {
+            syncError = URLError(.notConnectedToInternet)
+        } else if mode == .refresh {
             do {
                 try await withLeaderboardTimeout(seconds: networkTimeoutSeconds) {
                     try await LeaderboardSyncCoordinator.shared.flushNow(
@@ -121,8 +132,18 @@ struct LeaderboardHubView: View {
             return
         }
 
+        let refreshIssue = syncError.map(LeaderboardNetworkIssue.classify)
+        let shouldPreferCachedRefresh: Bool = {
+            guard mode == .refresh, let refreshIssue else { return false }
+            switch refreshIssue {
+            case .offline, .slowConnection:
+                return true
+            case .other:
+                return false
+            }
+        }()
+
         var fetchedStats: [LeaderboardMetric: [FirestoreLeaderboardStats]] = [:]
-        var fetchedEntries: [LeaderboardMetric: [LeaderboardEntry]] = [:]
         var failedMetrics = 0
         let repository = self.repository
         let previewLimit = self.previewLimit
@@ -133,6 +154,24 @@ struct LeaderboardHubView: View {
         ) { group in
             for metric in LeaderboardMetric.allCases {
                 group.addTask {
+                    if shouldPreferCachedRefresh {
+                        if let cachedStats = await LeaderboardSessionCache.shared.previewEntries(for: selectedTimeFrame)?[metric] {
+                            return (metric, cachedStats, false)
+                        }
+
+                        do {
+                            let cacheStats = try await repository.fetchLeaderboard(
+                                metric: metric,
+                                timeFrame: selectedTimeFrame,
+                                limit: previewLimit,
+                                source: .cache
+                            )
+                            return (metric, cacheStats, false)
+                        } catch {
+                            return (metric, nil, true)
+                        }
+                    }
+
                     do {
                         let stats = try await withLeaderboardTimeout(seconds: networkTimeoutSeconds) {
                             try await repository.fetchLeaderboard(
@@ -177,22 +216,35 @@ struct LeaderboardHubView: View {
         for (metric, stats, didFail) in metricResults {
             let resolvedStats = stats ?? []
             fetchedStats[metric] = resolvedStats
-            fetchedEntries[metric] = makePreviewEntries(from: resolvedStats, metric: metric, userId: userId)
 
             if didFail {
                 failedMetrics += 1
             }
         }
 
+        if let localStats = currentUserLocalStats(for: userId) {
+            fetchedStats = LeaderboardCurrentUserReconciler.reconcilePreviewStats(
+                fetchedStats,
+                userId: userId,
+                localStats: localStats,
+                displayName: authVM.displayName,
+                photoURL: authVM.displayPhotoURL
+            )
+        }
+
+        let fetchedEntries = Dictionary(uniqueKeysWithValues: fetchedStats.map { metric, stats in
+            (metric, makePreviewEntries(from: stats, metric: metric, userId: userId))
+        })
+
         guard activeLoadID == loadID else { return }
         previewEntries = fetchedEntries
         await LeaderboardSessionCache.shared.setPreviewEntries(fetchedStats, for: selectedTimeFrame)
         if failedMetrics == LeaderboardMetric.allCases.count {
-            switch syncError.map(LeaderboardNetworkIssue.classify) ?? .other {
+            switch refreshIssue ?? .other {
             case .offline:
-                errorMessage = "Offline - showing cached data"
+                errorMessage = hasAnyEntries ? nil : "You're offline. Pull to retry."
             case .slowConnection:
-                errorMessage = "Connection is slow - showing cached data"
+                errorMessage = "Latest changes may take a moment to appear."
             case .other:
                 errorMessage = "Couldn’t load leaderboard previews right now."
             }
@@ -201,9 +253,9 @@ struct LeaderboardHubView: View {
         } else if let syncError {
             switch LeaderboardNetworkIssue.classify(syncError) {
             case .offline:
-                errorMessage = "Latest changes haven’t synced yet."
+                errorMessage = nil
             case .slowConnection:
-                errorMessage = "Connection is slow. Latest changes may take a moment to appear."
+                errorMessage = "Latest changes may take a moment to appear."
             case .other:
                 errorMessage = hasAnyEntries
                     ? "Latest changes haven’t synced yet."
@@ -233,6 +285,11 @@ struct LeaderboardHubView: View {
         }
     }
 
+    private func currentUserLocalStats(for userId: String) -> LeaderboardStats? {
+        LeaderboardService.shared.configure(modelContext: modelContext)
+        return try? LeaderboardService.shared.getLocalStats(for: userId, timeFrame: selectedTimeFrame)
+    }
+
     private func formatValue(_ value: Double, for metric: LeaderboardMetric) -> String {
         switch metric {
         case .climb, .workouts:
@@ -250,7 +307,7 @@ struct LeaderboardHubView: View {
         }
     }
 
-    private let hubTimeFrames: [LeaderboardTimeFrame] = [.weekly, .monthly, .allTime]
+    private let hubTimeFrames: [LeaderboardTimeFrame] = [.weekly, .monthly, .yearly, .allTime]
 
     private var hubHeader: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -559,6 +616,7 @@ private extension View {
     NavigationStack {
         LeaderboardHubView()
             .environment(AuthenticationViewModel())
+            .environment(NetworkConnectivityService.shared)
             .environment(TabRouter())
     }
 }

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardPickerView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardPickerView.swift
@@ -30,6 +30,8 @@ struct LeaderboardPickerView: View {
                 } label: {
                     Text(timeFrame.displayName)
                         .font(.montserratMedium(size: 14))
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                         .foregroundStyle(
                             isSelected
                                 ? .accent
@@ -74,7 +76,7 @@ struct LeaderboardPickerView: View {
 #Preview {
     LeaderboardPickerView(
         selectedTimeFrame: .constant(.weekly),
-        timeFrames: [.weekly, .monthly, .allTime]
+        timeFrames: [.weekly, .monthly, .yearly, .allTime]
     )
     .padding()
     .themedBackground()

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
@@ -13,6 +13,7 @@ struct LeaderboardView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(AuthenticationViewModel.self) private var authVM
     @Environment(\.modelContext) private var modelContext
+    @Environment(NetworkConnectivityService.self) private var connectivityService
 
     @State private var viewModel: LeaderboardViewModel
     @State private var scrollResetTrigger = 0
@@ -51,7 +52,7 @@ struct LeaderboardView: View {
     }
 
     private var lockedTimeFrames: [LeaderboardTimeFrame] {
-        [.weekly, .monthly, .allTime]
+        [.weekly, .monthly, .yearly, .allTime]
     }
 
     private var isLockedMetricView: Bool {
@@ -86,11 +87,11 @@ struct LeaderboardView: View {
                                 .frame(height: 0)
                                 .id(ScrollTarget.top)
 
-                            if viewModel.isOffline && viewModel.hasCachedEntries {
-                                offlineBanner
-                                    .padding(.bottom, isLockedMetricView ? 12 : 0)
-                            } else if let error = viewModel.errorMessage, viewModel.hasCachedEntries {
-                                errorBanner(error)
+                            if let error = viewModel.errorMessage, viewModel.hasCachedEntries {
+                                StatusBannerView(
+                                    message: error,
+                                    style: .warning
+                                )
                                     .padding(.bottom, isLockedMetricView ? 12 : 0)
                             }
 
@@ -495,44 +496,6 @@ struct LeaderboardView: View {
         .padding(.vertical, 40)
     }
 
-    private var offlineBanner: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "wifi.slash")
-                .foregroundStyle(.orange)
-
-            Text("Offline - showing cached data")
-                .font(.montserratRegular(size: 13))
-                .foregroundStyle(colorScheme == .dark ? .white : .black)
-                .multilineTextAlignment(.leading)
-        }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(colorScheme == .dark ? Color.orange.opacity(0.15) : Color.orange.opacity(0.1))
-        )
-        .padding(.horizontal, 20)
-    }
-
-    private func errorBanner(_ message: String) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.red)
-
-            Text(message)
-                .font(.montserratRegular(size: 13))
-                .foregroundStyle(colorScheme == .dark ? .white : .black)
-                .multilineTextAlignment(.leading)
-        }
-        .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(colorScheme == .dark ? Color.red.opacity(0.2) : Color.red.opacity(0.1))
-        )
-        .padding(.horizontal, 20)
-    }
-
     private var emptyStateView: some View {
         VStack(spacing: 12) {
             Image(systemName: "person.3.fill")
@@ -587,7 +550,10 @@ struct LeaderboardView: View {
 
     private func loadData() async {
         guard let userId = authVM.user?.uid else { return }
-        await viewModel.loadLeaderboard(userId: userId)
+        await viewModel.loadLeaderboard(
+            userId: userId,
+            isNetworkConnected: connectivityService.isConnected
+        )
     }
 
     private func refreshData() async {
@@ -595,7 +561,8 @@ struct LeaderboardView: View {
         await viewModel.refreshLeaderboard(
             userId: userId,
             displayName: authVM.displayName,
-            photoURL: authVM.displayPhotoURL
+            photoURL: authVM.displayPhotoURL,
+            isNetworkConnected: connectivityService.isConnected
         )
     }
 
@@ -616,6 +583,7 @@ struct LeaderboardView: View {
     NavigationStack {
         LeaderboardView()
             .environment(AuthenticationViewModel())
+            .environment(NetworkConnectivityService.shared)
             .environment(TabRouter())
     }
     .modelContainer(for: [Workout.self, WorkoutSourceLink.self], inMemory: true)

--- a/AscendApp/Features/Workouts/Models/WorkoutInputValidation.swift
+++ b/AscendApp/Features/Workouts/Models/WorkoutInputValidation.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+enum WorkoutInputValidation {
+    static let nameMaxLength = 120
+    static let notesMaxLength = 5_000
+    static let minimumHeartRate = 25
+    static let maximumHeartRate = 230
+
+    static func isValidOptionalMetric(_ value: String) -> Bool {
+        guard value.isEmpty == false else { return true }
+        guard let intValue = Int(value) else { return false }
+        return intValue >= 0
+    }
+
+    static func isValidWorkoutName(_ value: String) -> Bool {
+        value.isEmpty || value.count <= nameMaxLength
+    }
+
+    static func isValidNotes(_ value: String) -> Bool {
+        value.count <= notesMaxLength
+    }
+
+    static func isValidOptionalHeartRate(_ value: String) -> Bool {
+        guard value.isEmpty == false else { return true }
+        guard let intValue = Int(value) else { return false }
+        return intValue >= minimumHeartRate && intValue <= maximumHeartRate
+    }
+
+    static func isValidOptionalCalories(_ value: String) -> Bool {
+        guard value.isEmpty == false else { return true }
+        guard let intValue = Int(value) else { return false }
+        return intValue >= 0
+    }
+
+    static func filterNumericInput(_ input: String) -> String {
+        input.filter(\.isNumber)
+    }
+
+    static func normalizeHeartRateOnSubmit(_ value: String) -> String {
+        let digits = filterNumericInput(value)
+        guard digits.isEmpty == false else { return "" }
+        guard let intValue = Int(digits) else { return value }
+
+        if intValue < minimumHeartRate {
+            return String(minimumHeartRate)
+        }
+
+        if intValue > maximumHeartRate {
+            return String(maximumHeartRate)
+        }
+
+        return String(intValue)
+    }
+
+    static func normalizeCaloriesOnSubmit(_ value: String) -> String {
+        let digits = filterNumericInput(value)
+        guard digits.isEmpty == false else { return "" }
+        guard let intValue = Int(digits) else { return value }
+        return String(max(intValue, 0))
+    }
+}

--- a/AscendApp/Features/Workouts/Services/SelectedMediaPreparationService.swift
+++ b/AscendApp/Features/Workouts/Services/SelectedMediaPreparationService.swift
@@ -1,0 +1,193 @@
+//
+//  SelectedMediaPreparationService.swift
+//  AscendApp
+//
+//  Created by Codex on 4/13/26.
+//
+
+import AVFoundation
+import Foundation
+import PhotosUI
+import SwiftUI
+
+enum SelectedMediaPreparationService {
+    static let maximumMediaCount = 3
+    static let maximumVideoCount = 1
+    static let maximumVideoDuration: TimeInterval = 15
+
+    struct PreparationOutcome {
+        let items: [SelectedPhotoItem]
+        let alertMessage: String?
+        let wasCancelled: Bool
+    }
+
+    static func validationMessage(
+        forAdditionalMediaCount additionalMediaCount: Int,
+        additionalVideoCount: Int,
+        currentMediaCount: Int,
+        currentVideoCount: Int
+    ) -> String? {
+        let potentialTotal = currentMediaCount + additionalMediaCount
+        if potentialTotal > maximumMediaCount {
+            return "Only 3 combined photos and videos (max 1 video) can be added to a given workout."
+        }
+
+        if currentVideoCount + additionalVideoCount > maximumVideoCount {
+            return "You can only add one video with a max length of 15 seconds."
+        }
+
+        return nil
+    }
+
+    static func prepareItems(
+        _ newItems: [PhotosPickerItem],
+        currentMediaCount: Int,
+        currentVideoCount: Int
+    ) async -> PreparationOutcome {
+        if let validationMessage = validationMessage(
+            forAdditionalMediaCount: newItems.count,
+            additionalVideoCount: additionalVideoCount(in: newItems),
+            currentMediaCount: currentMediaCount,
+            currentVideoCount: currentVideoCount
+        ) {
+            return PreparationOutcome(items: [], alertMessage: validationMessage, wasCancelled: false)
+        }
+
+        let newSelectedImages = await withTaskGroup(of: SelectedPhotoItem?.self) { group in
+            for item in newItems {
+                group.addTask {
+                    await createSelectedPhotoItem(from: item)
+                }
+            }
+
+            var results: [SelectedPhotoItem] = []
+            for await result in group {
+                if let item = result {
+                    results.append(item)
+                }
+            }
+            return results
+        }
+
+        if Task.isCancelled {
+            cleanupTemporaryVideoFiles(in: newSelectedImages)
+            return PreparationOutcome(items: [], alertMessage: nil, wasCancelled: true)
+        }
+
+        var validItems: [SelectedPhotoItem] = []
+        var hasInvalidVideo = false
+
+        for item in newSelectedImages {
+            if item.isVideo {
+                guard let duration = item.duration, duration <= maximumVideoDuration else {
+                    hasInvalidVideo = true
+                    cleanupTemporaryVideoFile(at: item.videoURL)
+                    continue
+                }
+            }
+
+            validItems.append(item)
+        }
+
+        if Task.isCancelled {
+            cleanupTemporaryVideoFiles(in: validItems)
+            return PreparationOutcome(items: [], alertMessage: nil, wasCancelled: true)
+        }
+
+        let alertMessage = hasInvalidVideo ? "Video must be 15 seconds or less." : nil
+        return PreparationOutcome(items: validItems, alertMessage: alertMessage, wasCancelled: false)
+    }
+
+    static func cleanupTemporaryVideoFiles(in items: [SelectedPhotoItem]) {
+        for item in items {
+            cleanupTemporaryVideoFile(at: item.videoURL)
+        }
+    }
+
+    static func cleanupTemporaryVideoFile(at url: URL?) {
+        guard let url else { return }
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private static func additionalVideoCount(in items: [PhotosPickerItem]) -> Int {
+        var newVideoCount = 0
+        for item in items {
+            if let contentType = item.supportedContentTypes.first?.identifier,
+               contentType.contains("video") || contentType.contains("movie") {
+                newVideoCount += 1
+            }
+        }
+        return newVideoCount
+    }
+
+    private static func createSelectedPhotoItem(from item: PhotosPickerItem) async -> SelectedPhotoItem? {
+        if let contentType = item.supportedContentTypes.first?.identifier,
+           contentType.contains("video") || contentType.contains("movie") {
+            return await createVideoItem(from: item)
+        } else {
+            return await createPhotoItem(from: item)
+        }
+    }
+
+    private static func createPhotoItem(from item: PhotosPickerItem) async -> SelectedPhotoItem? {
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self),
+                  let uiImage = UIImage(data: data) else {
+                return nil
+            }
+
+            try Task.checkCancellation()
+
+            return SelectedPhotoItem(
+                pickerItem: item,
+                image: Image(uiImage: uiImage),
+                localIdentifier: item.itemIdentifier ?? UUID().uuidString,
+                isVideo: false,
+                duration: nil
+            )
+        } catch {
+            return nil
+        }
+    }
+
+    private static func createVideoItem(from item: PhotosPickerItem) async -> SelectedPhotoItem? {
+        guard let movie = try? await item.loadTransferable(type: VideoPickerTransferable.self) else {
+            return nil
+        }
+
+        do {
+            try Task.checkCancellation()
+
+            let asset = AVURLAsset(url: movie.url)
+            let loadedDuration = try await asset.load(.duration)
+            let duration = loadedDuration.seconds
+            guard duration.isFinite else {
+                cleanupTemporaryVideoFile(at: movie.url)
+                return nil
+            }
+
+            try Task.checkCancellation()
+
+            let imageGenerator = AVAssetImageGenerator(asset: asset)
+            imageGenerator.appliesPreferredTrackTransform = true
+
+            let cgImage = try await imageGenerator.image(at: .zero).image
+
+            try Task.checkCancellation()
+
+            let uiImage = UIImage(cgImage: cgImage)
+
+            return SelectedPhotoItem(
+                pickerItem: item,
+                image: Image(uiImage: uiImage),
+                localIdentifier: item.itemIdentifier ?? UUID().uuidString,
+                isVideo: true,
+                duration: duration,
+                videoURL: movie.url
+            )
+        } catch {
+            cleanupTemporaryVideoFile(at: movie.url)
+            return nil
+        }
+    }
+}

--- a/AscendApp/Features/Workouts/ViewModels/WorkoutFormViewModel.swift
+++ b/AscendApp/Features/Workouts/ViewModels/WorkoutFormViewModel.swift
@@ -100,12 +100,14 @@ class WorkoutFormViewModel {
     // MARK: - Computed Properties
     var isFormValid: Bool {
         // Steps/floors is optional - only validate if provided
-        let metricValid = metricValue.isEmpty || Int(metricValue) != nil
+        let metricValid = WorkoutInputValidation.isValidOptionalMetric(metricValue)
 
         // Workout name is optional - will use default if empty
-        let nameValid = workoutName.isEmpty || workoutName.count <= 50
+        let nameValid = WorkoutInputValidation.isValidWorkoutName(workoutName)
+        let notesValid = WorkoutInputValidation.isValidNotes(notes)
 
         let basicValidation = nameValid &&
+        notesValid &&
         !durationMinutes.isEmpty &&
         !durationSeconds.isEmpty &&
         metricValid &&
@@ -123,9 +125,9 @@ class WorkoutFormViewModel {
         let durationValid = totalDurationSeconds > 0
 
         // Validate health metrics if provided
-        let avgHRValid = avgHeartRate.isEmpty || (Int(avgHeartRate) != nil && (Int(avgHeartRate) ?? 0) >= 25 && (Int(avgHeartRate) ?? 0) <= 230)
-        let maxHRValid = maxHeartRate.isEmpty || (Int(maxHeartRate) != nil && (Int(maxHeartRate) ?? 0) >= 25 && (Int(maxHeartRate) ?? 0) <= 230)
-        let caloriesValid = caloriesBurned.isEmpty || (Int(caloriesBurned) != nil && (Int(caloriesBurned) ?? 0) >= 0)
+        let avgHRValid = WorkoutInputValidation.isValidOptionalHeartRate(avgHeartRate)
+        let maxHRValid = WorkoutInputValidation.isValidOptionalHeartRate(maxHeartRate)
+        let caloriesValid = WorkoutInputValidation.isValidOptionalCalories(caloriesBurned)
 
         return basicValidation && durationValid && avgHRValid && maxHRValid && caloriesValid && !isUploading
     }
@@ -153,7 +155,8 @@ class WorkoutFormViewModel {
             try WorkoutMutationHandler.shared.workoutsDidChange(
                 modelContext: modelContext,
                 mutation: .created([LeaderboardWorkoutSnapshot(workout: workout)]),
-                newWorkouts: [workout]
+                newWorkouts: [workout],
+                changedWorkouts: [workout]
             )
 
             // Queue media uploads asynchronously (fire-and-forget)
@@ -190,11 +193,7 @@ class WorkoutFormViewModel {
     
     /// Clean up temporary video files
     func cleanupVideoFiles() {
-        for item in selectedImages {
-            if let videoURL = item.videoURL {
-                try? FileManager.default.removeItem(at: videoURL)
-            }
-        }
+        SelectedMediaPreparationService.cleanupTemporaryVideoFiles(in: selectedImages)
     }
 
     private func queueMediaUploadsInBackground(
@@ -310,30 +309,15 @@ class WorkoutFormViewModel {
     }
 
     func validateHeartRateOnSubmit(_ value: String) -> String {
-        let digits = value.filter { $0.isNumber }
-        if digits.isEmpty { return "" }
-
-        guard let intValue = Int(digits) else { return value }
-
-        if intValue < 25 {
-            return "25"
-        } else if intValue > 230 {
-            return "230"
-        } else {
-            return String(intValue)
-        }
+        WorkoutInputValidation.normalizeHeartRateOnSubmit(value)
     }
 
     func validateCaloriesOnSubmit(_ value: String) -> String {
-        let digits = value.filter { $0.isNumber }
-        if digits.isEmpty { return "" }
-
-        guard let intValue = Int(digits) else { return value }
-        return intValue < 0 ? "0" : String(intValue)
+        WorkoutInputValidation.normalizeCaloriesOnSubmit(value)
     }
 
     func filterNumericInput(_ input: String) -> String {
-        return input.filter { $0.isNumber }
+        WorkoutInputValidation.filterNumericInput(input)
     }
 
     func formatWorkoutDateTime() -> String {

--- a/AscendApp/Features/Workouts/Views/Components/DurationPickerSheet.swift
+++ b/AscendApp/Features/Workouts/Views/Components/DurationPickerSheet.swift
@@ -29,7 +29,13 @@ struct DurationPickerSheet: View {
             Button {
                 onDone()
             } label: {
-                Text("Done")
+                HStack {
+                    Spacer()
+                    Text("Done")
+                    Spacer()
+                }
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
             }
             .appSheetButtonStyle(tone: .primary)
         }

--- a/AscendApp/Features/Workouts/Views/Components/WorkoutDetailHeroView.swift
+++ b/AscendApp/Features/Workouts/Views/Components/WorkoutDetailHeroView.swift
@@ -84,6 +84,8 @@ private struct HeroMediaItem: View {
     let geometry: GeometryProxy
     let onTap: () -> Void
 
+    @Environment(NetworkConnectivityService.self) private var connectivityService
+
     @State private var loadedImage: UIImage?
     @State private var isLoading = true
     @State private var player: AVPlayer?
@@ -106,6 +108,10 @@ private struct HeroMediaItem: View {
         }
         .task(id: photo.id) {
             await loadMedia()
+        }
+        .onChange(of: connectivityService.isConnected) { oldValue, newValue in
+            guard oldValue == false, newValue == true else { return }
+            retryFailedLoadIfNeeded()
         }
         .onChange(of: isVisible) { _, visible in
             updatePlayback(isVisible: visible)
@@ -236,5 +242,20 @@ private struct HeroMediaItem: View {
     private func toggleMute() {
         isMuted.toggle()
         player?.isMuted = isMuted
+    }
+
+    private func retryFailedLoadIfNeeded() {
+        guard isLoading == false else { return }
+
+        if photo.isVideo {
+            guard player == nil else { return }
+        } else {
+            guard loadedImage == nil else { return }
+        }
+
+        isLoading = true
+        Task {
+            await loadMedia()
+        }
     }
 }

--- a/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
+++ b/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
@@ -82,12 +82,14 @@ struct EditWorkoutView: View {
     
     private var isFormValid: Bool {
         // Steps/floors is optional - only validate if provided
-        let metricValid = metricValue.isEmpty || Int(metricValue) != nil
+        let metricValid = WorkoutInputValidation.isValidOptionalMetric(metricValue)
 
         // Workout name is optional - will use default if empty
-        let nameValid = workoutName.isEmpty || workoutName.count <= 50
+        let nameValid = WorkoutInputValidation.isValidWorkoutName(workoutName)
+        let notesValid = WorkoutInputValidation.isValidNotes(notes)
 
         let basicValidation = nameValid &&
+        notesValid &&
         !durationMinutes.isEmpty &&
         !durationSeconds.isEmpty &&
         metricValid &&
@@ -105,9 +107,9 @@ struct EditWorkoutView: View {
         let durationValid = totalDurationSeconds > 0
         
         // Validate health metrics if provided
-        let avgHRValid = avgHeartRate.isEmpty || (Int(avgHeartRate) != nil && (Int(avgHeartRate) ?? 0) >= 25 && (Int(avgHeartRate) ?? 0) <= 230)
-        let maxHRValid = maxHeartRate.isEmpty || (Int(maxHeartRate) != nil && (Int(maxHeartRate) ?? 0) >= 25 && (Int(maxHeartRate) ?? 0) <= 230)
-        let caloriesValid = caloriesBurned.isEmpty || (Int(caloriesBurned) != nil && (Int(caloriesBurned) ?? 0) >= 0)
+        let avgHRValid = WorkoutInputValidation.isValidOptionalHeartRate(avgHeartRate)
+        let maxHRValid = WorkoutInputValidation.isValidOptionalHeartRate(maxHeartRate)
+        let caloriesValid = WorkoutInputValidation.isValidOptionalCalories(caloriesBurned)
         
         return basicValidation && durationValid && avgHRValid && maxHRValid && caloriesValid && !isSaving
     }
@@ -269,7 +271,7 @@ struct EditWorkoutView: View {
                                     fieldIdentifier: WorkoutFormField.avgHeartRate
                                 )
                                 .onChange(of: avgHeartRate) { _, newValue in
-                                    avgHeartRate = filterNumericInput(newValue)
+                                    avgHeartRate = WorkoutInputValidation.filterNumericInput(newValue)
                                 }
 
                                 // Maximum Heart Rate
@@ -282,7 +284,7 @@ struct EditWorkoutView: View {
                                     fieldIdentifier: WorkoutFormField.maxHeartRate
                                 )
                                 .onChange(of: maxHeartRate) { _, newValue in
-                                    maxHeartRate = filterNumericInput(newValue)
+                                    maxHeartRate = WorkoutInputValidation.filterNumericInput(newValue)
                                 }
 
                                 // Calories Burned
@@ -295,7 +297,7 @@ struct EditWorkoutView: View {
                                     fieldIdentifier: WorkoutFormField.caloriesBurned
                                 )
                                 .onChange(of: caloriesBurned) { _, newValue in
-                                    caloriesBurned = filterNumericInput(newValue)
+                                    caloriesBurned = WorkoutInputValidation.filterNumericInput(newValue)
                                 }
                             }
                         }
@@ -317,11 +319,11 @@ struct EditWorkoutView: View {
             .onChange(of: focusedField) { oldFocus, newFocus in
                 // Validate fields when focus changes
                 if oldFocus == .avgHeartRate {
-                    validateHeartRateOnSubmit($avgHeartRate)
+                    avgHeartRate = WorkoutInputValidation.normalizeHeartRateOnSubmit(avgHeartRate)
                 } else if oldFocus == .maxHeartRate {
-                    validateHeartRateOnSubmit($maxHeartRate)
+                    maxHeartRate = WorkoutInputValidation.normalizeHeartRateOnSubmit(maxHeartRate)
                 } else if oldFocus == .caloriesBurned {
-                    validateCaloriesOnSubmit()
+                    caloriesBurned = WorkoutInputValidation.normalizeCaloriesOnSubmit(caloriesBurned)
                 }
             }
             .scrollDismissesKeyboard(.interactively)
@@ -336,7 +338,7 @@ struct EditWorkoutView: View {
                 text: $workoutName,
                 focusedField: $focusedField,
                 fieldIdentifier: WorkoutFormField.workoutName,
-                maxLength: 50
+                maxLength: WorkoutInputValidation.nameMaxLength
             )
 
             // Description
@@ -346,7 +348,8 @@ struct EditWorkoutView: View {
                 placeholder: "Add a description for your workout",
                 text: $notes,
                 focusedField: $focusedField,
-                fieldIdentifier: WorkoutFormField.notes
+                fieldIdentifier: WorkoutFormField.notes,
+                maxLength: WorkoutInputValidation.notesMaxLength
             )
             
             if existingPhotos.isEmpty {
@@ -394,7 +397,7 @@ struct EditWorkoutView: View {
                         fieldIdentifier: WorkoutFormField.metricValue
                     )
                     .onChange(of: metricValue) { _, newValue in
-                        metricValue = filterNumericInput(newValue)
+                        metricValue = WorkoutInputValidation.filterNumericInput(newValue)
                     }
 
                     // Effort Rating
@@ -625,39 +628,6 @@ struct EditWorkoutView: View {
         }
     }
     
-    private func validateHeartRateOnSubmit(_ field: Binding<String>) {
-        let digits = field.wrappedValue.filter { $0.isNumber }
-        if digits.isEmpty { 
-            field.wrappedValue = ""
-            return 
-        }
-        
-        guard let value = Int(digits) else { return }
-        
-        if value < 25 { 
-            field.wrappedValue = "25" 
-        } else if value > 230 { 
-            field.wrappedValue = "230" 
-        } else {
-            field.wrappedValue = String(value)
-        }
-    }
-    
-    private func validateCaloriesOnSubmit() {
-        let digits = caloriesBurned.filter { $0.isNumber }
-        if digits.isEmpty { 
-            caloriesBurned = ""
-            return 
-        }
-        
-        guard let value = Int(digits) else { return }
-        caloriesBurned = value < 0 ? "0" : String(value)
-    }
-    
-    private func filterNumericInput(_ input: String) -> String {
-        return input.filter { $0.isNumber }
-    }
-    
     private func effortRatingDisplayText() -> String {
         guard let rating = effortRating else {
             return "Add effort rating (optional)"
@@ -788,7 +758,8 @@ struct EditWorkoutView: View {
                 mutation: .updated(
                     before: leaderboardSnapshotBeforeEdit,
                     after: LeaderboardWorkoutSnapshot(workout: workout)
-                )
+                ),
+                changedWorkouts: [workout]
             )
             
             let photosToDelete = photosMarkedForDeletion
@@ -831,11 +802,7 @@ struct EditWorkoutView: View {
     }
     
     private func cleanupVideoFiles() {
-        for item in selectedImages {
-            if let videoURL = item.videoURL {
-                try? FileManager.default.removeItem(at: videoURL)
-            }
-        }
+        SelectedMediaPreparationService.cleanupTemporaryVideoFiles(in: selectedImages)
     }
     
     private func ensureHighlightSelectionIsValid() {

--- a/AscendApp/Features/Workouts/Views/PhotoGalleryView.swift
+++ b/AscendApp/Features/Workouts/Views/PhotoGalleryView.swift
@@ -5,10 +5,8 @@
 //  Created by Tyler Pavay on 9/20/25.
 //
 
-
 import SwiftUI
 import PhotosUI
-import AVFoundation
 
 struct PhotoGalleryView: View {
     @Binding private var selectedImages: [SelectedPhotoItem]
@@ -23,6 +21,8 @@ struct PhotoGalleryView: View {
     @State private var showErrorAlert = false
     @State private var errorMessage = ""
     @State private var isLoadingMedia = false // Loading state for media processing
+    @State private var mediaProcessingTask: Task<Void, Never>?
+    @State private var activeProcessingToken = UUID()
     
     init(
         selectedImages: Binding<[SelectedPhotoItem]>,
@@ -88,10 +88,11 @@ struct PhotoGalleryView: View {
                 .scrollTargetBehavior(.paging)
             }
         }
-        .onChange(of: selectedPhotos) {
-            Task {
-                await processNewPhotos(selectedPhotos)
-            }
+        .onChange(of: selectedPhotos) { _, newItems in
+            beginProcessing(newItems)
+        }
+        .onDisappear {
+            cancelMediaProcessing()
         }
         .sheet(item: $itemForActionSheet) { item in
             SelectedPhotoActionSheet(
@@ -168,140 +169,65 @@ struct PhotoGalleryView: View {
 
 extension PhotoGalleryView {
     @MainActor
-    private func processNewPhotos(_ newItems: [PhotosPickerItem]) async {
-        // Set loading state
+    private func beginProcessing(_ newItems: [PhotosPickerItem]) {
+        mediaProcessingTask?.cancel()
+
+        guard !newItems.isEmpty else {
+            activeProcessingToken = UUID()
+            mediaProcessingTask = nil
+            isLoadingMedia = false
+            return
+        }
+
+        let token = UUID()
+        activeProcessingToken = token
         isLoadingMedia = true
-        
-        // Validate total media count first
-        let potentialTotal = totalMediaCount + newItems.count
-        if potentialTotal > 3 {
-            errorMessage = "Only 3 combined photos and videos (max 1 video) can be added to a given workout."
-            showErrorAlert = true
-            selectedPhotos.removeAll()
-            isLoadingMedia = false
-            return
-        }
-        
-        // Count videos in new items
-        var newVideoCount = 0
-        for item in newItems {
-            if let contentType = item.supportedContentTypes.first?.identifier,
-               contentType.contains("video") || contentType.contains("movie") {
-                newVideoCount += 1
-            }
-        }
-        
-        // Check video limit (including existing videos)
-        if totalVideoCount + newVideoCount > 1 {
-            errorMessage = "You can only add one video with a max length of 15 seconds."
-            showErrorAlert = true
-            selectedPhotos.removeAll()
-            isLoadingMedia = false
-            return
-        }
-        
-        // Process photos/videos on background, update UI on main
-        let newSelectedImages = await withTaskGroup(of: SelectedPhotoItem?.self) { group in
-            for item in newItems {
-                group.addTask {
-                    await createSelectedPhotoItem(from: item)
-                }
+
+        mediaProcessingTask = Task {
+            defer {
+                finishProcessing(token)
             }
 
-            var results: [SelectedPhotoItem] = []
-            for await result in group {
-                if let item = result {
-                    results.append(item)
-                }
+            let preparationOutcome = await SelectedMediaPreparationService.prepareItems(
+                newItems,
+                currentMediaCount: totalMediaCount,
+                currentVideoCount: totalVideoCount
+            )
+
+            guard activeProcessingToken == token else {
+                SelectedMediaPreparationService.cleanupTemporaryVideoFiles(in: preparationOutcome.items)
+                return
             }
-            return results
-        }
 
-        // Check if any videos exceed 15 seconds or have unknown duration
-        var validItems: [SelectedPhotoItem] = []
-        var hasInvalidVideo = false
-
-        for item in newSelectedImages {
-            if item.isVideo {
-                // Reject if duration is unknown (nil) or exceeds 15 seconds
-                guard let duration = item.duration, duration <= 15 else {
-                    hasInvalidVideo = true
-                    // Clean up the temporary file
-                    if let videoURL = item.videoURL {
-                        try? FileManager.default.removeItem(at: videoURL)
-                    }
-                    continue
-                }
+            if let alertMessage = preparationOutcome.alertMessage {
+                errorMessage = alertMessage
+                showErrorAlert = true
             }
-            validItems.append(item)
+
+            guard preparationOutcome.wasCancelled == false else {
+                return
+            }
+
+            selectedImages.append(contentsOf: preparationOutcome.items)
         }
+    }
 
-        // Show error if any video was invalid
-        if hasInvalidVideo {
-            errorMessage = "Video must be 15 seconds or less."
-            showErrorAlert = true
-        }
-
-        // Add valid items
-        selectedImages.append(contentsOf: validItems)
-
-        // Clear loading state
-        isLoadingMedia = false
+    @MainActor
+    private func cancelMediaProcessing() {
+        activeProcessingToken = UUID()
+        mediaProcessingTask?.cancel()
+        mediaProcessingTask = nil
         selectedPhotos.removeAll()
+        isLoadingMedia = false
     }
 
-    private func createSelectedPhotoItem(from item: PhotosPickerItem) async -> SelectedPhotoItem? {
-        // Check if it's a video
-        if let contentType = item.supportedContentTypes.first?.identifier,
-           contentType.contains("video") || contentType.contains("movie") {
-            return await createVideoItem(from: item)
-        } else {
-            return await createPhotoItem(from: item)
-        }
-    }
-    
-    private func createPhotoItem(from item: PhotosPickerItem) async -> SelectedPhotoItem? {
-        guard let data = try? await item.loadTransferable(type: Data.self),
-              let uiImage = UIImage(data: data) else {
-            return nil
-        }
+    @MainActor
+    private func finishProcessing(_ token: UUID) {
+        guard activeProcessingToken == token else { return }
 
-        return SelectedPhotoItem(
-            pickerItem: item,
-            image: Image(uiImage: uiImage),
-            localIdentifier: item.itemIdentifier ?? UUID().uuidString,
-            isVideo: false,
-            duration: nil
-        )
-    }
-    
-    private func createVideoItem(from item: PhotosPickerItem) async -> SelectedPhotoItem? {
-        guard let movie = try? await item.loadTransferable(type: VideoPickerTransferable.self) else {
-            return nil
-        }
-        
-        let asset = AVURLAsset(url: movie.url)
-        let duration = try? await asset.load(.duration).seconds
-        
-        // Generate thumbnail
-        let imageGenerator = AVAssetImageGenerator(asset: asset)
-        imageGenerator.appliesPreferredTrackTransform = true
-        
-        guard let cgImage = try? await imageGenerator.image(at: .zero).image,
-              let duration = duration else {
-            return nil
-        }
-        
-        let uiImage = UIImage(cgImage: cgImage)
-        
-        return SelectedPhotoItem(
-            pickerItem: item,
-            image: Image(uiImage: uiImage),
-            localIdentifier: item.itemIdentifier ?? UUID().uuidString,
-            isVideo: true,
-            duration: duration,
-            videoURL: movie.url
-        )
+        mediaProcessingTask = nil
+        selectedPhotos.removeAll()
+        isLoadingMedia = false
     }
 
     private func deletePhoto(_ item: SelectedPhotoItem) {
@@ -311,10 +237,7 @@ extension PhotoGalleryView {
             highlightedSelectedItemId = nil
         }
 
-        // Clean up video temporary file if it exists
-        if let videoURL = item.videoURL {
-            try? FileManager.default.removeItem(at: videoURL)
-        }
+        SelectedMediaPreparationService.cleanupTemporaryVideoFile(at: item.videoURL)
 
         photoToDelete = nil
     }

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -836,14 +836,47 @@ struct WorkoutDetailView: View {
             }
         }
 
+        let remoteSyncUserId = workout.ownerUserId ?? authVM.user?.uid
+        let didQueueRemoteDeletion: Bool
+
+        do {
+            didQueueRemoteDeletion = try WorkoutSyncCoordinator.shared.enqueuePendingDeletions(
+                for: [workout],
+                fallbackUserId: authVM.user?.uid,
+                modelContext: modelContext
+            )
+        } catch {
+            print("❌ Error queueing remote workout deletion: \(error)")
+            await MainActor.run {
+                isDeleting = false
+                showingDeleteConfirmation = false
+                deleteErrorMessage = "Failed to prepare workout deletion. Please try again."
+                showingDeleteError = true
+                HapticsManager.shared.trigger(.error)
+            }
+            return
+        }
+
+        var shouldProcessRemoteDeletion = false
+
         modelContext.delete(workout)
         do {
             let deletedSnapshot = LeaderboardWorkoutSnapshot(workout: workout)
             try modelContext.save()
+            shouldProcessRemoteDeletion = didQueueRemoteDeletion
             try WorkoutMutationHandler.shared.workoutsDidChange(
                 modelContext: modelContext,
                 mutation: .deleted([deletedSnapshot])
             )
+
+            if shouldProcessRemoteDeletion, let remoteSyncUserId {
+                Task { @MainActor in
+                    await WorkoutSyncCoordinator.shared.processPendingWorkouts(
+                        modelContext: modelContext,
+                        currentUserId: remoteSyncUserId
+                    )
+                }
+            }
 
             await MainActor.run {
                 isDeleting = false
@@ -853,6 +886,16 @@ struct WorkoutDetailView: View {
             }
         } catch {
             print("❌ Error deleting workout: \(error)")
+
+            if shouldProcessRemoteDeletion, let remoteSyncUserId {
+                Task { @MainActor in
+                    await WorkoutSyncCoordinator.shared.processPendingWorkouts(
+                        modelContext: modelContext,
+                        currentUserId: remoteSyncUserId
+                    )
+                }
+            }
+
             await MainActor.run {
                 isDeleting = false
                 showingDeleteConfirmation = false

--- a/AscendApp/Features/Workouts/Views/WorkoutFormView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutFormView.swift
@@ -125,7 +125,7 @@ struct WorkoutFormView: View {
                 text: $viewModel.workoutName,
                 focusedField: $focusedField,
                 fieldIdentifier: WorkoutFormField.workoutName,
-                maxLength: 50
+                maxLength: WorkoutInputValidation.nameMaxLength
             )
 
             // Description
@@ -135,7 +135,8 @@ struct WorkoutFormView: View {
                 placeholder: "Add a description for your workout",
                 text: $viewModel.notes,
                 focusedField: $focusedField,
-                fieldIdentifier: WorkoutFormField.notes
+                fieldIdentifier: WorkoutFormField.notes,
+                maxLength: WorkoutInputValidation.notesMaxLength
             )
 
             PhotoGalleryView(

--- a/AscendApp/Features/Workouts/Views/WorkoutListView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutListView.swift
@@ -277,6 +277,16 @@ struct WorkoutListView: View {
         }
 
         let workoutsToDelete = workouts.filter { selectedWorkouts.contains($0.id) }
+        let remoteSyncUserId = workoutsToDelete.lazy.compactMap { workout in
+            workout.ownerUserId ?? authVM.user?.uid
+        }.first
+
+        for workout in workoutsToDelete {
+            await MediaUploadManager.shared.cancelUploads(
+                for: workout.id,
+                modelContext: modelContext
+            )
+        }
 
         // Delete photos from Firebase first - ALL must succeed
         let photoService = PhotoService()
@@ -316,18 +326,34 @@ struct WorkoutListView: View {
         }
 
         // Only delete workouts if ALL photo deletions succeeded
+        var shouldProcessRemoteDeletion = false
         do {
+            let didQueueRemoteDeletion = try WorkoutSyncCoordinator.shared.enqueuePendingDeletions(
+                for: workoutsToDelete,
+                fallbackUserId: authVM.user?.uid,
+                modelContext: modelContext
+            )
             let deletedSnapshots = workoutsToDelete.map(LeaderboardWorkoutSnapshot.init(workout:))
             for workout in workoutsToDelete {
                 modelContext.delete(workout)
             }
             try modelContext.save()
+            shouldProcessRemoteDeletion = didQueueRemoteDeletion
 
             // Recalculate PRs and leaderboard stats after deletion
             try WorkoutMutationHandler.shared.workoutsDidChange(
                 modelContext: modelContext,
                 mutation: .deleted(deletedSnapshots)
             )
+
+            if shouldProcessRemoteDeletion, let remoteSyncUserId {
+                Task { @MainActor in
+                    await WorkoutSyncCoordinator.shared.processPendingWorkouts(
+                        modelContext: modelContext,
+                        currentUserId: remoteSyncUserId
+                    )
+                }
+            }
 
             await MainActor.run {
                 isDeleting = false
@@ -337,6 +363,16 @@ struct WorkoutListView: View {
             }
         } catch {
             print("❌ Error deleting workouts: \(error)")
+
+            if shouldProcessRemoteDeletion, let remoteSyncUserId {
+                Task { @MainActor in
+                    await WorkoutSyncCoordinator.shared.processPendingWorkouts(
+                        modelContext: modelContext,
+                        currentUserId: remoteSyncUserId
+                    )
+                }
+            }
+
             await MainActor.run {
                 isDeleting = false
                 showingDeleteConfirmation = false

--- a/AscendApp/Shared/Components/LoadablePhotoView.swift
+++ b/AscendApp/Shared/Components/LoadablePhotoView.swift
@@ -13,6 +13,8 @@ struct LoadablePhotoView: View {
     let cornerRadius: CGFloat
     let onTap: (() -> Void)?
 
+    @Environment(NetworkConnectivityService.self) private var connectivityService
+
     @State private var loadedImage: UIImage?
     @State private var isLoading = true
 
@@ -93,6 +95,10 @@ struct LoadablePhotoView: View {
         .task {
             await loadMedia()
         }
+        .onChange(of: connectivityService.isConnected) { oldValue, newValue in
+            guard oldValue == false, newValue == true else { return }
+            retryFailedLoadIfNeeded()
+        }
     }
 
     private func loadMedia() async {
@@ -123,8 +129,16 @@ struct LoadablePhotoView: View {
         let totalSeconds = Int(duration.rounded())
         let minutes = totalSeconds / 60
         let seconds = totalSeconds % 60
-        
+
         return "\(minutes):\(seconds < 10 ? "0" : "")\(seconds)"
+    }
+
+    private func retryFailedLoadIfNeeded() {
+        guard isLoading == false, loadedImage == nil else { return }
+        isLoading = true
+        Task {
+            await loadMedia()
+        }
     }
 }
 

--- a/AscendApp/Shared/Models/PendingWorkoutDeletion.swift
+++ b/AscendApp/Shared/Models/PendingWorkoutDeletion.swift
@@ -1,0 +1,30 @@
+import Foundation
+import SwiftData
+
+@Model
+final class PendingWorkoutDeletion {
+    var id: UUID
+    var workoutId: UUID
+    var ownerUserId: String
+    var enqueuedAt: Date
+    var retryCount: Int
+    var lastError: String?
+
+    init(
+        workoutId: UUID,
+        ownerUserId: String,
+        enqueuedAt: Date = Date()
+    ) {
+        self.id = UUID()
+        self.workoutId = workoutId
+        self.ownerUserId = ownerUserId
+        self.enqueuedAt = enqueuedAt
+        self.retryCount = 0
+        self.lastError = nil
+    }
+
+    func recordFailure(_ message: String) {
+        retryCount += 1
+        lastError = message
+    }
+}

--- a/AscendApp/Shared/Models/Workout.swift
+++ b/AscendApp/Shared/Models/Workout.swift
@@ -128,6 +128,12 @@ class Workout {
     var stepsPerFloor: Int // Snapshot of conversion rate at workout creation (for historical accuracy)
     var notes: String
     var createdAt: Date
+    var ownerUserId: String?
+    var lastModifiedAt: Date = Date()
+    var lastRemoteSyncAt: Date?
+    var lastRemoteHeartRateSeriesStoragePath: String?
+    var remoteSyncStatusRawValue: String = WorkoutRemoteSyncStatus.pendingUpsert.rawValue
+    var lastRemoteSyncError: String?
     var avgHeartRate: Int? // Average heart rate in BPM
     var maxHeartRate: Int? // Maximum heart rate in BPM
     var caloriesBurned: Int? // Calories burned during workout
@@ -258,6 +264,7 @@ class Workout {
     }
 
     init(name: String = "", date: Date = Date(), duration: TimeInterval, steps: Int, floors: Int, stepsPerFloor: Int = 16, notes: String = "", avgHeartRate: Int? = nil, maxHeartRate: Int? = nil, caloriesBurned: Int? = nil, effortRating: Double? = nil, heartRateTimeSeries: [HeartRateDataPoint]? = nil, averageMETs: Double? = nil, source: WorkoutSource = .manual, deviceModel: String? = nil, sourceMetadata: String? = nil, healthKitUUID: String? = nil, hevyWorkoutId: String? = nil, photos: [Photo] = [], highlightedPhotoId: UUID? = nil, personalRecordTypes: [String]? = nil, weightConfiguration: WeightConfiguration? = nil) {
+        let createdAt = Date()
         self.id = UUID()
         self.name = name.isEmpty ? "Workout" : name
         self.date = date
@@ -266,7 +273,13 @@ class Workout {
         self.floors = floors
         self.stepsPerFloor = stepsPerFloor
         self.notes = notes
-        self.createdAt = Date()
+        self.createdAt = createdAt
+        self.ownerUserId = nil
+        self.lastModifiedAt = createdAt
+        self.lastRemoteSyncAt = nil
+        self.lastRemoteHeartRateSeriesStoragePath = nil
+        self.remoteSyncStatusRawValue = WorkoutRemoteSyncStatus.pendingUpsert.rawValue
+        self.lastRemoteSyncError = nil
         self.avgHeartRate = avgHeartRate
         self.maxHeartRate = maxHeartRate
         self.caloriesBurned = caloriesBurned
@@ -287,6 +300,33 @@ class Workout {
         self.sourceLinks = []
         self.personalRecordTypes = personalRecordTypes
         self.weightConfiguration = weightConfiguration
+    }
+
+    var remoteSyncStatus: WorkoutRemoteSyncStatus {
+        get { WorkoutRemoteSyncStatus(rawValue: remoteSyncStatusRawValue) ?? .pendingUpsert }
+        set { remoteSyncStatusRawValue = newValue.rawValue }
+    }
+
+    func markPendingRemoteUpsert(ownerUserId: String, modifiedAt: Date = Date()) {
+        self.ownerUserId = ownerUserId
+        lastModifiedAt = modifiedAt
+        remoteSyncStatus = .pendingUpsert
+        lastRemoteSyncError = nil
+    }
+
+    func markRemoteSyncSucceeded(
+        syncedAt: Date = Date(),
+        heartRateSeriesStoragePath: String?
+    ) {
+        lastRemoteSyncAt = syncedAt
+        lastRemoteHeartRateSeriesStoragePath = heartRateSeriesStoragePath
+        remoteSyncStatus = .synced
+        lastRemoteSyncError = nil
+    }
+
+    func markRemoteSyncFailed(_ errorMessage: String) {
+        remoteSyncStatus = .failed
+        lastRemoteSyncError = errorMessage
     }
     
     // Computed properties for convenience
@@ -644,7 +684,7 @@ class Workout {
 }
 
 // MARK: - Heart Rate Data Extensions
-struct HeartRateDataPoint: Codable, Equatable {
+struct HeartRateDataPoint: Codable, Equatable, Sendable {
     let timestamp: Date
     let heartRate: Int
 }

--- a/AscendApp/Shared/Models/WorkoutRemoteSyncStatus.swift
+++ b/AscendApp/Shared/Models/WorkoutRemoteSyncStatus.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum WorkoutRemoteSyncStatus: String, Codable, Sendable {
+    case pendingUpsert
+    case synced
+    case failed
+}

--- a/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutDocument.swift
+++ b/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutDocument.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+struct FirestoreWorkoutDocument: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 1
+
+    let userId: String
+    let schemaVersion: Int
+    let name: String
+    let startedAt: Date
+    let durationSeconds: Double
+    let steps: Int
+    let floors: Int
+    let stepsPerFloor: Int
+    let notes: String
+    let source: String
+    let integrityLevel: String
+    let createdAt: Date
+    let updatedAt: Date
+    let avgHeartRateBpm: Int?
+    let maxHeartRateBpm: Int?
+    let caloriesBurned: Int?
+    let effortRating: Double?
+    let averageMETs: Double?
+    let deviceModel: String?
+    let sourceMetadata: String?
+    let healthKitUUID: String?
+    let hevyWorkoutId: String?
+    let media: [FirestoreWorkoutMediaItem]?
+    let highlightedMediaId: String?
+    let weightConfiguration: FirestoreWorkoutWeightConfiguration?
+    let heartRateSeries: FirestoreWorkoutHeartRateSeriesReference?
+
+    init(
+        userId: String,
+        schemaVersion: Int = FirestoreWorkoutDocument.currentSchemaVersion,
+        name: String,
+        startedAt: Date,
+        durationSeconds: Double,
+        steps: Int,
+        floors: Int,
+        stepsPerFloor: Int,
+        notes: String,
+        source: String,
+        integrityLevel: String,
+        createdAt: Date,
+        updatedAt: Date,
+        avgHeartRateBpm: Int? = nil,
+        maxHeartRateBpm: Int? = nil,
+        caloriesBurned: Int? = nil,
+        effortRating: Double? = nil,
+        averageMETs: Double? = nil,
+        deviceModel: String? = nil,
+        sourceMetadata: String? = nil,
+        healthKitUUID: String? = nil,
+        hevyWorkoutId: String? = nil,
+        media: [FirestoreWorkoutMediaItem]? = nil,
+        highlightedMediaId: String? = nil,
+        weightConfiguration: FirestoreWorkoutWeightConfiguration? = nil,
+        heartRateSeries: FirestoreWorkoutHeartRateSeriesReference? = nil
+    ) {
+        self.userId = userId
+        self.schemaVersion = schemaVersion
+        self.name = name
+        self.startedAt = startedAt
+        self.durationSeconds = durationSeconds
+        self.steps = steps
+        self.floors = floors
+        self.stepsPerFloor = stepsPerFloor
+        self.notes = notes
+        self.source = source
+        self.integrityLevel = integrityLevel
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.avgHeartRateBpm = avgHeartRateBpm
+        self.maxHeartRateBpm = maxHeartRateBpm
+        self.caloriesBurned = caloriesBurned
+        self.effortRating = effortRating
+        self.averageMETs = averageMETs
+        self.deviceModel = deviceModel
+        self.sourceMetadata = sourceMetadata
+        self.healthKitUUID = healthKitUUID
+        self.hevyWorkoutId = hevyWorkoutId
+        self.media = media
+        self.highlightedMediaId = highlightedMediaId
+        self.weightConfiguration = weightConfiguration
+        self.heartRateSeries = heartRateSeries
+    }
+}

--- a/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutHeartRateSeriesReference.swift
+++ b/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutHeartRateSeriesReference.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct FirestoreWorkoutHeartRateSeriesReference: Codable, Equatable, Sendable {
+    static let defaultEncoding = "json+gzip"
+
+    let storagePath: String
+    let encoding: String
+    let sampleCount: Int
+    let seriesStartAt: Date
+    let seriesEndAt: Date
+
+    init(
+        storagePath: String,
+        encoding: String = FirestoreWorkoutHeartRateSeriesReference.defaultEncoding,
+        sampleCount: Int,
+        seriesStartAt: Date,
+        seriesEndAt: Date
+    ) {
+        self.storagePath = storagePath
+        self.encoding = encoding
+        self.sampleCount = sampleCount
+        self.seriesStartAt = seriesStartAt
+        self.seriesEndAt = seriesEndAt
+    }
+}

--- a/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutMediaItem.swift
+++ b/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutMediaItem.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct FirestoreWorkoutMediaItem: Codable, Equatable, Sendable {
+    let id: String
+    let url: String
+    let uploadedAt: Date
+    let type: String
+    let durationSeconds: Double?
+
+    init(
+        id: String,
+        url: String,
+        uploadedAt: Date,
+        type: String,
+        durationSeconds: Double? = nil
+    ) {
+        self.id = id
+        self.url = url
+        self.uploadedAt = uploadedAt
+        self.type = type
+        self.durationSeconds = durationSeconds
+    }
+}

--- a/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutWeightConfiguration.swift
+++ b/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutWeightConfiguration.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct FirestoreWorkoutWeightConfiguration: Codable, Equatable, Sendable {
+    let entries: [FirestoreWorkoutWeightEntry]
+
+    init(entries: [FirestoreWorkoutWeightEntry]) {
+        self.entries = entries
+    }
+}

--- a/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutWeightEntry.swift
+++ b/AscendApp/Shared/Repositories/Firebase/FirestoreWorkoutWeightEntry.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct FirestoreWorkoutWeightEntry: Codable, Equatable, Sendable {
+    let id: String
+    let equipmentType: String
+    let weightValue: Double
+    let isEnabled: Bool
+
+    init(
+        id: String,
+        equipmentType: String,
+        weightValue: Double,
+        isEnabled: Bool
+    ) {
+        self.id = id
+        self.equipmentType = equipmentType
+        self.weightValue = weightValue
+        self.isEnabled = isEnabled
+    }
+}

--- a/AscendApp/Shared/Repositories/Firebase/GzipCodec.swift
+++ b/AscendApp/Shared/Repositories/Firebase/GzipCodec.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+enum GzipCodec {
+    enum Error: LocalizedError {
+        case compressionFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .compressionFailed:
+                return "Failed to compress the heart-rate series."
+            }
+        }
+    }
+
+    static func compress(_ data: Data) throws -> Data {
+        guard let compressedNSData = try (data as NSData).compressed(using: .zlib) as Data?,
+              compressedNSData.count >= 6 else {
+            throw Error.compressionFailed
+        }
+
+        let deflatePayload = compressedNSData.dropFirst(2).dropLast(4)
+        var gzipData = Data([
+            0x1f, 0x8b, // magic
+            0x08,       // deflate
+            0x00,       // flags
+            0x00, 0x00, 0x00, 0x00, // mtime
+            0x00,       // extra flags
+            0xff        // OS unknown
+        ])
+        gzipData.append(deflatePayload)
+
+        var crc32 = Self.crc32(for: data).littleEndian
+        withUnsafeBytes(of: &crc32) { gzipData.append(contentsOf: $0) }
+
+        var inputSize = UInt32(truncatingIfNeeded: data.count).littleEndian
+        withUnsafeBytes(of: &inputSize) { gzipData.append(contentsOf: $0) }
+
+        return gzipData
+    }
+}
+
+private extension GzipCodec {
+    static func crc32(for data: Data) -> UInt32 {
+        var crc: UInt32 = 0xffff_ffff
+
+        for byte in data {
+            let index = Int((crc ^ UInt32(byte)) & 0xff)
+            crc = crcTable[index] ^ (crc >> 8)
+        }
+
+        return crc ^ 0xffff_ffff
+    }
+
+    static let crcTable: [UInt32] = (0..<256).map { value in
+        var crc = UInt32(value)
+        for _ in 0..<8 {
+            if (crc & 1) == 1 {
+                crc = 0xedb8_8320 ^ (crc >> 1)
+            } else {
+                crc = crc >> 1
+            }
+        }
+        return crc
+    }
+}

--- a/AscendApp/Shared/Repositories/Firebase/WorkoutHeartRateStorageBlob.swift
+++ b/AscendApp/Shared/Repositories/Firebase/WorkoutHeartRateStorageBlob.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct WorkoutHeartRateStorageBlob: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let workoutId: String
+    let samples: [HeartRateDataPoint]
+
+    init(
+        schemaVersion: Int = WorkoutHeartRateStorageBlob.currentSchemaVersion,
+        workoutId: String,
+        samples: [HeartRateDataPoint]
+    ) {
+        self.schemaVersion = schemaVersion
+        self.workoutId = workoutId
+        self.samples = samples
+    }
+}

--- a/AscendApp/Shared/Repositories/Firebase/WorkoutHeartRateStorageRepository.swift
+++ b/AscendApp/Shared/Repositories/Firebase/WorkoutHeartRateStorageRepository.swift
@@ -1,0 +1,62 @@
+import Foundation
+import FirebaseStorage
+
+final class WorkoutHeartRateStorageRepository: WorkoutHeartRateStorageRepositoryProtocol, @unchecked Sendable {
+    static let shared = WorkoutHeartRateStorageRepository()
+
+    private let storage = Storage.storage()
+
+    private init() {}
+
+    func uploadHeartRateSeries(
+        userId: String,
+        workoutId: UUID,
+        blob: WorkoutHeartRateStorageBlob
+    ) async throws -> FirestoreWorkoutHeartRateSeriesReference {
+        let storagePath = storagePath(userId: userId, workoutId: workoutId)
+        let storageRef = storage.reference().child(storagePath)
+
+        let encodedBlob = try JSONEncoder().encode(blob)
+        let gzipData = try GzipCodec.compress(encodedBlob)
+        let metadata = StorageMetadata()
+        metadata.contentType = "application/gzip"
+
+        let _ = try await storageRef.putDataAsync(gzipData, metadata: metadata)
+
+        let timestamps = seriesBounds(for: blob.samples)
+        return FirestoreWorkoutHeartRateSeriesReference(
+            storagePath: storagePath,
+            sampleCount: blob.samples.count,
+            seriesStartAt: timestamps.start,
+            seriesEndAt: timestamps.end
+        )
+    }
+
+    func deleteHeartRateSeriesIfPresent(
+        userId: String,
+        workoutId: UUID
+    ) async throws {
+        let storageRef = storage.reference().child(storagePath(userId: userId, workoutId: workoutId))
+        do {
+            try await storageRef.delete()
+        } catch let error as NSError {
+            if error.domain == StorageErrorDomain,
+               error.code == StorageErrorCode.objectNotFound.rawValue {
+                return
+            }
+            throw error
+        }
+    }
+}
+
+private extension WorkoutHeartRateStorageRepository {
+    func storagePath(userId: String, workoutId: UUID) -> String {
+        "users/\(userId)/workout_heart_rate/\(workoutId.uuidString).json.gz"
+    }
+
+    func seriesBounds(for samples: [HeartRateDataPoint]) -> (start: Date, end: Date) {
+        let start = samples.map(\.timestamp).min() ?? .distantPast
+        let end = samples.map(\.timestamp).max() ?? start
+        return (start, end)
+    }
+}

--- a/AscendApp/Shared/Repositories/Firebase/WorkoutRemoteRepository.swift
+++ b/AscendApp/Shared/Repositories/Firebase/WorkoutRemoteRepository.swift
@@ -1,0 +1,133 @@
+import Foundation
+@preconcurrency import FirebaseFirestore
+
+final class WorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol, @unchecked Sendable {
+    static let shared = WorkoutRemoteRepository()
+
+    private let db = Firestore.firestore()
+
+    private init() {}
+
+    func upsertWorkout(
+        userId: String,
+        workoutId: UUID,
+        document: FirestoreWorkoutDocument
+    ) async throws {
+        let docRef = workoutDocumentReference(userId: userId, workoutId: workoutId)
+        try await docRef.setData(firestoreData(for: document))
+    }
+
+    func deleteWorkout(
+        userId: String,
+        workoutId: UUID
+    ) async throws {
+        try await workoutDocumentReference(userId: userId, workoutId: workoutId).delete()
+    }
+}
+
+private extension WorkoutRemoteRepository {
+    func workoutDocumentReference(userId: String, workoutId: UUID) -> DocumentReference {
+        db.collection("users")
+            .document(userId)
+            .collection("workouts")
+            .document(workoutId.uuidString)
+    }
+
+    func firestoreData(for document: FirestoreWorkoutDocument) -> [String: Any] {
+        var data: [String: Any] = [
+            "userId": document.userId,
+            "schemaVersion": document.schemaVersion,
+            "name": document.name,
+            "startedAt": Timestamp(date: document.startedAt),
+            "durationSeconds": document.durationSeconds,
+            "steps": document.steps,
+            "floors": document.floors,
+            "stepsPerFloor": document.stepsPerFloor,
+            "notes": document.notes,
+            "source": document.source,
+            "integrityLevel": document.integrityLevel,
+            "createdAt": Timestamp(date: document.createdAt),
+            "updatedAt": Timestamp(date: document.updatedAt)
+        ]
+
+        if let avgHeartRateBpm = document.avgHeartRateBpm {
+            data["avgHeartRateBpm"] = avgHeartRateBpm
+        }
+        if let maxHeartRateBpm = document.maxHeartRateBpm {
+            data["maxHeartRateBpm"] = maxHeartRateBpm
+        }
+        if let caloriesBurned = document.caloriesBurned {
+            data["caloriesBurned"] = caloriesBurned
+        }
+        if let effortRating = document.effortRating {
+            data["effortRating"] = effortRating
+        }
+        if let averageMETs = document.averageMETs {
+            data["averageMETs"] = averageMETs
+        }
+        if let deviceModel = document.deviceModel {
+            data["deviceModel"] = deviceModel
+        }
+        if let sourceMetadata = document.sourceMetadata {
+            data["sourceMetadata"] = sourceMetadata
+        }
+        if let healthKitUUID = document.healthKitUUID {
+            data["healthKitUUID"] = healthKitUUID
+        }
+        if let hevyWorkoutId = document.hevyWorkoutId {
+            data["hevyWorkoutId"] = hevyWorkoutId
+        }
+        if let media = document.media {
+            data["media"] = media.map(firestoreMediaItem(_:))
+        }
+        if let highlightedMediaId = document.highlightedMediaId {
+            data["highlightedMediaId"] = highlightedMediaId
+        }
+        if let weightConfiguration = document.weightConfiguration {
+            data["weightConfiguration"] = firestoreWeightConfiguration(weightConfiguration)
+        }
+        if let heartRateSeries = document.heartRateSeries {
+            data["heartRateSeries"] = firestoreHeartRateSeriesReference(heartRateSeries)
+        }
+
+        return data
+    }
+
+    func firestoreMediaItem(_ item: FirestoreWorkoutMediaItem) -> [String: Any] {
+        var data: [String: Any] = [
+            "id": item.id,
+            "url": item.url,
+            "uploadedAt": Timestamp(date: item.uploadedAt),
+            "type": item.type
+        ]
+        if let durationSeconds = item.durationSeconds {
+            data["durationSeconds"] = durationSeconds
+        }
+        return data
+    }
+
+    func firestoreWeightConfiguration(_ config: FirestoreWorkoutWeightConfiguration) -> [String: Any] {
+        [
+            "entries": config.entries.map { entry in
+                [
+                    "id": entry.id,
+                    "equipmentType": entry.equipmentType,
+                    "weightValue": entry.weightValue,
+                    "isEnabled": entry.isEnabled
+                ]
+            }
+        ]
+    }
+
+    func firestoreHeartRateSeriesReference(
+        _ reference: FirestoreWorkoutHeartRateSeriesReference
+    ) -> [String: Any] {
+        [
+            "storagePath": reference.storagePath,
+            "encoding": reference.encoding,
+            "sampleCount": reference.sampleCount,
+            "seriesStartAt": Timestamp(date: reference.seriesStartAt),
+            "seriesEndAt": Timestamp(date: reference.seriesEndAt)
+        ]
+    }
+}

--- a/AscendApp/Shared/Repositories/Protocols/WorkoutHeartRateStorageRepositoryProtocol.swift
+++ b/AscendApp/Shared/Repositories/Protocols/WorkoutHeartRateStorageRepositoryProtocol.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+protocol WorkoutHeartRateStorageRepositoryProtocol: Sendable {
+    func uploadHeartRateSeries(
+        userId: String,
+        workoutId: UUID,
+        blob: WorkoutHeartRateStorageBlob
+    ) async throws -> FirestoreWorkoutHeartRateSeriesReference
+
+    func deleteHeartRateSeriesIfPresent(
+        userId: String,
+        workoutId: UUID
+    ) async throws
+}

--- a/AscendApp/Shared/Repositories/Protocols/WorkoutRemoteRepositoryProtocol.swift
+++ b/AscendApp/Shared/Repositories/Protocols/WorkoutRemoteRepositoryProtocol.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+protocol WorkoutRemoteRepositoryProtocol: Sendable {
+    func upsertWorkout(
+        userId: String,
+        workoutId: UUID,
+        document: FirestoreWorkoutDocument
+    ) async throws
+
+    func deleteWorkout(
+        userId: String,
+        workoutId: UUID
+    ) async throws
+}

--- a/AscendApp/Shared/Services/MediaUploadManager.swift
+++ b/AscendApp/Shared/Services/MediaUploadManager.swift
@@ -50,7 +50,7 @@ final class MediaUploadManager {
     // MARK: - Private State
 
     /// Active upload tasks keyed by PendingMediaUpload.id (for cancellation)
-    private var activeUploadTasks: [UUID: Task<Void, Never>] = [:]
+    private var activeUploadTasks: [UUID: Task<Bool, Never>] = [:]
 
     /// Workouts currently being processed (prevents double-processing)
     private var processingWorkoutIds: Set<UUID> = []
@@ -250,24 +250,37 @@ final class MediaUploadManager {
         }
 
         // Process uploads sequentially
+        var didUploadAnyMedia = false
+
         for (currentIndex, upload) in pendingUploads.enumerated() {
             // Update status to show progress
             let total = pendingUploads.count
             uploadStatuses[workoutId] = .uploading(current: currentIndex + 1, total: total)
 
             // Create task for this upload
-            let task = Task<Void, Never> { [weak self] in
-                guard let self else { return }
-                await self.processUpload(upload, workout: workout, modelContext: modelContext)
+            let task = Task<Bool, Never> { [weak self] in
+                guard let self else { return false }
+                return await self.processUpload(
+                    upload,
+                    workout: workout,
+                    modelContext: modelContext
+                )
             }
 
             activeUploadTasks[upload.id] = task
-            await task.value
+            let didUploadMedia = await task.value
             activeUploadTasks[upload.id] = nil
+            didUploadAnyMedia = didUploadAnyMedia || didUploadMedia
 
             // Check if cancelled
             if Task.isCancelled { break }
         }
+
+        guard didUploadAnyMedia else { return }
+        await queueRemoteSyncForUploadedMedia(
+            workoutId: workoutId,
+            modelContext: modelContext
+        )
     }
 
     /// Process a single upload with retry logic
@@ -275,7 +288,7 @@ final class MediaUploadManager {
         _ upload: PendingMediaUpload,
         workout: Workout,
         modelContext: ModelContext
-    ) async {
+    ) async -> Bool {
         upload.uploadStatus = .uploading
         try? modelContext.save()
 
@@ -283,7 +296,7 @@ final class MediaUploadManager {
         var currentDelay = initialDelaySeconds
 
         for attempt in 0..<maxRetries {
-            if Task.isCancelled { return }
+            if Task.isCancelled { return false }
 
             do {
                 // Read local file data
@@ -338,13 +351,13 @@ final class MediaUploadManager {
                 try? modelContext.save()
                 await LocalMediaStorage.deleteIfExists(filename: upload.localFileName)
 
-                return // Success
+                return true // Success
 
             } catch {
                 lastError = error
                 print("[MediaUploadManager] Upload attempt \(attempt + 1) failed for \(upload.localFileName): \(error.localizedDescription)")
 
-                if Task.isCancelled { return }
+                if Task.isCancelled { return false }
 
                 // Wait before retry (unless last attempt)
                 if attempt < maxRetries - 1 {
@@ -370,6 +383,36 @@ final class MediaUploadManager {
             print("[MediaUploadManager] Upload failed after \(maxRetries) attempts for \(upload.localFileName): Unknown error")
         }
         try? modelContext.save()
+        return false
+    }
+
+    private func queueRemoteSyncForUploadedMedia(
+        workoutId: UUID,
+        modelContext: ModelContext
+    ) async {
+        guard let currentUserId = Auth.auth().currentUser?.uid else { return }
+
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { workout in
+                workout.id == workoutId
+            }
+        )
+
+        guard let workout = try? modelContext.fetch(descriptor).first else { return }
+
+        workout.markPendingRemoteUpsert(ownerUserId: currentUserId)
+
+        do {
+            try modelContext.save()
+        } catch {
+            print("[MediaUploadManager] Failed to mark workout \(workoutId) pending for remote sync: \(error.localizedDescription)")
+            return
+        }
+
+        await WorkoutSyncCoordinator.shared.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: currentUserId
+        )
     }
 
     /// Update the upload status for a workout based on pending uploads
@@ -379,12 +422,12 @@ final class MediaUploadManager {
         )
 
         guard let uploads = try? modelContext.fetch(descriptor) else {
-            uploadStatuses[workoutId] = .none
+            uploadStatuses[workoutId] = MediaUploadStatus.none
             return
         }
 
         if uploads.isEmpty {
-            uploadStatuses[workoutId] = .none
+            uploadStatuses[workoutId] = MediaUploadStatus.none
             return
         }
 
@@ -397,7 +440,7 @@ final class MediaUploadManager {
             if pendingCount > 0 {
                 uploadStatuses[workoutId] = .uploading(current: 1, total: pendingCount)
             } else {
-                uploadStatuses[workoutId] = .none
+                uploadStatuses[workoutId] = MediaUploadStatus.none
             }
         }
     }

--- a/AscendApp/Shared/Services/NetworkConnectivityService.swift
+++ b/AscendApp/Shared/Services/NetworkConnectivityService.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Network
+import Observation
+
+@MainActor
+@Observable
+final class NetworkConnectivityService {
+    static let shared = NetworkConnectivityService()
+
+    private let monitor = NWPathMonitor()
+    private let monitorQueue = DispatchQueue(label: "com.ascend.network-connectivity")
+
+    private(set) var isConnected = true
+    private(set) var isExpensive = false
+    private(set) var isConstrained = false
+
+    private init() {
+        monitor.pathUpdateHandler = { [weak self] path in
+            Task { @MainActor in
+                self?.apply(path: path)
+            }
+        }
+        monitor.start(queue: monitorQueue)
+    }
+
+    deinit {
+        monitor.cancel()
+    }
+
+    private func apply(path: NWPath) {
+        isConnected = path.status == .satisfied
+        isExpensive = path.isExpensive
+        isConstrained = path.isConstrained
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
@@ -936,9 +936,8 @@ final class WorkoutImportCoordinator {
         try WorkoutMutationHandler.shared.workoutsDidChange(
             modelContext: modelContext,
             mutation: .imported(newWorkouts.map(LeaderboardWorkoutSnapshot.init(workout:))),
-            newWorkouts: newWorkouts
+            newWorkouts: newWorkouts,
+            changedWorkouts: newWorkouts
         )
-
-        try modelContext.save()
     }
 }

--- a/AscendApp/Shared/Services/WorkoutMutationHandler.swift
+++ b/AscendApp/Shared/Services/WorkoutMutationHandler.swift
@@ -5,7 +5,8 @@ import SwiftData
 /// Centralized handler for post-workout-mutation side effects.
 ///
 /// Every code path that creates, edits, deletes, or imports workouts should call
-/// `workoutsDidChange(modelContext:mutation:newWorkouts:)` after the mutation is persisted.
+/// `workoutsDidChange(modelContext:mutation:newWorkouts:changedWorkouts:)`
+/// after the mutation is persisted.
 @MainActor
 final class WorkoutMutationHandler {
     static let shared = WorkoutMutationHandler()
@@ -18,8 +19,16 @@ final class WorkoutMutationHandler {
     func workoutsDidChange(
         modelContext: ModelContext,
         mutation: WorkoutMutation = .rebuildAll,
-        newWorkouts: [Workout] = []
+        newWorkouts: [Workout] = [],
+        changedWorkouts: [Workout] = []
     ) throws {
+        let currentUser = Auth.auth().currentUser
+        let currentUserId = currentUser?.uid
+
+        if let currentUserId {
+            markChangedWorkoutsForRemoteSync(changedWorkouts, userId: currentUserId)
+        }
+
         try PersonalRecordService.recalculateAllPersonalRecords(
             modelContext: modelContext,
             measurementSystem: settingsManager.measurementSystem,
@@ -28,26 +37,52 @@ final class WorkoutMutationHandler {
 
         try ClimbService.shared.apply(workouts: newWorkouts, modelContext: modelContext)
 
-        guard let user = Auth.auth().currentUser else { return }
-        let userId = user.uid
+        if let currentUser {
+            let userId = currentUser.uid
+            leaderboardService.configure(modelContext: modelContext)
+            let impact = LeaderboardMutationImpact.classify(mutation)
+            let didUpdateLeaderboard = try leaderboardService.applyMutationImpact(impact, for: userId)
 
-        leaderboardService.configure(modelContext: modelContext)
-        let impact = LeaderboardMutationImpact.classify(mutation)
-        let didUpdateLeaderboard = try leaderboardService.applyMutationImpact(impact, for: userId)
-        guard didUpdateLeaderboard else { return }
+            try modelContext.save()
 
-        let cachedDisplayName = UserDataRepository.shared.getCachedDisplayName()?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let displayName = cachedDisplayName?.isEmpty == false ? cachedDisplayName! : (user.displayName ?? "You")
-        let cachedPhotoURL = UserDataRepository.shared.getCachedProfilePictureURL().flatMap(URL.init(string:))
-        let photoURL = cachedPhotoURL ?? user.photoURL
+            if !changedWorkouts.isEmpty {
+                Task { @MainActor in
+                    await WorkoutSyncCoordinator.shared.processPendingWorkouts(
+                        modelContext: modelContext,
+                        currentUserId: userId
+                    )
+                }
+            }
 
-        Task {
-            await LeaderboardSessionCache.shared.invalidateAll()
-            await LeaderboardSyncCoordinator.shared.enqueueSync(
-                userId: userId,
-                displayName: displayName,
-                photoURL: photoURL
-            )
+            guard didUpdateLeaderboard else { return }
+
+            let cachedDisplayName = UserDataRepository.shared.getCachedDisplayName()?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let displayName = cachedDisplayName?.isEmpty == false ? cachedDisplayName! : (currentUser.displayName ?? "You")
+            let cachedPhotoURL = UserDataRepository.shared.getCachedProfilePictureURL().flatMap(URL.init(string:))
+            let photoURL = cachedPhotoURL ?? currentUser.photoURL
+
+            Task {
+                await LeaderboardSessionCache.shared.invalidateAll()
+                await LeaderboardSyncCoordinator.shared.enqueueSync(
+                    userId: userId,
+                    displayName: displayName,
+                    photoURL: photoURL
+                )
+            }
+
+            return
+        }
+
+        try modelContext.save()
+    }
+
+    func markChangedWorkoutsForRemoteSync(
+        _ changedWorkouts: [Workout],
+        userId: String,
+        modifiedAt: Date = Date()
+    ) {
+        for workout in changedWorkouts {
+            workout.markPendingRemoteUpsert(ownerUserId: userId, modifiedAt: modifiedAt)
         }
     }
 }

--- a/AscendApp/Shared/Services/WorkoutRemoteSyncMapper.swift
+++ b/AscendApp/Shared/Services/WorkoutRemoteSyncMapper.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+enum WorkoutRemoteSyncMapper {
+    static func snapshot(from workout: Workout) throws -> WorkoutRemoteSyncSnapshot {
+        guard let userId = workout.ownerUserId, !userId.isEmpty else {
+            throw WorkoutSyncError.missingOwner
+        }
+
+        guard supportedSourceRawValues.contains(workout.source.rawValue) else {
+            throw WorkoutSyncError.unsupportedSource(workout.source.rawValue)
+        }
+
+        let media = workout.photos.isEmpty
+            ? nil
+            : workout.photos.map { photo in
+                FirestoreWorkoutMediaItem(
+                    id: photo.id.uuidString,
+                    url: photo.url.absoluteString,
+                    uploadedAt: photo.uploadedAt,
+                    type: photo.type.rawValue,
+                    durationSeconds: photo.duration
+                )
+            }
+
+        let highlightedMediaId = workout.highlightedPhotoId.flatMap { highlightedId in
+            workout.photos.contains(where: { $0.id == highlightedId }) ? highlightedId.uuidString : nil
+        }
+
+        let weightConfiguration = workout.weightConfiguration.flatMap { config in
+            config.entries.isEmpty ? nil : FirestoreWorkoutWeightConfiguration(
+                entries: config.entries.map { entry in
+                    FirestoreWorkoutWeightEntry(
+                        id: entry.id.uuidString,
+                        equipmentType: entry.equipmentType.rawValue,
+                        weightValue: entry.weightValue,
+                        isEnabled: entry.isEnabled
+                    )
+                }
+            )
+        }
+
+        let heartRateBlob = try heartRateBlob(for: workout)
+        let heartRateSeriesReference = heartRateBlob.map { blob in
+            let seriesBounds = seriesBounds(for: blob.samples)
+            return FirestoreWorkoutHeartRateSeriesReference(
+                storagePath: "users/\(userId)/workout_heart_rate/\(workout.id.uuidString).json.gz",
+                sampleCount: blob.samples.count,
+                seriesStartAt: seriesBounds.start,
+                seriesEndAt: seriesBounds.end
+            )
+        }
+
+        let document = FirestoreWorkoutDocument(
+            userId: userId,
+            name: workout.name,
+            startedAt: workout.date,
+            durationSeconds: workout.duration,
+            steps: workout.steps,
+            floors: workout.floors,
+            stepsPerFloor: workout.stepsPerFloor,
+            notes: workout.notes,
+            source: workout.source.rawValue,
+            integrityLevel: workout.integrityLevel.rawValue,
+            createdAt: workout.createdAt,
+            updatedAt: workout.lastModifiedAt,
+            avgHeartRateBpm: workout.avgHeartRate,
+            maxHeartRateBpm: workout.maxHeartRate,
+            caloriesBurned: workout.caloriesBurned,
+            effortRating: workout.effortRating,
+            averageMETs: workout.averageMETs,
+            deviceModel: workout.deviceModel,
+            sourceMetadata: workout.sourceMetadata,
+            healthKitUUID: workout.healthKitUUID,
+            hevyWorkoutId: workout.hevyWorkoutId,
+            media: media,
+            highlightedMediaId: highlightedMediaId,
+            weightConfiguration: weightConfiguration,
+            heartRateSeries: heartRateSeriesReference
+        )
+
+        return WorkoutRemoteSyncSnapshot(
+            workoutId: workout.id,
+            userId: userId,
+            createdAt: workout.createdAt,
+            lastModifiedAt: workout.lastModifiedAt,
+            document: document,
+            heartRateBlob: heartRateBlob,
+            previousHeartRateSeriesStoragePath: workout.lastRemoteHeartRateSeriesStoragePath
+        )
+    }
+}
+
+private extension WorkoutRemoteSyncMapper {
+    static let supportedSourceRawValues: Set<String> = [
+        WorkoutSource.manual.rawValue,
+        WorkoutSource.appleHealth.rawValue,
+        WorkoutSource.garmin.rawValue,
+        WorkoutSource.fitbit.rawValue,
+        WorkoutSource.hevy.rawValue
+    ]
+
+    static func heartRateBlob(for workout: Workout) throws -> WorkoutHeartRateStorageBlob? {
+        let samples = workout.heartRateTimeSeries
+        guard !samples.isEmpty else { return nil }
+
+        guard samples.allSatisfy({ $0.heartRate > 0 }) else {
+            throw WorkoutSyncError.invalidHeartRateSeries
+        }
+
+        return WorkoutHeartRateStorageBlob(
+            workoutId: workout.id.uuidString,
+            samples: samples
+        )
+    }
+
+    static func seriesBounds(for samples: [HeartRateDataPoint]) -> (start: Date, end: Date) {
+        let start = samples.map(\.timestamp).min() ?? .distantPast
+        let end = samples.map(\.timestamp).max() ?? start
+        return (start, end)
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutRemoteSyncMigrationService.swift
+++ b/AscendApp/Shared/Services/WorkoutRemoteSyncMigrationService.swift
@@ -1,0 +1,48 @@
+import Foundation
+import SwiftData
+
+enum WorkoutRemoteSyncMigrationService {
+    private static let migrationVersion = 1
+
+    static func runIfNeeded(
+        modelContext: ModelContext,
+        currentUserId: String,
+        userDefaults: UserDefaults = .standard
+    ) throws {
+        let versionKey = migrationVersionKey(for: currentUserId)
+        guard userDefaults.bool(forKey: versionKey) == false else { return }
+
+        let workouts = try modelContext.fetch(FetchDescriptor<Workout>())
+        var didChangeAnyWorkout = false
+
+        for workout in workouts {
+            didChangeAnyWorkout = repairLocalSyncMetadata(
+                for: workout,
+                currentUserId: currentUserId
+            ) || didChangeAnyWorkout
+        }
+
+        if didChangeAnyWorkout {
+            try modelContext.save()
+        }
+
+        userDefaults.set(true, forKey: versionKey)
+    }
+
+    static func repairLocalSyncMetadata(
+        for workout: Workout,
+        currentUserId: String
+    ) -> Bool {
+        guard workout.ownerUserId == nil else { return false }
+
+        workout.markPendingRemoteUpsert(
+            ownerUserId: currentUserId,
+            modifiedAt: max(workout.createdAt, workout.date)
+        )
+        return true
+    }
+
+    static func migrationVersionKey(for userId: String) -> String {
+        "workoutRemoteSyncMigration.v\(migrationVersion).\(userId)"
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutRemoteSyncSnapshot.swift
+++ b/AscendApp/Shared/Services/WorkoutRemoteSyncSnapshot.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct WorkoutRemoteSyncSnapshot: Sendable {
+    let workoutId: UUID
+    let userId: String
+    let createdAt: Date
+    let lastModifiedAt: Date
+    let document: FirestoreWorkoutDocument
+    let heartRateBlob: WorkoutHeartRateStorageBlob?
+    let previousHeartRateSeriesStoragePath: String?
+}

--- a/AscendApp/Shared/Services/WorkoutSyncCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutSyncCoordinator.swift
@@ -1,0 +1,388 @@
+import Foundation
+import FirebaseStorage
+import SwiftData
+
+@MainActor
+final class WorkoutSyncCoordinator {
+    static let shared = WorkoutSyncCoordinator()
+
+    private let remoteRepository: any WorkoutRemoteRepositoryProtocol
+    private let heartRateStorageRepository: any WorkoutHeartRateStorageRepositoryProtocol
+    private let operationTimeoutSeconds: Double
+    private var isProcessingPendingWorkouts = false
+    private var shouldProcessPendingWorkoutsAgain = false
+
+    init(
+        remoteRepository: any WorkoutRemoteRepositoryProtocol = WorkoutRemoteRepository.shared,
+        heartRateStorageRepository: any WorkoutHeartRateStorageRepositoryProtocol = WorkoutHeartRateStorageRepository.shared,
+        operationTimeoutSeconds: Double = 15.0
+    ) {
+        self.remoteRepository = remoteRepository
+        self.heartRateStorageRepository = heartRateStorageRepository
+        self.operationTimeoutSeconds = operationTimeoutSeconds
+    }
+
+    func enqueuePendingDeletions(
+        for workouts: [Workout],
+        fallbackUserId: String?,
+        modelContext: ModelContext
+    ) throws -> Bool {
+        guard !workouts.isEmpty else { return false }
+
+        let existingDescriptor = FetchDescriptor<PendingWorkoutDeletion>()
+        var existingKeys = try Set(
+            modelContext.fetch(existingDescriptor).map {
+                PendingDeletionKey(
+                    workoutId: $0.workoutId,
+                    ownerUserId: $0.ownerUserId
+                )
+            }
+        )
+
+        var didInsertDeletion = false
+
+        for workout in workouts {
+            guard let ownerUserId = workout.ownerUserId ?? fallbackUserId else { continue }
+
+            let key = PendingDeletionKey(
+                workoutId: workout.id,
+                ownerUserId: ownerUserId
+            )
+
+            guard existingKeys.insert(key).inserted else { continue }
+            modelContext.insert(
+                PendingWorkoutDeletion(
+                    workoutId: workout.id,
+                    ownerUserId: ownerUserId
+                )
+            )
+            didInsertDeletion = true
+        }
+
+        return didInsertDeletion
+    }
+
+    func processPendingWorkouts(
+        modelContext: ModelContext,
+        currentUserId: String
+    ) async {
+        if isProcessingPendingWorkouts {
+            shouldProcessPendingWorkoutsAgain = true
+            return
+        }
+
+        repeat {
+            isProcessingPendingWorkouts = true
+            shouldProcessPendingWorkoutsAgain = false
+
+            do {
+                let deletedWorkoutIds = try await processPendingDeletions(
+                    modelContext: modelContext,
+                    currentUserId: currentUserId
+                )
+
+                let snapshots = try loadPendingSnapshots(
+                    modelContext: modelContext,
+                    currentUserId: currentUserId,
+                    excludedWorkoutIds: deletedWorkoutIds
+                )
+
+                for snapshot in snapshots {
+                    do {
+                        let heartRateSeriesStoragePath = try await sync(snapshot)
+                        try markSynced(
+                            workoutId: snapshot.workoutId,
+                            userId: snapshot.userId,
+                            expectedModifiedAt: snapshot.lastModifiedAt,
+                            heartRateSeriesStoragePath: heartRateSeriesStoragePath,
+                            modelContext: modelContext
+                        )
+                    } catch {
+                        recordSyncFailure(error, workoutId: snapshot.workoutId)
+                        try? markFailed(
+                            workoutId: snapshot.workoutId,
+                            userId: snapshot.userId,
+                            expectedModifiedAt: snapshot.lastModifiedAt,
+                            errorMessage: error.localizedDescription,
+                            modelContext: modelContext
+                        )
+                    }
+                }
+            } catch {
+                recordSyncFailure(error, workoutId: nil)
+            }
+
+            isProcessingPendingWorkouts = false
+        } while shouldProcessPendingWorkoutsAgain
+    }
+}
+
+private extension WorkoutSyncCoordinator {
+    struct PendingDeletionKey: Hashable {
+        let workoutId: UUID
+        let ownerUserId: String
+    }
+
+    func sync(_ snapshot: WorkoutRemoteSyncSnapshot) async throws -> String? {
+        let baseDocument = snapshot.document
+        let finalDocument: FirestoreWorkoutDocument
+
+        if let heartRateBlob = snapshot.heartRateBlob {
+            let heartRateSeries = try await withWorkoutSyncTimeout(seconds: operationTimeoutSeconds) {
+                try await self.heartRateStorageRepository.uploadHeartRateSeries(
+                    userId: snapshot.userId,
+                    workoutId: snapshot.workoutId,
+                    blob: heartRateBlob
+                )
+            }
+
+            finalDocument = FirestoreWorkoutDocument(
+                userId: baseDocument.userId,
+                schemaVersion: baseDocument.schemaVersion,
+                name: baseDocument.name,
+                startedAt: baseDocument.startedAt,
+                durationSeconds: baseDocument.durationSeconds,
+                steps: baseDocument.steps,
+                floors: baseDocument.floors,
+                stepsPerFloor: baseDocument.stepsPerFloor,
+                notes: baseDocument.notes,
+                source: baseDocument.source,
+                integrityLevel: baseDocument.integrityLevel,
+                createdAt: baseDocument.createdAt,
+                updatedAt: baseDocument.updatedAt,
+                avgHeartRateBpm: baseDocument.avgHeartRateBpm,
+                maxHeartRateBpm: baseDocument.maxHeartRateBpm,
+                caloriesBurned: baseDocument.caloriesBurned,
+                effortRating: baseDocument.effortRating,
+                averageMETs: baseDocument.averageMETs,
+                deviceModel: baseDocument.deviceModel,
+                sourceMetadata: baseDocument.sourceMetadata,
+                healthKitUUID: baseDocument.healthKitUUID,
+                hevyWorkoutId: baseDocument.hevyWorkoutId,
+                media: baseDocument.media,
+                highlightedMediaId: baseDocument.highlightedMediaId,
+                weightConfiguration: baseDocument.weightConfiguration,
+                heartRateSeries: heartRateSeries
+            )
+        } else if snapshot.previousHeartRateSeriesStoragePath != nil {
+            try await withWorkoutSyncTimeout(seconds: operationTimeoutSeconds) {
+                try await self.heartRateStorageRepository.deleteHeartRateSeriesIfPresent(
+                    userId: snapshot.userId,
+                    workoutId: snapshot.workoutId
+                )
+            }
+            finalDocument = baseDocument
+        } else {
+            finalDocument = baseDocument
+        }
+
+        try await withWorkoutSyncTimeout(seconds: operationTimeoutSeconds) {
+            try await self.remoteRepository.upsertWorkout(
+                userId: snapshot.userId,
+                workoutId: snapshot.workoutId,
+                document: finalDocument
+            )
+        }
+
+        return finalDocument.heartRateSeries?.storagePath
+    }
+
+    func processPendingDeletions(
+        modelContext: ModelContext,
+        currentUserId: String
+    ) async throws -> Set<UUID> {
+        let pendingDeletions = try loadPendingDeletions(
+            modelContext: modelContext,
+            currentUserId: currentUserId
+        )
+        var deletedWorkoutIds: Set<UUID> = []
+
+        for pendingDeletion in pendingDeletions {
+            do {
+                try await deleteRemoteResources(for: pendingDeletion)
+                deletedWorkoutIds.insert(pendingDeletion.workoutId)
+                modelContext.delete(pendingDeletion)
+                try modelContext.save()
+            } catch {
+                recordDeletionFailure(error, workoutId: pendingDeletion.workoutId)
+                pendingDeletion.recordFailure(error.localizedDescription)
+                try? modelContext.save()
+            }
+        }
+
+        return deletedWorkoutIds
+    }
+
+    func deleteRemoteResources(
+        for pendingDeletion: PendingWorkoutDeletion
+    ) async throws {
+        let userId = pendingDeletion.ownerUserId
+        let workoutId = pendingDeletion.workoutId
+
+        try await withWorkoutSyncTimeout(seconds: operationTimeoutSeconds) {
+            try await self.heartRateStorageRepository.deleteHeartRateSeriesIfPresent(
+                userId: userId,
+                workoutId: workoutId
+            )
+        }
+
+        try await withWorkoutSyncTimeout(seconds: operationTimeoutSeconds) {
+            try await self.remoteRepository.deleteWorkout(
+                userId: userId,
+                workoutId: workoutId
+            )
+        }
+    }
+
+    func loadPendingSnapshots(
+        modelContext: ModelContext,
+        currentUserId: String,
+        excludedWorkoutIds: Set<UUID> = []
+    ) throws -> [WorkoutRemoteSyncSnapshot] {
+        let pendingDeletionDescriptor = FetchDescriptor<PendingWorkoutDeletion>(
+            predicate: #Predicate<PendingWorkoutDeletion> { deletion in
+                deletion.ownerUserId == currentUserId
+            }
+        )
+        let pendingDeletionIds = try Set(
+            modelContext.fetch(pendingDeletionDescriptor).map(\.workoutId)
+        ).union(excludedWorkoutIds)
+
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { workout in
+                workout.ownerUserId == currentUserId
+            },
+            sortBy: [SortDescriptor(\Workout.lastModifiedAt)]
+        )
+
+        return try modelContext.fetch(descriptor)
+            .filter { workout in
+                guard !pendingDeletionIds.contains(workout.id) else { return false }
+                let status = workout.remoteSyncStatus
+                return status == .pendingUpsert || status == .failed
+            }
+            .map { workout in
+                try WorkoutRemoteSyncMapper.snapshot(from: workout)
+            }
+    }
+
+    func loadPendingDeletions(
+        modelContext: ModelContext,
+        currentUserId: String
+    ) throws -> [PendingWorkoutDeletion] {
+        let descriptor = FetchDescriptor<PendingWorkoutDeletion>(
+            predicate: #Predicate<PendingWorkoutDeletion> { deletion in
+                deletion.ownerUserId == currentUserId
+            },
+            sortBy: [SortDescriptor(\PendingWorkoutDeletion.enqueuedAt)]
+        )
+        return try modelContext.fetch(descriptor)
+    }
+
+    func markSynced(
+        workoutId: UUID,
+        userId: String,
+        expectedModifiedAt: Date,
+        heartRateSeriesStoragePath: String?,
+        modelContext: ModelContext
+    ) throws {
+        guard let workout = try Self.fetchWorkout(
+            workoutId: workoutId,
+            userId: userId,
+            modelContext: modelContext
+        ) else { return }
+
+        guard workout.lastModifiedAt <= expectedModifiedAt else { return }
+
+        workout.markRemoteSyncSucceeded(
+            heartRateSeriesStoragePath: heartRateSeriesStoragePath
+        )
+        try modelContext.save()
+    }
+
+    func markFailed(
+        workoutId: UUID,
+        userId: String,
+        expectedModifiedAt: Date,
+        errorMessage: String,
+        modelContext: ModelContext
+    ) throws {
+        guard let workout = try Self.fetchWorkout(
+            workoutId: workoutId,
+            userId: userId,
+            modelContext: modelContext
+        ) else { return }
+
+        guard workout.lastModifiedAt <= expectedModifiedAt else { return }
+
+        workout.markRemoteSyncFailed(errorMessage)
+        try modelContext.save()
+    }
+
+    static func fetchWorkout(
+        workoutId: UUID,
+        userId: String,
+        modelContext: ModelContext
+    ) throws -> Workout? {
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { workout in
+                workout.id == workoutId && workout.ownerUserId == userId
+            }
+        )
+        return try modelContext.fetch(descriptor).first
+    }
+
+    func recordSyncFailure(_ error: Error, workoutId: UUID?) {
+        let additionalInfo = workoutId.map { ["workout_id": $0.uuidString] }
+        let context: TelemetryManager.ErrorContext
+        let code: String
+
+        switch error {
+        case is WorkoutSyncError,
+             is WorkoutSyncTimeoutError:
+            context = .firestore
+            code = "workout_sync_failed"
+        case is GzipCodec.Error:
+            context = .storage
+            code = "workout_hr_encoding_failed"
+        default:
+            let nsError = error as NSError
+            if nsError.domain == StorageErrorDomain {
+                context = .storage
+                code = "workout_hr_upload_failed"
+            } else {
+                context = .firestore
+                code = "workout_sync_failed"
+            }
+        }
+
+        TelemetryManager.shared.recordError(
+            error,
+            context: context,
+            code: code,
+            additionalInfo: additionalInfo
+        )
+    }
+
+    func recordDeletionFailure(_ error: Error, workoutId: UUID?) {
+        let additionalInfo = workoutId.map { ["workout_id": $0.uuidString] }
+        let nsError = error as NSError
+        let context: TelemetryManager.ErrorContext
+        let code: String
+
+        if nsError.domain == StorageErrorDomain {
+            context = .storage
+            code = "workout_hr_delete_failed"
+        } else {
+            context = .firestore
+            code = "workout_delete_failed"
+        }
+
+        TelemetryManager.shared.recordError(
+            error,
+            context: context,
+            code: code,
+            additionalInfo: additionalInfo
+        )
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutSyncError.swift
+++ b/AscendApp/Shared/Services/WorkoutSyncError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum WorkoutSyncError: LocalizedError {
+    case notAuthenticated
+    case missingOwner
+    case unsupportedSource(String)
+    case invalidHeartRateSeries
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthenticated:
+            return "You must be signed in to sync workouts."
+        case .missingOwner:
+            return "Workout sync requires an owning user."
+        case .unsupportedSource(let source):
+            return "Workout sync does not support source '\(source)' yet."
+        case .invalidHeartRateSeries:
+            return "Heart-rate samples must include at least one entry."
+        }
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutSyncTimeout.swift
+++ b/AscendApp/Shared/Services/WorkoutSyncTimeout.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum WorkoutSyncTimeoutError: LocalizedError {
+    case operationTimedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .operationTimedOut:
+            return "The workout sync request timed out."
+        }
+    }
+}
+
+func withWorkoutSyncTimeout<T: Sendable>(
+    seconds: Double,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await operation()
+        }
+
+        group.addTask {
+            try await Task.sleep(for: .seconds(seconds))
+            throw WorkoutSyncTimeoutError.operationTimedOut
+        }
+
+        let result = try await group.next()!
+        group.cancelAll()
+        return result
+    }
+}

--- a/AscendApp/Shared/Views/AppSheet.swift
+++ b/AscendApp/Shared/Views/AppSheet.swift
@@ -280,6 +280,7 @@ private struct AppSheetButtonModifier: ViewModifier {
                 RoundedRectangle(cornerRadius: 12)
                     .stroke(strokeColor, lineWidth: 1)
             )
+            .contentShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 

--- a/AscendApp/Shared/Views/MainTabBarPreviewScaffold.swift
+++ b/AscendApp/Shared/Views/MainTabBarPreviewScaffold.swift
@@ -1,0 +1,98 @@
+//
+//  MainTabBarPreviewScaffold.swift
+//  AscendApp
+//
+//  Created by Codex on 4/17/26.
+//
+
+import SwiftUI
+
+struct MainTabBarPreviewScaffold: View {
+    let selectedTab: AppTab
+    let status: MainTabBarView.Status?
+    let statusBackground: Color?
+
+    var body: some View {
+        ZStack {
+            Color.black
+                .ignoresSafeArea()
+
+            VStack(alignment: .leading, spacing: 18) {
+                Text("Good Evening, Tyler")
+                    .font(.montserratBold(size: 18))
+                    .foregroundStyle(.white)
+
+                RoundedRectangle(cornerRadius: 18)
+                    .fill(Color.accent)
+                    .frame(height: 76)
+                    .overlay(alignment: .leading) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Log Workout")
+                                .font(.montserratBold(size: 16))
+                                .foregroundStyle(.black)
+
+                            Text("Manual entry, routines, imports")
+                                .font(.montserratRegular(size: 14))
+                                .foregroundStyle(.black.opacity(0.65))
+                        }
+                        .padding(.horizontal, 16)
+                    }
+
+                previewCard(title: "THIS WEEK", height: 108)
+                previewCard(title: "WEEKLY GOAL", height: 84)
+                previewCard(title: "ROUTINES", height: 92)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 24)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            MainTabBarView(
+                tabs: MainTabBarView.previewTabs,
+                selectedTab: selectedTab,
+                effectiveColorScheme: .dark,
+                status: status,
+                statusBackground: statusBackground,
+                onSelect: { _ in }
+            )
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    private func previewCard(title: String, height: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 18)
+            .fill(Color.white.opacity(0.06))
+            .frame(height: height)
+            .overlay(alignment: .topLeading) {
+                Text(title)
+                    .font(.montserratSemiBold(size: 12))
+                    .foregroundStyle(.white.opacity(0.55))
+                    .padding(16)
+            }
+    }
+}
+
+#Preview("Tab Bar With Offline Status") {
+    MainTabBarPreviewScaffold(
+        selectedTab: .home,
+        status: .init(message: "You're offline", iconName: "wifi.slash"),
+        statusBackground: .blue
+    )
+}
+
+#Preview("Tab Bar With Settled Offline Status") {
+    MainTabBarPreviewScaffold(
+        selectedTab: .home,
+        status: .init(message: "You're offline", iconName: "wifi.slash"),
+        statusBackground: nil
+    )
+}
+
+#Preview("Tab Bar With Reconnect Status") {
+    MainTabBarPreviewScaffold(
+        selectedTab: .leaderboard,
+        status: .init(message: "You're back online", iconName: "checkmark.circle.fill"),
+        statusBackground: .green
+    )
+}

--- a/AscendApp/Shared/Views/MainTabBarPreviewScaffold.swift
+++ b/AscendApp/Shared/Views/MainTabBarPreviewScaffold.swift
@@ -12,6 +12,14 @@ struct MainTabBarPreviewScaffold: View {
     let status: MainTabBarView.Status?
     let statusBackground: Color?
 
+    private static let previewTabs: [TabItem] = [
+        TabItem(identifier: .home, title: "Home", icon: .tabHome, selectedIcon: .tabHomeSelected) { Color.clear },
+        TabItem(identifier: .workouts, title: "Workouts", icon: .tabWorkouts, selectedIcon: .tabWorkoutsSelected) { Color.clear },
+        TabItem(identifier: .progress, title: "Progress", icon: .tabProgress, selectedIcon: .tabProgressSelected) { Color.clear },
+        TabItem(identifier: .leaderboard, title: "Leaderboard", icon: .tabLeaderboard, selectedIcon: .tabLeaderboardSelected) { Color.clear },
+        TabItem(identifier: .settings, title: "Settings", icon: .tabSettings, selectedIcon: .tabSettingsSelected) { Color.clear }
+    ]
+
     var body: some View {
         ZStack {
             Color.black
@@ -49,7 +57,7 @@ struct MainTabBarPreviewScaffold: View {
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             MainTabBarView(
-                tabs: MainTabBarView.previewTabs,
+                tabs: Self.previewTabs,
                 selectedTab: selectedTab,
                 effectiveColorScheme: .dark,
                 status: status,

--- a/AscendApp/Shared/Views/MainTabBarView.swift
+++ b/AscendApp/Shared/Views/MainTabBarView.swift
@@ -1,0 +1,241 @@
+//
+//  MainTabBarView.swift
+//  AscendApp
+//
+//  Created by Codex on 4/14/26.
+//
+
+import SwiftUI
+import UIKit
+
+struct MainTabBarView: View {
+    struct Status: Equatable {
+        let message: String
+        let iconName: String
+    }
+
+    let tabs: [TabItem]
+    let selectedTab: AppTab
+    let effectiveColorScheme: ColorScheme
+    let status: Status?
+    let statusBackground: Color?
+    let onSelect: (TabItem) -> Void
+
+    // Styling knobs for the compact connectivity strip.
+    private static let topInset: CGFloat = 8
+    private static let tabRowBottomInset: CGFloat = 8
+    private static let compactBottomInset: CGFloat = 4
+    private static let previewBottomStatusAreaHeight: CGFloat = 34
+    private static let statusVerticalInset: CGFloat = 6
+    private static let statusFontSize: CGFloat = 13
+    private static let statusIconSize: CGFloat = 11
+    private static let tabLabelFontSize: CGFloat = 10
+    private static let tabIconSize: CGFloat = 24
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(tabs) { tab in
+                tabBarButton(for: tab)
+            }
+        }
+        .padding(.top, Self.topInset)
+        .padding(.bottom, Self.tabRowBottomInset + Self.compactBottomInset)
+        .background {
+            tabBarBackground
+                .ignoresSafeArea(edges: .bottom)
+        }
+        .overlay(alignment: .bottom) {
+            HStack(spacing: 0) {
+                if let status {
+                    statusOverlay(for: status)
+                }
+            }
+        }
+    }
+
+    private func tabBarButton(for tab: TabItem) -> some View {
+        let isSelected = selectedTab == tab.identifier
+
+        return Button {
+            onSelect(tab)
+        } label: {
+            VStack(spacing: 3) {
+                let iconToUse = iconToken(for: tab, isSelected: isSelected)
+                tabBarIcon(for: iconToUse)
+                    .frame(width: Self.tabIconSize, height: Self.tabIconSize)
+
+                Text(tab.title)
+                    .font(.system(size: Self.tabLabelFontSize, weight: isSelected ? .semibold : .regular))
+            }
+            .foregroundStyle(
+                isSelected
+                    ? Color.accent
+                    : effectiveColorScheme == .dark
+                        ? .white.opacity(0.6)
+                        : Color.gray
+            )
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var tabBarBackground: some View {
+        if effectiveColorScheme == .dark {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+        } else {
+            Rectangle()
+                .fill(Color(uiColor: .systemBackground))
+        }
+    }
+
+    private func statusOverlay(for status: Status) -> some View {
+        let bottomAreaHeight = bottomStatusAreaHeight
+
+        return ZStack {
+            if let statusBackground {
+                Rectangle()
+                    .fill(statusBackground)
+            }
+
+            HStack(spacing: 6) {
+                Image(systemName: status.iconName)
+                    .font(.system(size: Self.statusIconSize, weight: .semibold))
+
+                Text(status.message)
+                    .font(.system(size: Self.statusFontSize, weight: .semibold))
+                    .lineLimit(1)
+            }
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Self.statusVerticalInset)
+        }
+        .frame(maxWidth: .infinity, minHeight: bottomAreaHeight, maxHeight: bottomAreaHeight)
+        .offset(y: bottomAreaHeight)
+        .allowsHitTesting(false)
+    }
+
+    private var bottomStatusAreaHeight: CGFloat {
+        let windowInset = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)?
+            .safeAreaInsets.bottom ?? 0
+
+        return max(windowInset, Self.previewBottomStatusAreaHeight)
+    }
+
+    private func iconToken(for tab: TabItem, isSelected: Bool) -> AppIconToken {
+        if isSelected, let selectedIcon = tab.selectedIcon {
+            return selectedIcon
+        }
+        return tab.icon
+    }
+
+    @ViewBuilder
+    private func tabBarIcon(for token: AppIconToken) -> some View {
+        switch token.source {
+        case .asset(let name):
+            Image(uiImage: resizedTabBarImage(named: name))
+        case .systemSymbol:
+            AppIcon(token: token, pointSize: 20)
+        }
+    }
+
+    private func resizedTabBarImage(named name: String) -> UIImage {
+        let size = CGSize(width: Self.tabIconSize, height: Self.tabIconSize)
+        guard let sourceImage = UIImage(named: name) else {
+            return UIImage(systemName: "questionmark.circle") ?? UIImage()
+        }
+
+        let format = UIGraphicsImageRendererFormat.default()
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+
+        let rendered = renderer.image { _ in
+            sourceImage.draw(in: CGRect(origin: .zero, size: size))
+        }
+
+        return rendered.withRenderingMode(.alwaysTemplate)
+    }
+}
+
+#if DEBUG
+extension MainTabBarView {
+    @MainActor
+    static var previewTabs: [TabItem] {
+        [
+            TabItem(identifier: .home, title: "Home", icon: .tabHome, selectedIcon: .tabHomeSelected) { Color.clear },
+            TabItem(identifier: .workouts, title: "Workouts", icon: .tabWorkouts, selectedIcon: .tabWorkoutsSelected) { Color.clear },
+            TabItem(identifier: .progress, title: "Progress", icon: .tabProgress, selectedIcon: .tabProgressSelected) { Color.clear },
+            TabItem(identifier: .leaderboard, title: "Leaderboard", icon: .tabLeaderboard, selectedIcon: .tabLeaderboardSelected) { Color.clear },
+            TabItem(identifier: .settings, title: "Settings", icon: .tabSettings, selectedIcon: .tabSettingsSelected) { Color.clear }
+        ]
+    }
+}
+
+#Preview("Default Tab Bar") {
+    VStack(spacing: 0) {
+        Spacer()
+        MainTabBarView(
+            tabs: MainTabBarView.previewTabs,
+            selectedTab: .home,
+            effectiveColorScheme: .dark,
+            status: nil,
+            statusBackground: nil,
+            onSelect: { _ in }
+        )
+    }
+    .background(Color.black)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Offline Highlight") {
+    VStack(spacing: 0) {
+        Spacer()
+        MainTabBarView(
+            tabs: MainTabBarView.previewTabs,
+            selectedTab: .home,
+            effectiveColorScheme: .dark,
+            status: .init(message: "You're offline", iconName: "wifi.slash"),
+            statusBackground: .blue,
+            onSelect: { _ in }
+        )
+    }
+    .background(Color.black)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Offline Settled") {
+    VStack(spacing: 0) {
+        Spacer()
+        MainTabBarView(
+            tabs: MainTabBarView.previewTabs,
+            selectedTab: .home,
+            effectiveColorScheme: .dark,
+            status: .init(message: "You're offline", iconName: "wifi.slash"),
+            statusBackground: nil,
+            onSelect: { _ in }
+        )
+    }
+    .background(Color.black)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Back Online") {
+    VStack(spacing: 0) {
+        Spacer()
+        MainTabBarView(
+            tabs: MainTabBarView.previewTabs,
+            selectedTab: .leaderboard,
+            effectiveColorScheme: .dark,
+            status: .init(message: "You're back online", iconName: "checkmark.circle.fill"),
+            statusBackground: .green,
+            onSelect: { _ in }
+        )
+    }
+    .background(Color.black)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/AscendApp/Shared/Views/MainTabView.swift
+++ b/AscendApp/Shared/Views/MainTabView.swift
@@ -11,11 +11,16 @@ import SwiftData
 struct MainTabView: View {
     @Environment(\.colorScheme) private var systemColorScheme
     @Environment(\.modelContext) private var modelContext
+    @Environment(NetworkConnectivityService.self) private var connectivityService
     @State private var themeManager = ThemeManager.shared
     @State private var settingsManager = SettingsManager.shared
     @State private var tabRouter = TabRouter()
     @State private var hasCheckedRatingOnLaunch = false
     @State private var showingBaseLevelOnboarding = false
+    @State private var showBackOnlineBanner = false
+    @State private var onlineBannerTask: Task<Void, Never>?
+    @State private var showOfflineHighlight = false
+    @State private var offlineHighlightTask: Task<Void, Never>?
 
     // Easy configuration - just change this array to modify tabs
     private let tabs = TabItem.activeTabs
@@ -43,6 +48,9 @@ struct MainTabView: View {
             checkForRatingPromptOnLaunch()
             syncBaseLevelOnboardingPresentation()
         }
+        .onChange(of: connectivityService.isConnected) { oldValue, newValue in
+            handleConnectivityChange(from: oldValue, to: newValue)
+        }
         .onChange(of: settingsManager.hasCompletedBaseLevelOnboarding) { _, _ in
             syncBaseLevelOnboardingPresentation()
         }
@@ -50,58 +58,44 @@ struct MainTabView: View {
             BaseLevelOnboardingView()
         }
         .themeAware()
+        .animation(.smooth(duration: 0.2), value: connectivityService.isConnected)
+        .animation(.smooth(duration: 0.2), value: showBackOnlineBanner)
     }
 
     // MARK: - Custom Tab Bar
 
     private var tabBar: some View {
-        HStack(spacing: 0) {
-            ForEach(tabs) { tab in
-                tabBarButton(for: tab)
-            }
-        }
-        .padding(.top, 8)
-        .padding(.bottom, 2)
-        .background {
-            tabBarBackground
-                .ignoresSafeArea(edges: .bottom)
-        }
-    }
-
-    private func tabBarButton(for tab: TabItem) -> some View {
-        let isSelected = tabRouter.selectedTab == tab.identifier
-        return Button {
+        MainTabBarView(
+            tabs: tabs,
+            selectedTab: tabRouter.selectedTab,
+            effectiveColorScheme: effectiveColorScheme,
+            status: tabBarStatus,
+            statusBackground: tabBarAccentBackground
+        ) { tab in
             guard tabRouter.selectedTab != tab.identifier else { return }
+
             let generator = UIImpactFeedbackGenerator(style: .light)
             generator.impactOccurred()
             tabRouter.selectedTab = tab.identifier
-        } label: {
-            VStack(spacing: 3) {
-                let iconToUse = iconToken(for: tab, isSelected: isSelected)
-                tabBarIcon(for: iconToUse)
-                    .frame(width: 24, height: 24)
-                Text(tab.title)
-                    .font(.system(size: 10, weight: isSelected ? .semibold : .regular))
-            }
-            .foregroundStyle(isSelected ? Color.accent : effectiveColorScheme == .dark ? .white.opacity(0.6) : Color.gray)
-            .frame(maxWidth: .infinity)
-            .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
     }
 
-    @ViewBuilder
-    private var tabBarBackground: some View {
-        if effectiveColorScheme == .dark {
-            Rectangle()
-                .fill(.ultraThinMaterial)
-        } else {
-            VStack(spacing: 0) {
-                Divider()
-                Rectangle()
-                    .fill(Color(uiColor: .systemBackground))
-            }
+    private var tabBarStatus: MainTabBarView.Status? {
+        if connectivityService.isConnected == false {
+            return .init(message: "You're offline", iconName: "wifi.slash")
+        } else if showBackOnlineBanner {
+            return .init(message: "You're back online", iconName: "checkmark.circle.fill")
         }
+        return nil
+    }
+
+    private var tabBarAccentBackground: Color? {
+        if showOfflineHighlight {
+            return Color.blue
+        } else if showBackOnlineBanner {
+            return Color.green
+        }
+        return nil
     }
 
     // MARK: - Helpers
@@ -125,41 +119,51 @@ struct MainTabView: View {
         showingBaseLevelOnboarding = settingsManager.shouldPresentBaseLevelOnboarding
     }
 
-    private func iconToken(for tab: TabItem, isSelected: Bool) -> AppIconToken {
-        if isSelected, let selectedIcon = tab.selectedIcon {
-            return selectedIcon
+    private func handleConnectivityChange(from oldValue: Bool, to newValue: Bool) {
+        guard oldValue != newValue else { return }
+
+        onlineBannerTask?.cancel()
+        offlineHighlightTask?.cancel()
+
+        if newValue {
+            showOfflineHighlight = false
+            showBackOnlineBanner = true
+            onlineBannerTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(3))
+                showBackOnlineBanner = false
+            }
+        } else {
+            showBackOnlineBanner = false
+            showOfflineHighlight = true
+            offlineHighlightTask = Task { @MainActor in
+                try? await Task.sleep(for: .seconds(5))
+                if connectivityService.isConnected == false {
+                    showOfflineHighlight = false
+                }
+            }
         }
-        return tab.icon
     }
 
-    @ViewBuilder
-    private func tabBarIcon(for token: AppIconToken) -> some View {
-        switch token.source {
-        case .asset(let name):
-            Image(uiImage: resizedTabBarImage(named: name))
-        case .systemSymbol:
-            AppIcon(token: token, pointSize: 20)
-        }
-    }
-
-    private func resizedTabBarImage(named name: String) -> UIImage {
-        let size = CGSize(width: 24, height: 24)
-        guard let sourceImage = UIImage(named: name) else {
-            return UIImage(systemName: "questionmark.circle") ?? UIImage()
-        }
-
-        let format = UIGraphicsImageRendererFormat.default()
-        let renderer = UIGraphicsImageRenderer(size: size, format: format)
-
-        let rendered = renderer.image { _ in
-            sourceImage.draw(in: CGRect(origin: .zero, size: size))
-        }
-
-        return rendered.withRenderingMode(.alwaysTemplate)
-    }
 }
 
 #Preview {
     MainTabView()
         .environment(AuthenticationViewModel())
+        .environment(NetworkConnectivityService.shared)
+}
+
+#Preview("Offline Connectivity Banner") {
+    MainTabBarPreviewScaffold(
+        selectedTab: .home,
+        status: .init(message: "You're offline", iconName: "wifi.slash"),
+        statusBackground: .blue
+    )
+}
+
+#Preview("Back Online Connectivity Banner") {
+    MainTabBarPreviewScaffold(
+        selectedTab: .leaderboard,
+        status: .init(message: "You're back online", iconName: "checkmark.circle.fill"),
+        statusBackground: .green
+    )
 }

--- a/AscendApp/Shared/Views/StatusBannerView.swift
+++ b/AscendApp/Shared/Views/StatusBannerView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct StatusBannerView: View {
+    enum Style {
+        case warning
+        case success
+        case error
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    let message: String
+    let style: Style
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: iconName)
+                .foregroundStyle(iconColor)
+
+            Text(message)
+                .font(.montserratRegular(size: 13))
+                .foregroundStyle(colorScheme == .dark ? .white : .black)
+                .multilineTextAlignment(.leading)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(backgroundColor)
+        )
+    }
+
+    private var iconName: String {
+        switch style {
+        case .warning:
+            return "wifi.slash"
+        case .success:
+            return "checkmark.circle.fill"
+        case .error:
+            return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var iconColor: Color {
+        switch style {
+        case .warning:
+            return .orange
+        case .success:
+            return .green
+        case .error:
+            return .red
+        }
+    }
+
+    private var backgroundColor: Color {
+        switch style {
+        case .warning:
+            return colorScheme == .dark ? Color.orange.opacity(0.15) : Color.orange.opacity(0.1)
+        case .success:
+            return colorScheme == .dark ? Color.green.opacity(0.18) : Color.green.opacity(0.12)
+        case .error:
+            return colorScheme == .dark ? Color.red.opacity(0.2) : Color.red.opacity(0.1)
+        }
+    }
+}

--- a/AscendAppTests/FirestoreWorkoutDocumentTests.swift
+++ b/AscendAppTests/FirestoreWorkoutDocumentTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct FirestoreWorkoutDocumentTests {
+    @Test
+    func workoutDocumentRoundTripsWithNestedContracts() throws {
+        let createdAt = makeDate(year: 2026, month: 4, day: 11, hour: 8)
+        let updatedAt = makeDate(year: 2026, month: 4, day: 11, hour: 9)
+        let startedAt = makeDate(year: 2026, month: 4, day: 10, hour: 6, minute: 30)
+
+        let document = FirestoreWorkoutDocument(
+            userId: "user-123",
+            name: "Morning Stair Stepper",
+            startedAt: startedAt,
+            durationSeconds: 1_800,
+            steps: 1_200,
+            floors: 75,
+            stepsPerFloor: 16,
+            notes: "Felt strong",
+            source: "apple_health",
+            integrityLevel: "verified",
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            avgHeartRateBpm: 142,
+            maxHeartRateBpm: 168,
+            caloriesBurned: 310,
+            effortRating: 4.5,
+            averageMETs: 8.2,
+            deviceModel: "Apple Watch",
+            sourceMetadata: "{\"sourceDevice\":\"Apple Watch\"}",
+            healthKitUUID: "550E8400-E29B-41D4-A716-446655440000",
+            hevyWorkoutId: "hevy-123",
+            media: [
+                FirestoreWorkoutMediaItem(
+                    id: "11111111-1111-1111-1111-111111111111",
+                    url: "https://example.com/photo.jpg",
+                    uploadedAt: updatedAt,
+                    type: "photo"
+                )
+            ],
+            highlightedMediaId: "11111111-1111-1111-1111-111111111111",
+            weightConfiguration: FirestoreWorkoutWeightConfiguration(
+                entries: [
+                    FirestoreWorkoutWeightEntry(
+                        id: "22222222-2222-2222-2222-222222222222",
+                        equipmentType: "weighted_vest",
+                        weightValue: 20,
+                        isEnabled: true
+                    )
+                ]
+            ),
+            heartRateSeries: FirestoreWorkoutHeartRateSeriesReference(
+                storagePath: "users/user-123/workout_heart_rate/550e8400-e29b-41d4-a716-446655440000.json.gz",
+                sampleCount: 3,
+                seriesStartAt: startedAt,
+                seriesEndAt: updatedAt
+            )
+        )
+
+        let encoded = try JSONEncoder().encode(document)
+        let decoded = try JSONDecoder().decode(FirestoreWorkoutDocument.self, from: encoded)
+
+        #expect(decoded == document)
+        #expect(decoded.schemaVersion == FirestoreWorkoutDocument.currentSchemaVersion)
+    }
+
+    @Test
+    func heartRateSeriesReferenceDefaultsToGzippedJsonEncoding() {
+        let start = makeDate(year: 2026, month: 4, day: 10, hour: 6)
+        let end = makeDate(year: 2026, month: 4, day: 10, hour: 6, minute: 45)
+
+        let reference = FirestoreWorkoutHeartRateSeriesReference(
+            storagePath: "users/user-123/workout_heart_rate/550e8400-e29b-41d4-a716-446655440000.json.gz",
+            sampleCount: 24,
+            seriesStartAt: start,
+            seriesEndAt: end
+        )
+
+        #expect(reference.encoding == FirestoreWorkoutHeartRateSeriesReference.defaultEncoding)
+        #expect(reference.seriesEndAt >= reference.seriesStartAt)
+    }
+
+    @Test
+    func heartRateStorageBlobRoundTripsSamples() throws {
+        let start = makeDate(year: 2026, month: 4, day: 10, hour: 6)
+        let samples = [
+            HeartRateDataPoint(timestamp: start, heartRate: 118),
+            HeartRateDataPoint(timestamp: start.addingTimeInterval(300), heartRate: 132),
+            HeartRateDataPoint(timestamp: start.addingTimeInterval(600), heartRate: 145)
+        ]
+
+        let blob = WorkoutHeartRateStorageBlob(
+            workoutId: "550e8400-e29b-41d4-a716-446655440000",
+            samples: samples
+        )
+
+        let encoded = try JSONEncoder().encode(blob)
+        let decoded = try JSONDecoder().decode(WorkoutHeartRateStorageBlob.self, from: encoded)
+
+        #expect(decoded == blob)
+        #expect(decoded.samples.count == 3)
+        #expect(decoded.schemaVersion == WorkoutHeartRateStorageBlob.currentSchemaVersion)
+    }
+
+    private func makeDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int = 0
+    ) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return components.date!
+    }
+}

--- a/AscendAppTests/InternalQALocalCredentialsLoaderTests.swift
+++ b/AscendAppTests/InternalQALocalCredentialsLoaderTests.swift
@@ -1,0 +1,38 @@
+import Testing
+@testable import AscendApp
+
+struct InternalQALocalCredentialsLoaderTests {
+    @Test
+    func loadReturnsCredentialsWhenBothEnvironmentValuesExist() {
+        let loader = InternalQALocalCredentialsLoader(
+            environment: [
+                InternalQALocalCredentialsLoader.emailEnvironmentKey: " qa-smoke@example.com ",
+                InternalQALocalCredentialsLoader.passwordEnvironmentKey: "secret-value"
+            ]
+        )
+
+        let credentials = loader.load()
+
+        #expect(credentials == InternalQALocalCredentials(
+            email: "qa-smoke@example.com",
+            password: "secret-value"
+        ))
+    }
+
+    @Test
+    func loadReturnsNilWhenEitherEnvironmentValueIsMissing() {
+        let missingEmailLoader = InternalQALocalCredentialsLoader(
+            environment: [
+                InternalQALocalCredentialsLoader.passwordEnvironmentKey: "secret-value"
+            ]
+        )
+        let missingPasswordLoader = InternalQALocalCredentialsLoader(
+            environment: [
+                InternalQALocalCredentialsLoader.emailEnvironmentKey: "qa-smoke@example.com"
+            ]
+        )
+
+        #expect(missingEmailLoader.load() == nil)
+        #expect(missingPasswordLoader.load() == nil)
+    }
+}

--- a/AscendAppTests/InternalQASignInAvailabilityTests.swift
+++ b/AscendAppTests/InternalQASignInAvailabilityTests.swift
@@ -1,0 +1,12 @@
+import Testing
+@testable import AscendApp
+
+struct InternalQASignInAvailabilityTests {
+    @Test
+    func enabledOnlyForDevAndStagingFirebaseProjects() {
+        #expect(InternalQASignInAvailability.isEnabled(projectID: "ascend-f2e4f"))
+        #expect(InternalQASignInAvailability.isEnabled(projectID: "ascend-staging-fa7d5"))
+        #expect(InternalQASignInAvailability.isEnabled(projectID: "ascend-prod-9c8f2") == false)
+        #expect(InternalQASignInAvailability.isEnabled(projectID: nil) == false)
+    }
+}

--- a/AscendAppTests/LeaderboardCurrentUserReconcilerTests.swift
+++ b/AscendAppTests/LeaderboardCurrentUserReconcilerTests.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct LeaderboardCurrentUserReconcilerTests {
+    @Test
+    func previewReconciliationUpdatesCurrentUserAndResortsMetric() {
+        let period = LeaderboardTimeFrame.weekly.currentPeriod(referenceDate: utcDate(year: 2026, month: 4, day: 14))
+        let localStats = LeaderboardStats(
+            userId: "me",
+            timeFrame: .weekly,
+            period: period,
+            totalSteps: 200,
+            totalFloors: 10,
+            totalWorkouts: 2,
+            totalDuration: 1_200,
+            stepsPerMinute: 10
+        )
+
+        let original = [
+            LeaderboardMetric.climb: [
+                makeRemoteStat(userId: "other", displayName: "Other", steps: 150, period: period),
+                makeRemoteStat(userId: "me", displayName: "Old Me", steps: 123, period: period)
+            ]
+        ]
+
+        let reconciled = LeaderboardCurrentUserReconciler.reconcilePreviewStats(
+            original,
+            userId: "me",
+            localStats: localStats,
+            displayName: "Dev QA",
+            photoURL: URL(string: "https://example.com/me.jpg")
+        )
+
+        let climbStats = try! #require(reconciled[.climb])
+        #expect(climbStats.count == 2)
+        #expect(climbStats[0].userId == "me")
+        #expect(climbStats[0].displayName == "Dev QA")
+        #expect(climbStats[0].photoURL == "https://example.com/me.jpg")
+        #expect(climbStats[0].totalSteps == 200)
+    }
+
+    @Test
+    func detailReconciliationRemovesCurrentUserWhenLocalStatsHaveNoActivity() {
+        let period = LeaderboardTimeFrame.weekly.currentPeriod(referenceDate: utcDate(year: 2026, month: 4, day: 14))
+        let localStats = LeaderboardStats(
+            userId: "me",
+            timeFrame: .weekly,
+            period: period,
+            totalSteps: 0,
+            totalFloors: 0,
+            totalWorkouts: 0,
+            totalDuration: 0,
+            stepsPerMinute: 0
+        )
+
+        let original = [
+            makeRemoteStat(userId: "me", displayName: "Old Me", steps: 123, period: period),
+            makeRemoteStat(userId: "other", displayName: "Other", steps: 75, period: period)
+        ]
+
+        let reconciled = LeaderboardCurrentUserReconciler.reconcileDetailStats(
+            original,
+            metric: .climb,
+            userId: "me",
+            localStats: localStats,
+            displayName: "Dev QA",
+            photoURL: nil
+        )
+
+        #expect(reconciled.count == 1)
+        #expect(reconciled[0].userId == "other")
+    }
+
+    @Test
+    func previewReconciliationInsertsCurrentUserWhenRemoteCacheIsMissingRow() {
+        let period = LeaderboardTimeFrame.weekly.currentPeriod(referenceDate: utcDate(year: 2026, month: 4, day: 14))
+        let localStats = LeaderboardStats(
+            userId: "me",
+            timeFrame: .weekly,
+            period: period,
+            totalSteps: 80,
+            totalFloors: 8,
+            totalWorkouts: 1,
+            totalDuration: 900,
+            stepsPerMinute: 5.3
+        )
+
+        let original = [
+            LeaderboardMetric.climb: [
+                makeRemoteStat(userId: "other", displayName: "Other", steps: 60, period: period)
+            ]
+        ]
+
+        let reconciled = LeaderboardCurrentUserReconciler.reconcilePreviewStats(
+            original,
+            userId: "me",
+            localStats: localStats,
+            displayName: "Dev QA",
+            photoURL: nil
+        )
+
+        let climbStats = try! #require(reconciled[.climb])
+        #expect(climbStats.count == 2)
+        #expect(climbStats[0].userId == "me")
+        #expect(climbStats[0].displayName == "Dev QA")
+        #expect(climbStats[0].totalSteps == 80)
+    }
+
+    private func makeRemoteStat(
+        userId: String,
+        displayName: String,
+        steps: Int,
+        period: LeaderboardPeriod
+    ) -> FirestoreLeaderboardStats {
+        let aggregate = LeaderboardAggregate(totalSteps: steps, totalFloors: 5, totalWorkouts: 1, totalDuration: 900)
+        return FirestoreLeaderboardStats(
+            userId: userId,
+            displayName: displayName,
+            photoURL: nil,
+            timeFrame: LeaderboardTimeFrame.weekly.rawValue,
+            schemaVersion: LeaderboardStats.currentSchemaVersion,
+            periodKey: period.key,
+            periodStartAt: period.startAt,
+            totalSteps: aggregate.totalSteps,
+            totalFloors: aggregate.totalFloors,
+            totalWorkouts: aggregate.totalWorkouts,
+            totalDuration: aggregate.totalDuration,
+            stepsPerMinute: aggregate.stepsPerMinute,
+            lastUpdated: utcDate(year: 2026, month: 4, day: 14, hour: 12)
+        )
+    }
+
+    private func utcDate(year: Int, month: Int, day: Int, hour: Int = 0) -> Date {
+        var components = DateComponents()
+        components.calendar = WeekConfiguration.calendar(timeZone: LeaderboardTimeFrame.canonicalTimeZone)
+        components.timeZone = LeaderboardTimeFrame.canonicalTimeZone
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        return components.date!
+    }
+}

--- a/AscendAppTests/LeaderboardTimeoutTests.swift
+++ b/AscendAppTests/LeaderboardTimeoutTests.swift
@@ -1,14 +1,14 @@
-import Foundation
 import Testing
 @testable import AscendApp
 
 struct LeaderboardTimeoutTests {
     @Test
-    func timeoutFailsSlowOperations() async {
+    func timeoutCompletesWhenOperationDoesNotCooperateWithCancellation() async {
         await #expect(throws: LeaderboardTimeoutError.operationTimedOut) {
-            try await withLeaderboardTimeout(seconds: 0.05) {
-                try await Task.sleep(for: .milliseconds(200))
-                return 1
+            let _: Int = try await withLeaderboardTimeout(seconds: 0.1) {
+                try await withCheckedThrowingContinuation { (_: CheckedContinuation<Int, Error>) in
+                    // Intentionally never resumes to simulate a non-cooperative async dependency.
+                }
             }
         }
     }

--- a/AscendAppTests/LeaderboardViewModelTests.swift
+++ b/AscendAppTests/LeaderboardViewModelTests.swift
@@ -8,6 +8,7 @@ struct LeaderboardViewModelTests {
     func cachedFastPathClearsStaleOfflineBannerState() async {
         let cache = LeaderboardSessionCache.shared
         await cache.invalidateAll()
+        let userId = UUID().uuidString
 
         let viewModel = LeaderboardViewModel()
         viewModel.selectedMetric = .climb
@@ -15,10 +16,10 @@ struct LeaderboardViewModelTests {
         viewModel.isOffline = true
         viewModel.errorMessage = "Offline - showing cached data"
 
-        let stats = [makeRemoteStat(userId: "user-1", displayName: "User")]
+        let stats = [makeRemoteStat(userId: userId, displayName: "User")]
         await cache.setDetailEntries(stats, for: .climb, timeFrame: .weekly)
 
-        await viewModel.loadLeaderboard(userId: "user-1")
+        await viewModel.loadLeaderboard(userId: userId)
 
         #expect(viewModel.isOffline == false)
         #expect(viewModel.errorMessage == nil)

--- a/AscendAppTests/SelectedMediaPreparationServiceTests.swift
+++ b/AscendAppTests/SelectedMediaPreparationServiceTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct SelectedMediaPreparationServiceTests {
+    @Test
+    func allowsSelectionWithinConfiguredLimits() {
+        let validationMessage = SelectedMediaPreparationService.validationMessage(
+            forAdditionalMediaCount: 1,
+            additionalVideoCount: 0,
+            currentMediaCount: 1,
+            currentVideoCount: 0
+        )
+
+        #expect(validationMessage == nil)
+    }
+
+    @Test
+    func rejectsSelectionAboveMediaLimit() {
+        let validationMessage = SelectedMediaPreparationService.validationMessage(
+            forAdditionalMediaCount: 2,
+            additionalVideoCount: 0,
+            currentMediaCount: 2,
+            currentVideoCount: 0
+        )
+
+        #expect(validationMessage == "Only 3 combined photos and videos (max 1 video) can be added to a given workout.")
+    }
+
+    @Test
+    func rejectsSelectionAboveVideoLimit() {
+        let validationMessage = SelectedMediaPreparationService.validationMessage(
+            forAdditionalMediaCount: 1,
+            additionalVideoCount: 1,
+            currentMediaCount: 0,
+            currentVideoCount: 1
+        )
+
+        #expect(validationMessage == "You can only add one video with a max length of 15 seconds.")
+    }
+
+    @Test
+    func cleanupTemporaryVideoFileRemovesExistingFile() throws {
+        let tempURL = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).mov")
+        let fileContents = Data("temp".utf8)
+        try fileContents.write(to: tempURL)
+
+        #expect(FileManager.default.fileExists(atPath: tempURL.path()))
+
+        SelectedMediaPreparationService.cleanupTemporaryVideoFile(at: tempURL)
+
+        #expect(FileManager.default.fileExists(atPath: tempURL.path()) == false)
+    }
+
+    @Test
+    func cleanupTemporaryVideoFileIgnoresMissingFile() {
+        let tempURL = URL.temporaryDirectory.appending(path: "\(UUID().uuidString).mov")
+
+        SelectedMediaPreparationService.cleanupTemporaryVideoFile(at: tempURL)
+
+        #expect(FileManager.default.fileExists(atPath: tempURL.path()) == false)
+    }
+}

--- a/AscendAppTests/WorkoutInputValidationTests.swift
+++ b/AscendAppTests/WorkoutInputValidationTests.swift
@@ -1,0 +1,47 @@
+import Testing
+@testable import AscendApp
+
+struct WorkoutInputValidationTests {
+    @Test
+    func workoutNameAllowsUpToConfiguredLimit() {
+        let validName = String(repeating: "A", count: WorkoutInputValidation.nameMaxLength)
+        let invalidName = validName + "A"
+
+        #expect(WorkoutInputValidation.isValidWorkoutName(validName))
+        #expect(WorkoutInputValidation.isValidWorkoutName(""))
+        #expect(WorkoutInputValidation.isValidWorkoutName(invalidName) == false)
+    }
+
+    @Test
+    func notesAllowUpToConfiguredLimit() {
+        let validNotes = String(repeating: "N", count: WorkoutInputValidation.notesMaxLength)
+        let invalidNotes = validNotes + "N"
+
+        #expect(WorkoutInputValidation.isValidNotes(validNotes))
+        #expect(WorkoutInputValidation.isValidNotes(invalidNotes) == false)
+    }
+
+    @Test
+    func optionalMetricRequiresNonNegativeInteger() {
+        #expect(WorkoutInputValidation.isValidOptionalMetric(""))
+        #expect(WorkoutInputValidation.isValidOptionalMetric("0"))
+        #expect(WorkoutInputValidation.isValidOptionalMetric("42"))
+        #expect(WorkoutInputValidation.isValidOptionalMetric("-1") == false)
+        #expect(WorkoutInputValidation.isValidOptionalMetric("abc") == false)
+    }
+
+    @Test
+    func heartRateNormalizationClampsToSupportedRange() {
+        #expect(WorkoutInputValidation.normalizeHeartRateOnSubmit("") == "")
+        #expect(WorkoutInputValidation.normalizeHeartRateOnSubmit("12") == "25")
+        #expect(WorkoutInputValidation.normalizeHeartRateOnSubmit("145") == "145")
+        #expect(WorkoutInputValidation.normalizeHeartRateOnSubmit("999") == "230")
+    }
+
+    @Test
+    func caloriesNormalizationKeepsOnlyNonNegativeDigits() {
+        #expect(WorkoutInputValidation.normalizeCaloriesOnSubmit("") == "")
+        #expect(WorkoutInputValidation.normalizeCaloriesOnSubmit("450") == "450")
+        #expect(WorkoutInputValidation.filterNumericInput("-12a3") == "123")
+    }
+}

--- a/AscendAppTests/WorkoutRemoteSyncMigrationServiceTests.swift
+++ b/AscendAppTests/WorkoutRemoteSyncMigrationServiceTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import AscendApp
+
+struct WorkoutRemoteSyncMigrationServiceTests {
+    @Test
+    func newWorkoutsDefaultToPendingRemoteSync() {
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 10, hour: 6))
+
+        #expect(workout.ownerUserId == nil)
+        #expect(workout.remoteSyncStatus == .pendingUpsert)
+        #expect(workout.lastRemoteSyncAt == nil)
+        #expect(workout.lastRemoteSyncError == nil)
+        #expect(abs(workout.lastModifiedAt.timeIntervalSince(workout.createdAt)) < 1)
+    }
+
+    @Test
+    func migrationAssignsLegacyWorkoutsToSignedInUser() throws {
+        let modelContext = try makeModelContext()
+        let workoutDate = makeDate(year: 2026, month: 4, day: 10, hour: 6)
+        let workout = makeWorkout(date: workoutDate)
+        workout.remoteSyncStatusRawValue = "unknown"
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let suiteName = "WorkoutRemoteSyncMigrationServiceTests.\(UUID().uuidString)"
+        let userDefaults = try #require(UserDefaults(suiteName: suiteName))
+
+        try WorkoutRemoteSyncMigrationService.runIfNeeded(
+            modelContext: modelContext,
+            currentUserId: "user-123",
+            userDefaults: userDefaults
+        )
+
+        let migratedWorkout = try #require(fetchWorkouts(in: modelContext).first)
+        #expect(migratedWorkout.ownerUserId == "user-123")
+        #expect(migratedWorkout.remoteSyncStatus == .pendingUpsert)
+        #expect(migratedWorkout.lastRemoteSyncError == nil)
+        #expect(migratedWorkout.lastModifiedAt == max(migratedWorkout.createdAt, workoutDate))
+        #expect(
+            userDefaults.bool(
+                forKey: WorkoutRemoteSyncMigrationService.migrationVersionKey(for: "user-123")
+            )
+        )
+
+        userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    @Test
+    func migrationDoesNotReassignOwnedWorkouts() throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 10, hour: 6))
+        let syncedAt = makeDate(year: 2026, month: 4, day: 12, hour: 9)
+        workout.ownerUserId = "existing-owner"
+        workout.remoteSyncStatus = .synced
+        workout.lastRemoteSyncAt = syncedAt
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let suiteName = "WorkoutRemoteSyncMigrationServiceTests.\(UUID().uuidString)"
+        let userDefaults = try #require(UserDefaults(suiteName: suiteName))
+
+        try WorkoutRemoteSyncMigrationService.runIfNeeded(
+            modelContext: modelContext,
+            currentUserId: "new-owner",
+            userDefaults: userDefaults
+        )
+
+        let migratedWorkout = try #require(fetchWorkouts(in: modelContext).first)
+        #expect(migratedWorkout.ownerUserId == "existing-owner")
+        #expect(migratedWorkout.remoteSyncStatus == .synced)
+        #expect(migratedWorkout.lastRemoteSyncAt == syncedAt)
+
+        userDefaults.removePersistentDomain(forName: suiteName)
+    }
+
+    @Test
+    @MainActor
+    func mutationHandlerMarksChangedWorkoutsForRemoteSync() {
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 10, hour: 6))
+        let modifiedAt = makeDate(year: 2026, month: 4, day: 13, hour: 8)
+        workout.remoteSyncStatus = .failed
+        workout.lastRemoteSyncError = "timed out"
+
+        WorkoutMutationHandler.shared.markChangedWorkoutsForRemoteSync(
+            [workout],
+            userId: "user-123",
+            modifiedAt: modifiedAt
+        )
+
+        #expect(workout.ownerUserId == "user-123")
+        #expect(workout.remoteSyncStatus == .pendingUpsert)
+        #expect(workout.lastRemoteSyncError == nil)
+        #expect(workout.lastModifiedAt == modifiedAt)
+    }
+
+    private func makeModelContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: Workout.self,
+            WorkoutSourceLink.self,
+            PendingWorkoutDeletion.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func fetchWorkouts(in modelContext: ModelContext) throws -> [Workout] {
+        try modelContext.fetch(FetchDescriptor<Workout>())
+    }
+
+    private func makeWorkout(date: Date) -> Workout {
+        Workout(
+            name: "Workout",
+            date: date,
+            duration: 1_800,
+            steps: 1_000,
+            floors: 63,
+            stepsPerFloor: 16,
+            source: .manual
+        )
+    }
+
+    private func makeDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int = 0
+    ) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return components.date!
+    }
+}

--- a/AscendAppTests/WorkoutSyncCoordinatorTests.swift
+++ b/AscendAppTests/WorkoutSyncCoordinatorTests.swift
@@ -1,0 +1,671 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import AscendApp
+
+@MainActor
+struct WorkoutSyncCoordinatorTests {
+    @Test
+    func noHeartRateWorkoutSyncsDocumentOnly() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 13, hour: 9))
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let remoteRepository = FakeWorkoutRemoteRepository()
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let syncedWorkout = try #require(fetchWorkouts(in: modelContext).first)
+        #expect(syncedWorkout.remoteSyncStatus == .synced)
+        #expect(syncedWorkout.lastRemoteSyncAt != nil)
+
+        let upserts = await remoteRepository.recordedUpserts()
+        #expect(upserts.count == 1)
+        #expect(upserts.first?.document.heartRateSeries == nil)
+        #expect(await heartRateRepository.uploads().isEmpty)
+    }
+
+    @Test
+    func heartRateWorkoutUploadsBlobBeforeDocument() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(
+            date: makeDate(year: 2026, month: 4, day: 13, hour: 9),
+            heartRateSamples: [
+                HeartRateDataPoint(timestamp: makeDate(year: 2026, month: 4, day: 13, hour: 9), heartRate: 110),
+                HeartRateDataPoint(timestamp: makeDate(year: 2026, month: 4, day: 13, hour: 9, minute: 5), heartRate: 124)
+            ]
+        )
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let recorder = CallRecorder()
+        let remoteRepository = FakeWorkoutRemoteRepository(recorder: recorder)
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository(recorder: recorder)
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let events = await recorder.events()
+        #expect(events == ["heart-rate-upload", "workout-upsert"])
+
+        let upsert = try #require(await remoteRepository.recordedUpserts().first)
+        let heartRateSeries = try #require(upsert.document.heartRateSeries)
+        #expect(heartRateSeries.sampleCount == 2)
+        #expect(
+            heartRateSeries.storagePath ==
+                "users/user-123/workout_heart_rate/\(workout.id.uuidString).json.gz"
+        )
+    }
+
+    @Test
+    func syncFailureMarksWorkoutFailed() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 13, hour: 9))
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let remoteRepository = FakeWorkoutRemoteRepository(
+            upsertError: TestSyncFailure()
+        )
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let failedWorkout = try #require(fetchWorkouts(in: modelContext).first)
+        #expect(failedWorkout.remoteSyncStatus == .failed)
+        #expect(failedWorkout.lastRemoteSyncError?.isEmpty == false)
+        #expect(failedWorkout.lastRemoteSyncAt == nil)
+    }
+
+    @Test
+    func heartRateUploadFailureMarksWorkoutFailedWithoutUpsertingDocument() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(
+            date: makeDate(year: 2026, month: 4, day: 13, hour: 9),
+            heartRateSamples: [
+                HeartRateDataPoint(timestamp: makeDate(year: 2026, month: 4, day: 13, hour: 9), heartRate: 110)
+            ]
+        )
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let remoteRepository = FakeWorkoutRemoteRepository()
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository(
+            uploadError: TestSyncFailure()
+        )
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let failedWorkout = try #require(fetchWorkouts(in: modelContext).first)
+        #expect(failedWorkout.remoteSyncStatus == .failed)
+        #expect(failedWorkout.lastRemoteSyncAt == nil)
+        #expect((await remoteRepository.recordedUpserts()).isEmpty)
+    }
+
+    @Test
+    func failedWorkoutRetriesSuccessfullyOnNextPass() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 13, hour: 9))
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let remoteRepository = FlakyWorkoutRemoteRepository(failingUpsertAttempts: 1)
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let failedWorkout = try #require(fetchWorkouts(in: modelContext).first)
+        #expect(failedWorkout.remoteSyncStatus == .failed)
+        #expect(failedWorkout.lastRemoteSyncAt == nil)
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let syncedWorkout = try #require(fetchWorkouts(in: modelContext).first)
+        #expect(syncedWorkout.remoteSyncStatus == .synced)
+        #expect(syncedWorkout.lastRemoteSyncAt != nil)
+        #expect(await remoteRepository.successfulUpsertCount() == 1)
+    }
+
+    @Test
+    func noHeartRateWorkoutDoesNotDeleteSidecarWhenNoneWasPreviouslySynced() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 13, hour: 9))
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        workout.markRemoteSyncSucceeded(
+            syncedAt: workout.createdAt,
+            heartRateSeriesStoragePath: nil
+        )
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt.addingTimeInterval(60))
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let remoteRepository = FakeWorkoutRemoteRepository()
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        #expect(await heartRateRepository.deletes().isEmpty)
+    }
+
+    @Test
+    func noHeartRateWorkoutDeletesSidecarWhenOneWasPreviouslySynced() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 13, hour: 9))
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        workout.markRemoteSyncSucceeded(
+            syncedAt: workout.createdAt,
+            heartRateSeriesStoragePath: "users/user-123/workout_heart_rate/\(workout.id.uuidString).json.gz"
+        )
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt.addingTimeInterval(60))
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let remoteRepository = FakeWorkoutRemoteRepository()
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let deletes = await heartRateRepository.deletes()
+        #expect(deletes.count == 1)
+        #expect(deletes.first?.workoutId == workout.id)
+    }
+
+    @Test
+    func newerLocalMutationStaysPendingAfterSuccessfulUpload() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 13, hour: 9))
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let updatedAt = workout.createdAt.addingTimeInterval(3_600)
+        let remoteRepository = FakeWorkoutRemoteRepository(
+            onUpsert: {
+                workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: updatedAt)
+                try? modelContext.save()
+            }
+        )
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let pendingWorkout = try #require(fetchWorkouts(in: modelContext).first)
+        #expect(pendingWorkout.remoteSyncStatus == .pendingUpsert)
+        #expect(pendingWorkout.lastRemoteSyncAt == nil)
+        #expect(pendingWorkout.lastModifiedAt == updatedAt)
+    }
+
+    @Test
+    func concurrentProcessRequestsCoalesceIntoSingleSyncPass() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 13, hour: 9))
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let coordinatorReference = CoordinatorReference()
+        let remoteRepository = FakeWorkoutRemoteRepository(
+            onUpsert: {
+                await coordinatorReference.value?.processPendingWorkouts(
+                    modelContext: modelContext,
+                    currentUserId: "user-123"
+                )
+            },
+            upsertDelayNanoseconds: 200_000_000
+        )
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+        coordinatorReference.value = coordinator
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let upserts = await remoteRepository.recordedUpserts()
+        #expect(upserts.count == 1)
+    }
+
+    @Test
+    func pendingDeletionDeletesRemoteResourcesAndRemovesQueueRecord() async throws {
+        let modelContext = try makeModelContext()
+        let pendingDeletion = PendingWorkoutDeletion(
+            workoutId: UUID(),
+            ownerUserId: "user-123"
+        )
+        modelContext.insert(pendingDeletion)
+        try modelContext.save()
+
+        let recorder = CallRecorder()
+        let remoteRepository = FakeWorkoutRemoteRepository(recorder: recorder)
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository(recorder: recorder)
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        #expect(try fetchPendingDeletions(in: modelContext).isEmpty)
+
+        let events = await recorder.events()
+        #expect(events == ["heart-rate-delete", "workout-delete"])
+
+        let deletes = await remoteRepository.recordedDeletes()
+        #expect(deletes.count == 1)
+        #expect(deletes.first?.workoutId == pendingDeletion.workoutId)
+        #expect((await heartRateRepository.deletes()).count == 1)
+    }
+
+    @Test
+    func pendingDeletionFailureRetriesAndKeepsQueueRecord() async throws {
+        let modelContext = try makeModelContext()
+        let pendingDeletion = PendingWorkoutDeletion(
+            workoutId: UUID(),
+            ownerUserId: "user-123"
+        )
+        modelContext.insert(pendingDeletion)
+        try modelContext.save()
+
+        let remoteRepository = FakeWorkoutRemoteRepository(
+            deleteError: TestSyncFailure()
+        )
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let persistedDeletion = try #require(fetchPendingDeletions(in: modelContext).first)
+        #expect(persistedDeletion.retryCount == 1)
+        #expect(persistedDeletion.lastError?.isEmpty == false)
+    }
+
+    @Test
+    func pendingDeletionHeartRateDeleteFailureKeepsQueueRecordAndSkipsRemoteDelete() async throws {
+        let modelContext = try makeModelContext()
+        let pendingDeletion = PendingWorkoutDeletion(
+            workoutId: UUID(),
+            ownerUserId: "user-123"
+        )
+        modelContext.insert(pendingDeletion)
+        try modelContext.save()
+
+        let remoteRepository = FakeWorkoutRemoteRepository()
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository(
+            deleteError: TestSyncFailure()
+        )
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let persistedDeletion = try #require(fetchPendingDeletions(in: modelContext).first)
+        #expect(persistedDeletion.retryCount == 1)
+        #expect(persistedDeletion.lastError?.isEmpty == false)
+        #expect((await remoteRepository.recordedDeletes()).isEmpty)
+    }
+
+    @Test
+    func pendingDeletionPreventsWorkoutFromBeingReuploaded() async throws {
+        let modelContext = try makeModelContext()
+        let workout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 13, hour: 9))
+        workout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: workout.createdAt)
+        modelContext.insert(workout)
+        modelContext.insert(
+            PendingWorkoutDeletion(
+                workoutId: workout.id,
+                ownerUserId: "user-123"
+            )
+        )
+        try modelContext.save()
+
+        let remoteRepository = FakeWorkoutRemoteRepository()
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        #expect((await remoteRepository.recordedUpserts()).isEmpty)
+        #expect((await remoteRepository.recordedDeletes()).count == 1)
+    }
+
+    private func makeModelContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: Workout.self,
+            WorkoutSourceLink.self,
+            PendingWorkoutDeletion.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func fetchWorkouts(in modelContext: ModelContext) throws -> [Workout] {
+        try modelContext.fetch(FetchDescriptor<Workout>())
+    }
+
+    private func fetchPendingDeletions(
+        in modelContext: ModelContext
+    ) throws -> [PendingWorkoutDeletion] {
+        try modelContext.fetch(FetchDescriptor<PendingWorkoutDeletion>())
+    }
+
+    private func makeWorkout(
+        date: Date,
+        heartRateSamples: [HeartRateDataPoint] = []
+    ) -> Workout {
+        Workout(
+            name: "Workout",
+            date: date,
+            duration: 1_800,
+            steps: 1_000,
+            floors: 63,
+            stepsPerFloor: 16,
+            notes: "Test",
+            heartRateTimeSeries: heartRateSamples.isEmpty ? nil : heartRateSamples,
+            source: .manual
+        )
+    }
+
+    private func makeDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int = 0
+    ) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return components.date!
+    }
+}
+
+private actor CallRecorder {
+    private var recordedEvents: [String] = []
+
+    func record(_ value: String) {
+        recordedEvents.append(value)
+    }
+
+    func events() -> [String] {
+        recordedEvents
+    }
+}
+
+private actor FakeWorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol {
+    struct Upsert: Equatable {
+        let userId: String
+        let workoutId: UUID
+        let document: FirestoreWorkoutDocument
+    }
+
+    struct Delete: Equatable {
+        let userId: String
+        let workoutId: UUID
+    }
+
+    private var upserts: [Upsert] = []
+    private var deletes: [Delete] = []
+    private let recorder: CallRecorder?
+    private let upsertError: (any Error & Sendable)?
+    private let deleteError: (any Error & Sendable)?
+    private let onUpsert: (@MainActor () async -> Void)?
+    private let upsertDelayNanoseconds: UInt64?
+
+    init(
+        recorder: CallRecorder? = nil,
+        upsertError: (any Error & Sendable)? = nil,
+        deleteError: (any Error & Sendable)? = nil,
+        onUpsert: (@MainActor () async -> Void)? = nil,
+        upsertDelayNanoseconds: UInt64? = nil
+    ) {
+        self.recorder = recorder
+        self.upsertError = upsertError
+        self.deleteError = deleteError
+        self.onUpsert = onUpsert
+        self.upsertDelayNanoseconds = upsertDelayNanoseconds
+    }
+
+    func upsertWorkout(
+        userId: String,
+        workoutId: UUID,
+        document: FirestoreWorkoutDocument
+    ) async throws {
+        await recorder?.record("workout-upsert")
+        if let upsertError {
+            throw upsertError
+        }
+
+        if let upsertDelayNanoseconds {
+            try? await Task.sleep(nanoseconds: upsertDelayNanoseconds)
+        }
+
+        upserts.append(Upsert(userId: userId, workoutId: workoutId, document: document))
+        await onUpsert?()
+    }
+
+    func deleteWorkout(userId: String, workoutId: UUID) async throws {
+        await recorder?.record("workout-delete")
+        if let deleteError {
+            throw deleteError
+        }
+
+        deletes.append(Delete(userId: userId, workoutId: workoutId))
+    }
+
+    func recordedUpserts() -> [Upsert] {
+        upserts
+    }
+
+    func recordedDeletes() -> [Delete] {
+        deletes
+    }
+}
+
+private actor FakeWorkoutHeartRateStorageRepository: WorkoutHeartRateStorageRepositoryProtocol {
+    struct Upload: Equatable {
+        let userId: String
+        let workoutId: UUID
+        let blob: WorkoutHeartRateStorageBlob
+    }
+
+    struct Delete: Equatable {
+        let userId: String
+        let workoutId: UUID
+    }
+
+    private var recordedUploads: [Upload] = []
+    private var recordedDeletes: [Delete] = []
+    private let recorder: CallRecorder?
+    private let uploadError: (any Error & Sendable)?
+    private let deleteError: (any Error & Sendable)?
+
+    init(
+        recorder: CallRecorder? = nil,
+        uploadError: (any Error & Sendable)? = nil,
+        deleteError: (any Error & Sendable)? = nil
+    ) {
+        self.recorder = recorder
+        self.uploadError = uploadError
+        self.deleteError = deleteError
+    }
+
+    func uploadHeartRateSeries(
+        userId: String,
+        workoutId: UUID,
+        blob: WorkoutHeartRateStorageBlob
+    ) async throws -> FirestoreWorkoutHeartRateSeriesReference {
+        await recorder?.record("heart-rate-upload")
+        if let uploadError {
+            throw uploadError
+        }
+
+        recordedUploads.append(Upload(userId: userId, workoutId: workoutId, blob: blob))
+        return FirestoreWorkoutHeartRateSeriesReference(
+            storagePath: "users/\(userId)/workout_heart_rate/\(workoutId.uuidString).json.gz",
+            sampleCount: blob.samples.count,
+            seriesStartAt: blob.samples.first?.timestamp ?? .distantPast,
+            seriesEndAt: blob.samples.last?.timestamp ?? .distantPast
+        )
+    }
+
+    func deleteHeartRateSeriesIfPresent(
+        userId: String,
+        workoutId: UUID
+    ) async throws {
+        await recorder?.record("heart-rate-delete")
+        if let deleteError {
+            throw deleteError
+        }
+        recordedDeletes.append(Delete(userId: userId, workoutId: workoutId))
+    }
+
+    func uploads() -> [Upload] {
+        recordedUploads
+    }
+
+    func deletes() -> [Delete] {
+        recordedDeletes
+    }
+}
+
+private struct TestSyncFailure: Error, Sendable {}
+
+private actor FlakyWorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol {
+    private var remainingFailingUpsertAttempts: Int
+    private var upsertCount = 0
+
+    init(failingUpsertAttempts: Int) {
+        self.remainingFailingUpsertAttempts = failingUpsertAttempts
+    }
+
+    func upsertWorkout(
+        userId: String,
+        workoutId: UUID,
+        document: FirestoreWorkoutDocument
+    ) async throws {
+        if remainingFailingUpsertAttempts > 0 {
+            remainingFailingUpsertAttempts -= 1
+            throw TestSyncFailure()
+        }
+
+        upsertCount += 1
+    }
+
+    func deleteWorkout(userId: String, workoutId: UUID) async throws {}
+
+    func successfulUpsertCount() -> Int {
+        upsertCount
+    }
+}
+
+@MainActor
+private final class CoordinatorReference {
+    var value: WorkoutSyncCoordinator?
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,15 @@ let hostingURL = "https://\(projectId).web.app"
 let functionsURL = "https://\(region)-\(projectId).cloudfunctions.net"
 ```
 
+### Internal QA Sign-In
+- Internal QA sign-in exists only for **dev** and **staging** builds and must stay unavailable in production.
+- Internal QA sign-in must create a real Firebase-authenticated user session (email/password in dev/staging), not a fake authenticated client state.
+- Gate the feature by both build configuration and Firebase project ID so the UI only appears for `ascend-f2e4f` and `ascend-staging-fa7d5`.
+- Local simulator/automation credentials should come from user-local scheme environment variables or other non-committed secrets sources such as `ASC_INTERNAL_QA_EMAIL` and `ASC_INTERNAL_QA_PASSWORD`.
+- XcodeBuildMCP simulator automation should inject `ASC_INTERNAL_QA_EMAIL` and `ASC_INTERNAL_QA_PASSWORD` through `session_set_defaults(env: ...)` or `launch_app_sim(env: ...)` instead of relying on user-local Xcode scheme environment inheritance.
+- Do not persist Internal QA credentials in repo-local `.xcodebuildmcp/config.yaml`; keep them in user-local scheme settings or pass them into the MCP session at runtime.
+- Never commit QA credentials, never bundle them into production builds, and never use the internal QA path to bypass Firestore/Storage/Auth server enforcement.
+
 ### Data Models (SwiftData)
 Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightPersonalRecord, AggregateWeightRecord, PendingMediaUpload
 
@@ -76,9 +85,24 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
   - `users/{uid}/photos/...`
   - `users/{uid}/videos/...`
   - `users/{uid}/profile_pictures/...`
+  - `users/{uid}/workout_heart_rate/...`
 - Never write user media to shared root paths (`photos/`, `videos/`, `profile_pictures/`) in production.
 - Legacy share card template assets may still live under `share-card-templates/...`, but workout share cards in v1 must not fetch their backgrounds or layout config from Firebase.
-- Account deletion and cleanup should target only the authenticated user's scoped prefix.
+- Account deletion and cleanup should target only the authenticated user's scoped prefixes, including durable workout heart-rate sidecars and private workout backup documents.
+
+### Workout Durability Architecture
+- Canonical private workout backups live at `users/{uid}/workouts/{workoutId}`. These documents are the durable backend record for private workout metadata, while `Workout` in SwiftData remains the local-first cache and editing surface.
+- Workout document IDs should use the workout's stable UUID string. Heart-rate sidecars must use the matching Storage path `users/{uid}/workout_heart_rate/{workoutId}.json.gz` so cleanup and repair flows can derive both resources from the same identity.
+- `WorkoutRemoteRepository` owns Firestore upserts/deletes for the canonical workout document, and `WorkoutHeartRateStorageRepository` owns the gzip-compressed heart-rate sidecar upload/delete path.
+- Full heart-rate chart samples should not be embedded directly in Firestore workout documents. Store the full series as a Storage sidecar and keep only pointer/metadata fields in Firestore, alongside summary values like average and max heart rate.
+- A workout that includes heart-rate series data is not fully synced until both the Storage sidecar upload and Firestore workout document upsert succeed.
+- Local workout sync state lives on `Workout` itself (`ownerUserId`, last-modified timestamp, last-remote-sync timestamp, last remote heart-rate sidecar path, sync status, and last sync error) so the app can track pending remote backup work without changing the current local-first UX.
+- Existing on-device workouts are backfilled once per signed-in user into that sync model. Phase 1 explicitly assumes one account per install for this backfill, so shared local workout history is not a supported multi-account scenario yet.
+- Pending remote deletes are tracked locally in `PendingWorkoutDeletion` so delete/retry flows can become durable without overloading the canonical workout record.
+- Workout backup is mutation-driven for create/edit/import flows. `WorkoutMutationHandler` persists the local sync-state changes and immediately kicks the remote coordinator after successful mutations instead of waiting for the user to relaunch the app.
+- Background media uploads are part of the same durability contract. When `Workout.photos` or `highlightedPhotoId` changes after upload completion, the app should mark that workout pending and republish the private workout backup immediately.
+- `WorkoutSyncCoordinator` is the single orchestrator for pending workout backup work. It currently runs both during authenticated bootstrap/foreground repair and from mutation-triggered flushes, processes pending workout deletions before pending upserts, uploads any required heart-rate sidecar before the Firestore upsert, and coalesces overlapping process requests so launch/auth/lifecycle hooks do not issue duplicate remote work for the same workout.
+- Future public sharing or social features must not read directly from the private workout backup collection. Public posts/comments/likes should use separate public models.
 
 ### Workout Share Card Architecture
 - Workout share cards in v1 use bundled poster background assets so the share surface renders instantly and offline.
@@ -96,6 +120,13 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
   1. Update `firestore.rules` to allow the new/changed fields
   2. Update Swift model + write logic
   3. Deploy rules to all environments before or alongside the app update
+
+### Connectivity UX
+- `NetworkConnectivityService` is the app-wide source of truth for immediate connected-vs-offline UX using `NWPathMonitor`.
+- App-wide offline and back-online messaging should be owned by `MainTabView` as a slim conditional status row inside the custom tab bar chrome, so connectivity state appears in one consistent bottom-of-screen location without covering feature content.
+- When connectivity drops, the custom tab bar should briefly emphasize the offline transition by tinting the full tab-bar chrome blue before settling back to the normal tab-bar background with the compact offline status text still visible.
+- Use connectivity state to fail fast for user-initiated refreshes or uploads when there is no network path, instead of waiting for request timeouts to tell the user they are offline.
+- Request-level failures and timeouts are still a separate concern. Features should keep their own timeout/error handling for slow connections, backend failures, or partial cached-data fallbacks.
 
 ### Import UX
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.

--- a/firestore.rules
+++ b/firestore.rules
@@ -124,6 +124,296 @@ service cloud.firestore {
       return type in ["feature_request", "bug_report", "get_help"];
     }
 
+    function isValidWorkoutSource(source) {
+      return source in [
+        "manual",
+        "apple_health",
+        "garmin",
+        "fitbit",
+        "hevy"
+      ];
+    }
+
+    function isValidIntegrityLevel(level) {
+      return level in ["verified", "unverified"];
+    }
+
+    function isValidWorkoutId(workoutId) {
+      return workoutId.matches("^[0-9a-fA-F-]{36}$");
+    }
+
+    function isValidWorkoutMediaId(mediaId) {
+      return isValidWorkoutId(mediaId);
+    }
+
+    function isValidWorkoutMediaType(type) {
+      return type in ["photo", "video"];
+    }
+
+    function isValidWorkoutWeightEquipmentType(type) {
+      return type in [
+        "weighted_vest",
+        "dumbbells",
+        "barbell",
+        "ankle_weights",
+        "wrist_weights"
+      ];
+    }
+
+    function isValidWorkoutMediaItem(item) {
+      return item is map &&
+        item.keys().hasOnly([
+          "id",
+          "url",
+          "uploadedAt",
+          "type",
+          "durationSeconds"
+        ]) &&
+        item.keys().hasAll([
+          "id",
+          "url",
+          "uploadedAt",
+          "type"
+        ]) &&
+        item.id is string &&
+        isValidWorkoutMediaId(item.id) &&
+        item.url is string &&
+        item.url.size() > 0 &&
+        item.url.size() <= 2048 &&
+        item.uploadedAt is timestamp &&
+        item.type is string &&
+        isValidWorkoutMediaType(item.type) &&
+        (!item.keys().hasAny(["durationSeconds"]) ||
+          (isNonNegativeNumber(item.durationSeconds) &&
+            item.type == "video"));
+    }
+
+    function mediaListContainsId(media, mediaId) {
+      return media is list &&
+        media.size() > 0 &&
+        (
+          media[0].id == mediaId ||
+          (media.size() > 1 && media[1].id == mediaId) ||
+          (media.size() > 2 && media[2].id == mediaId)
+        );
+    }
+
+    function isValidWorkoutMediaList(media) {
+      return media is list &&
+        media.size() <= 3 &&
+        (media.size() == 0 || isValidWorkoutMediaItem(media[0])) &&
+        (media.size() <= 1 || isValidWorkoutMediaItem(media[1])) &&
+        (media.size() <= 2 || isValidWorkoutMediaItem(media[2]));
+    }
+
+    function isValidWorkoutWeightEntry(entry) {
+      return entry is map &&
+        entry.keys().hasOnly([
+          "id",
+          "equipmentType",
+          "weightValue",
+          "isEnabled"
+        ]) &&
+        entry.keys().hasAll([
+          "id",
+          "equipmentType",
+          "weightValue",
+          "isEnabled"
+        ]) &&
+        entry.id is string &&
+        isValidWorkoutId(entry.id) &&
+        entry.equipmentType is string &&
+        isValidWorkoutWeightEquipmentType(entry.equipmentType) &&
+        isNonNegativeNumber(entry.weightValue) &&
+        entry.isEnabled is bool;
+    }
+
+    function hasUniqueWorkoutWeightEquipmentTypes(entries) {
+      return
+        (entries.size() <= 1 || entries[0].equipmentType != entries[1].equipmentType) &&
+        (entries.size() <= 2 || entries[0].equipmentType != entries[2].equipmentType) &&
+        (entries.size() <= 3 || entries[0].equipmentType != entries[3].equipmentType) &&
+        (entries.size() <= 4 || entries[0].equipmentType != entries[4].equipmentType) &&
+        (entries.size() <= 2 || entries[1].equipmentType != entries[2].equipmentType) &&
+        (entries.size() <= 3 || entries[1].equipmentType != entries[3].equipmentType) &&
+        (entries.size() <= 4 || entries[1].equipmentType != entries[4].equipmentType) &&
+        (entries.size() <= 3 || entries[2].equipmentType != entries[3].equipmentType) &&
+        (entries.size() <= 4 || entries[2].equipmentType != entries[4].equipmentType) &&
+        (entries.size() <= 4 || entries[3].equipmentType != entries[4].equipmentType);
+    }
+
+    function isValidWorkoutWeightEntryList(entries) {
+      return entries is list &&
+        entries.size() <= 5 &&
+        (entries.size() == 0 || isValidWorkoutWeightEntry(entries[0])) &&
+        (entries.size() <= 1 || isValidWorkoutWeightEntry(entries[1])) &&
+        (entries.size() <= 2 || isValidWorkoutWeightEntry(entries[2])) &&
+        (entries.size() <= 3 || isValidWorkoutWeightEntry(entries[3])) &&
+        (entries.size() <= 4 || isValidWorkoutWeightEntry(entries[4])) &&
+        hasUniqueWorkoutWeightEquipmentTypes(entries);
+    }
+
+    function isValidWorkoutWeightConfiguration(config) {
+      return config is map &&
+        config.keys().hasOnly(["entries"]) &&
+        config.keys().hasAll(["entries"]) &&
+        isValidWorkoutWeightEntryList(config.entries);
+    }
+
+    function isValidWorkoutHeartRateSeriesReference(userId, workoutId, reference) {
+      return reference is map &&
+        reference.keys().hasOnly([
+          "storagePath",
+          "encoding",
+          "sampleCount",
+          "seriesStartAt",
+          "seriesEndAt"
+        ]) &&
+        reference.keys().hasAll([
+          "storagePath",
+          "encoding",
+          "sampleCount",
+          "seriesStartAt",
+          "seriesEndAt"
+        ]) &&
+        reference.storagePath is string &&
+        reference.storagePath.size() <= 256 &&
+        reference.storagePath ==
+          "users/" + userId + "/workout_heart_rate/" + workoutId + ".json.gz" &&
+        reference.encoding == "json+gzip" &&
+        reference.sampleCount is int &&
+        reference.sampleCount > 0 &&
+        reference.seriesStartAt is timestamp &&
+        reference.seriesEndAt is timestamp &&
+        reference.seriesEndAt >= reference.seriesStartAt;
+    }
+
+    function currentWorkoutSchemaVersion() {
+      return 1;
+    }
+
+    function isSupportedWorkoutSchemaVersion(version) {
+      return version is int &&
+        version == currentWorkoutSchemaVersion();
+    }
+
+    function isValidWorkoutDocument(userId, workoutId) {
+      return isValidWorkoutId(workoutId) &&
+        request.resource.data.keys().hasOnly([
+          "userId",
+          "schemaVersion",
+          "name",
+          "startedAt",
+          "durationSeconds",
+          "steps",
+          "floors",
+          "stepsPerFloor",
+          "notes",
+          "source",
+          "integrityLevel",
+          "createdAt",
+          "updatedAt",
+          "avgHeartRateBpm",
+          "maxHeartRateBpm",
+          "caloriesBurned",
+          "effortRating",
+          "averageMETs",
+          "deviceModel",
+          "sourceMetadata",
+          "healthKitUUID",
+          "hevyWorkoutId",
+          "media",
+          "highlightedMediaId",
+          "weightConfiguration",
+          "heartRateSeries"
+        ]) &&
+        request.resource.data.keys().hasAll([
+          "userId",
+          "schemaVersion",
+          "name",
+          "startedAt",
+          "durationSeconds",
+          "steps",
+          "floors",
+          "stepsPerFloor",
+          "notes",
+          "source",
+          "integrityLevel",
+          "createdAt",
+          "updatedAt"
+        ]) &&
+        request.resource.data.userId == userId &&
+        isSupportedWorkoutSchemaVersion(request.resource.data.schemaVersion) &&
+        request.resource.data.name is string &&
+        request.resource.data.name.size() > 0 &&
+        request.resource.data.name.size() <= 120 &&
+        request.resource.data.startedAt is timestamp &&
+        isNonNegativeNumber(request.resource.data.durationSeconds) &&
+        request.resource.data.steps is int &&
+        request.resource.data.steps >= 0 &&
+        request.resource.data.floors is int &&
+        request.resource.data.floors >= 0 &&
+        request.resource.data.stepsPerFloor is int &&
+        request.resource.data.stepsPerFloor > 0 &&
+        request.resource.data.stepsPerFloor <= 100 &&
+        request.resource.data.notes is string &&
+        request.resource.data.notes.size() <= 5000 &&
+        request.resource.data.source is string &&
+        isValidWorkoutSource(request.resource.data.source) &&
+        request.resource.data.integrityLevel is string &&
+        isValidIntegrityLevel(request.resource.data.integrityLevel) &&
+        request.resource.data.createdAt is timestamp &&
+        request.resource.data.updatedAt is timestamp &&
+        (!request.resource.data.keys().hasAny(["avgHeartRateBpm"]) ||
+          (request.resource.data.avgHeartRateBpm is int &&
+            request.resource.data.avgHeartRateBpm >= 25 &&
+            request.resource.data.avgHeartRateBpm <= 240)) &&
+        (!request.resource.data.keys().hasAny(["maxHeartRateBpm"]) ||
+          (request.resource.data.maxHeartRateBpm is int &&
+            request.resource.data.maxHeartRateBpm >= 25 &&
+            request.resource.data.maxHeartRateBpm <= 240)) &&
+        (!request.resource.data.keys().hasAny(["caloriesBurned"]) ||
+          (request.resource.data.caloriesBurned is int &&
+            request.resource.data.caloriesBurned >= 0)) &&
+        (!request.resource.data.keys().hasAny(["effortRating"]) ||
+          (isNonNegativeNumber(request.resource.data.effortRating) &&
+            request.resource.data.effortRating <= 5)) &&
+        (!request.resource.data.keys().hasAny(["averageMETs"]) ||
+          isNonNegativeNumber(request.resource.data.averageMETs)) &&
+        (!request.resource.data.keys().hasAny(["deviceModel"]) ||
+          (request.resource.data.deviceModel is string &&
+            request.resource.data.deviceModel.size() <= 120)) &&
+        (!request.resource.data.keys().hasAny(["sourceMetadata"]) ||
+          (request.resource.data.sourceMetadata is string &&
+            request.resource.data.sourceMetadata.size() <= 4000)) &&
+        (!request.resource.data.keys().hasAny(["healthKitUUID"]) ||
+          (request.resource.data.healthKitUUID is string &&
+            request.resource.data.healthKitUUID.size() <= 128)) &&
+        (!request.resource.data.keys().hasAny(["hevyWorkoutId"]) ||
+          (request.resource.data.hevyWorkoutId is string &&
+            request.resource.data.hevyWorkoutId.size() <= 128)) &&
+        (!request.resource.data.keys().hasAny(["media"]) ||
+          isValidWorkoutMediaList(request.resource.data.media)) &&
+        (!request.resource.data.keys().hasAny(["highlightedMediaId"]) ||
+          (request.resource.data.highlightedMediaId is string &&
+            isValidWorkoutMediaId(request.resource.data.highlightedMediaId) &&
+            request.resource.data.keys().hasAny(["media"]) &&
+            mediaListContainsId(
+              request.resource.data.media,
+              request.resource.data.highlightedMediaId
+            ))) &&
+        (!request.resource.data.keys().hasAny(["weightConfiguration"]) ||
+          isValidWorkoutWeightConfiguration(
+            request.resource.data.weightConfiguration
+          )) &&
+        (!request.resource.data.keys().hasAny(["heartRateSeries"]) ||
+          isValidWorkoutHeartRateSeriesReference(
+            userId,
+            workoutId,
+            request.resource.data.heartRateSeries
+          ));
+    }
+
     function userRateLimitDocPath() {
       return /databases/$(database)/documents/userRateLimits/$(request.auth.uid);
     }
@@ -200,6 +490,18 @@ service cloud.firestore {
       match /integrations/{integrationId} {
         allow read: if isOwner(userId);
         allow write: if false;
+      }
+
+      match /workouts/{workoutId} {
+        allow read: if isOwner(userId);
+        allow create: if isOwner(userId) &&
+          isValidWorkoutDocument(userId, workoutId);
+        allow update: if isOwner(userId) &&
+          isValidWorkoutDocument(userId, workoutId) &&
+          request.resource.data.userId == resource.data.userId &&
+          request.resource.data.schemaVersion == resource.data.schemaVersion &&
+          request.resource.data.createdAt == resource.data.createdAt;
+        allow delete: if isOwner(userId);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "test:firebase-rules": "npx -y firebase-tools@latest emulators:exec --project demo-ascendapp-rules --only firestore,storage \"node --test tests/firebase-rules/*.test.mjs\""
   },
   "repository": {
     "type": "git",
@@ -18,6 +19,8 @@
   "homepage": "https://github.com/tpavay/AscendApp#readme",
   "description": "",
   "devDependencies": {
+    "@firebase/rules-unit-testing": "^5.0.0",
+    "firebase": "^12.4.0",
     "firebase-tools": "^14.27.0"
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -27,6 +27,19 @@ service firebase.storage {
         request.resource.contentType.matches("video/.*");
     }
 
+    function validWorkoutHeartRateFileName(fileName) {
+      return fileName.matches("^[0-9a-fA-F-]{36}\\.json\\.gz$");
+    }
+
+    function isCompressedHeartRateUpload(maxBytes) {
+      return request.resource != null &&
+        request.resource.size > 0 &&
+        request.resource.size <= maxBytes &&
+        request.resource.contentType.matches(
+          "application/(gzip|x-gzip|octet-stream)"
+        );
+    }
+
     // User workout photos.
     match /users/{userId}/photos/{fileName} {
       allow get: if isOwner(userId) && validFileName(fileName);
@@ -45,6 +58,16 @@ service firebase.storage {
         validFileName(fileName) &&
         isVideoUpload(200 * 1024 * 1024);
       allow delete: if isOwner(userId) && validFileName(fileName);
+    }
+
+    // User workout heart-rate sidecars.
+    match /users/{userId}/workout_heart_rate/{fileName} {
+      allow get: if isOwner(userId) && validWorkoutHeartRateFileName(fileName);
+      allow list: if isOwner(userId);
+      allow create, update: if isOwner(userId) &&
+        validWorkoutHeartRateFileName(fileName) &&
+        isCompressedHeartRateUpload(5 * 1024 * 1024);
+      allow delete: if isOwner(userId) && validWorkoutHeartRateFileName(fileName);
     }
 
     // User profile pictures.

--- a/tests/firebase-rules/workout-contract.test.mjs
+++ b/tests/firebase-rules/workout-contract.test.mjs
@@ -1,0 +1,197 @@
+import { readFileSync } from 'node:fs';
+import { after, before, beforeEach, test } from 'node:test';
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { doc, setDoc } from 'firebase/firestore';
+import { ref, uploadBytes } from 'firebase/storage';
+
+const projectId = 'demo-ascendapp-rules';
+const firestoreRules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+const storageRules = readFileSync(new URL('../../storage.rules', import.meta.url), 'utf8');
+
+const userId = 'user-123';
+const otherUserId = 'user-456';
+const workoutId = '550e8400-e29b-41d4-a716-446655440000';
+const mediaId = '11111111-1111-1111-1111-111111111111';
+const secondMediaId = '22222222-2222-2222-2222-222222222222';
+const weightEntryId = '33333333-3333-3333-3333-333333333333';
+
+let testEnv;
+
+before(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId,
+    firestore: {
+      rules: firestoreRules,
+      host: '127.0.0.1',
+      port: 8080,
+    },
+    storage: {
+      rules: storageRules,
+      host: '127.0.0.1',
+      port: 9199,
+    },
+  });
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.clearStorage();
+});
+
+after(async () => {
+  await testEnv.cleanup();
+});
+
+test('owner can write a valid workout backup document', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const workoutRef = doc(context.firestore(), `users/${userId}/workouts/${workoutId}`);
+
+  await assertSucceeds(setDoc(workoutRef, makeWorkoutDocument({
+    media: [makeMediaItem()],
+    highlightedMediaId: mediaId,
+    weightConfiguration: {
+      entries: [makeWeightEntry()],
+    },
+    heartRateSeries: makeHeartRateSeriesReference(userId, workoutId),
+  })));
+});
+
+test('highlighted media id must point to an uploaded media item', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const workoutRef = doc(context.firestore(), `users/${userId}/workouts/${workoutId}`);
+
+  await assertFails(setDoc(workoutRef, makeWorkoutDocument({
+    media: [makeMediaItem()],
+    highlightedMediaId: secondMediaId,
+  })));
+});
+
+test('invalid nested media items are rejected', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const workoutRef = doc(context.firestore(), `users/${userId}/workouts/${workoutId}`);
+
+  await assertFails(setDoc(workoutRef, makeWorkoutDocument({
+    media: [
+      makeMediaItem(),
+      {
+        ...makeMediaItem(secondMediaId),
+        type: 'gif',
+      },
+    ],
+    highlightedMediaId: mediaId,
+  })));
+});
+
+test('invalid weight entries are rejected', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const workoutRef = doc(context.firestore(), `users/${userId}/workouts/${workoutId}`);
+
+  await assertFails(setDoc(workoutRef, makeWorkoutDocument({
+    weightConfiguration: {
+      entries: [
+        makeWeightEntry(),
+        {
+          ...makeWeightEntry('44444444-4444-4444-4444-444444444444'),
+          equipmentType: 'sled',
+        },
+      ],
+    },
+  })));
+});
+
+test('users cannot write workouts into another users path', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const workoutRef = doc(context.firestore(), `users/${otherUserId}/workouts/${workoutId}`);
+
+  await assertFails(setDoc(workoutRef, makeWorkoutDocument({
+    userId: otherUserId,
+  })));
+});
+
+test('owner can upload a valid heart-rate sidecar blob', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const sidecarRef = ref(
+    context.storage(),
+    `users/${userId}/workout_heart_rate/${workoutId}.json.gz`
+  );
+
+  await assertSucceeds(uploadBytes(sidecarRef, new Uint8Array([1, 2, 3]), {
+    contentType: 'application/gzip',
+  }));
+});
+
+test('non-owners cannot upload heart-rate sidecars into another users scope', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const sidecarRef = ref(
+    context.storage(),
+    `users/${otherUserId}/workout_heart_rate/${workoutId}.json.gz`
+  );
+
+  await assertFails(uploadBytes(sidecarRef, new Uint8Array([1, 2, 3]), {
+    contentType: 'application/gzip',
+  }));
+});
+
+test('heart-rate sidecars must be compressed uploads', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const sidecarRef = ref(
+    context.storage(),
+    `users/${userId}/workout_heart_rate/${workoutId}.json.gz`
+  );
+
+  await assertFails(uploadBytes(sidecarRef, new Uint8Array([1, 2, 3]), {
+    contentType: 'application/json',
+  }));
+});
+
+function makeWorkoutDocument(overrides = {}) {
+  return {
+    userId,
+    schemaVersion: 1,
+    name: 'Morning Stair Session',
+    startedAt: new Date('2026-04-10T06:30:00.000Z'),
+    durationSeconds: 1800,
+    steps: 1200,
+    floors: 75,
+    stepsPerFloor: 16,
+    notes: 'Felt strong',
+    source: 'apple_health',
+    integrityLevel: 'verified',
+    createdAt: new Date('2026-04-10T06:00:00.000Z'),
+    updatedAt: new Date('2026-04-10T07:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function makeMediaItem(id = mediaId) {
+  return {
+    id,
+    url: 'https://example.com/workout-media.jpg',
+    uploadedAt: new Date('2026-04-10T07:00:00.000Z'),
+    type: 'photo',
+  };
+}
+
+function makeWeightEntry(id = weightEntryId) {
+  return {
+    id,
+    equipmentType: 'weighted_vest',
+    weightValue: 20,
+    isEnabled: true,
+  };
+}
+
+function makeHeartRateSeriesReference(ownerUserId, ownerWorkoutId) {
+  return {
+    storagePath: `users/${ownerUserId}/workout_heart_rate/${ownerWorkoutId}.json.gz`,
+    encoding: 'json+gzip',
+    sampleCount: 3,
+    seriesStartAt: new Date('2026-04-10T06:30:00.000Z'),
+    seriesEndAt: new Date('2026-04-10T06:45:00.000Z'),
+  };
+}


### PR DESCRIPTION
## Summary
- add durable private workout backup sync to Firestore and heart-rate sidecars in Storage
- wire retry/delete/account-deletion cleanup for workout sync, plus emulator-backed rules tests and targeted app tests
- add internal QA sign-in for dev/staging and harden leaderboard/connectivity/media recovery behavior discovered during device testing

## Why
Ascend needed a real backend durability path for workouts, including imported Apple Health workouts with heart-rate charts, plus a simulator-friendly QA auth path and follow-up fixes uncovered during validation. This change moves workout backup from local-only behavior to a real synced model while tightening related UX and cleanup flows.

## User / Developer Impact
- workouts, edits, deletes, imports, and HR sidecars now sync durably to Firebase
- account deletion removes private workout backups and heart-rate storage sidecars
- dev/staging builds expose Internal QA sign-in with real Firebase auth for reliable testing
- leaderboard refresh and offline/online handling are more predictable
- media and remote image surfaces recover after connectivity returns

## Validation
- `build_sim` for `AscendApp-Staging`
- full `test_sim` suite for `AscendApp-Staging` passed: 75/75
- `npm run test:firebase-rules` passed: 8/8
- device validation covered offline create/edit/import sync recovery, imported HR durability, media recovery, leaderboard refresh behavior, and full account deletion cleanup on dev

Closes #84
Addresses #73
Addresses #76
Addresses #131
