### PR TITLE
[codex] Add Live Climb completion leaderboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,8 +230,8 @@ Workout, LeaderboardStats, PersonalRecord, Routine, RoutineFolder, WeightPersona
 - Climb detail has 3 swipe pages:
   - `Overview` (real)
   - `Your History` (real)
-  - `Leaderboard` (present but clearly coming soon in v1)
-- Per-climb rank and total-climber counts must stay hidden until real backend data exists.
+  - `Leaderboard` (real; shows fastest completed attempts from the server-published replay index)
+- Per-climb rank and total-climber counts must stay hidden until real backend data exists; do not show placeholder public stats.
 - Climb content uses a remote-first catalog and remote-only climb images:
   - a tiny hosted manifest at `/climbs/manifest.json`
   - a versioned hosted catalog at `/climbs/catalog-v{N}.json`

--- a/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
@@ -10,6 +10,10 @@ final class ClimbDetailViewModel {
     var historySummary: ClimbHistorySummary
     var leaderboardSummary: LiveReplayLeaderboardSummary = .empty
     var leaderboardPreviewRows: [LiveReplayLeaderboardRow] = []
+    var completionLeaderboard: LiveReplayCompletionLeaderboard = .empty
+    var personalCompletionRank: LiveReplayCompletionRank?
+    var isLeaderboardLoading = false
+    var leaderboardErrorMessage: String?
     var collectionOrder: Int?
     var projectedCollectionOrder: Int?
     var loadErrorMessage: String?
@@ -92,7 +96,11 @@ final class ClimbDetailViewModel {
     }
 
     var communityCompletedCount: Int {
-        max(leaderboardSummary.completedCount, hasCompletionHistory ? 1 : 0)
+        max(
+            leaderboardSummary.completedCount,
+            completionLeaderboard.completedCount,
+            hasCompletionHistory ? 1 : 0
+        )
     }
 
     var communityTotalClimbers: Int {
@@ -105,6 +113,24 @@ final class ClimbDetailViewModel {
 
     var showsCommunityStats: Bool {
         true
+    }
+
+    var hasCompletionLeaderboardRows: Bool {
+        !completionLeaderboard.rows.isEmpty
+    }
+
+    var completionLeaderboardRows: [LiveReplayLeaderboardRow] {
+        completionLeaderboard.rows
+    }
+
+    var completionLeaderboardCompletedCount: Int {
+        max(completionLeaderboard.completedCount, leaderboardSummary.completedCount)
+    }
+
+    var shouldShowPersonalRankSummary: Bool {
+        guard let personalCompletionRank else { return false }
+        return !completionLeaderboard.rows.contains(where: \.isCurrentUser) &&
+            personalCompletionRank.completedCount > 0
     }
 
     var stripOrderText: String? {
@@ -137,6 +163,9 @@ final class ClimbDetailViewModel {
             climbId: climb.id,
             targetSteps: climb.referenceStepCount
         )
+        isLeaderboardLoading = true
+        leaderboardErrorMessage = nil
+
         async let fetchedSummary = leaderboardService.fetchSummary(context: context)
         async let fetchedPreviewWindow = leaderboardService.refreshIfNeeded(
             context: context,
@@ -144,6 +173,11 @@ final class ClimbDetailViewModel {
             currentSteps: 0,
             force: true
         )
+        async let fetchedCompletionLeaderboard = leaderboardService.fetchCompletionLeaderboard(
+            context: context,
+            limit: 25
+        )
+        async let fetchedPersonalRank = fetchPersonalCompletionRank(context: context)
 
         do {
             leaderboardSummary = try await fetchedSummary
@@ -157,6 +191,41 @@ final class ClimbDetailViewModel {
         } catch {
             leaderboardPreviewRows = []
         }
+
+        do {
+            let leaderboard = try await fetchedCompletionLeaderboard
+            completionLeaderboard = leaderboard
+            leaderboardSummary = LiveReplayLeaderboardSummary(
+                totalClimbers: max(leaderboardSummary.totalClimbers, leaderboard.completedCount),
+                completedCount: max(leaderboardSummary.completedCount, leaderboard.completedCount),
+                personalBestDurationSeconds: leaderboardSummary.personalBestDurationSeconds,
+                updatedAt: leaderboardSummary.updatedAt ?? leaderboard.updatedAt
+            )
+        } catch {
+            completionLeaderboard = .empty
+            leaderboardErrorMessage = error.localizedDescription
+        }
+
+        do {
+            personalCompletionRank = try await fetchedPersonalRank
+        } catch {
+            personalCompletionRank = nil
+        }
+
+        isLeaderboardLoading = false
+    }
+
+    private func fetchPersonalCompletionRank(
+        context: LiveReplayLeaderboardContext
+    ) async throws -> LiveReplayCompletionRank? {
+        guard let bestCompletionDurationSeconds = historySummary.bestCompletionDurationSeconds else {
+            return nil
+        }
+
+        return try await leaderboardService.fetchCompletionRank(
+            context: context,
+            completionDurationSeconds: TimeInterval(bestCompletionDurationSeconds)
+        )
     }
 
     func startClimb(modelContext: ModelContext) throws {

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -580,21 +580,245 @@ struct ClimbDetailView: View {
 
     private var leaderboardPage: some View {
         VStack(alignment: .leading, spacing: 18) {
-            Text("Leaderboard")
-                .font(.montserratBold(size: 22))
-                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Leaderboard")
+                        .font(.montserratBold(size: 22))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
 
-            Text("Coming Soon")
-                .font(.montserratBold(size: 20))
-                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                    Text("Fastest completion times")
+                        .font(.montserratRegular(size: 14))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.62) : .black.opacity(0.58))
+                }
 
-            Text("Landmark-specific leaderboards are planned, but this climb-first pass keeps everything private for now while the core progress loop ships.")
-                .font(.montserratRegular(size: 15))
-                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.72) : .black.opacity(0.62))
+                Spacer(minLength: 0)
+
+                if viewModel.completionLeaderboardCompletedCount > 0 {
+                    Text("\(viewModel.completionLeaderboardCompletedCount.formatted()) completed")
+                        .font(.montserratSemiBold(size: 13))
+                        .foregroundStyle(.accent)
+                        .monospacedDigit()
+                }
+            }
+
+            if viewModel.isLeaderboardLoading && !viewModel.hasCompletionLeaderboardRows {
+                leaderboardLoadingState
+            } else if viewModel.hasCompletionLeaderboardRows {
+                if viewModel.shouldShowPersonalRankSummary {
+                    personalLeaderboardRankSummary
+                }
+
+                VStack(spacing: 0) {
+                    ForEach(viewModel.completionLeaderboardRows) { row in
+                        leaderboardRow(for: row)
+                    }
+                }
+            } else {
+                leaderboardEmptyState
+            }
+
+            if viewModel.leaderboardErrorMessage != nil,
+               !viewModel.isLeaderboardLoading {
+                Text("Leaderboard unavailable")
+                    .font(.montserratSemiBold(size: 12))
+                    .foregroundStyle(Color.red.opacity(0.82))
+            }
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 2)
         .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var leaderboardLoadingState: some View {
+        HStack(spacing: 10) {
+            ProgressView()
+                .tint(.accent)
+
+            Text("Loading leaderboard")
+                .font(.montserratMedium(size: 14))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.64) : .black.opacity(0.58))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 24)
+    }
+
+    private var leaderboardEmptyState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("No completed times yet")
+                .font(.montserratBold(size: 18))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+
+            Text("Complete this climb to put the first time on the board.")
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.66) : .black.opacity(0.58))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 16)
+    }
+
+    @ViewBuilder
+    private var personalLeaderboardRankSummary: some View {
+        if let personalCompletionRank = viewModel.personalCompletionRank,
+           let bestCompletionDurationSeconds = viewModel.historySummary.bestCompletionDurationSeconds {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Your best")
+                        .font(.montserratSemiBold(size: 12))
+                        .tracking(1.0)
+                        .foregroundStyle(Color.customGray)
+
+                    Text(DurationFormatter.format(duration: TimeInterval(bestCompletionDurationSeconds)))
+                        .font(.montserratBold(size: 20))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                        .monospacedDigit()
+                }
+
+                Spacer(minLength: 0)
+
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text("#\(personalCompletionRank.rank.formatted())")
+                        .font(.montserratBold(size: 20))
+                        .foregroundStyle(.accent)
+                        .monospacedDigit()
+
+                    Text("of \(personalCompletionRank.completedCount.formatted())")
+                        .font(.montserratSemiBold(size: 12))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.58) : .black.opacity(0.5))
+                        .monospacedDigit()
+                }
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color.accent.opacity(effectiveColorScheme == .dark ? 0.12 : 0.10))
+            )
+        }
+    }
+
+    private func leaderboardRow(for row: LiveReplayLeaderboardRow) -> some View {
+        HStack(alignment: .center, spacing: 12) {
+            Text("#\(row.rank?.formatted() ?? "--")")
+                .font(.montserratBold(size: 15))
+                .foregroundStyle(row.isCurrentUser ? .accent : Color.customGray)
+                .frame(width: 46, alignment: .leading)
+                .monospacedDigit()
+
+            leaderboardAvatar(for: row)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 7) {
+                    Text(row.isCurrentUser ? "You" : row.displayName)
+                        .font(.montserratBold(size: 15))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.78)
+
+                    if row.isCurrentUser {
+                        Text("YOU")
+                            .font(.montserratBold(size: 9))
+                            .foregroundStyle(.black)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .background(
+                                Capsule(style: .continuous)
+                                    .fill(Color.accent)
+                            )
+                    }
+                }
+
+                Text("\(row.finalSteps.formatted()) steps")
+                    .font(.montserratMedium(size: 12))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.54) : .black.opacity(0.48))
+                    .monospacedDigit()
+            }
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(leaderboardDurationText(for: row))
+                    .font(.montserratBold(size: 17))
+                    .foregroundStyle(row.isCurrentUser ? .accent : (effectiveColorScheme == .dark ? .white : .black))
+                    .monospacedDigit()
+
+                if let averageStepsPerMinute = row.averageStepsPerMinute {
+                    Text("\(Int(averageStepsPerMinute.rounded()).formatted()) avg SPM")
+                        .font(.montserratSemiBold(size: 11))
+                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.50) : .black.opacity(0.46))
+                        .monospacedDigit()
+                }
+            }
+        }
+        .padding(.vertical, 13)
+        .padding(.horizontal, row.isCurrentUser ? 12 : 0)
+        .background {
+            if row.isCurrentUser {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color.accent.opacity(effectiveColorScheme == .dark ? 0.12 : 0.10))
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if !row.isCurrentUser {
+                Rectangle()
+                    .fill(.white.opacity(0.08))
+                    .frame(height: 1)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private func leaderboardDurationText(for row: LiveReplayLeaderboardRow) -> String {
+        guard let completionDurationSeconds = row.completionDurationSeconds else {
+            return "--"
+        }
+
+        return DurationFormatter.format(duration: completionDurationSeconds)
+    }
+
+    @ViewBuilder
+    private func leaderboardAvatar(for row: LiveReplayLeaderboardRow) -> some View {
+        if let photoURL = row.isCurrentUser ? (row.photoURL ?? currentUserPhotoURL) : row.photoURL {
+            AsyncImage(
+                url: photoURL,
+                transaction: Transaction(animation: .easeInOut(duration: 0.2))
+            ) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                case .empty, .failure:
+                    leaderboardAvatarToken(for: row)
+                @unknown default:
+                    leaderboardAvatarToken(for: row)
+                }
+            }
+            .frame(width: 42, height: 42)
+            .clipShape(Circle())
+            .overlay(
+                Circle()
+                    .stroke(row.isCurrentUser ? Color.accent : .white.opacity(0.14), lineWidth: row.isCurrentUser ? 2 : 1)
+            )
+            .id(photoURL)
+        } else {
+            leaderboardAvatarToken(for: row)
+        }
+    }
+
+    private func leaderboardAvatarToken(for row: LiveReplayLeaderboardRow) -> some View {
+        Text(row.isCurrentUser ? currentUserAvatar.token : row.avatarToken)
+            .font(.montserratBold(size: 13))
+            .foregroundStyle(.white)
+            .lineLimit(1)
+            .minimumScaleFactor(0.72)
+            .frame(width: 42, height: 42)
+            .background(
+                Circle()
+                    .fill(row.isCurrentUser ? Color.accent : communityAvatarColor(for: row.id))
+            )
+            .overlay(
+                Circle()
+                    .stroke(row.isCurrentUser ? Color.accent.opacity(0.7) : .white.opacity(0.14), lineWidth: 1)
+            )
     }
 
     private var metricDivider: some View {

--- a/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
+++ b/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
@@ -329,6 +329,8 @@ struct LiveClimbSessionView: View {
 }
 
 private struct LiveReplayLeaderboardPanel: View {
+    @State private var hasScrolledToInitialCurrentUser = false
+
     let rows: [LiveReplayLeaderboardRow]
     let targetSteps: Int
     let progress: Double
@@ -349,43 +351,53 @@ private struct LiveReplayLeaderboardPanel: View {
 
                 HStack(alignment: .firstTextBaseline, spacing: 5) {
                     Text(targetSteps.formatted())
-                        .font(.montserratBold(size: 14))
+                        .font(.montserratBold(size: 20))
                         .foregroundStyle(primaryColor)
                         .monospacedDigit()
+                        .contentTransition(.numericText())
 
                     Text("STEPS")
-                        .font(.montserratBold(size: 12))
+                        .font(.montserratBold(size: 13))
                         .tracking(0.8)
                         .foregroundStyle(secondaryColor)
                 }
             }
             .padding(.horizontal, 4)
-            .padding(.bottom, 10)
+            .padding(.bottom, 12)
 
             Rectangle()
                 .fill(.white.opacity(0.08))
                 .frame(height: 1)
 
-            ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(rows) { row in
-                        LiveReplayLeaderboardRowView(
-                            row: row,
-                            targetSteps: targetSteps,
-                            progress: progress,
-                            currentUserPhotoURL: currentUserPhotoURL,
-                            tint: tint,
-                            effectiveColorScheme: effectiveColorScheme
-                        )
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(rows) { row in
+                            LiveReplayLeaderboardRowView(
+                                row: row,
+                                targetSteps: targetSteps,
+                                progress: progress,
+                                currentUserPhotoURL: currentUserPhotoURL,
+                                tint: tint,
+                                effectiveColorScheme: effectiveColorScheme
+                            )
+                            .id(row.id)
+                        }
                     }
+                    .padding(.vertical, 8)
                 }
-                .padding(.vertical, 8)
+                .scrollIndicators(.hidden)
+                .onAppear {
+                    scrollToCurrentUserIfNeeded(using: proxy)
+                }
+                .onChange(of: currentUserRowID) { _, _ in
+                    scrollToCurrentUserIfNeeded(using: proxy)
+                }
+                .animation(
+                    .spring(response: 0.3, dampingFraction: 0.82),
+                    value: rows.map(\.id)
+                )
             }
