### PR TITLE
Add HealthKit auto-import review flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,20 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.
 - Import architecture uses one canonical `Workout` plus local `WorkoutSourceLink` provenance records per provider. New import UI and state should flow through `WorkoutImportCoordinator`, not provider-specific views/services.
 - Apple Health is read-only. First connect may backfill historical workouts, but routine checks must stay incremental and sample-only until a workout is actually imported.
+- Apple Health auto-import is optional and user-controlled from the Apple Health manage sheet.
+- Auto-import only applies to newly finished Apple Health workouts from the moment the user enables it; older pending history remains in the manual review/import flow.
+- If older local settings have auto-import enabled but no stored activation timestamp, use the previous successful HealthKit check as the conservative activation fallback so newly discovered workouts can import without opening older pending history.
+- Auto-imported Apple Health workouts should use a single latest-unseen review model, not a backlog queue:
+  - Home may surface one quick-edit review sheet for only the latest unseen auto-imported workout
+  - if a newer unseen auto-import arrives before review is completed, it replaces the older unresolved review candidate
+  - completing or deleting that review should advance the review watermark so older auto-imported workouts never surface one-by-one later
+- The Home header bell is the primary import entry point. Newly authenticated users should get a one-time per-user coach mark there that explains imports and review, rather than a dedicated Apple Health onboarding screen.
+- `WorkoutImportSheet` should own Apple Health setup regardless of entry path using inline setup states, not a setup sheet layered on top of the import page. The bell and other manual review entry points should always open the import page rather than jumping straight into the auto-import review flow.
+- While Apple Health still needs setup, suppress the generic `No New Workouts` empty state so setup remains the only focus.
+- After Apple Health access is granted, enable auto-import by default and show inline guidance for where to change that later in Settings > Edit Profile > Integrations > Apple Health.
+- The auto-import review screen is a cleanup pass on an already-saved workout, so it should use `Done` instead of `Save`, omit `Not Now`, open as a quick-edit sheet (about 75% height with expansion to large) that cannot be swiped away, allow edits to `title`, `notes`, `media`, `duration`, and `steps`, keep the imported workout date visible but read-only, and keep the destructive `Delete Workout` action inside the sheet content while suppressing re-import of that same Apple Health sample.
+- HealthKit auto-import freshness should use HealthKit observer/background delivery when available, while keeping the existing launch/foreground incremental refresh as a fallback.
+- HealthKit observer callbacks should only wake the import pipeline; the coordinator must serialize refreshes and fetch changes with an anchored query before completing observer delivery.
 
 ### Analytics Architecture
 - `TelemetryManager` remains the app-facing facade, while reusable telemetry types and sinks live under `Shared/Services/Telemetry`.