-            .scrollIndicators(.hidden)
-            .animation(
-                .spring(response: 0.3, dampingFraction: 0.82),
-                value: rows.map(\.id)
-            )
 
             if fetchFailed && rows.count <= 1 {
                 Text("Leaderboard unavailable")
@@ -403,6 +415,26 @@ private struct LiveReplayLeaderboardPanel: View {
 
     private var secondaryColor: Color {
         effectiveColorScheme == .dark ? .white.opacity(0.42) : .black.opacity(0.4)
+    }
+
+    private var currentUserRowID: String? {
+        rows.first(where: \.isCurrentUser)?.id
+    }
+
+    private func scrollToCurrentUserIfNeeded(using proxy: ScrollViewProxy) {
+        guard !hasScrolledToInitialCurrentUser,
+              let currentUserRowID else {
+            return
+        }
+
+        hasScrolledToInitialCurrentUser = true
+
+        Task {
+            await Task.yield()
+            withAnimation(.easeOut(duration: 0.24)) {
+                proxy.scrollTo(currentUserRowID, anchor: .center)
+            }
+        }
     }
 }
 
@@ -422,30 +454,32 @@ private struct LiveReplayLeaderboardRowView: View {
 
             HStack(spacing: 10) {
                 Text(rankLabel)
-                    .font(.montserratBold(size: 13))
+                    .font(.montserratBold(size: 16))
                     .foregroundStyle(row.isCurrentUser ? tint : secondaryColor)
-                    .frame(width: 31, alignment: .center)
+                    .frame(width: 38, alignment: .center)
                     .monospacedDigit()
 
                 avatarView
 
                 Text(row.displayName)
-                    .font(.montserratBold(size: 14))
+                    .font(.montserratBold(size: 17))
                     .foregroundStyle(primaryColor)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.82)
+                    .minimumScaleFactor(0.78)
 
                 Spacer(minLength: 0)
 
                 Text(row.stepsAtBucket.formatted())
-                    .font(.montserratBold(size: row.isCurrentUser ? 15 : 17))
+                    .font(.montserratBold(size: row.isCurrentUser ? 24 : 22))
                     .foregroundStyle(row.isCurrentUser ? tint : primaryColor)
                     .monospacedDigit()
                     .contentTransition(.numericText())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.84)
             }
-            .padding(.trailing, 2)
+            .padding(.trailing, 4)
         }
-        .frame(height: row.isCurrentUser ? 58 : 57)
+        .frame(height: row.isCurrentUser ? 74 : 70)
         .accessibilityElement(children: .combine)
     }
 
@@ -496,7 +530,7 @@ private struct LiveReplayLeaderboardRowView: View {
                     avatarTokenView
                 }
             }
-            .frame(width: 35, height: 35)
+            .frame(width: 44, height: 44)
             .clipShape(Circle())
             .overlay(
                 Circle()
@@ -514,9 +548,9 @@ private struct LiveReplayLeaderboardRowView: View {
 
     private var avatarTokenView: some View {
         Text(row.avatarToken)
-            .font(.montserratBold(size: 10))
+            .font(.montserratBold(size: 13))
             .foregroundStyle(row.isCurrentUser ? .black : .white)
-            .frame(width: 35, height: 35)
+            .frame(width: 44, height: 44)
             .background(Circle().fill(row.isCurrentUser ? tint : avatarColor))
     }
 

--- a/AscendApp/Shared/Repositories/Firebase/FirestoreLiveReplayLeaderboardRepository.swift
+++ b/AscendApp/Shared/Repositories/Firebase/FirestoreLiveReplayLeaderboardRepository.swift
@@ -62,6 +62,38 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
         )
     }
 