--- a/AscendApp/App/RootView.swift
+++ b/AscendApp/App/RootView.swift
@@ -12,6 +12,7 @@ struct RootView: View {
     @Environment(AuthenticationViewModel.self) private var authVM
     @Environment(\.modelContext) private var modelContext
     @Environment(MediaUploadManager.self) private var uploadManager
+    @State private var importCoordinator = WorkoutImportCoordinator.shared
 
     var body: some View {
         Group {
@@ -29,6 +30,7 @@ struct RootView: View {
         .animation(.easeInOut(duration: 0.25), value: authVM.authenticationState)
         .themeAware()
         .task {
+            importCoordinator.configure(modelContext: modelContext)
             // Resume any pending uploads from previous session
             await uploadManager.processPendingUploads(modelContext: modelContext)
             await bootstrapLeaderboardState()
@@ -36,6 +38,7 @@ struct RootView: View {
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             // Retry pending uploads when app comes to foreground (network may have restored)
             Task {
+                importCoordinator.configure(modelContext: modelContext)
                 await uploadManager.processPendingUploads(modelContext: modelContext)
                 await bootstrapLeaderboardState()
             }

--- a/AscendApp/AscendApp.entitlements
+++ b/AscendApp/AscendApp.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.developer.healthkit.access</key>
 	<array/>
+	<key>com.apple.developer.healthkit.background-delivery</key>
+	<true/>
 </dict>
 </plist>

--- a/AscendApp/Features/Debug/Services/DebugToolsService.swift
+++ b/AscendApp/Features/Debug/Services/DebugToolsService.swift
@@ -43,6 +43,20 @@ final class DebugToolsService {
     func clearSeededWorkoutData(modelContext: ModelContext) async throws -> Int {
         try workoutSeeder.clearSeededWorkouts(modelContext: modelContext)
     }
+
+    func queueSimulatedAppleHealthAutoImportReview(
+        modelContext: ModelContext
+    ) async throws -> Workout {
+        try await WorkoutImportCoordinator.shared.debugQueueSimulatedAutoImportedReview(
+            modelContext: modelContext
+        )
+    }
+
+    func clearSimulatedAppleHealthAutoImports(modelContext: ModelContext) async throws -> Int {
+        try WorkoutImportCoordinator.shared.debugClearSimulatedAutoImports(
+            modelContext: modelContext
+        )
+    }
     
     // MARK: - Future: Add more debug operations
     // func clearAllData() async throws { }

--- a/AscendApp/Features/Debug/ViewModels/DebugToolsViewModel.swift
+++ b/AscendApp/Features/Debug/ViewModels/DebugToolsViewModel.swift
@@ -20,6 +20,8 @@ class DebugToolsViewModel {
         static let clearLeaderboard = "Clear Test Data"
         static let seedWorkouts = "Seed Workouts"
         static let clearSeededWorkouts = "Clear Seeded Workouts"
+        static let queueAutoImportReview = "Queue Auto-Import Review"
+        static let clearAutoImportSimulations = "Clear Auto-Import Simulations"
     }
 
     var selectedWorkoutPreset: WorkoutSeedPreset = .appStoreScreenshots
@@ -31,9 +33,34 @@ class DebugToolsViewModel {
 
     var sections: [DebugSection] {
         [
+            appleHealthImportSection,
             workoutsSection,
             leaderboardSection
         ]
+    }
+
+    // MARK: - Apple Health Section
+
+    private var appleHealthImportSection: DebugSection {
+        DebugSection(
+            title: "Apple Health Import",
+            subtitle: "Simulator hooks for the auto-import review flow",
+            actions: [
+                DebugAction(
+                    title: ActionTitle.queueAutoImportReview,
+                    description: "Creates a synthetic Apple Health import, queues it for review, and waits for the next foreground activation to present the full-screen review flow.",
+                    icon: "rectangle.stack.badge.plus",
+                    iconColor: .accent
+                ),
+                DebugAction(
+                    title: ActionTitle.clearAutoImportSimulations,
+                    description: "Removes only the synthetic Apple Health auto-import workouts created from Debug Tools.",
+                    icon: "trash.fill",
+                    iconColor: .red,
+                    isDestructive: true
+                )
+            ]
+        )
     }
 
     // MARK: - Workouts Section
@@ -94,6 +121,13 @@ class DebugToolsViewModel {
         do {
             // Map action titles to service methods
             switch action.title {
+            case ActionTitle.queueAutoImportReview:
+                _ = try await service.queueSimulatedAppleHealthAutoImportReview(modelContext: modelContext)
+
+            case ActionTitle.clearAutoImportSimulations:
+                let count = try await service.clearSimulatedAppleHealthAutoImports(modelContext: modelContext)
+                successMessage = "Cleared \(count) simulated auto-import workout\(count == 1 ? "" : "s")."
+
             case ActionTitle.seedWorkouts:
                 let count = try await service.seedWorkoutData(
                     preset: selectedWorkoutPreset,

--- a/AscendApp/Features/Home/Views/AppleHealthImportCoachMarkView.swift
+++ b/AscendApp/Features/Home/Views/AppleHealthImportCoachMarkView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+struct AppleHealthImportCoachMarkView: View {
+    @Environment(\.colorScheme) private var systemColorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var themeManager = ThemeManager.shared
+    @State private var isPointerAnimating = false
+
+    let pointerX: CGFloat
+    let onOpen: () -> Void
+    let onDismiss: () -> Void
+
+    private let cardWidth: CGFloat = 248
+    private let pointerSize: CGFloat = 22
+
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: systemColorScheme)
+    }
+
+    private var backgroundColor: Color {
+        effectiveColorScheme == .dark ? .jetLighter.opacity(0.98) : .white
+    }
+
+    private var borderColor: Color {
+        effectiveColorScheme == .dark ? .white.opacity(0.08) : .black.opacity(0.08)
+    }
+
+    private var primaryTextColor: Color {
+        effectiveColorScheme == .dark ? .white : .black
+    }
+
+    private var secondaryTextColor: Color {
+        effectiveColorScheme == .dark ? .white.opacity(0.72) : .gray
+    }
+
+    private var clampedPointerX: CGFloat {
+        min(max(pointerX, 22), cardWidth - 22)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 10) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Import workouts here")
+                        .font(.montserratSemiBold(size: 16))
+                        .foregroundStyle(primaryTextColor)
+
+                    Text("Bring in Apple Health or other connected workouts, and review new auto-imports in one place.")
+                        .font(.montserratRegular(size: 13))
+                        .foregroundStyle(secondaryTextColor)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(secondaryTextColor)
+                        .frame(width: 28, height: 28)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss import tip")
+            }
+
+            HStack(spacing: 10) {
+                Button("Not now", action: onDismiss)
+                    .appSheetButtonStyle(tone: .secondary)
+
+                Button("Open", action: onOpen)
+                    .appSheetButtonStyle()
+            }
+        }
+        .padding(14)
+        .frame(width: cardWidth, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18)
+                .fill(backgroundColor)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(borderColor, lineWidth: 1)
+        )
+        .overlay(alignment: .topLeading) {
+            Image(systemName: "arrow.up.circle.fill")
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(.accent)
+                .shadow(color: .accent.opacity(0.24), radius: 10, y: 4)
+                .offset(
+                    x: clampedPointerX - (pointerSize / 2),
+                    y: reduceMotion ? -10 : (isPointerAnimating ? -16 : -10)
+                )
+        }
+        .shadow(color: .black.opacity(effectiveColorScheme == .dark ? 0.28 : 0.12), radius: 18, y: 10)
+        .onAppear {
+            guard !reduceMotion else { return }
+
+            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                isPointerAnimating = true
+            }
+        }
+    }
+}
+
+#Preview {
+    AppleHealthImportCoachMarkView(
+        pointerX: 214,
+        onOpen: {},
+        onDismiss: {}
+    )
+    .padding()
+    .themedBackground()
+}

--- a/AscendApp/Features/Home/Views/HomeView.swift
+++ b/AscendApp/Features/Home/Views/HomeView.swift
@@ -10,10 +10,12 @@ import SwiftData
 
 struct HomeView: View {
     @Environment(AuthenticationViewModel.self) private var authVM
+    @Environment(TabRouter.self) private var tabRouter
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Workout.date, order: .reverse) private var workouts: [Workout]
     @State private var importCoordinator = WorkoutImportCoordinator.shared
+    @State private var settingsManager = SettingsManager.shared
     @State private var showingImportSheet = false
     @State private var showingGoalsSheet = false
     @State private var showingWorkoutEntrySheet = false
@@ -25,6 +27,24 @@ struct HomeView: View {
     @State private var selectedHomeClimb: Climb?
     @State private var globeViewModel = GlobeViewModel()
     @AppStorage("firstLaunchDate") private var firstLaunchDate: Double = 0
+    @State private var showingImportCoachMark = false
+    @State private var importBellFrame: CGRect = .zero
+    @State private var autoImportedReviewWorkout: Workout?
+
+    private let importCoachMarkWidth: CGFloat = 248
+    private let importCoachMarkHorizontalPadding: CGFloat = 20
+
+    private var isHomeTabSelected: Bool {
+        tabRouter.selectedTab == .home
+    }
+
+    private var hasBlockingModalPresentation: Bool {
+        showingWorkoutEntrySheet ||
+        showingWorkoutForm ||
+        showingCompletedView ||
+        showingImportSheet ||
+        showingGoalsSheet
+    }
 
     private var greeting: String {
         // If first launch date not set, this is the first launch
@@ -70,15 +90,10 @@ struct HomeView: View {
 
                     Spacer()
 
-                    // Notification bell for workout imports
-                    NotificationBellView(pendingImports: importCoordinator.pendingCount) {
-                        Task {
-                            await importCoordinator.refreshPendingImports(trigger: .manualReview)
-                            showingImportSheet = true
-                        }
-                    }
-                    .onChange(of: importCoordinator.pendingCount) { oldValue, newValue in
+                    importBell
+                    .onChange(of: importCoordinator.attentionCount) { oldValue, newValue in
                         print("🔄 HomeView detected count change from \(oldValue) to \(newValue)")
+                        syncAutoImportedReviewPresentation()
                     }
                 }
 
@@ -111,6 +126,28 @@ struct HomeView: View {
         .scrollIndicators(.hidden)
         .safeAreaPadding(.top, 8)
         .themedBackground()
+        .coordinateSpace(name: "homeView")
+        .overlay(alignment: .topLeading) {
+            GeometryReader { geometry in
+                if showingImportCoachMark, importBellFrame != .zero {
+                    let coachMarkOriginX = importCoachMarkOriginX(containerWidth: geometry.size.width)
+                    AppleHealthImportCoachMarkView(
+                        pointerX: importBellFrame.midX - coachMarkOriginX,
+                        onOpen: openImportInbox,
+                        onDismiss: dismissImportCoachMark
+                    )
+                    .offset(
+                        x: coachMarkOriginX,
+                        y: importBellFrame.maxY + 12
+                    )
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    .zIndex(1)
+                }
+            }
+        }
+        .onPreferenceChange(ImportBellFramePreferenceKey.self) { frame in
+            importBellFrame = frame
+        }
         .navigationDestination(item: $selectedHomeClimb) { climb in
             ClimbDetailView(climb: climb)
         }
@@ -125,7 +162,7 @@ struct HomeView: View {
                 onManualEntry: presentWorkoutForm,
                 onStartRoutine: presentRoutines,
                 onImportWorkouts: presentImportSheet,
-                pendingImportCount: importCoordinator.pendingCount
+                pendingImportCount: importCoordinator.attentionCount
             )
             .appSheetStyle(.fitted())
         }
@@ -161,6 +198,22 @@ struct HomeView: View {
         .sheet(isPresented: $showingGoalsSheet) {
             GoalsSheet(isPresented: $showingGoalsSheet, workouts: workouts)
         }
+        .sheet(item: $autoImportedReviewWorkout, onDismiss: {
+            importCoordinator.dismissCurrentAutoImportedReview()
+        }) { workout in
+            AutoImportedWorkoutReviewView(
+                workout: workout,
+                onDone: {
+                    importCoordinator.completeAutoImportedReview(for: workout.id)
+                    autoImportedReviewWorkout = nil
+                },
+                onDelete: {
+                    importCoordinator.completeAutoImportedReview(for: workout.id)
+                    autoImportedReviewWorkout = nil
+                }
+            )
+            .appSheetStyle(.detents([.fraction(0.75), .large]), isInteractiveDismissDisabled: true)
+        }
         .task {
             // Set first launch date if not already set
             if firstLaunchDate == 0 {
@@ -170,14 +223,34 @@ struct HomeView: View {
             // Configure the unified import service with model context
             importCoordinator.configure(modelContext: modelContext)
             globeViewModel.loadIfNeeded(modelContext: modelContext)
+            syncImportCoachMarkPresentation()
 
             // Check for workouts from all sources on app launch
-            await importCoordinator.refreshPendingImports(trigger: .automatic)
+            await importCoordinator.refreshPendingImports(trigger: .homeEntry)
+            syncAutoImportedReviewPresentation()
+        }
+        .onChange(of: authVM.user?.uid) { _, _ in
+            syncImportCoachMarkPresentation()
+        }
+        .onChange(of: tabRouter.selectedTab) { _, newValue in
+            guard newValue == .home else { return }
+            Task {
+                await importCoordinator.refreshPendingImports(trigger: .homeEntry)
+                syncAutoImportedReviewPresentation()
+            }
+        }
+        .onChange(of: importCoordinator.currentAutoImportedReviewWorkoutID) { _, _ in
+            syncAutoImportedReviewPresentation()
+        }
+        .onChange(of: showingImportSheet) { _, isShowing in
+            guard !isShowing else { return }
+            syncAutoImportedReviewPresentation()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             // Check for new workouts when app comes to foreground (throttled to prevent spam)
             Task {
                 await importCoordinator.refreshPendingImports(trigger: .automatic)
+                syncAutoImportedReviewPresentation()
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .climbStateDidChange)) { _ in
@@ -190,6 +263,36 @@ struct HomeView: View {
             // Reset throttling when app goes to background so next foreground check works
             importCoordinator.resetAutomaticCheckThrottle()
         }
+    }
+
+    private var importBell: some View {
+        ZStack {
+            NotificationBellView(
+                pendingImports: importCoordinator.attentionCount,
+                isHighlighted: showingImportCoachMark
+            ) {
+                openImportInbox()
+            }
+        }
+        .frame(width: 44, height: 44)
+        .background {
+            GeometryReader { geometry in
+                Color.clear
+                    .preference(
+                        key: ImportBellFramePreferenceKey.self,
+                        value: geometry.frame(in: .named("homeView"))
+                    )
+            }
+        }
+        .zIndex(showingImportCoachMark ? 1 : 0)
+    }
+
+    private func importCoachMarkOriginX(containerWidth: CGFloat) -> CGFloat {
+        let minimumX = importCoachMarkHorizontalPadding
+        let maximumX = max(minimumX, containerWidth - importCoachMarkWidth - importCoachMarkHorizontalPadding)
+        let preferredPointerInset: CGFloat = 26
+        let preferredX = importBellFrame.midX - (importCoachMarkWidth - preferredPointerInset)
+        return min(max(preferredX, minimumX), maximumX)
     }
 
     private func presentWorkoutForm() {
@@ -211,6 +314,7 @@ struct HomeView: View {
     }
 
     private func presentImportSheet() {
+        dismissImportCoachMark()
         showingWorkoutEntrySheet = false
 
         Task {
@@ -218,6 +322,63 @@ struct HomeView: View {
             await importCoordinator.refreshPendingImports(trigger: .manualReview)
             showingImportSheet = true
         }
+    }
+
+    private func openImportInbox() {
+        dismissImportCoachMark()
+
+        Task {
+            _ = await importCoordinator.prepareImportInbox()
+            showingImportSheet = true
+        }
+    }
+
+    private func syncImportCoachMarkPresentation() {
+        guard let userID = authVM.user?.uid else {
+            showingImportCoachMark = false
+            return
+        }
+
+        showingImportCoachMark = !settingsManager.hasSeenAppleHealthImportCoachMark(for: userID)
+    }
+
+    private func dismissImportCoachMark() {
+        if let userID = authVM.user?.uid {
+            settingsManager.markAppleHealthImportCoachMarkSeen(for: userID)
+        }
+
+        withAnimation(.spring(duration: 0.28)) {
+            showingImportCoachMark = false
+        }
+    }
+
+    private func syncAutoImportedReviewPresentation() {
+        guard isHomeTabSelected else { return }
+        guard !hasBlockingModalPresentation else { return }
+
+        if importCoordinator.presentPendingAutoImportedReviewOnHomeIfNeeded() {
+            autoImportedReviewWorkout = resolveWorkout(id: importCoordinator.currentAutoImportedReviewWorkoutID)
+            if autoImportedReviewWorkout == nil {
+                importCoordinator.dismissCurrentAutoImportedReview()
+            }
+            return
+        }
+
+        if importCoordinator.currentAutoImportedReviewWorkoutID == nil {
+            autoImportedReviewWorkout = nil
+        }
+    }
+
+    private func resolveWorkout(id: UUID?) -> Workout? {
+        guard let id else { return nil }
+        let workoutID = id
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { workout in
+                workout.id == workoutID
+            }
+        )
+
+        return try? modelContext.fetch(descriptor).first
     }
 }
 

--- a/AscendApp/Features/Home/Views/HomeWorkoutActionSheet.swift
+++ b/AscendApp/Features/Home/Views/HomeWorkoutActionSheet.swift
@@ -47,8 +47,8 @@ struct HomeWorkoutActionSheet: View {
                 optionButton(action: onImportWorkouts) {
                     AppSheetOptionRow(
                         systemImage: "square.and.arrow.down",
-                        title: "Import Workouts",
-                        subtitle: "Apple Health and connected sources",
+                        title: "Import or Review",
+                        subtitle: "Apple Health, connected sources, and auto-import follow-up",
                         iconTint: .accent,
                         badgeCount: pendingImportCount,
                         trailingSymbol: "chevron.right",

--- a/AscendApp/Features/Home/Views/ImportBellFramePreferenceKey.swift
+++ b/AscendApp/Features/Home/Views/ImportBellFramePreferenceKey.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ImportBellFramePreferenceKey: PreferenceKey {
+    nonisolated(unsafe) static var defaultValue: CGRect = .zero
+
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        let nextFrame = nextValue()
+        guard nextFrame != .zero else { return }
+        value = nextFrame
+    }
+}

--- a/AscendApp/Features/Integrations/AppleHealth/Views/AppleHealthIntegrationCard.swift
+++ b/AscendApp/Features/Integrations/AppleHealth/Views/AppleHealthIntegrationCard.swift
@@ -12,6 +12,7 @@ import UIKit
 struct AppleHealthIntegrationCard: View {
     @Environment(\.colorScheme) private var systemColorScheme
     @Environment(\.modelContext) private var modelContext
+    @State private var settingsManager = SettingsManager.shared
     @State private var themeManager = ThemeManager.shared
     @State private var importCoordinator = WorkoutImportCoordinator.shared
     @State private var showingManageSheet = false
@@ -19,6 +20,7 @@ struct AppleHealthIntegrationCard: View {
     @State private var shouldPresentImportsAfterManageDismiss = false
     @State private var actionTask: Task<Void, Never>?
     @State private var isConnecting = false
+    @State private var isConfiguringDefaultAutoImport = false
     @State private var alertMessage = ""
     @State private var showingErrorAlert = false
 
@@ -31,7 +33,14 @@ struct AppleHealthIntegrationCard: View {
     }
 
     private var pendingCount: Int {
-        importCoordinator.appleHealthPendingCount
+        importCoordinator.appleHealthAttentionCount
+    }
+
+    private var autoImportEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { settingsManager.appleHealthAutoImportEnabled },
+            set: { settingsManager.setAppleHealthAutoImportEnabled($0) }
+        )
     }
 
     var body: some View {
@@ -54,14 +63,13 @@ struct AppleHealthIntegrationCard: View {
             )
         }
         .sheet(isPresented: $showingManageSheet, onDismiss: presentImportsAfterManageSheetDismissal) {
-            IntegrationManageSheet(
-                assetImage: "appleHealth-icon",
-                title: "Apple Health",
-                message: nil,
-                actions: manageActions,
-                onDismiss: {
-                    showingManageSheet = false
-                }
+            AppleHealthManageSheet(
+                isPresented: $showingManageSheet,
+                autoImportEnabled: autoImportEnabledBinding,
+                attentionCount: pendingCount,
+                onSyncNow: triggerManualSyncFromManageSheet,
+                onReviewImports: queueImportReviewFromManageSheet,
+                onOpenHealthPermissions: openPermissionsFromManageSheet
             )
         }
         .sheet(isPresented: $showingImportSheet) {
@@ -74,6 +82,10 @@ struct AppleHealthIntegrationCard: View {
         }
         .task {
             importCoordinator.configure(modelContext: modelContext)
+        }
+        .onChange(of: settingsManager.appleHealthAutoImportEnabled) { _, _ in
+            guard !isConfiguringDefaultAutoImport else { return }
+            handleAutoImportToggleChanged()
         }
     }
 
@@ -103,10 +115,6 @@ struct AppleHealthIntegrationCard: View {
         }
     }
 
-    private var reviewImportsTitle: String {
-        pendingCount > 0 ? "Review Imports (\(pendingCount))" : "Review Imports"
-    }
-
     private var headerStatusLabel: String? {
         switch connectionState {
         case .unavailable:
@@ -114,7 +122,7 @@ struct AppleHealthIntegrationCard: View {
         case .neverConnected:
             return nil
         case .connected:
-            return "Connected"
+            return settingsManager.appleHealthAutoImportEnabled ? "Connected • Auto-Import On" : "Connected"
         case .revoked:
             return "Permissions Disabled"
         }
@@ -127,6 +135,9 @@ struct AppleHealthIntegrationCard: View {
         case .neverConnected:
             return "Import your stairstepper workouts from Apple Health."
         case .connected:
+            if settingsManager.appleHealthAutoImportEnabled {
+                return "New Apple Health workouts import automatically and stay ready for quick review in Ascend."
+            }
             return "Import your stairstepper workouts from Apple Health."
         case .revoked:
             return "Import your stairstepper workouts from Apple Health."
@@ -144,50 +155,31 @@ struct AppleHealthIntegrationCard: View {
         }
     }
 
-    private var manageActions: [IntegrationManageAction] {
-        [
-            IntegrationManageAction(
-                systemImage: "arrow.clockwise",
-                title: "Sync now",
-                iconTint: .accent,
-                isEnabled: connectionState == .connected
-            ) {
-                triggerManualSyncFromManageSheet()
-            },
-            IntegrationManageAction(
-                systemImage: "magnifyingglass",
-                title: "Review imports",
-                iconTint: .accent,
-                badgeCount: pendingCount,
-                isEnabled: pendingCount > 0
-            ) {
-                queueImportReviewFromManageSheet()
-            },
-            IntegrationManageAction(
-                systemImage: "lock",
-                title: "Manage permissions",
-                iconTint: .accent
-            ) {
-                openPermissionsFromManageSheet()
-            }
-        ]
-    }
-
     private func connectAppleHealth() {
         actionTask?.cancel()
         isConnecting = true
         actionTask = Task {
             let didConnect = await importCoordinator.requestAppleHealthAuthorizationIfNeeded()
+            guard didConnect else {
+                await MainActor.run {
+                    isConnecting = false
+
+                    if let errorMessage = importCoordinator.lastErrorMessage, !errorMessage.isEmpty {
+                        presentError(errorMessage)
+                    }
+                }
+                return
+            }
+
             await MainActor.run {
                 isConnecting = false
-
-                if didConnect {
-                    if importCoordinator.pendingCount > 0 {
-                        showingImportSheet = true
-                    }
-                } else if let errorMessage = importCoordinator.lastErrorMessage, !errorMessage.isEmpty {
-                    presentError(errorMessage)
-                }
+                isConfiguringDefaultAutoImport = true
+                settingsManager.setAppleHealthAutoImportEnabled(true)
+            }
+            await importCoordinator.handleAppleHealthAutoImportPreferenceChanged()
+            await MainActor.run {
+                isConfiguringDefaultAutoImport = false
+                showingImportSheet = importCoordinator.pendingCount > 0
             }
         }
     }
@@ -208,13 +200,13 @@ struct AppleHealthIntegrationCard: View {
     private func queueImportReviewFromManageSheet() {
         actionTask?.cancel()
         actionTask = Task {
-            await importCoordinator.refreshPendingImports(trigger: .manualReview)
+            let resolution = await importCoordinator.prepareImportInbox()
             await MainActor.run {
                 if let errorMessage = importCoordinator.lastErrorMessage, !errorMessage.isEmpty {
                     presentError(errorMessage)
                     shouldPresentImportsAfterManageDismiss = false
                 } else {
-                    shouldPresentImportsAfterManageDismiss = true
+                    shouldPresentImportsAfterManageDismiss = resolution == .showImportSheet
                 }
                 showingManageSheet = false
             }
@@ -235,6 +227,13 @@ struct AppleHealthIntegrationCard: View {
     private func openHealthApp() {
         guard let healthURL = URL(string: "x-apple-health://") else { return }
         UIApplication.shared.open(healthURL)
+    }
+
+    private func handleAutoImportToggleChanged() {
+        actionTask?.cancel()
+        actionTask = Task {
+            await importCoordinator.handleAppleHealthAutoImportPreferenceChanged()
+        }
     }
 
     private func presentError(_ message: String) {

--- a/AscendApp/Features/Integrations/AppleHealth/Views/AppleHealthManageSheet.swift
+++ b/AscendApp/Features/Integrations/AppleHealth/Views/AppleHealthManageSheet.swift
@@ -1,0 +1,87 @@
+//
+//  AppleHealthManageSheet.swift
+//  AscendApp
+//
+//  Created by Codex on 4/20/26.
+//
+
+import SwiftUI
+
+struct AppleHealthManageSheet: View {
+    @Binding var isPresented: Bool
+    @Binding var autoImportEnabled: Bool
+
+    let attentionCount: Int
+    let onSyncNow: () -> Void
+    let onReviewImports: () -> Void
+    let onOpenHealthPermissions: () -> Void
+
+    private var autoImportSubtitle: String {
+        "Automatically import new Apple Health workouts and keep their follow-up review ready in Ascend."
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            IntegrationManageHeader(assetImage: "appleHealth-icon", title: "Apple Health")
+
+            IntegrationManageToggleCard(
+                title: "Auto-import new workouts",
+                subtitle: autoImportSubtitle,
+                isOn: $autoImportEnabled,
+                isEnabled: true
+            )
+
+            manageActionButton(
+                systemImage: "arrow.clockwise",
+                title: "Sync now",
+                badgeCount: 0,
+                action: onSyncNow
+            )
+
+            manageActionButton(
+                systemImage: "sparkles",
+                title: "Review workouts",
+                badgeCount: attentionCount,
+                action: onReviewImports
+            )
+
+            manageActionButton(
+                systemImage: "heart.text.square",
+                title: "Manage Health permissions",
+                badgeCount: 0,
+                action: onOpenHealthPermissions
+            )
+
+            Button("Close") {
+                isPresented = false
+            }
+            .appSheetButtonStyle(tone: .subtle)
+        }
+        .padding(.top, 24)
+        .padding(.horizontal, 20)
+        .padding(.bottom, 12)
+        .appSheetBackground()
+        .appSheetStyle(.actionMenu)
+    }
+
+    private func manageActionButton(
+        systemImage: String,
+        title: String,
+        badgeCount: Int,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            IntegrationManageActionRow(
+                action: IntegrationManageAction(
+                    systemImage: systemImage,
+                    title: title,
+                    iconTint: .accent,
+                    badgeCount: badgeCount,
+                    isEnabled: true,
+                    action: action
+                )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/AscendApp/Features/Workouts/Analytics/WorkoutImportAnalyticsEvent.swift
+++ b/AscendApp/Features/Workouts/Analytics/WorkoutImportAnalyticsEvent.swift
@@ -117,6 +117,7 @@ extension WorkoutImportAnalyticsEvent {
         case single
         case selected
         case all
+        case automatic
     }
 
     enum Outcome: String {

--- a/AscendApp/Features/Workouts/Views/AutoImportedWorkoutReviewView.swift
+++ b/AscendApp/Features/Workouts/Views/AutoImportedWorkoutReviewView.swift
@@ -1,0 +1,552 @@
+import PhotosUI
+import SwiftData
+import SwiftUI
+
+struct AutoImportedWorkoutReviewView: View {
+    private enum ReviewField: Hashable {
+        case workoutName
+        case notes
+        case steps
+    }
+
+    let workout: Workout
+    let onDone: () -> Void
+    let onDelete: () -> Void
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var importCoordinator = WorkoutImportCoordinator.shared
+
+    @State private var workoutName = ""
+    @State private var notes = ""
+    @State private var durationHours = ""
+    @State private var durationMinutes = ""
+    @State private var durationSeconds = ""
+    @State private var durationFormatted = ""
+    @State private var stepsValue = ""
+
+    @State private var existingPhotos: [Photo] = []
+    @State private var selectedImages: [SelectedPhotoItem] = []
+    @State private var photosMarkedForDeletion: [Photo] = []
+    @State private var photoPendingDeletion: Photo?
+
+    @State private var showingDurationPicker = false
+    @State private var durationPickerHours = 0
+    @State private var durationPickerMinutes = 0
+    @State private var durationPickerSeconds = 0
+
+    @State private var isSaving = false
+    @State private var isDeleting = false
+    @State private var showingDeleteConfirmation = false
+    @State private var errorTitle = ""
+    @State private var errorMessage: String?
+    @FocusState private var focusedField: ReviewField?
+
+    private let photoService = PhotoService()
+
+    private var isFormValid: Bool {
+        let trimmedName = workoutName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let minutes = Int(durationMinutes)
+        let seconds = Int(durationSeconds)
+        let hours = Int(durationHours) ?? 0
+        let totalDurationSeconds = hours * 3600 + (minutes ?? 0) * 60 + (seconds ?? 0)
+        let stepsValid = stepsValue.isEmpty || Int(stepsValue) != nil
+
+        return !isSaving &&
+            !isDeleting &&
+            trimmedName.count <= 50 &&
+            minutes != nil &&
+            seconds != nil &&
+            (minutes ?? 0) < 60 &&
+            (seconds ?? 0) < 60 &&
+            totalDurationSeconds > 0 &&
+            stepsValid
+    }
+
+    private var totalDuration: TimeInterval {
+        let hours = Int(durationHours) ?? 0
+        let minutes = Int(durationMinutes) ?? 0
+        let seconds = Int(durationSeconds) ?? 0
+        return TimeInterval(hours * 3600 + minutes * 60 + seconds)
+    }
+
+    private var effectiveName: String {
+        let trimmedName = workoutName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedName.isEmpty ? Workout.generateDefaultName(for: workout.date) : trimmedName
+    }
+
+    private var effectiveColorScheme: ColorScheme {
+        colorScheme
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(spacing: 24) {
+                    FormTextField(
+                        label: "Workout Name",
+                        isRequired: false,
+                        text: $workoutName,
+                        focusedField: $focusedField,
+                        fieldIdentifier: ReviewField.workoutName,
+                        maxLength: 50
+                    )
+
+                    FormTextEditor(
+                        label: "Description",
+                        isRequired: false,
+                        placeholder: "Add a description for your workout",
+                        text: $notes,
+                        focusedField: $focusedField,
+                        fieldIdentifier: ReviewField.notes
+                    )
+
+                    mediaSection
+
+                    FormSection(title: "Workout Details") {
+                        VStack(spacing: 12) {
+                            importedDateRow
+
+                            FormButton(
+                                label: "Duration",
+                                isRequired: true,
+                                icon: "clock",
+                                value: durationFormatted,
+                                action: {
+                                    syncDurationPicker()
+                                    showingDurationPicker = true
+                                }
+                            )
+
+                            FormTextField(
+                                label: "Steps",
+                                isRequired: false,
+                                icon: "figure.stairs",
+                                keyboardType: .numberPad,
+                                text: $stepsValue,
+                                focusedField: $focusedField,
+                                fieldIdentifier: ReviewField.steps
+                            )
+                            .onChange(of: stepsValue) { _, newValue in
+                                stepsValue = filterNumericInput(newValue)
+                            }
+                        }
+                    }
+
+                    deleteSection
+                }
+                .padding(20)
+                .background(sheetContentSurface)
+                .padding(.horizontal, 16)
+                .padding(.top, 12)
+                .padding(.bottom, 28)
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .themedBackground()
+            .navigationTitle("Review Workout")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        Task {
+                            await completeReview()
+                        }
+                    } label: {
+                        if isSaving {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .accent))
+                        } else {
+                            Text("Done")
+                        }
+                    }
+                    .font(.montserratSemiBold)
+                    .foregroundStyle(isFormValid ? .accent : .gray)
+                    .disabled(!isFormValid || isDeleting)
+                }
+
+                ToolbarItem(placement: .keyboard) {
+                    KeyboardDismissButton {
+                        focusedField = nil
+                    }
+                }
+            }
+        }
+        .interactiveDismissDisabled()
+        .sheet(isPresented: $showingDurationPicker) {
+            DurationPickerSheet(
+                hours: $durationPickerHours,
+                minutes: $durationPickerMinutes,
+                seconds: $durationPickerSeconds
+            ) {
+                setDuration(
+                    hours: durationPickerHours,
+                    minutes: durationPickerMinutes,
+                    seconds: durationPickerSeconds
+                )
+                showingDurationPicker = false
+            }
+            .appSheetStyle(.durationPicker, isInteractiveDismissDisabled: true)
+        }
+        .sheet(item: $photoPendingDeletion) { _ in
+            DeletePhotoConfirmationView(
+                onDelete: {
+                    if let photoPendingDeletion {
+                        removeExistingPhoto(photoPendingDeletion)
+                    }
+                },
+                onCancel: {
+                    photoPendingDeletion = nil
+                }
+            )
+        }
+        .sheet(isPresented: $showingDeleteConfirmation) {
+            ConfirmationView(
+                title: "Delete Workout",
+                message: "Delete \"\(effectiveName)\" from Ascend? This Apple Health workout will not auto-import again.",
+                confirmButtonText: "Delete",
+                isDestructive: true,
+                isLoading: isDeleting,
+                onCancel: {
+                    showingDeleteConfirmation = false
+                },
+                onConfirm: {
+                    Task {
+                        await deleteWorkout()
+                    }
+                }
+            )
+            .appSheetStyle(.destructiveConfirmation)
+        }
+        .alert(errorTitle, isPresented: Binding(
+            get: { errorMessage != nil },
+            set: { newValue in
+                if !newValue {
+                    errorMessage = nil
+                }
+            }
+        )) {
+            Button("OK", role: .cancel) {
+                errorMessage = nil
+            }
+        } message: {
+            Text(errorMessage ?? "")
+        }
+        .onAppear {
+            populateFields()
+        }
+        .onDisappear {
+            cleanupVideoFiles()
+        }
+    }
+
+    @ViewBuilder
+    private var mediaSection: some View {
+        FormSection(title: "Media") {
+            if existingPhotos.isEmpty {
+                PhotoGalleryView(
+                    selectedImages: $selectedImages,
+                    existingMediaCount: 0,
+                    existingVideoCount: 0
+                )
+            } else {
+                ScrollView(.horizontal) {
+                    LazyHStack(spacing: 12) {
+                        ForEach(existingPhotos) { photo in
+                            ZStack(alignment: .topTrailing) {
+                                LoadablePhotoView(
+                                    photo: photo,
+                                    size: CGSize(width: 110, height: 110),
+                                    cornerRadius: 12
+                                )
+
+                                MediaTileDeleteButton {
+                                    photoPendingDeletion = photo
+                                }
+                                .padding(6)
+                            }
+                        }
+
+                        PhotoGalleryView(
+                            selectedImages: $selectedImages,
+                            existingMediaCount: existingPhotos.count,
+                            existingVideoCount: existingPhotos.filter(\.isVideo).count,
+                            embeddedInScrollRow: true
+                        )
+                    }
+                    .padding(.vertical, 4)
+                }
+                .scrollIndicators(.hidden)
+            }
+        }
+    }
+
+    private var deleteSection: some View {
+        FormSection(title: "Actions") {
+            Button(role: .destructive) {
+                showingDeleteConfirmation = true
+            } label: {
+                Text("Delete Workout")
+            }
+            .appSheetButtonStyle(tone: .destructive)
+            .disabled(isSaving || isDeleting)
+        }
+    }
+
+    private var importedDateRow: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "calendar")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(.gray)
+                .frame(width: 24)
+
+            Text(formatWorkoutDateTime())
+                .font(.montserratRegular(size: 16))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+
+            Spacer()
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(effectiveColorScheme == .dark ? .white.opacity(0.05) : .gray.opacity(0.06))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(
+                            effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15),
+                            lineWidth: 1
+                        )
+                )
+        )
+    }
+
+    private var sheetContentSurface: some View {
+        RoundedRectangle(cornerRadius: 28)
+            .fill(effectiveColorScheme == .dark ? .white.opacity(0.03) : .black.opacity(0.025))
+            .overlay(
+                RoundedRectangle(cornerRadius: 28)
+                    .stroke(
+                        effectiveColorScheme == .dark ? .white.opacity(0.08) : .black.opacity(0.08),
+                        lineWidth: 1
+                    )
+            )
+    }
+
+    private func populateFields() {
+        workoutName = workout.name
+        notes = workout.notes
+        stepsValue = workout.steps == 0 ? "" : String(workout.steps)
+        existingPhotos = workout.photos
+        photosMarkedForDeletion = []
+        selectedImages = []
+
+        let totalSeconds = Int(workout.duration)
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        durationHours = String(format: "%02d", hours)
+        durationMinutes = String(format: "%02d", minutes)
+        durationSeconds = String(format: "%02d", seconds)
+        durationFormatted = workout.durationFormatted
+    }
+
+    private func formatWorkoutDateTime() -> String {
+        let calendar = Calendar.current
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateFormat = "h:mm a"
+
+        if calendar.isDateInToday(workout.date) {
+            return "Today at \(timeFormatter.string(from: workout.date))"
+        } else if calendar.isDateInYesterday(workout.date) {
+            return "Yesterday at \(timeFormatter.string(from: workout.date))"
+        } else {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "MMM d"
+            return "\(dateFormatter.string(from: workout.date)) at \(timeFormatter.string(from: workout.date))"
+        }
+    }
+
+    private func syncDurationPicker() {
+        durationPickerHours = Int(durationHours) ?? 0
+        durationPickerMinutes = Int(durationMinutes) ?? 0
+        durationPickerSeconds = Int(durationSeconds) ?? 0
+    }
+
+    private func setDuration(hours: Int, minutes: Int, seconds: Int) {
+        let clampedHours = min(max(hours, 0), 999)
+        let clampedMinutes = min(max(minutes, 0), 59)
+        let clampedSeconds = min(max(seconds, 0), 59)
+
+        durationHours = String(format: "%02d", clampedHours)
+        durationMinutes = String(format: "%02d", clampedMinutes)
+        durationSeconds = String(format: "%02d", clampedSeconds)
+
+        if clampedHours > 0 {
+            durationFormatted = "\(clampedHours):\(String(format: "%02d", clampedMinutes)):\(String(format: "%02d", clampedSeconds))"
+        } else {
+            durationFormatted = "\(String(format: "%02d", clampedMinutes)):\(String(format: "%02d", clampedSeconds))"
+        }
+    }
+
+    private func filterNumericInput(_ input: String) -> String {
+        input.filter(\.isNumber)
+    }
+
+    private func removeExistingPhoto(_ photo: Photo) {
+        if !photosMarkedForDeletion.contains(where: { $0.id == photo.id }) {
+            photosMarkedForDeletion.append(photo)
+        }
+
+        existingPhotos.removeAll { $0.id == photo.id }
+        photoPendingDeletion = nil
+    }
+
+    private func cleanupVideoFiles() {
+        for item in selectedImages {
+            if let videoURL = item.videoURL {
+                try? FileManager.default.removeItem(at: videoURL)
+            }
+        }
+    }
+
+    @MainActor
+    private func completeReview() async {
+        focusedField = nil
+        await Task.yield()
+        await saveWorkout()
+    }
+
+    @MainActor
+    private func saveWorkout() async {
+        guard isFormValid, !isSaving else { return }
+
+        isSaving = true
+        errorMessage = nil
+
+        let selectedImagesSnapshot = selectedImages
+        let existingPhotosSnapshot = existingPhotos
+        let deletedPhotosSnapshot = photosMarkedForDeletion
+        let leaderboardSnapshotBeforeEdit = LeaderboardWorkoutSnapshot(workout: workout)
+        var newlyUploadedPhotos: [Photo] = []
+
+        do {
+            if !selectedImagesSnapshot.isEmpty {
+                newlyUploadedPhotos = try await photoService.uploadSelectedPhotos(selectedImagesSnapshot)
+            }
+
+            let steps = Int(stepsValue) ?? 0
+            workout.name = effectiveName
+            workout.notes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
+            workout.duration = totalDuration
+            workout.steps = steps
+            workout.floors = Workout.stepsToFloors(steps, stepsPerFloor: workout.stepsPerFloor)
+
+            let combinedPhotos = existingPhotosSnapshot + newlyUploadedPhotos
+            workout.photos = combinedPhotos
+            if let highlightedPhotoID = workout.highlightedPhotoId,
+               !combinedPhotos.contains(where: { $0.id == highlightedPhotoID }) {
+                workout.highlightedPhotoId = combinedPhotos.first?.id
+            } else if workout.highlightedPhotoId == nil {
+                workout.highlightedPhotoId = combinedPhotos.first?.id
+            }
+
+            try modelContext.save()
+
+            try WorkoutMutationHandler.shared.workoutsDidChange(
+                modelContext: modelContext,
+                mutation: .updated(
+                    before: leaderboardSnapshotBeforeEdit,
+                    after: LeaderboardWorkoutSnapshot(workout: workout)
+                )
+            )
+
+            if !deletedPhotosSnapshot.isEmpty {
+                Task {
+                    try? await photoService.deletePhotos(deletedPhotosSnapshot)
+                }
+            }
+
+            cleanupVideoFiles()
+            onDone()
+        } catch {
+            if !newlyUploadedPhotos.isEmpty {
+                Task {
+                    try? await photoService.deletePhotos(newlyUploadedPhotos)
+                }
+            }
+
+            cleanupVideoFiles()
+            errorTitle = "Unable to Save"
+            errorMessage = error.userFriendlyMessage
+        }
+
+        isSaving = false
+    }
+
+    @MainActor
+    private func deleteWorkout() async {
+        guard !isDeleting else { return }
+
+        isDeleting = true
+
+        await MediaUploadManager.shared.cancelUploads(for: workout.id, modelContext: modelContext)
+
+        if !workout.photos.isEmpty {
+            do {
+                try await photoService.deletePhotos(workout.photos)
+            } catch let error as PhotoDeletionError {
+                switch error {
+                case .partialFailure(let result):
+                    errorTitle = "Unable to Delete"
+                    errorMessage = "Failed to delete \(result.failedCount) photo(s) from cloud storage. Please check your internet connection and try again."
+                case .timeout:
+                    errorTitle = "Unable to Delete"
+                    errorMessage = "Photo deletion timed out. Please check your internet connection and try again."
+                case .allRetriesExhausted:
+                    errorTitle = "Unable to Delete"
+                    errorMessage = "Failed to delete photos after multiple attempts. Please try again later."
+                }
+
+                showingDeleteConfirmation = false
+                isDeleting = false
+                return
+            } catch {
+                errorTitle = "Unable to Delete"
+                errorMessage = "Failed to delete photos from cloud storage. Please check your internet connection and try again."
+                showingDeleteConfirmation = false
+                isDeleting = false
+                return
+            }
+        }
+
+        let deletedSnapshot = LeaderboardWorkoutSnapshot(workout: workout)
+        modelContext.delete(workout)
+
+        do {
+            try modelContext.save()
+
+            if let appleHealthExternalRecordID = appleHealthExternalRecordID {
+                importCoordinator.ignoreAppleHealthWorkout(externalRecordID: appleHealthExternalRecordID)
+            }
+
+            try WorkoutMutationHandler.shared.workoutsDidChange(
+                modelContext: modelContext,
+                mutation: .deleted([deletedSnapshot])
+            )
+
+            cleanupVideoFiles()
+            showingDeleteConfirmation = false
+            isDeleting = false
+            onDelete()
+        } catch {
+            errorTitle = "Unable to Delete"
+            errorMessage = "Failed to delete workout from local storage. Please try again."
+            showingDeleteConfirmation = false
+            isDeleting = false
+        }
+    }
+
+    private var appleHealthExternalRecordID: String? {
+        workout.sourceLink(for: .appleHealth)?.externalRecordID ?? workout.healthKitUUID
+    }
+}

--- a/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
+++ b/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
@@ -12,6 +12,13 @@ import SwiftData
 struct EditWorkoutView: View {
     let workout: Workout
     @Binding var showingEditWorkout: Bool
+    let title: String
+    let primaryActionTitle: String
+    let cancelActionTitle: String?
+    let destructiveActionTitle: String?
+    let onSave: (() -> Void)?
+    let onCancel: (() -> Void)?
+    let onDestructiveAction: (() -> Void)?
     
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
@@ -57,6 +64,28 @@ struct EditWorkoutView: View {
     @FocusState private var focusedField: WorkoutFormField?
     
     private let photoService = PhotoService()
+
+    init(
+        workout: Workout,
+        showingEditWorkout: Binding<Bool>,
+        title: String = "Edit Workout",
+        primaryActionTitle: String = "Update",
+        cancelActionTitle: String? = "Cancel",
+        destructiveActionTitle: String? = nil,
+        onSave: (() -> Void)? = nil,
+        onCancel: (() -> Void)? = nil,
+        onDestructiveAction: (() -> Void)? = nil
+    ) {
+        self.workout = workout
+        self._showingEditWorkout = showingEditWorkout
+        self.title = title
+        self.primaryActionTitle = primaryActionTitle
+        self.cancelActionTitle = cancelActionTitle
+        self.destructiveActionTitle = destructiveActionTitle
+        self.onSave = onSave
+        self.onCancel = onCancel
+        self.onDestructiveAction = onDestructiveAction
+    }
     
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
@@ -207,16 +236,23 @@ struct EditWorkoutView: View {
     private var permanentHeader: some View {
         VStack(spacing: 0) {
             HStack {
-                Button("Cancel") {
-                    cleanupVideoFiles()
-                    showingEditWorkout = false
+                if let cancelActionTitle {
+                    Button(cancelActionTitle) {
+                        cleanupVideoFiles()
+                        onCancel?()
+                        showingEditWorkout = false
+                    }
+                    .font(.montserratRegular)
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    .frame(minWidth: 80, alignment: .leading)
+                } else {
+                    Color.clear
+                        .frame(width: 80, height: 1)
                 }
-                .font(.montserratRegular)
-                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
 
                 Spacer()
 
-                Text("Edit Workout")
+                Text(title)
                     .font(.montserratSemiBold(size: 18))
                     .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
 
@@ -232,13 +268,13 @@ struct EditWorkoutView: View {
                             .scaleEffect(0.8)
                             .progressViewStyle(CircularProgressViewStyle(tint: .accent))
                     } else {
-                        Text("Update")
+                        Text(primaryActionTitle)
                     }
                 }
                 .font(.montserratSemiBold)
                 .foregroundStyle(isFormValid ? .accent : .gray)
                 .disabled(!isFormValid)
-                .frame(width: 80)
+                .frame(minWidth: 80)
             }
             .padding(.horizontal, 20)
             .padding(.top, 8)
@@ -305,6 +341,16 @@ struct EditWorkoutView: View {
                                 configuration: $weightConfiguration,
                                 measurementSystem: settingsManager.measurementSystem
                             )
+                        }
+
+                        if let destructiveActionTitle {
+                            Button(role: .destructive) {
+                                onDestructiveAction?()
+                            } label: {
+                                Text(destructiveActionTitle)
+                            }
+                            .appSheetButtonStyle(tone: .destructive)
+                            .disabled(isSaving)
                         }
                     }
 
@@ -797,11 +843,12 @@ struct EditWorkoutView: View {
                     try? await photoService.deletePhotos(photosToDelete)
                 }
             }
-            
+
             // Clean up video files
             cleanupVideoFiles()
 
             showingEditWorkout = false
+            onSave?()
         } catch {
             if !newlyUploadedPhotos.isEmpty {
                 Task {

--- a/AscendApp/Features/Workouts/Views/WorkoutEntrySelectionView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutEntrySelectionView.swift
@@ -40,7 +40,7 @@ struct WorkoutEntrySelectionView: View {
                 } label: {
                     AppSheetOptionRow(
                         assetImage: "appleHealth-icon",
-                        title: "Import Workouts",
+                        title: "Import or Review",
                         badgeCount: pendingImportCount,
                         trailingSymbol: "chevron.right"
                     )

--- a/AscendApp/Features/Workouts/Views/WorkoutImportSheet.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutImportSheet.swift
@@ -10,8 +10,10 @@ import SwiftData
 
 struct WorkoutImportSheet: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
     @Environment(\.modelContext) private var modelContext
     @Environment(\.colorScheme) private var colorScheme
+    @State private var settingsManager = SettingsManager.shared
     @State private var themeManager = ThemeManager.shared
     @State private var importCoordinator = WorkoutImportCoordinator.shared
     @State private var hevyManager = HevyManager.shared
@@ -20,6 +22,10 @@ struct WorkoutImportSheet: View {
     @State private var importTask: Task<Void, Never>?
     @State private var isSelectionMode = false
     @State private var selectedCandidateIDs: Set<String> = []
+    @State private var isRequestingAppleHealthAuthorization = false
+    @State private var autoImportStatusMessage: String?
+    @State private var setupAlertMessage = ""
+    @State private var showingSetupAlert = false
 
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
@@ -41,6 +47,19 @@ struct WorkoutImportSheet: View {
         selectedCandidateIDs.intersection(candidateIDs).count
     }
 
+    private var appleHealthConnectionState: AppleHealthConnectionState {
+        importCoordinator.appleHealthConnectionState
+    }
+
+    private var shouldShowAppleHealthSetupCard: Bool {
+        importCoordinator.isAppleHealthAvailable &&
+        (appleHealthConnectionState == .neverConnected || appleHealthConnectionState == .revoked)
+    }
+
+    private var shouldHideGenericEmptyState: Bool {
+        shouldShowAppleHealthSetupCard
+    }
+
     private var allCandidatesSelected: Bool {
         candidateCount > 0 && selectedCount == candidateCount
     }
@@ -48,8 +67,22 @@ struct WorkoutImportSheet: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                VStack(spacing: 0) {
-                    if importCoordinator.isChecking && candidates.isEmpty {
+                VStack(spacing: 20) {
+                    if shouldShowAppleHealthSetupCard {
+                        appleHealthSetupCard
+                            .padding(.horizontal, 20)
+                            .padding(.top, 20)
+                    }
+
+                    if let autoImportStatusMessage {
+                        autoImportEnabledCard(message: autoImportStatusMessage)
+                            .padding(.horizontal, 20)
+                            .padding(.top, shouldShowAppleHealthSetupCard ? 0 : 20)
+                    }
+
+                    if shouldHideGenericEmptyState {
+                        EmptyView()
+                    } else if importCoordinator.isChecking && candidates.isEmpty {
                         loadingStateView
                     } else if candidates.isEmpty {
                         emptyStateView
@@ -103,9 +136,15 @@ struct WorkoutImportSheet: View {
                 }
             }
         }
+        .alert("Apple Health", isPresented: $showingSetupAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(setupAlertMessage)
+        }
         .task {
             importCoordinator.configure(modelContext: modelContext)
             syncSelectionWithCandidates()
+            await importCoordinator.refreshPendingImports(trigger: .manualReview)
         }
         .onChange(of: candidates.map(\.id)) { _, _ in
             syncSelectionWithCandidates()
@@ -159,13 +198,131 @@ struct WorkoutImportSheet: View {
         }
         .padding(.horizontal, 40)
         .padding(.top, 60)
+        .padding(.bottom, 24)
     }
 
     private var emptyStateMessage: String {
+        if shouldShowAppleHealthSetupCard {
+            if hevyManager.isConnected {
+                return "Connect Apple Health here, or keep importing from your connected sources."
+            }
+            return "Connect Apple Health above to import existing workouts and optionally auto-import new ones."
+        }
+
         if hevyManager.isConnected {
             return "All your Apple Health and Hevy workouts are already imported."
         }
         return "All your Apple Health workouts are already imported."
+    }
+
+    private var appleHealthSetupCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 12) {
+                Image("appleHealth-icon")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 36, height: 36)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(appleHealthSetupTitle)
+                        .font(.montserratSemiBold(size: 16))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+
+                    if !appleHealthSetupSubtitle.isEmpty {
+                        Text(appleHealthSetupSubtitle)
+                            .font(.montserratRegular(size: 13))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+
+            Text(appleHealthSetupMessage)
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if !appleHealthSetupSecondaryLine.isEmpty {
+                Text(appleHealthSetupSecondaryLine)
+                    .font(.montserratRegular(size: 13))
+                    .foregroundStyle(.secondary.opacity(0.92))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Button(appleHealthSetupButtonTitle) {
+                handleAppleHealthSetupButtonTapped()
+            }
+            .appSheetButtonStyle()
+            .disabled(isRequestingAppleHealthAuthorization)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.white)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(effectiveColorScheme == .dark ? .white.opacity(0.08) : .black.opacity(0.08), lineWidth: 1)
+        }
+    }
+
+    private var appleHealthSetupTitle: String {
+        switch appleHealthConnectionState {
+        case .neverConnected:
+            return "Import Apple Health workouts"
+        case .revoked:
+            return "Reconnect Apple Health"
+        case .connected, .unavailable:
+            return "Apple Health"
+        }
+    }
+
+    private var appleHealthSetupSubtitle: String {
+        switch appleHealthConnectionState {
+        case .neverConnected:
+            return ""
+        case .revoked:
+            return "Health permissions were turned off outside Ascend."
+        case .connected, .unavailable:
+            return ""
+        }
+    }
+
+    private var appleHealthSetupMessage: String {
+        switch appleHealthConnectionState {
+        case .neverConnected:
+            return "Connect Apple Health to import your existing stairstepper workouts and automatically import new ones when you finish them."
+        case .revoked:
+            return "Re-enable workout access in the Health app to bring Apple Health workouts into Ascend again."
+        case .connected, .unavailable:
+            return ""
+        }
+    }
+
+    private var appleHealthSetupSecondaryLine: String {
+        switch appleHealthConnectionState {
+        case .neverConnected:
+            return "Turn off auto-import anytime in Settings > Edit Profile > Integrations > Apple Health."
+        case .revoked, .connected, .unavailable:
+            return ""
+        }
+    }
+
+    private var appleHealthSetupButtonTitle: String {
+        if isRequestingAppleHealthAuthorization, appleHealthConnectionState == .neverConnected {
+            return "Connecting..."
+        }
+
+        switch appleHealthConnectionState {
+        case .neverConnected:
+            return "Connect Apple Health"
+        case .revoked:
+            return "Open Health Permissions"
+        case .connected, .unavailable:
+            return "Manage"
+        }
     }
 
     private var workoutListSection: some View {
@@ -236,6 +393,53 @@ struct WorkoutImportSheet: View {
             onPrimaryTapped: importSelectedWorkouts,
             isPrimaryDisabled: selectedCount == 0 || importCoordinator.isImporting
         )
+    }
+
+    private func autoImportEnabledCard(message: String) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(.accent)
+                    .frame(width: 36, height: 36)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Apple Health connected")
+                        .font(.montserratSemiBold(size: 16))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+
+                    Text("Auto-import is on")
+                        .font(.montserratRegular(size: 13))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                Button {
+                    autoImportStatusMessage = nil
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 28, height: 28)
+                }
+                .buttonStyle(.plain)
+            }
+
+            Text(message)
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(effectiveColorScheme == .dark ? Color.white.opacity(0.06) : Color.white)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .stroke(effectiveColorScheme == .dark ? .white.opacity(0.08) : .black.opacity(0.08), lineWidth: 1)
+        }
     }
 
     private func importWorkout(_ candidate: ImportedWorkoutCandidate) {
@@ -342,6 +546,57 @@ struct WorkoutImportSheet: View {
         withAnimation(.easeInOut(duration: 0.2)) {
             isSelectionMode = false
         }
+    }
+
+    private func handleAppleHealthSetupButtonTapped() {
+        switch appleHealthConnectionState {
+        case .neverConnected:
+            requestAppleHealthAuthorization()
+        case .revoked:
+            openHealthPermissions()
+        case .connected, .unavailable:
+            break
+        }
+    }
+
+    private func requestAppleHealthAuthorization() {
+        guard !isRequestingAppleHealthAuthorization else { return }
+
+        isRequestingAppleHealthAuthorization = true
+        Task {
+            let didConnect = await importCoordinator.requestAppleHealthAuthorizationIfNeeded()
+
+            guard didConnect else {
+                await MainActor.run {
+                    isRequestingAppleHealthAuthorization = false
+                    if let errorMessage = importCoordinator.lastErrorMessage, !errorMessage.isEmpty {
+                        presentSetupAlert(errorMessage)
+                    }
+                }
+                return
+            }
+
+            await MainActor.run {
+                isRequestingAppleHealthAuthorization = false
+                settingsManager.setAppleHealthAutoImportEnabled(true)
+                autoImportStatusMessage = defaultAutoImportStatusMessage
+            }
+            await importCoordinator.handleAppleHealthAutoImportPreferenceChanged()
+        }
+    }
+
+    private func openHealthPermissions() {
+        guard let healthURL = URL(string: "x-apple-health://") else { return }
+        openURL(healthURL)
+    }
+
+    private var defaultAutoImportStatusMessage: String {
+        "New Apple Health workouts will auto-import by default. You can change this anytime in Settings > Edit Profile > Integrations > Apple Health."
+    }
+
+    private func presentSetupAlert(_ message: String) {
+        setupAlertMessage = message
+        showingSetupAlert = true
     }
 
     private typealias PreGoalCapture = (goal: Goal, progress: GoalProgress, referenceDate: Date)
@@ -546,5 +801,6 @@ struct ImportedWorkoutCandidateRow: View {
 
 #Preview {
     WorkoutImportSheet()
+        .environment(AuthenticationViewModel())
         .modelContainer(for: [Workout.self, WorkoutSourceLink.self, Goal.self], inMemory: true)
 }

--- a/AscendApp/Features/Workouts/Views/WorkoutListView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutListView.swift
@@ -49,7 +49,7 @@ struct WorkoutListView: View {
                     isInDeleteMode: isInDeleteMode,
                     totalCount: workouts.count,
                     effectiveColorScheme: effectiveColorScheme,
-                    pendingImportCount: importCoordinator.pendingCount,
+                    pendingImportCount: importCoordinator.attentionCount,
                     workouts: workouts,
                     filterState: filterState,
                     onCancelDelete: exitDeleteMode,
@@ -132,7 +132,7 @@ struct WorkoutListView: View {
                             handleImportTapped()
                         }
                     },
-                    pendingImportCount: importCoordinator.pendingCount
+                    pendingImportCount: importCoordinator.attentionCount
                 )
                 .appSheetStyle(.fitted())
             }
@@ -248,8 +248,10 @@ struct WorkoutListView: View {
 
     private func handleImportTapped() {
         Task {
-            await importCoordinator.refreshPendingImports(trigger: .manualReview)
-            showingImportSheet = true
+            let resolution = await importCoordinator.prepareImportInbox()
+            if resolution == .showImportSheet {
+                showingImportSheet = true
+            }
         }
     }
 

--- a/AscendApp/Shared/Managers/SettingsManager.swift
+++ b/AscendApp/Shared/Managers/SettingsManager.swift
@@ -24,6 +24,9 @@ final class SettingsManager {
     private let manualBaseLevelOverrideKey = "manualBaseLevelOverride"
     private let hasCompletedBaseLevelOnboardingKey = "hasCompletedBaseLevelOnboarding"
     private let firstLaunchDateKey = "firstLaunchDate"
+    private let appleHealthAutoImportEnabledKey = "appleHealthAutoImportEnabled"
+    private let appleHealthAutoImportActivatedAtKey = "appleHealthAutoImportActivatedAt"
+    private let appleHealthImportCoachMarkSeenUserIDsKey = "appleHealthImportCoachMarkSeenUserIDs"
     var preferredWorkoutMetric: WorkoutMetric {
         didSet {
             savePreferredMetric()
@@ -78,6 +81,24 @@ final class SettingsManager {
     var hasCompletedBaseLevelOnboarding: Bool {
         didSet {
             saveHasCompletedBaseLevelOnboarding()
+        }
+    }
+
+    var appleHealthAutoImportEnabled: Bool {
+        didSet {
+            if appleHealthAutoImportEnabled && !oldValue {
+                appleHealthAutoImportActivatedAt = Date()
+            } else if !appleHealthAutoImportEnabled {
+                appleHealthAutoImportActivatedAt = nil
+            }
+
+            saveAppleHealthAutoImportEnabled()
+        }
+    }
+
+    var appleHealthAutoImportActivatedAt: Date? {
+        didSet {
+            saveAppleHealthAutoImportActivatedAt()
         }
     }
 
@@ -177,6 +198,9 @@ final class SettingsManager {
             }
         }
 
+        self.appleHealthAutoImportEnabled = UserDefaults.standard.bool(forKey: appleHealthAutoImportEnabledKey)
+        self.appleHealthAutoImportActivatedAt = UserDefaults.standard.object(forKey: appleHealthAutoImportActivatedAtKey) as? Date
+
     }
     
     private func savePreferredMetric() {
@@ -232,6 +256,16 @@ final class SettingsManager {
         UserDefaults.standard.synchronize()
     }
 
+    private func saveAppleHealthAutoImportEnabled() {
+        UserDefaults.standard.set(appleHealthAutoImportEnabled, forKey: appleHealthAutoImportEnabledKey)
+        UserDefaults.standard.synchronize()
+    }
+
+    private func saveAppleHealthAutoImportActivatedAt() {
+        UserDefaults.standard.set(appleHealthAutoImportActivatedAt, forKey: appleHealthAutoImportActivatedAtKey)
+        UserDefaults.standard.synchronize()
+    }
+
     private func convertStepHeight(from oldSystem: MeasurementSystem, to newSystem: MeasurementSystem) {
         guard oldSystem != newSystem else { return }
         
@@ -259,7 +293,27 @@ final class SettingsManager {
             measurementSystem = system
         }
     }
-    
+
+    func setAppleHealthAutoImportEnabled(_ enabled: Bool) {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            appleHealthAutoImportEnabled = enabled
+        }
+    }
+
+    func hasSeenAppleHealthImportCoachMark(for userID: String) -> Bool {
+        Set(UserDefaults.standard.stringArray(forKey: appleHealthImportCoachMarkSeenUserIDsKey) ?? [])
+            .contains(userID)
+    }
+
+    func markAppleHealthImportCoachMarkSeen(for userID: String) {
+        var seenUserIDs = Set(UserDefaults.standard.stringArray(forKey: appleHealthImportCoachMarkSeenUserIDsKey) ?? [])
+        let inserted = seenUserIDs.insert(userID).inserted
+        guard inserted else { return }
+
+        UserDefaults.standard.set(Array(seenUserIDs).sorted(), forKey: appleHealthImportCoachMarkSeenUserIDsKey)
+        UserDefaults.standard.synchronize()
+    }
+
     func setStepHeight(_ height: Double) {
         stepHeight = height
     }

--- a/AscendApp/Shared/Models/TabItem.swift
+++ b/AscendApp/Shared/Models/TabItem.swift
@@ -15,6 +15,7 @@ enum AppTab: Hashable {
     case settings
 }
 
+@MainActor
 @Observable
 final class TabRouter {
     var selectedTab: AppTab = .home

--- a/AscendApp/Shared/Services/AppleHealthAutoImportPolicy.swift
+++ b/AscendApp/Shared/Services/AppleHealthAutoImportPolicy.swift
@@ -1,0 +1,26 @@
+//
+//  AppleHealthAutoImportPolicy.swift
+//  AscendApp
+//
+//  Created by Codex on 4/20/26.
+//
+
+import Foundation
+
+struct AppleHealthAutoImportPolicy {
+    let activatedAt: Date?
+    let missingActivationFallback: Date?
+
+    init(activatedAt: Date?, missingActivationFallback: Date? = nil) {
+        self.activatedAt = activatedAt
+        self.missingActivationFallback = missingActivationFallback
+    }
+
+    func shouldAutoImport(_ candidate: ImportedWorkoutCandidate) -> Bool {
+        guard candidate.kind == .appleHealth else { return false }
+        guard let sample = candidate.appleHealthSample else { return false }
+        guard let activatedAt = activatedAt ?? missingActivationFallback else { return false }
+
+        return sample.endDate >= activatedAt
+    }
+}

--- a/AscendApp/Shared/Services/HealthKitBackgroundSyncManager.swift
+++ b/AscendApp/Shared/Services/HealthKitBackgroundSyncManager.swift
@@ -1,0 +1,115 @@
+//
+//  HealthKitBackgroundSyncManager.swift
+//  AscendApp
+//
+//  Created by Codex on 4/20/26.
+//
+
+import Foundation
+import HealthKit
+
+@MainActor
+final class HealthKitBackgroundSyncManager {
+    static let shared = HealthKitBackgroundSyncManager()
+
+    private let healthStore: HKHealthStore
+    private var observerQuery: HKObserverQuery?
+    private var isObserving = false
+
+    private init(healthStore: HKHealthStore = HKHealthStore()) {
+        self.healthStore = healthStore
+    }
+
+    func updateObservation(enabled: Bool) async {
+        guard HKHealthStore.isHealthDataAvailable() else { return }
+
+        if enabled {
+            guard !isObserving else { return }
+
+            let query = HKObserverQuery(
+                sampleType: HKObjectType.workoutType(),
+                predicate: HealthKitWorkoutReader.stairWorkoutPredicate()
+            ) { _, completionHandler, error in
+                guard error == nil else {
+                    completionHandler()
+                    return
+                }
+
+                let deliveryCompletion = HealthKitObserverDeliveryCompletion(completionHandler)
+                Task {
+                    defer { deliveryCompletion.complete() }
+                    await WorkoutImportCoordinator.shared.refreshPendingImports(trigger: .backgroundObserver)
+                }
+            }
+
+            observerQuery = query
+            healthStore.execute(query)
+            try? await enableBackgroundDelivery()
+            isObserving = true
+        } else {
+            if let observerQuery {
+                healthStore.stop(observerQuery)
+                self.observerQuery = nil
+            }
+
+            try? await disableBackgroundDelivery()
+            isObserving = false
+        }
+    }
+
+    private func enableBackgroundDelivery() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            healthStore.enableBackgroundDelivery(
+                for: HKObjectType.workoutType(),
+                frequency: .immediate
+            ) { success, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: BackgroundDeliveryError.enableFailed)
+                }
+            }
+        }
+    }
+
+    private func disableBackgroundDelivery() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            healthStore.disableBackgroundDelivery(for: HKObjectType.workoutType()) { success, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if success {
+                    continuation.resume()
+                } else {
+                    continuation.resume(throwing: BackgroundDeliveryError.disableFailed)
+                }
+            }
+        }
+    }
+}
+
+private extension HealthKitBackgroundSyncManager {
+    enum BackgroundDeliveryError: Error {
+        case enableFailed
+        case disableFailed
+    }
+}
+
+private final class HealthKitObserverDeliveryCompletion: @unchecked Sendable {
+    private let lock = NSLock()
+    private var completionHandler: (() -> Void)?
+
+    init(_ completionHandler: @escaping () -> Void) {
+        self.completionHandler = completionHandler
+    }
+
+    func complete() {
+        lock.lock()
+        let completionHandler = completionHandler
+        self.completionHandler = nil
+        lock.unlock()
+
+        completionHandler?()
+    }
+}

--- a/AscendApp/Shared/Services/HealthKitWorkoutReader.swift
+++ b/AscendApp/Shared/Services/HealthKitWorkoutReader.swift
@@ -46,36 +46,21 @@ final class HealthKitWorkoutReader: HealthKitWorkoutReading {
         }
 
         let anchor = HealthKitSyncState.unarchiveAnchor(from: anchorData)
-        let predicate = stairWorkoutPredicate()
+        let predicate = Self.stairWorkoutPredicate()
+        let descriptor = HKAnchoredObjectQueryDescriptor<HKWorkout>(
+            predicates: [.workout(predicate)],
+            anchor: anchor
+        )
+        let result = try await descriptor.result(for: healthStore)
+        let addedSamples = result.addedSamples.map(Self.makeSample(from:))
+        let deletedExternalRecordIDs = result.deletedObjects.map { $0.uuid.uuidString }
+        let newAnchorData = HealthKitSyncState.archive(anchor: result.newAnchor)
 
-        return try await withCheckedThrowingContinuation { continuation in
-            let query = HKAnchoredObjectQuery(
-                type: HKObjectType.workoutType(),
-                predicate: predicate,
-                anchor: anchor,
-                limit: HKObjectQueryNoLimit
-            ) { _, samples, deletedObjects, newAnchor, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                    return
-                }
-
-                let workouts = (samples as? [HKWorkout]) ?? []
-                let addedSamples = workouts.map(Self.makeSample(from:))
-                let deletedExternalRecordIDs = deletedObjects?.map { $0.uuid.uuidString } ?? []
-                let newAnchorData = HealthKitSyncState.archive(anchor: newAnchor)
-
-                continuation.resume(
-                    returning: HealthKitWorkoutDiscoveryResult(
-                        addedSamples: addedSamples,
-                        deletedExternalRecordIDs: deletedExternalRecordIDs,
-                        anchorData: newAnchorData
-                    )
-                )
-            }
-
-            healthStore.execute(query)
-        }
+        return HealthKitWorkoutDiscoveryResult(
+            addedSamples: addedSamples,
+            deletedExternalRecordIDs: deletedExternalRecordIDs,
+            anchorData: newAnchorData
+        )
     }
 
     func fetchWorkout(withExternalRecordID externalRecordID: String) async throws -> HKWorkout? {
@@ -110,7 +95,7 @@ final class HealthKitWorkoutReader: HealthKitWorkoutReading {
             end: dateRange.upperBound,
             options: .strictStartDate
         )
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [stairWorkoutPredicate(), datePredicate])
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [Self.stairWorkoutPredicate(), datePredicate])
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
 
         return try await withCheckedThrowingContinuation { continuation in
@@ -133,7 +118,7 @@ final class HealthKitWorkoutReader: HealthKitWorkoutReading {
         }
     }
 
-    private func stairWorkoutPredicate() -> NSPredicate {
+    nonisolated static func stairWorkoutPredicate() -> NSPredicate {
         NSCompoundPredicate(orPredicateWithSubpredicates: [
             HKQuery.predicateForWorkouts(with: .stairClimbing),
             HKQuery.predicateForWorkouts(with: .stepTraining)

--- a/AscendApp/Shared/Services/IgnoredAppleHealthWorkoutStore.swift
+++ b/AscendApp/Shared/Services/IgnoredAppleHealthWorkoutStore.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct IgnoredAppleHealthWorkoutStore {
+    private let defaults: UserDefaults
+    private let key: String
+
+    init(
+        defaults: UserDefaults = .standard,
+        key: String = "workoutImport.ignoredAppleHealthExternalRecordIDs"
+    ) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    func load() -> Set<String> {
+        Set(defaults.stringArray(forKey: key) ?? [])
+    }
+
+    func contains(_ externalRecordID: String) -> Bool {
+        load().contains(externalRecordID)
+    }
+
+    func insert(_ externalRecordID: String) {
+        var ignoredIDs = load()
+        let inserted = ignoredIDs.insert(externalRecordID).inserted
+        guard inserted else { return }
+        save(ignoredIDs)
+    }
+
+    func prune(validExternalRecordIDs: Set<String>) {
+        let prunedIDs = load().intersection(validExternalRecordIDs)
+        save(prunedIDs)
+    }
+
+    func clear() {
+        defaults.removeObject(forKey: key)
+    }
+
+    private func save(_ ignoredIDs: Set<String>) {
+        defaults.set(Array(ignoredIDs).sorted(), forKey: key)
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/DebugTelemetryConsoleEntry.swift
+++ b/AscendApp/Shared/Services/Telemetry/DebugTelemetryConsoleEntry.swift
@@ -232,6 +232,8 @@ private extension DebugTelemetryConsoleEntry {
             return "Selected workouts"
         case "all":
             return "Import all"
+        case "automatic":
+            return "Automatic import"
         case "apple_health_only":
             return "Apple Health only"
         case "hevy_only":
@@ -301,7 +303,7 @@ private extension DebugTelemetryConsoleEntry {
         case "candidate_count_bucket":
             return "How many workout candidates were included in this import action."
         case "import_mode":
-            return "Whether the user imported one workout, a selected set, or everything available."
+            return "Whether the user imported one workout, a selected set, everything available, or an automatic Apple Health import."
         case "source_mix":
             return "Which source combination the imported workouts came from."
         case "imported_count_bucket":

--- a/AscendApp/Shared/Services/WorkoutAutoImportReviewStateStore.swift
+++ b/AscendApp/Shared/Services/WorkoutAutoImportReviewStateStore.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+struct WorkoutAutoImportReviewStateStore {
+    private struct Snapshot: Codable {
+        var latestWorkoutID: UUID?
+        var latestReferenceDate: Date?
+        var lastHandledReferenceDate: Date?
+    }
+
+    private let defaults: UserDefaults
+    private let key: String
+
+    init(
+        defaults: UserDefaults = .standard,
+        key: String = "workoutImport.autoImportedReviewState"
+    ) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    func latestUnseenWorkoutID() -> UUID? {
+        let snapshot = loadSnapshot()
+        guard let latestWorkoutID = snapshot.latestWorkoutID,
+              let latestReferenceDate = snapshot.latestReferenceDate else {
+            return nil
+        }
+
+        if let lastHandledReferenceDate = snapshot.lastHandledReferenceDate,
+           latestReferenceDate <= lastHandledReferenceDate {
+            return nil
+        }
+
+        return latestWorkoutID
+    }
+
+    func hasUnseenWorkout() -> Bool {
+        latestUnseenWorkoutID() != nil
+    }
+
+    func latestReferenceDate(for workoutID: UUID) -> Date? {
+        let snapshot = loadSnapshot()
+        guard snapshot.latestWorkoutID == workoutID else { return nil }
+        return snapshot.latestReferenceDate
+    }
+
+    func recordLatestWorkout(id: UUID, referenceDate: Date) {
+        var snapshot = loadSnapshot()
+
+        if let existingLatestReferenceDate = snapshot.latestReferenceDate,
+           let existingLatestWorkoutID = snapshot.latestWorkoutID,
+           existingLatestReferenceDate > referenceDate,
+           existingLatestWorkoutID != id {
+            return
+        }
+
+        snapshot.latestWorkoutID = id
+        snapshot.latestReferenceDate = referenceDate
+        saveSnapshot(snapshot)
+    }
+
+    func markHandled(referenceDate: Date) {
+        var snapshot = loadSnapshot()
+        let resolvedHandledDate = max(snapshot.lastHandledReferenceDate ?? .distantPast, referenceDate)
+        snapshot.lastHandledReferenceDate = resolvedHandledDate
+
+        if let latestReferenceDate = snapshot.latestReferenceDate,
+           latestReferenceDate <= resolvedHandledDate {
+            snapshot.latestWorkoutID = nil
+            snapshot.latestReferenceDate = nil
+        }
+
+        saveSnapshot(snapshot)
+    }
+
+    func clearLatestWorkout(ifMatches workoutID: UUID? = nil) {
+        var snapshot = loadSnapshot()
+
+        if let workoutID, snapshot.latestWorkoutID != workoutID {
+            return
+        }
+
+        snapshot.latestWorkoutID = nil
+        snapshot.latestReferenceDate = nil
+        saveSnapshot(snapshot)
+    }
+
+    func prune(validIDs: Set<UUID>) {
+        var snapshot = loadSnapshot()
+
+        if let latestWorkoutID = snapshot.latestWorkoutID,
+           !validIDs.contains(latestWorkoutID) {
+            snapshot.latestWorkoutID = nil
+            snapshot.latestReferenceDate = nil
+        }
+
+        saveSnapshot(snapshot)
+    }
+
+    func clear() {
+        defaults.removeObject(forKey: key)
+    }
+
+    private func loadSnapshot() -> Snapshot {
+        guard let data = defaults.data(forKey: key),
+              let snapshot = try? JSONDecoder().decode(Snapshot.self, from: data) else {
+            return Snapshot()
+        }
+
+        return snapshot
+    }
+
+    private func saveSnapshot(_ snapshot: Snapshot) {
+        guard let data = try? JSONEncoder().encode(snapshot) else { return }
+        defaults.set(data, forKey: key)
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
@@ -5,7 +5,6 @@
 //  Created by Codex on 3/11/26.
 //
 
-import FirebaseAuth
 import Foundation
 import HealthKit
 import SwiftData
@@ -13,6 +12,8 @@ import Observation
 
 enum ImportRefreshTrigger {
     case automatic
+    case backgroundObserver
+    case homeEntry
     case manualReview
     case manualSync
 }
@@ -35,6 +36,10 @@ protocol WorkoutDataProviding {
 @Observable
 final class WorkoutImportCoordinator {
     static let shared = WorkoutImportCoordinator()
+
+    enum ImportInboxResolution {
+        case showImportSheet
+    }
 
     enum ImportOutcome {
         case imported(Workout)
@@ -69,22 +74,34 @@ final class WorkoutImportCoordinator {
     private let hevyManager: HevyManager
     private let telemetry: TelemetryManager
     private let leaderboardService = LeaderboardService.shared
+    private let settingsManager: SettingsManager
+    private let reviewStateStore: WorkoutAutoImportReviewStateStore
+    private let ignoredAppleHealthWorkoutStore: IgnoredAppleHealthWorkoutStore
 
     private var modelContext: ModelContext?
     private var lastAutomaticCheckAt: Date?
+    private var refreshTask: Task<Void, Never>?
+    private var activeRefreshTrigger: ImportRefreshTrigger?
+    var currentAutoImportedReviewWorkoutID: UUID?
 
     init(
         authorizationController: any HealthKitAuthorizationControlling = HealthKitAuthorizationClient.shared,
         workoutReader: any HealthKitWorkoutReading = HealthKitWorkoutReader.shared,
         metricsReader: any HealthKitMetricsReading = HealthKitMetricsReader.shared,
         hevyManager: HevyManager = .shared,
-        telemetry: TelemetryManager = .shared
+        telemetry: TelemetryManager = .shared,
+        settingsManager: SettingsManager = .shared,
+        reviewStateStore: WorkoutAutoImportReviewStateStore = WorkoutAutoImportReviewStateStore(),
+        ignoredAppleHealthWorkoutStore: IgnoredAppleHealthWorkoutStore = IgnoredAppleHealthWorkoutStore()
     ) {
         self.authorizationController = authorizationController
         self.workoutReader = workoutReader
         self.metricsReader = metricsReader
         self.hevyManager = hevyManager
         self.telemetry = telemetry
+        self.settingsManager = settingsManager
+        self.reviewStateStore = reviewStateStore
+        self.ignoredAppleHealthWorkoutStore = ignoredAppleHealthWorkoutStore
         self.lastCheckAt = HealthKitSyncState.lastSuccessfulCheckAt
     }
 
@@ -92,8 +109,20 @@ final class WorkoutImportCoordinator {
         pendingCandidates.count
     }
 
+    var pendingAutoImportedReviewCount: Int {
+        reviewStateStore.hasUnseenWorkout() ? 1 : 0
+    }
+
+    var attentionCount: Int {
+        pendingCount + pendingAutoImportedReviewCount
+    }
+
     var appleHealthPendingCount: Int {
         pendingCandidates.filter { $0.sourceProviders.contains(.appleHealth) }.count
+    }
+
+    var appleHealthAttentionCount: Int {
+        appleHealthPendingCount + pendingAutoImportedReviewCount
     }
 
     var appleHealthConnectionState: AppleHealthConnectionState {
@@ -122,8 +151,13 @@ final class WorkoutImportCoordinator {
 
         do {
             try WorkoutSourceMigrationService.runIfNeeded(modelContext: modelContext)
+            try pruneAutoImportedReviewState(modelContext: modelContext)
         } catch {
             lastErrorMessage = error.localizedDescription
+        }
+
+        Task {
+            await syncAppleHealthAutomationServices()
         }
     }
 
@@ -151,14 +185,35 @@ final class WorkoutImportCoordinator {
             return false
         }
 
-        let didRefresh = await performAppleHealthRefreshIfNeeded(trigger: .manualSync)
-        if didRefresh {
-            lastErrorMessage = nil
-        }
-        return didRefresh
+        await refreshPendingImports(trigger: .manualSync)
+        await syncAppleHealthAutomationServices()
+        return lastErrorMessage == nil
     }
 
     func refreshPendingImports(trigger: ImportRefreshTrigger) async {
+        if let refreshTask {
+            let activeRefreshTrigger = activeRefreshTrigger
+            await refreshTask.value
+
+            if activeRefreshTrigger?.covers(trigger) == false {
+                await refreshPendingImports(trigger: trigger)
+            }
+
+            return
+        }
+
+        let refreshTask = Task { @MainActor [weak self] in
+            await self?.performRefreshPendingImports(trigger: trigger)
+            self?.refreshTask = nil
+            self?.activeRefreshTrigger = nil
+        }
+        self.refreshTask = refreshTask
+        activeRefreshTrigger = trigger
+
+        await refreshTask.value
+    }
+
+    private func performRefreshPendingImports(trigger: ImportRefreshTrigger) async {
         guard let modelContext else { return }
 
         if trigger == .automatic,
@@ -177,15 +232,28 @@ final class WorkoutImportCoordinator {
         do {
             try WorkoutSourceMigrationService.runIfNeeded(modelContext: modelContext)
             await authorizationController.refreshAuthorizationRequestStatus()
+            let previousSuccessfulCheckAt = HealthKitSyncState.lastSuccessfulCheckAt ?? lastCheckAt
             _ = await performAppleHealthRefreshIfNeeded(trigger: trigger)
 
             let existingIndex = try buildExistingWorkoutIndex(modelContext: modelContext)
             pendingCandidates = try await buildPendingCandidates(existingIndex: existingIndex)
+            try pruneAutoImportedReviewState(modelContext: modelContext)
+            await autoImportEligibleAppleHealthCandidatesIfNeeded(
+                modelContext: modelContext,
+                missingActivationFallback: previousSuccessfulCheckAt
+            )
             lastCheckAt = Date()
             lastErrorMessage = nil
         } catch {
             lastErrorMessage = error.localizedDescription
         }
+
+        await syncAppleHealthAutomationServices()
+    }
+
+    func prepareImportInbox() async -> ImportInboxResolution {
+        await refreshPendingImports(trigger: .manualReview)
+        return .showImportSheet
     }
 
     func importCandidate(_ candidate: ImportedWorkoutCandidate) async -> ImportOutcome {
@@ -269,17 +337,48 @@ final class WorkoutImportCoordinator {
         lastAutomaticCheckAt = nil
     }
 
+    @discardableResult
+    func presentPendingAutoImportedReviewOnHomeIfNeeded() -> Bool {
+        guard let nextWorkoutID = reviewStateStore.latestUnseenWorkoutID() else {
+            currentAutoImportedReviewWorkoutID = nil
+            return false
+        }
+
+        if currentAutoImportedReviewWorkoutID != nextWorkoutID {
+            currentAutoImportedReviewWorkoutID = nextWorkoutID
+        }
+
+        return true
+    }
+
+    func dismissCurrentAutoImportedReview() {
+        currentAutoImportedReviewWorkoutID = nil
+    }
+
+    func completeAutoImportedReview(for workoutID: UUID) {
+        markAutoImportedReviewHandled(for: workoutID)
+        reviewStateStore.clearLatestWorkout(ifMatches: workoutID)
+        if currentAutoImportedReviewWorkoutID == workoutID {
+            currentAutoImportedReviewWorkoutID = nil
+        }
+    }
+
+    func handleAppleHealthAutoImportPreferenceChanged() async {
+        await syncAppleHealthAutomationServices()
+    }
+
     private func performAppleHealthRefreshIfNeeded(trigger: ImportRefreshTrigger) async -> Bool {
         guard authorizationController.isHealthDataAvailable else { return false }
 
-        let isExplicitRefresh = trigger == .manualReview || trigger == .manualSync
+        let shouldRequestAuthorization = trigger == .manualSync
+        let shouldAllowInitialBackfill = trigger == .homeEntry || trigger == .manualReview || trigger == .manualSync
 
         if authorizationController.connectionState == .revoked {
             return false
         }
 
         if !authorizationController.hasRequestedAuthorization {
-            guard isExplicitRefresh else { return false }
+            guard shouldRequestAuthorization else { return false }
             let granted = await authorizationController.requestAuthorization()
             if !granted {
                 lastErrorMessage = authorizationController.lastPermissionErrorMessage
@@ -288,7 +387,7 @@ final class WorkoutImportCoordinator {
         }
 
         if !authorizationController.hasCompletedInitialBackfill {
-            guard isExplicitRefresh else { return false }
+            guard shouldAllowInitialBackfill else { return false }
         }
 
         do {
@@ -298,6 +397,9 @@ final class WorkoutImportCoordinator {
             HealthKitSyncState.updateCachedWorkoutSamples(
                 added: result.addedSamples,
                 deletedExternalRecordIDs: result.deletedExternalRecordIDs
+            )
+            ignoredAppleHealthWorkoutStore.prune(
+                validExternalRecordIDs: Set(HealthKitSyncState.cachedWorkoutSamples.map(\.externalRecordID))
             )
             HealthKitSyncState.workoutAnchorData = result.anchorData
             HealthKitSyncState.lastSuccessfulCheckAt = Date()
@@ -315,8 +417,49 @@ final class WorkoutImportCoordinator {
         }
     }
 
+    private func autoImportEligibleAppleHealthCandidatesIfNeeded(
+        modelContext: ModelContext,
+        missingActivationFallback: Date?
+    ) async {
+        guard settingsManager.appleHealthAutoImportEnabled else { return }
+
+        let policy = AppleHealthAutoImportPolicy(
+            activatedAt: settingsManager.appleHealthAutoImportActivatedAt,
+            missingActivationFallback: missingActivationFallback
+        )
+        let autoImportCandidates = pendingCandidates.filter(policy.shouldAutoImport(_:))
+        guard !autoImportCandidates.isEmpty else { return }
+
+        let result = await importCandidatesInternal(
+            candidates: autoImportCandidates,
+            mode: .automatic
+        )
+
+        for workout in result.importedWorkouts {
+            recordAutoImportedWorkoutForReview(workout)
+        }
+
+        do {
+            try pruneAutoImportedReviewState(modelContext: modelContext)
+        } catch {
+            lastErrorMessage = error.localizedDescription
+        }
+    }
+
+    private func syncAppleHealthAutomationServices() async {
+        let shouldObserveForAutoImport =
+            settingsManager.appleHealthAutoImportEnabled &&
+            authorizationController.connectionState == .connected &&
+            authorizationController.hasCompletedInitialBackfill
+
+        await HealthKitBackgroundSyncManager.shared.updateObservation(enabled: shouldObserveForAutoImport)
+    }
+
     private func buildPendingCandidates(existingIndex: ExistingWorkoutIndex) async throws -> [ImportedWorkoutCandidate] {
-        let appleSamples = HealthKitSyncState.cachedWorkoutSamples.sorted { $0.startDate > $1.startDate }
+        let ignoredAppleHealthWorkoutIDs = ignoredAppleHealthWorkoutStore.load()
+        let appleSamples = HealthKitSyncState.cachedWorkoutSamples
+            .filter { !ignoredAppleHealthWorkoutIDs.contains($0.externalRecordID) }
+            .sorted { $0.startDate > $1.startDate }
         let hevyMetricType = HevySyncState.templateType == "floors" ? WorkoutMetric.floors : WorkoutMetric.steps
 
         var matchedAppleIDs = Set<String>()
@@ -526,6 +669,12 @@ final class WorkoutImportCoordinator {
 
             switch candidate.kind {
             case .appleHealth:
+                guard let appleHealthSample = candidate.appleHealthSample else {
+                    return .failed(candidateID: candidate.id)
+                }
+                if let existingWorkout = existingIndex.workout(forAppleHealthID: appleHealthSample.externalRecordID) {
+                    return .updatedExisting(existingWorkout)
+                }
                 return try await importAppleHealthCandidate(candidate, modelContext: modelContext)
             case .hevy, .linkedHevyAppleHealth:
                 return try await importHevyCandidate(
@@ -553,6 +702,11 @@ final class WorkoutImportCoordinator {
         let settings = SettingsManager.shared
         let workout = hkWorkout.toAscendWorkout(with: metrics, stepsPerFloor: settings.stepsPerFloor)
         let appleHealthLink = makeAppleHealthSourceLink(from: sample, workout: workout)
+
+        let refreshedIndex = try buildExistingWorkoutIndex(modelContext: modelContext)
+        if let existingWorkout = refreshedIndex.workout(forAppleHealthID: sample.externalRecordID) {
+            return .updatedExisting(existingWorkout)
+        }
 
         modelContext.insert(workout)
         modelContext.insert(appleHealthLink)
@@ -920,6 +1074,69 @@ final class WorkoutImportCoordinator {
         return try modelContext.fetch(descriptor)
     }
 
+    private func pruneAutoImportedReviewState(modelContext: ModelContext) throws {
+        let validWorkoutIDs = try Set(fetchAllWorkouts(from: modelContext).map(\.id))
+        reviewStateStore.prune(validIDs: validWorkoutIDs)
+
+        if let currentAutoImportedReviewWorkoutID,
+           !validWorkoutIDs.contains(currentAutoImportedReviewWorkoutID) {
+            self.currentAutoImportedReviewWorkoutID = nil
+        }
+    }
+
+    private func recordAutoImportedWorkoutForReview(_ workout: Workout) {
+        let referenceDate = autoImportedReviewReferenceDate(for: workout)
+        reviewStateStore.recordLatestWorkout(
+            id: workout.id,
+            referenceDate: referenceDate
+        )
+
+        if let currentAutoImportedReviewWorkoutID,
+           currentAutoImportedReviewWorkoutID != workout.id,
+           let currentReferenceDate = autoImportedReferenceDate(forWorkoutID: currentAutoImportedReviewWorkoutID),
+           currentReferenceDate >= referenceDate {
+            return
+        }
+
+        currentAutoImportedReviewWorkoutID = workout.id
+    }
+
+    private func markAutoImportedReviewHandled(for workoutID: UUID) {
+        if let referenceDate = autoImportedReferenceDate(forWorkoutID: workoutID) {
+            reviewStateStore.markHandled(referenceDate: referenceDate)
+            return
+        }
+
+        if let latestReferenceDate = reviewStateStore.latestReferenceDate(for: workoutID) {
+            reviewStateStore.markHandled(referenceDate: latestReferenceDate)
+        }
+    }
+
+    private func autoImportedReferenceDate(forWorkoutID workoutID: UUID) -> Date? {
+        guard let modelContext else { return nil }
+
+        let workoutID = workoutID
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { workout in
+                workout.id == workoutID
+            }
+        )
+
+        guard let workout = try? modelContext.fetch(descriptor).first else {
+            return nil
+        }
+
+        return autoImportedReviewReferenceDate(for: workout)
+    }
+
+    private func autoImportedReviewReferenceDate(for workout: Workout) -> Date {
+        workout.date.addingTimeInterval(workout.duration)
+    }
+
+    func ignoreAppleHealthWorkout(externalRecordID: String) {
+        ignoredAppleHealthWorkoutStore.insert(externalRecordID)
+    }
+
     private func recalculateDerivedData(modelContext: ModelContext, newWorkouts: [Workout] = []) throws {
         let allWorkouts = try fetchAllWorkouts(from: modelContext)
         let settings = SettingsManager.shared
@@ -940,5 +1157,97 @@ final class WorkoutImportCoordinator {
         )
 
         try modelContext.save()
+    }
+
+#if DEBUG
+    func debugQueueSimulatedAutoImportedReview(modelContext: ModelContext) async throws -> Workout {
+        let workout = try await debugCreateSimulatedAppleHealthWorkout(modelContext: modelContext)
+        currentAutoImportedReviewWorkoutID = nil
+        print("DEBUG auto-import queued review workout: \(workout.id.uuidString)")
+        return workout
+    }
+
+    func debugClearSimulatedAutoImports(modelContext: ModelContext) throws -> Int {
+        let workouts = try fetchAllWorkouts(from: modelContext).filter { workout in
+            workout.healthKitUUID?.hasPrefix("debug-auto-import-") == true
+        }
+
+        for workout in workouts {
+            modelContext.delete(workout)
+        }
+
+        try modelContext.save()
+        try recalculateDerivedData(modelContext: modelContext)
+        try pruneAutoImportedReviewState(modelContext: modelContext)
+
+        print("DEBUG auto-import cleared simulated workouts: \(workouts.count)")
+        return workouts.count
+    }
+
+    private func debugCreateSimulatedAppleHealthWorkout(
+        modelContext: ModelContext
+    ) async throws -> Workout {
+        let duration: TimeInterval = 26 * 60
+        let completedAt = Date().addingTimeInterval(-60)
+        let startedAt = completedAt.addingTimeInterval(-duration)
+        let externalRecordID = "debug-auto-import-\(UUID().uuidString.lowercased())"
+        let sample = HealthKitWorkoutSample(
+            externalRecordID: externalRecordID,
+            startDate: startedAt,
+            endDate: completedAt,
+            duration: duration,
+            sourceName: "Apple Watch Simulator",
+            sourceBundleIdentifier: "com.apple.Health",
+            deviceModel: "Apple Watch Simulator"
+        )
+
+        let stepsPerFloor = settingsManager.stepsPerFloor
+        let floors = 132
+        let workout = Workout(
+            name: "Simulated Apple Health Import",
+            date: sample.startDate,
+            duration: sample.duration,
+            steps: Workout.floorsToSteps(floors, stepsPerFloor: stepsPerFloor),
+            floors: floors,
+            stepsPerFloor: stepsPerFloor,
+            notes: "Debug-only Apple Health auto-import simulation.",
+            avgHeartRate: 146,
+            maxHeartRate: 168,
+            caloriesBurned: 318,
+            averageMETs: 9.1,
+            source: .appleHealth,
+            deviceModel: sample.deviceModel,
+            sourceMetadata: appleHealthMetadataJSON(for: sample),
+            healthKitUUID: sample.externalRecordID
+        )
+        let sourceLink = makeAppleHealthSourceLink(from: sample, workout: workout)
+
+        modelContext.insert(workout)
+        modelContext.insert(sourceLink)
+        try modelContext.save()
+        try recalculateDerivedData(modelContext: modelContext, newWorkouts: [workout])
+
+        recordAutoImportedWorkoutForReview(workout)
+
+        lastErrorMessage = nil
+        return workout
+    }
+#endif
+}
+
+private extension ImportRefreshTrigger {
+    var capabilityLevel: Int {
+        switch self {
+        case .automatic, .backgroundObserver:
+            return 0
+        case .homeEntry, .manualReview:
+            return 1
+        case .manualSync:
+            return 2
+        }
+    }
+
+    func covers(_ trigger: ImportRefreshTrigger) -> Bool {
+        capabilityLevel >= trigger.capabilityLevel
     }
 }

--- a/AscendApp/Shared/Views/AppSheet.swift
+++ b/AscendApp/Shared/Views/AppSheet.swift
@@ -537,15 +537,19 @@ struct AppSheetOptionRow: View {
                 Text(title)
                     .font(.montserratSemiBold(size: 16))
                     .foregroundStyle(titleColor)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 if let subtitle {
                     Text(subtitle)
                         .font(.montserratRegular(size: 13))
                         .foregroundStyle(subtitleColor)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
-
-            Spacer(minLength: 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .layoutPriority(1)
 
             if let trailingSymbol {
                 Image(systemName: trailingSymbol)

--- a/AscendApp/Shared/Views/NotificationBellView.swift
+++ b/AscendApp/Shared/Views/NotificationBellView.swift
@@ -15,9 +15,22 @@ extension View {
 
 struct NotificationBellView: View {
     let pendingImports: Int
+    let isHighlighted: Bool
     let action: () -> Void
     
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isHighlightAnimating = false
+
+    init(
+        pendingImports: Int,
+        isHighlighted: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.pendingImports = pendingImports
+        self.isHighlighted = isHighlighted
+        self.action = action
+    }
     
     var body: some View {
         Button(action: action) {
@@ -47,14 +60,48 @@ struct NotificationBellView: View {
                         .shadow(color: .black.opacity(0.2), radius: 2, x: 0, y: 1)
                 }
             }
+            .frame(width: 44, height: 44)
+            .background {
+                if isHighlighted {
+                    Circle()
+                        .fill(.accent.opacity(reduceMotion ? 0.14 : (isHighlightAnimating ? 0.08 : 0.18)))
+                        .frame(width: 44, height: 44)
+                }
+            }
+            .overlay {
+                if isHighlighted {
+                    Circle()
+                        .stroke(.accent.opacity(reduceMotion ? 0.5 : (isHighlightAnimating ? 0.06 : 0.7)), lineWidth: 2)
+                        .frame(width: 44, height: 44)
+                        .scaleEffect(reduceMotion ? 1 : (isHighlightAnimating ? 1.18 : 0.94))
+                        .opacity(reduceMotion ? 1 : (isHighlightAnimating ? 0 : 1))
+                }
+            }
         }
-        .buttonStyle(PlainButtonStyle())
+        .buttonStyle(.plain)
+        .accessibilityLabel("Import or review workouts")
+        .accessibilityHint("Opens Apple Health and connected workout imports")
         .onAppear {
+            syncHighlightAnimation()
             if pendingImports > 0 {
                 print("🔔 NotificationBellView showing badge: \(pendingImports)")
             } else {
                 print("🔔 NotificationBellView no badge - count: \(pendingImports)")
             }
+        }
+        .onChange(of: isHighlighted) { _, _ in
+            syncHighlightAnimation()
+        }
+    }
+
+    private func syncHighlightAnimation() {
+        guard isHighlighted, !reduceMotion else {
+            isHighlightAnimating = false
+            return
+        }
+
+        withAnimation(.easeOut(duration: 1.05).repeatForever(autoreverses: false)) {
+            isHighlightAnimating = true
         }
     }
 }

--- a/AscendAppTests/AppleHealthAutoImportPolicyTests.swift
+++ b/AscendAppTests/AppleHealthAutoImportPolicyTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct AppleHealthAutoImportPolicyTests {
+    @Test
+    func ignoresManualImportCandidatesBeforeActivationDate() {
+        let activatedAt = Date(timeIntervalSince1970: 1_775_400_000)
+        let sample = HealthKitWorkoutSample(
+            externalRecordID: "ah_old",
+            startDate: Date(timeIntervalSince1970: 1_775_390_000),
+            endDate: Date(timeIntervalSince1970: 1_775_391_800),
+            duration: 1_800,
+            sourceName: "Apple Watch",
+            sourceBundleIdentifier: "com.apple.health",
+            deviceModel: "Apple Watch"
+        )
+
+        let policy = AppleHealthAutoImportPolicy(activatedAt: activatedAt)
+
+        #expect(policy.shouldAutoImport(.appleHealth(sample: sample)) == false)
+    }
+
+    @Test
+    func autoImportsAppleHealthCandidatesEndingAfterActivationDate() {
+        let activatedAt = Date(timeIntervalSince1970: 1_775_400_000)
+        let sample = HealthKitWorkoutSample(
+            externalRecordID: "ah_new",
+            startDate: Date(timeIntervalSince1970: 1_775_399_400),
+            endDate: Date(timeIntervalSince1970: 1_775_401_200),
+            duration: 1_800,
+            sourceName: "Apple Watch",
+            sourceBundleIdentifier: "com.apple.health",
+            deviceModel: "Apple Watch"
+        )
+
+        let policy = AppleHealthAutoImportPolicy(activatedAt: activatedAt)
+
+        #expect(policy.shouldAutoImport(.appleHealth(sample: sample)))
+    }
+
+    @Test
+    func usesFallbackActivationDateWhenStoredActivationDateIsMissing() {
+        let fallbackActivatedAt = Date(timeIntervalSince1970: 1_775_400_000)
+        let sample = HealthKitWorkoutSample(
+            externalRecordID: "ah_fallback_new",
+            startDate: Date(timeIntervalSince1970: 1_775_400_300),
+            endDate: Date(timeIntervalSince1970: 1_775_402_100),
+            duration: 1_800,
+            sourceName: "Apple Watch",
+            sourceBundleIdentifier: "com.apple.health",
+            deviceModel: "Apple Watch"
+        )
+
+        let policy = AppleHealthAutoImportPolicy(
+            activatedAt: nil,
+            missingActivationFallback: fallbackActivatedAt
+        )
+
+        #expect(policy.shouldAutoImport(.appleHealth(sample: sample)))
+    }
+
+    @Test
+    func ignoresFallbackCandidatesBeforeFallbackActivationDate() {
+        let fallbackActivatedAt = Date(timeIntervalSince1970: 1_775_400_000)
+        let sample = HealthKitWorkoutSample(
+            externalRecordID: "ah_fallback_old",
+            startDate: Date(timeIntervalSince1970: 1_775_397_000),
+            endDate: Date(timeIntervalSince1970: 1_775_398_800),
+            duration: 1_800,
+            sourceName: "Apple Watch",
+            sourceBundleIdentifier: "com.apple.health",
+            deviceModel: "Apple Watch"
+        )
+
+        let policy = AppleHealthAutoImportPolicy(
+            activatedAt: nil,
+            missingActivationFallback: fallbackActivatedAt
+        )
+
+        #expect(policy.shouldAutoImport(.appleHealth(sample: sample)) == false)
+    }
+
+    @Test
+    func doesNotAutoImportHevyCandidates() {
+        let policy = AppleHealthAutoImportPolicy(
+            activatedAt: Date(timeIntervalSince1970: 1_775_400_000)
+        )
+        let candidate = ImportedWorkoutCandidate.hevy(
+            workoutID: "hevy_123",
+            workoutTitle: "Morning Session",
+            startDate: Date(timeIntervalSince1970: 1_775_400_100),
+            endDate: Date(timeIntervalSince1970: 1_775_401_900),
+            duration: 1_800,
+            metricValue: 1_200,
+            metricType: .steps,
+            matchingAppleHealthSample: nil
+        )
+
+        #expect(policy.shouldAutoImport(candidate) == false)
+    }
+}

--- a/AscendAppTests/IgnoredAppleHealthWorkoutStoreTests.swift
+++ b/AscendAppTests/IgnoredAppleHealthWorkoutStoreTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct IgnoredAppleHealthWorkoutStoreTests {
+    @Test
+    func insertTracksIgnoredExternalRecordIDsUniquely() {
+        let defaults = makeDefaults()
+        let store = IgnoredAppleHealthWorkoutStore(defaults: defaults, key: "ignored")
+
+        store.insert("ah_1")
+        store.insert("ah_2")
+        store.insert("ah_1")
+
+        #expect(store.load() == Set(["ah_1", "ah_2"]))
+    }
+
+    @Test
+    func pruneDropsExternalRecordIDsThatNoLongerExist() {
+        let defaults = makeDefaults()
+        let store = IgnoredAppleHealthWorkoutStore(defaults: defaults, key: "ignored")
+
+        store.insert("ah_keep")
+        store.insert("ah_drop")
+        store.prune(validExternalRecordIDs: Set(["ah_keep"]))
+
+        #expect(store.load() == Set(["ah_keep"]))
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "IgnoredAppleHealthWorkoutStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/AscendAppTests/WorkoutAutoImportReviewStateStoreTests.swift
+++ b/AscendAppTests/WorkoutAutoImportReviewStateStoreTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct WorkoutAutoImportReviewStateStoreTests {
+    @Test
+    func recordsOnlyTheNewestWorkoutForReview() {
+        let defaults = makeDefaults()
+        let store = WorkoutAutoImportReviewStateStore(defaults: defaults, key: "review")
+        let olderWorkoutID = UUID()
+        let newerWorkoutID = UUID()
+
+        store.recordLatestWorkout(
+            id: newerWorkoutID,
+            referenceDate: Date(timeIntervalSince1970: 2_000)
+        )
+        store.recordLatestWorkout(
+            id: olderWorkoutID,
+            referenceDate: Date(timeIntervalSince1970: 1_000)
+        )
+
+        #expect(store.latestUnseenWorkoutID() == newerWorkoutID)
+    }
+
+    @Test
+    func markingLatestWorkoutHandledClearsItsReviewState() {
+        let defaults = makeDefaults()
+        let store = WorkoutAutoImportReviewStateStore(defaults: defaults, key: "review")
+        let workoutID = UUID()
+        let referenceDate = Date(timeIntervalSince1970: 2_000)
+
+        store.recordLatestWorkout(id: workoutID, referenceDate: referenceDate)
+        store.markHandled(referenceDate: referenceDate)
+
+        #expect(store.latestUnseenWorkoutID() == nil)
+    }
+
+    @Test
+    func pruningRemovesMissingLatestWorkout() {
+        let defaults = makeDefaults()
+        let store = WorkoutAutoImportReviewStateStore(defaults: defaults, key: "review")
+        let workoutID = UUID()
+
+        store.recordLatestWorkout(
+            id: workoutID,
+            referenceDate: Date(timeIntervalSince1970: 2_000)
+        )
+        store.prune(validIDs: [])
+
+        #expect(store.latestUnseenWorkoutID() == nil)
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "WorkoutAutoImportReviewStateStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/AscendAppTests/WorkoutImportAnalyticsEventTests.swift
+++ b/AscendAppTests/WorkoutImportAnalyticsEventTests.swift
@@ -68,6 +68,18 @@ struct WorkoutImportAnalyticsEventTests {
         #expect(record.parameters["source_mix"] == .string("mixed"))
     }
 
+    @Test
+    func automaticModeRecordsAutomaticImportValue() {
+        let candidate = ImportedWorkoutCandidate.appleHealth(sample: makeAppleHealthSample(id: "ah_automatic"))
+
+        let record = WorkoutImportAnalyticsEvent
+            .started(mode: .automatic, candidates: [candidate])
+            .record
+
+        #expect(record.parameters["import_mode"] == .string("automatic"))
+        #expect(record.parameters["source_mix"] == .string("apple_health_only"))
+    }
+
     private func makeAppleHealthSample(id: String) -> HealthKitWorkoutSample {
         let startDate = Date(timeIntervalSince1970: 1_775_390_400)
         return HealthKitWorkoutSample(

--- a/AscendAppTests/WorkoutImportCoordinatorDuplicateImportTests.swift
+++ b/AscendAppTests/WorkoutImportCoordinatorDuplicateImportTests.swift
@@ -1,0 +1,335 @@
+import HealthKit
+import SwiftData
+import Testing
+@testable import AscendApp
+
+@MainActor
+@Suite(.serialized)
+struct WorkoutImportCoordinatorDuplicateImportTests {
+    @Test
+    func importingSameAppleHealthCandidateTwiceReusesExistingWorkout() async throws {
+        let modelContext = try makeModelContext()
+        let workout = HKWorkout(
+            activityType: .stairClimbing,
+            start: Date(timeIntervalSince1970: 1_776_440_000),
+            end: Date(timeIntervalSince1970: 1_776_441_500)
+        )
+        let sample = HealthKitWorkoutSample(
+            externalRecordID: workout.uuid.uuidString,
+            startDate: workout.startDate,
+            endDate: workout.endDate,
+            duration: workout.duration,
+            sourceName: "Apple Health",
+            sourceBundleIdentifier: "com.apple.Health",
+            deviceModel: "Simulator"
+        )
+        let candidate = ImportedWorkoutCandidate.appleHealth(sample: sample)
+        let coordinator = WorkoutImportCoordinator(
+            workoutReader: StubHealthKitWorkoutReader(workout: workout),
+            metricsReader: StubHealthKitMetricsReader()
+        )
+        coordinator.configure(modelContext: modelContext)
+
+        let firstOutcome = await coordinator.importCandidate(candidate)
+        let secondOutcome = await coordinator.importCandidate(candidate)
+        let workouts = try modelContext.fetch(FetchDescriptor<Workout>())
+
+        guard case .imported = firstOutcome else {
+            Issue.record("Expected first import to insert a workout.")
+            return
+        }
+        guard case .updatedExisting = secondOutcome else {
+            Issue.record("Expected duplicate import to resolve to the existing workout.")
+            return
+        }
+        #expect(workouts.count == 1)
+        #expect(workouts.first?.healthKitUUID == sample.externalRecordID)
+    }
+
+    @Test
+    func homeEntryRefreshAutoImportsEligibleAppleHealthWorkout() async throws {
+        let modelContext = try makeModelContext()
+        let stateSnapshot = HealthKitSyncStateSnapshot.capture()
+        let settingsSnapshot = SettingsSnapshot.capture()
+        defer {
+            stateSnapshot.restore()
+            settingsSnapshot.restore()
+        }
+        resetHealthKitSyncStateForTest()
+        let isolatedStores = makeIsolatedImportStores(name: "home-entry")
+        defer { isolatedStores.defaults.removePersistentDomain(forName: isolatedStores.suiteName) }
+
+        let workout = HKWorkout(
+            activityType: .stairClimbing,
+            start: Date(timeIntervalSince1970: 1_776_530_000),
+            end: Date(timeIntervalSince1970: 1_776_531_500)
+        )
+        let sample = HealthKitWorkoutSample(
+            externalRecordID: workout.uuid.uuidString,
+            startDate: workout.startDate,
+            endDate: workout.endDate,
+            duration: workout.duration,
+            sourceName: "Apple Health",
+            sourceBundleIdentifier: "com.apple.Health",
+            deviceModel: "Simulator"
+        )
+        let settingsManager = SettingsManager.shared
+        settingsManager.appleHealthAutoImportEnabled = true
+        settingsManager.appleHealthAutoImportActivatedAt = sample.startDate.addingTimeInterval(-60)
+        let coordinator = WorkoutImportCoordinator(
+            authorizationController: StubHealthKitAuthorizationController(hasCompletedInitialBackfill: false),
+            workoutReader: StubHealthKitWorkoutReader(workout: workout, addedSamples: [sample]),
+            metricsReader: StubHealthKitMetricsReader(),
+            reviewStateStore: isolatedStores.reviewStateStore,
+            ignoredAppleHealthWorkoutStore: isolatedStores.ignoredAppleHealthWorkoutStore
+        )
+        coordinator.configure(modelContext: modelContext)
+
+        await coordinator.refreshPendingImports(trigger: .homeEntry)
+        let workouts = try modelContext.fetch(FetchDescriptor<Workout>())
+
+        #expect(workouts.count == 1)
+        #expect(workouts.first?.healthKitUUID == sample.externalRecordID)
+        #expect(coordinator.pendingCandidates.isEmpty)
+        #expect(coordinator.presentPendingAutoImportedReviewOnHomeIfNeeded())
+        #expect(coordinator.currentAutoImportedReviewWorkoutID == workouts.first?.id)
+    }
+
+    @Test
+    func autoImportUsesPreviousHealthKitCheckWhenActivationDateIsMissing() async throws {
+        let modelContext = try makeModelContext()
+        let stateSnapshot = HealthKitSyncStateSnapshot.capture()
+        let settingsSnapshot = SettingsSnapshot.capture()
+        defer {
+            stateSnapshot.restore()
+            settingsSnapshot.restore()
+        }
+        resetHealthKitSyncStateForTest()
+        let isolatedStores = makeIsolatedImportStores(name: "missing-activation")
+        defer { isolatedStores.defaults.removePersistentDomain(forName: isolatedStores.suiteName) }
+
+        let workout = HKWorkout(
+            activityType: .stairClimbing,
+            start: Date(timeIntervalSince1970: 1_776_620_000),
+            end: Date(timeIntervalSince1970: 1_776_621_800)
+        )
+        let sample = HealthKitWorkoutSample(
+            externalRecordID: workout.uuid.uuidString,
+            startDate: workout.startDate,
+            endDate: workout.endDate,
+            duration: workout.duration,
+            sourceName: "Apple Health",
+            sourceBundleIdentifier: "com.apple.Health",
+            deviceModel: "Simulator"
+        )
+        let settingsManager = SettingsManager.shared
+        settingsManager.appleHealthAutoImportEnabled = true
+        settingsManager.appleHealthAutoImportActivatedAt = nil
+        HealthKitSyncState.lastSuccessfulCheckAt = sample.startDate.addingTimeInterval(-60)
+        let coordinator = WorkoutImportCoordinator(
+            authorizationController: StubHealthKitAuthorizationController(hasCompletedInitialBackfill: true),
+            workoutReader: StubHealthKitWorkoutReader(workout: workout, addedSamples: [sample]),
+            metricsReader: StubHealthKitMetricsReader(),
+            reviewStateStore: isolatedStores.reviewStateStore,
+            ignoredAppleHealthWorkoutStore: isolatedStores.ignoredAppleHealthWorkoutStore
+        )
+        coordinator.configure(modelContext: modelContext)
+
+        await coordinator.refreshPendingImports(trigger: .homeEntry)
+        let workouts = try modelContext.fetch(FetchDescriptor<Workout>())
+
+        #expect(workouts.count == 1)
+        #expect(workouts.first?.healthKitUUID == sample.externalRecordID)
+        #expect(coordinator.presentPendingAutoImportedReviewOnHomeIfNeeded())
+    }
+
+    @Test
+    func refreshPendingImportsSerializesConcurrentTriggers() async throws {
+        let modelContext = try makeModelContext()
+        let stateSnapshot = HealthKitSyncStateSnapshot.capture()
+        let settingsSnapshot = SettingsSnapshot.capture()
+        defer {
+            stateSnapshot.restore()
+            settingsSnapshot.restore()
+        }
+        resetHealthKitSyncStateForTest()
+
+        let workout = HKWorkout(
+            activityType: .stairClimbing,
+            start: Date(timeIntervalSince1970: 1_776_710_000),
+            end: Date(timeIntervalSince1970: 1_776_711_500)
+        )
+        let reader = StubHealthKitWorkoutReader(
+            workout: workout,
+            anchoredFetchDelay: .milliseconds(50)
+        )
+        let coordinator = WorkoutImportCoordinator(
+            authorizationController: StubHealthKitAuthorizationController(hasCompletedInitialBackfill: true),
+            workoutReader: reader,
+            metricsReader: StubHealthKitMetricsReader()
+        )
+        SettingsManager.shared.appleHealthAutoImportEnabled = false
+        coordinator.configure(modelContext: modelContext)
+
+        async let firstRefresh: Void = coordinator.refreshPendingImports(trigger: .homeEntry)
+        async let secondRefresh: Void = coordinator.refreshPendingImports(trigger: .homeEntry)
+        _ = await (firstRefresh, secondRefresh)
+
+        #expect(reader.anchoredFetchCount == 1)
+    }
+
+    private func makeModelContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: Workout.self,
+            WorkoutSourceLink.self,
+            LeaderboardStats.self,
+            PersonalRecord.self,
+            Goal.self,
+            Routine.self,
+            RoutineFolder.self,
+            ClimbAttempt.self,
+            WeightPersonalRecord.self,
+            AggregateWeightRecord.self,
+            PendingMediaUpload.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func resetHealthKitSyncStateForTest() {
+        HealthKitSyncState.hasRequestedAuthorization = true
+        HealthKitSyncState.hasCompletedInitialBackfill = true
+        HealthKitSyncState.lastSuccessfulCheckAt = nil
+        HealthKitSyncState.workoutAnchorData = nil
+        HealthKitSyncState.cachedWorkoutSamples = []
+    }
+
+    private func makeIsolatedImportStores(name: String) -> (
+        suiteName: String,
+        defaults: UserDefaults,
+        reviewStateStore: WorkoutAutoImportReviewStateStore,
+        ignoredAppleHealthWorkoutStore: IgnoredAppleHealthWorkoutStore
+    ) {
+        let suiteName = "WorkoutImportCoordinatorDuplicateImportTests.\(name).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        return (
+            suiteName,
+            defaults,
+            WorkoutAutoImportReviewStateStore(defaults: defaults, key: "auto-review"),
+            IgnoredAppleHealthWorkoutStore(defaults: defaults, key: "ignored-apple-health")
+        )
+    }
+}
+
+@MainActor
+private final class StubHealthKitWorkoutReader: HealthKitWorkoutReading {
+    let isHealthDataAvailable = true
+    private let workout: HKWorkout
+    private let addedSamples: [HealthKitWorkoutSample]
+    private let anchoredFetchDelay: Duration?
+    private(set) var anchoredFetchCount = 0
+
+    init(
+        workout: HKWorkout,
+        addedSamples: [HealthKitWorkoutSample] = [],
+        anchoredFetchDelay: Duration? = nil
+    ) {
+        self.workout = workout
+        self.addedSamples = addedSamples
+        self.anchoredFetchDelay = anchoredFetchDelay
+    }
+
+    func fetchAnchoredStairStepperWorkouts(anchorData: Data?) async throws -> HealthKitWorkoutDiscoveryResult {
+        anchoredFetchCount += 1
+        if let anchoredFetchDelay {
+            try? await Task.sleep(for: anchoredFetchDelay)
+        }
+
+        return HealthKitWorkoutDiscoveryResult(
+            addedSamples: addedSamples,
+            deletedExternalRecordIDs: [],
+            anchorData: anchorData
+        )
+    }
+
+    func fetchWorkout(withExternalRecordID externalRecordID: String) async throws -> HKWorkout? {
+        externalRecordID == workout.uuid.uuidString ? workout : nil
+    }
+
+    func fetchStairStepperWorkouts(in dateRange: ClosedRange<Date>) async throws -> [HealthKitWorkoutSample] {
+        []
+    }
+}
+
+@MainActor
+private final class StubHealthKitMetricsReader: HealthKitMetricsReading {
+    func fetchMetrics(for workout: HKWorkout) async -> WorkoutMetrics {
+        WorkoutMetrics(steps: 1_500)
+    }
+}
+
+@MainActor
+private final class StubHealthKitAuthorizationController: HealthKitAuthorizationControlling {
+    let isHealthDataAvailable = true
+    let hasRequestedAuthorization = true
+    let hasCompletedInitialBackfill: Bool
+    var authorizationRequestStatus: HKAuthorizationRequestStatus = .unnecessary
+    var lastPermissionErrorMessage: String?
+    let connectionState: AppleHealthConnectionState = .neverConnected
+
+    init(hasCompletedInitialBackfill: Bool) {
+        self.hasCompletedInitialBackfill = hasCompletedInitialBackfill
+    }
+
+    func refreshAuthorizationRequestStatus() async {}
+
+    func requestAuthorization() async -> Bool {
+        true
+    }
+}
+
+private struct HealthKitSyncStateSnapshot {
+    let hasRequestedAuthorization: Bool
+    let hasCompletedInitialBackfill: Bool
+    let lastSuccessfulCheckAt: Date?
+    let workoutAnchorData: Data?
+    let cachedWorkoutSamples: [HealthKitWorkoutSample]
+
+    static func capture() -> Self {
+        HealthKitSyncStateSnapshot(
+            hasRequestedAuthorization: HealthKitSyncState.hasRequestedAuthorization,
+            hasCompletedInitialBackfill: HealthKitSyncState.hasCompletedInitialBackfill,
+            lastSuccessfulCheckAt: HealthKitSyncState.lastSuccessfulCheckAt,
+            workoutAnchorData: HealthKitSyncState.workoutAnchorData,
+            cachedWorkoutSamples: HealthKitSyncState.cachedWorkoutSamples
+        )
+    }
+
+    func restore() {
+        HealthKitSyncState.hasRequestedAuthorization = hasRequestedAuthorization
+        HealthKitSyncState.hasCompletedInitialBackfill = hasCompletedInitialBackfill
+        HealthKitSyncState.lastSuccessfulCheckAt = lastSuccessfulCheckAt
+        HealthKitSyncState.workoutAnchorData = workoutAnchorData
+        HealthKitSyncState.cachedWorkoutSamples = cachedWorkoutSamples
+    }
+}
+
+@MainActor
+private struct SettingsSnapshot {
+    let appleHealthAutoImportEnabled: Bool
+    let appleHealthAutoImportActivatedAt: Date?
+
+    static func capture() -> Self {
+        SettingsSnapshot(
+            appleHealthAutoImportEnabled: SettingsManager.shared.appleHealthAutoImportEnabled,
+            appleHealthAutoImportActivatedAt: SettingsManager.shared.appleHealthAutoImportActivatedAt
+        )
+    }
+
+    func restore() {
+        SettingsManager.shared.appleHealthAutoImportEnabled = appleHealthAutoImportEnabled
+        SettingsManager.shared.appleHealthAutoImportActivatedAt = appleHealthAutoImportActivatedAt
+    }
+}

--- a/AscendAppTests/WorkoutImportCoordinatorReviewPresentationTests.swift
+++ b/AscendAppTests/WorkoutImportCoordinatorReviewPresentationTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+@MainActor
+struct WorkoutImportCoordinatorReviewPresentationTests {
+    @Test
+    func presentingPendingReviewPrefersLatestUnseenWorkout() {
+        let suiteName = "WorkoutImportCoordinatorReviewPresentationTests.latest.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let reviewStateStore = WorkoutAutoImportReviewStateStore(
+            defaults: defaults,
+            key: "latest-unseen-review"
+        )
+        let coordinator = WorkoutImportCoordinator(reviewStateStore: reviewStateStore)
+
+        let olderWorkoutID = UUID()
+        let newerWorkoutID = UUID()
+        reviewStateStore.recordLatestWorkout(
+            id: olderWorkoutID,
+            referenceDate: Date(timeIntervalSince1970: 1_776_350_400)
+        )
+        coordinator.currentAutoImportedReviewWorkoutID = olderWorkoutID
+
+        reviewStateStore.recordLatestWorkout(
+            id: newerWorkoutID,
+            referenceDate: Date(timeIntervalSince1970: 1_776_436_800)
+        )
+
+        #expect(coordinator.presentPendingAutoImportedReviewOnHomeIfNeeded())
+        #expect(coordinator.currentAutoImportedReviewWorkoutID == newerWorkoutID)
+    }
+
+    @Test
+    func presentingPendingReviewClearsCurrentWhenAllUnseenWorkoutsAreHandled() {
+        let suiteName = "WorkoutImportCoordinatorReviewPresentationTests.handled.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let reviewStateStore = WorkoutAutoImportReviewStateStore(
+            defaults: defaults,
+            key: "handled-review"
+        )
+        let coordinator = WorkoutImportCoordinator(reviewStateStore: reviewStateStore)
+
+        let workoutID = UUID()
+        let referenceDate = Date(timeIntervalSince1970: 1_776_436_800)
+        reviewStateStore.recordLatestWorkout(id: workoutID, referenceDate: referenceDate)
+        reviewStateStore.markHandled(referenceDate: referenceDate)
+        coordinator.currentAutoImportedReviewWorkoutID = workoutID
+
+        #expect(coordinator.presentPendingAutoImportedReviewOnHomeIfNeeded() == false)
+        #expect(coordinator.currentAutoImportedReviewWorkoutID == nil)
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,20 @@ Workout, LeaderboardStats, PersonalRecord, Goal, Routine, RoutineFolder, WeightP
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.
 - Import architecture uses one canonical `Workout` plus local `WorkoutSourceLink` provenance records per provider. New import UI and state should flow through `WorkoutImportCoordinator`, not provider-specific views/services.
 - Apple Health is read-only. First connect may backfill historical workouts, but routine checks must stay incremental and sample-only until a workout is actually imported.
+- Apple Health auto-import is optional and user-controlled from the Apple Health manage sheet.
+- Auto-import only applies to newly finished Apple Health workouts from the moment the user enables it; older pending history remains in the manual review/import flow.
+- If older local settings have auto-import enabled but no stored activation timestamp, use the previous successful HealthKit check as the conservative activation fallback so newly discovered workouts can import without opening older pending history.
+- Auto-imported Apple Health workouts should use a single latest-unseen review model, not a backlog queue:
+  - Home may surface one quick-edit review sheet for only the latest unseen auto-imported workout
+  - if a newer unseen auto-import arrives before review is completed, it replaces the older unresolved review candidate
+  - completing or deleting that review should advance the review watermark so older auto-imported workouts never surface one-by-one later
+- The Home header bell is the primary import entry point. Newly authenticated users should get a one-time per-user coach mark there that explains imports and review, rather than a dedicated Apple Health onboarding screen.
+- `WorkoutImportSheet` should own Apple Health setup regardless of entry path using inline setup states, not a setup sheet layered on top of the import page. The bell and other manual review entry points should always open the import page rather than jumping straight into the auto-import review flow.
+- While Apple Health still needs setup, suppress the generic `No New Workouts` empty state so setup remains the only focus.
+- After Apple Health access is granted, enable auto-import by default and show inline guidance for where to change that later in Settings > Edit Profile > Integrations > Apple Health.
+- The auto-import review screen is a cleanup pass on an already-saved workout, so it should use `Done` instead of `Save`, omit `Not Now`, open as a quick-edit sheet (about 75% height with expansion to large) that cannot be swiped away, allow edits to `title`, `notes`, `media`, `duration`, and `steps`, keep the imported workout date visible but read-only, and keep the destructive `Delete Workout` action inside the sheet content while suppressing re-import of that same Apple Health sample.
+- HealthKit auto-import freshness should use HealthKit observer/background delivery when available, while keeping the existing launch/foreground incremental refresh as a fallback.
+- HealthKit observer callbacks should only wake the import pipeline; the coordinator must serialize refreshes and fetch changes with an anchored query before completing observer delivery.
 
 ### Analytics Architecture
 - `TelemetryManager` remains the app-facing facade, while reusable telemetry types and sinks live under `Shared/Services/Telemetry`.


### PR DESCRIPTION
## Summary
- Adds the Apple Health auto-import preference, default-on setup path after permission, and an Apple Health manage sheet.
- Routes imports and auto-import follow-up through the Home bell with a one-time coach mark and a quick review sheet for the latest unseen auto-imported workout.
- Modernizes HealthKit refresh with anchored async queries plus observer/background delivery wakeups, and serializes refreshes to prevent duplicate imports.
- Removes the local notification behavior from the auto-import flow and adds duplicate/ignored sample guards.
- Adds focused tests for auto-import policy, review state, ignored samples, duplicate prevention, review presentation, and import analytics.

## Validation
- `xcodebuild test -quiet -project AscendApp.xcodeproj -scheme AscendApp -destination 'platform=iOS Simulator,id=BD9471B9-9407-487A-A63B-F20F2764B3C8' -only-testing:AscendAppTests/AppleHealthAutoImportPolicyTests -only-testing:AscendAppTests/WorkoutImportCoordinatorDuplicateImportTests -only-testing:AscendAppTests/WorkoutImportCoordinatorReviewPresentationTests`
  - Result: 11 passed, 0 failed
- XcodeBuildMCP `build_run_sim` succeeded on iPhone 17 Pro simulator for `com.TylerPavay.AscendApp.dev`.
- Manual simulator testing confirmed the auto-import/review flow works.

Closes #84