+    func fetchCompletionLeaderboard(
+        context: LiveReplayLeaderboardContext,
+        limit: Int
+    ) async throws -> LiveReplayCompletionLeaderboard {
+        let resolvedLimit = max(limit, 1)
+
+        async let summary = fetchSummary(context: context)
+        async let completedCount = countRows(context: context, bucketIndex: 0)
+        async let rowSnapshot = entriesCollection(context: context, bucketIndex: 0)
+            .order(by: "completionDurationSeconds", descending: false)
+            .limit(to: resolvedLimit)
+            .getDocuments(source: .server)
+
+        let resolvedSummary = try await summary
+        let resolvedCompletedCount = try await completedCount
+        let currentUserId = Auth.auth().currentUser?.uid
+        let rows = try await rowSnapshot.documents.enumerated().compactMap { offset, document in
+            parseCompletionRow(
+                id: document.documentID,
+                data: document.data(),
+                rank: offset + 1,
+                currentUserId: currentUserId
+            )
+        }
+
+        return LiveReplayCompletionLeaderboard(
+            rows: rows,
+            completedCount: max(resolvedSummary.completedCount, resolvedCompletedCount),
+            updatedAt: resolvedSummary.updatedAt
+        )
+    }
+
     func fetchWindow(
         context: LiveReplayLeaderboardContext,
         bucketIndex: Int,
@@ -265,6 +297,39 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
             isCurrentUser: false,
             isPersonalBest: (data["isPersonalBest"] as? Bool) ?? false,
             completionDurationSeconds: doubleValue(for: "completionDurationSeconds", in: data)
+        )
+    }
+
+    private func parseCompletionRow(
+        id: String,
+        data: [String: Any],
+        rank: Int,
+        currentUserId: String?
+    ) -> LiveReplayLeaderboardRow? {
+        guard let completionDurationSeconds = doubleValue(
+            for: "completionDurationSeconds",
+            in: data
+        ) else {
+            return nil
+        }
+
+        let displayName = (data["displayName"] as? String)
+            .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty }
+            ?? "Climber"
+        let stepsAtBucket = intValue(for: "stepsAtBucket", in: data) ?? 0
+
+        return LiveReplayLeaderboardRow(
+            id: id,
+            rank: max(rank, 1),
+            displayName: displayName,
+            avatarToken: (data["avatarToken"] as? String) ?? Self.avatarToken(for: displayName),
+            photoURL: photoURLValue(for: "photoURL", in: data),
+            stepsAtBucket: stepsAtBucket,
+            finalSteps: intValue(for: "finalSteps", in: data) ?? stepsAtBucket,
+            deltaFromUser: 0,
+            isCurrentUser: id == currentUserId,
+            isPersonalBest: id == currentUserId,
+            completionDurationSeconds: completionDurationSeconds
         )
     }
 

--- a/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
+++ b/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
@@ -38,6 +38,28 @@ struct LiveReplayCompletionRank: Equatable, Sendable {
     }
 }
 
+struct LiveReplayCompletionLeaderboard: Equatable, Sendable {
+    let rows: [LiveReplayLeaderboardRow]
+    let completedCount: Int
+    let updatedAt: Date?
+
+    init(
+        rows: [LiveReplayLeaderboardRow],
+        completedCount: Int,
+        updatedAt: Date?
+    ) {
+        self.rows = rows
+        self.completedCount = max(completedCount, rows.count, 0)
+        self.updatedAt = updatedAt
+    }
+
+    static let empty = LiveReplayCompletionLeaderboard(
+        rows: [],
+        completedCount: 0,
+        updatedAt: nil
+    )
+}
+
 struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
     let id: String
     let rank: Int?
@@ -50,6 +72,17 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
     let isCurrentUser: Bool
     let isPersonalBest: Bool
     let completionDurationSeconds: TimeInterval?
+
+    var averageStepsPerMinute: Double? {
+        guard let completionDurationSeconds,
+              completionDurationSeconds > 0,
+              finalSteps > 0 else {
+            return nil
+        }
+
+        let value = Double(finalSteps) / (completionDurationSeconds / 60)
+        return value.isFinite ? value : nil
+    }
 
     static func currentUser(
         rank: Int?,

--- a/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardRepository.swift
+++ b/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardRepository.swift
@@ -10,6 +10,11 @@ protocol LiveReplayLeaderboardRepository: Sendable {
         completionDurationSeconds: TimeInterval
     ) async throws -> LiveReplayCompletionRank
 
+    func fetchCompletionLeaderboard(
+        context: LiveReplayLeaderboardContext,
+        limit: Int
+    ) async throws -> LiveReplayCompletionLeaderboard
+
     func fetchWindow(
         context: LiveReplayLeaderboardContext,
         bucketIndex: Int,

--- a/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardService.swift
+++ b/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardService.swift
@@ -10,6 +10,11 @@ protocol LiveReplayLeaderboardServicing: Sendable {
         completionDurationSeconds: TimeInterval
     ) async throws -> LiveReplayCompletionRank
 
+    func fetchCompletionLeaderboard(
+        context: LiveReplayLeaderboardContext,
+        limit: Int
+    ) async throws -> LiveReplayCompletionLeaderboard
+
     func refreshIfNeeded(
         context: LiveReplayLeaderboardContext,
         elapsedSeconds: Int,
@@ -62,6 +67,16 @@ actor LiveReplayLeaderboardService: LiveReplayLeaderboardServicing {
         try await repository.fetchCompletionRank(
             context: context,
             completionDurationSeconds: completionDurationSeconds
+        )
+    }
+
+    func fetchCompletionLeaderboard(
+        context: LiveReplayLeaderboardContext,
+        limit: Int
+    ) async throws -> LiveReplayCompletionLeaderboard {
+        try await repository.fetchCompletionLeaderboard(
+            context: context,
+            limit: limit
         )
     }
 

--- a/AscendAppTests/LiveReplayLeaderboardServiceTests.swift
+++ b/AscendAppTests/LiveReplayLeaderboardServiceTests.swift
@@ -121,6 +121,31 @@ private actor MockLiveReplayLeaderboardRepository: LiveReplayLeaderboardReposito
         )
     }
 
+    func fetchCompletionLeaderboard(
+        context: LiveReplayLeaderboardContext,
+        limit: Int
+    ) async throws -> LiveReplayCompletionLeaderboard {
+        LiveReplayCompletionLeaderboard(
+            rows: [
+                LiveReplayLeaderboardRow(
+                    id: "attempt-a",
+                    rank: 1,
+                    displayName: "Sarah K.",
+                    avatarToken: "SK",
+                    photoURL: URL(string: "https://example.com/sarah.jpg"),
+                    stepsAtBucket: 0,
+                    finalSteps: 809,
+                    deltaFromUser: 0,
+                    isCurrentUser: false,
+                    isPersonalBest: false,
+                    completionDurationSeconds: 800
+                )
+            ],
+            completedCount: 89,
+            updatedAt: Date(timeIntervalSince1970: 1_777_777_700)
+        )
+    }
+
     func fetchWindow(
         context: LiveReplayLeaderboardContext,
         bucketIndex: Int,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,8 @@ Workout, LeaderboardStats, PersonalRecord, Routine, RoutineFolder, WeightPersona
 - Climb detail has 3 swipe pages:
   - `Overview` (real)
   - `Your History` (real)
-  - `Leaderboard` (present but clearly coming soon in v1)
-- Per-climb rank and total-climber counts must stay hidden until real backend data exists.
+  - `Leaderboard` (real; shows fastest completed attempts from the server-published replay index)
+- Per-climb rank and total-climber counts must stay hidden until real backend data exists; do not show placeholder public stats.
 - Climb content uses a remote-first catalog and remote-only climb images:
   - a tiny hosted manifest at `/climbs/manifest.json`
   - a versioned hosted catalog at `/climbs/catalog-v{N}.json`


### PR DESCRIPTION
## Summary

Adds the real Climb Detail completion leaderboard for Live Climbs and replaces the placeholder coming-soon state.

- Fetches fastest completed replay rows from the server-published bucket-zero replay index.
- Adds `LiveReplayCompletionLeaderboard` and service/repository APIs for completion leaderboard reads.
- Shows leaderboard loading, empty, unavailable, personal-rank, and row states on the Climb Detail leaderboard page.
- Displays rank, avatar/photo, display name, final steps, completion duration, and average SPM for completed attempts.
- Keeps community completed counts aligned with real completion leaderboard data.
- Polishes the in-session replay leaderboard rows with larger typography/avatar sizing and initial scroll-to-current-user behavior.
- Updates `AGENTS.md` and `CLAUDE.md` so project context reflects that Climb Detail has a real leaderboard page.

## User Impact

Users can now swipe to the Climb Detail `Leaderboard` page and see real fastest completion times instead of placeholder copy. Users with a completed attempt can also see their personal rank summary when their best result is outside the visible top rows.

This stays aligned with the Live Replay architecture: the client reads server-published replay data and does not write leaderboard split indexes directly.

## UI Test Plan

Recommended test setup: dev/staging data with at least one Live Climb that has completed replay leaderboard rows published for bucket zero.

1. Open a Live Climb detail screen and swipe to the `Leaderboard` page.
2. Confirm the page title reads `Leaderboard` and the subtitle reads `Fastest completion times`.
3. Confirm completed-count copy appears when completed leaderboard data exists.
4. Confirm each row shows rank, avatar/photo or initials, display name, final steps, completion duration, and average SPM when available.
5. Sign in as a user with a completed attempt that appears in the visible rows and confirm the row is highlighted and labeled `YOU`.
6. Sign in as a user with a completed attempt outside the visible rows and confirm the `Your best` rank summary appears above the rows.
7. Test a climb with no completed rows and confirm the empty state says `No completed times yet`.
8. Temporarily disable network or force a repository failure and confirm the leaderboard page degrades to the empty/unavailable state without blocking the rest of Climb Detail.
9. Start a Live Climb session and confirm the in-session replay leaderboard still displays correctly with larger rows and initially scrolls to the current user.
10. Spot-check light/dark appearance for the leaderboard page, especially row separators, highlight backgrounds, and long display names.

## Validation

- `git diff --check`
- `xcodebuild -project AscendApp.xcodeproj -scheme AscendApp -configuration Debug -destination 'generic/platform=iOS Simulator' build`

## Notes

This PR intentionally excludes local Xcode scheme-ordering changes and the untracked Instruments `traces/` directory.