### PR TITLE
[codex] Fix Live Activity widget signing in deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -139,6 +139,8 @@ jobs:
           IOS_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
           IOS_PRODUCTION_BUNDLE_ID: com.TylerPavay.AscendApp
+          IOS_PRODUCTION_WIDGET_BUNDLE_ID: com.TylerPavay.AscendApp.LiveClimbWidgets
+          IOS_PRODUCTION_WIDGET_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.LiveClimbWidgets
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
           BUILD_NUMBER: ${{ github.run_number }}
         run: bundle exec fastlane build_production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -112,6 +112,8 @@ jobs:
           IOS_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.staging
           IOS_DEVELOPMENT_TEAM: QWGVB7TN4T
           IOS_STAGING_BUNDLE_ID: com.TylerPavay.AscendApp.staging
+          IOS_STAGING_WIDGET_BUNDLE_ID: com.TylerPavay.AscendApp.staging.LiveClimbWidgets
+          IOS_STAGING_WIDGET_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.staging.LiveClimbWidgets
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
           BUILD_NUMBER: ${{ github.run_number }}
         run: bundle exec fastlane build_staging

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,11 +11,11 @@ def match_readonly_enabled?
   ENV["CI"].to_s == "true"
 end
 
-def match_options_for(bundle_identifier)
+def match_options_for(bundle_identifiers)
   options = {
     type: "appstore",
     readonly: match_readonly_enabled?,
-    app_identifier: [bundle_identifier],
+    app_identifier: Array(bundle_identifiers),
     git_branch: ENV.fetch("MATCH_GIT_BRANCH", "main")
   }
 
@@ -46,7 +46,14 @@ end
 # We call xcodebuild directly (not through gym) so we can use
 # "app-store-connect" (which gym 2.230 doesn't support) and avoid
 # gym leaking archive xcargs into the export command.
-def write_export_plist(signing_certificate:, team_id:, bundle_id:, profile_name:)
+def write_export_plist(signing_certificate:, team_id:, provisioning_profiles:)
+  provisioning_profiles_xml = provisioning_profiles.map do |bundle_id, profile_name|
+    <<~PROFILE.chomp
+        <key>#{bundle_id}</key>
+        <string>#{profile_name}</string>
+    PROFILE
+  end.join("\n")
+
   plist = <<~PLIST
     <?xml version="1.0" encoding="UTF-8"?>
     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -62,8 +69,7 @@ def write_export_plist(signing_certificate:, team_id:, bundle_id:, profile_name:
       <string>#{team_id}</string>
       <key>provisioningProfiles</key>
       <dict>
-        <key>#{bundle_id}</key>
-        <string>#{profile_name}</string>
+    #{provisioning_profiles_xml}
       </dict>
     </dict>
     </plist>
@@ -83,6 +89,8 @@ platform :ios do
     staging_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp.staging")
     staging_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
     staging_bundle_identifier = ENV.fetch("IOS_STAGING_BUNDLE_ID", "com.TylerPavay.AscendApp.staging")
+    staging_widget_bundle_identifier = ENV.fetch("IOS_STAGING_WIDGET_BUNDLE_ID", "com.TylerPavay.AscendApp.staging.LiveClimbWidgets")
+    staging_widget_profile_specifier = ENV.fetch("IOS_STAGING_WIDGET_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp.staging.LiveClimbWidgets")
 
     # Auto-increment build number on CI using the workflow run number
     build_number = ENV["BUILD_NUMBER"]
@@ -93,17 +101,17 @@ platform :ios do
       )
     end
 
-    match(**match_options_for(staging_bundle_identifier))
+    match(**match_options_for([staging_bundle_identifier, staging_widget_bundle_identifier]))
 
     cert_name = match_cert_name(staging_bundle_identifier)
     export_signing_cert = cert_name || staging_signing_identity
     UI.message("Using signing certificate: #{export_signing_cert}")
 
-    # Set signing identity on the app target only (not globally via xcargs,
+    # Set signing identity on app-owned targets only (not globally via xcargs,
     # which would break SPM package targets that use automatic signing).
     update_code_signing_settings(
       path: "AscendApp.xcodeproj",
-      targets: ["AscendApp"],
+      targets: ["AscendApp", "AscendLiveActivityWidgets"],
       build_configurations: ["Staging"],
       code_sign_identity: export_signing_cert
     )
@@ -134,8 +142,10 @@ platform :ios do
     export_plist = write_export_plist(
       signing_certificate: export_signing_cert,
       team_id: staging_development_team,
-      bundle_id: staging_bundle_identifier,
-      profile_name: staging_profile_specifier
+      provisioning_profiles: {
+        staging_bundle_identifier => staging_profile_specifier,
+        staging_widget_bundle_identifier => staging_widget_profile_specifier
+      }
     )
 
     output_dir = File.expand_path("build")
@@ -161,6 +171,8 @@ platform :ios do
     production_profile_specifier = ENV.fetch("IOS_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp")
     production_development_team = ENV.fetch("IOS_DEVELOPMENT_TEAM", "QWGVB7TN4T")
     production_bundle_identifier = ENV.fetch("IOS_PRODUCTION_BUNDLE_ID", "com.TylerPavay.AscendApp")
+    production_widget_bundle_identifier = ENV.fetch("IOS_PRODUCTION_WIDGET_BUNDLE_ID", "com.TylerPavay.AscendApp.LiveClimbWidgets")
+    production_widget_profile_specifier = ENV.fetch("IOS_PRODUCTION_WIDGET_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp.LiveClimbWidgets")
 
     # Auto-increment build number on CI using the workflow run number
     build_number = ENV["BUILD_NUMBER"]
@@ -171,16 +183,16 @@ platform :ios do
       )
     end
 
-    match(**match_options_for(production_bundle_identifier))
+    match(**match_options_for([production_bundle_identifier, production_widget_bundle_identifier]))
 
     cert_name = match_cert_name(production_bundle_identifier)
     export_signing_cert = cert_name || production_signing_identity
     UI.message("Using signing certificate: #{export_signing_cert}")
 
-    # Set signing identity on the app target only (not globally via xcargs).
+    # Set signing identity on app-owned targets only (not globally via xcargs).
     update_code_signing_settings(
       path: "AscendApp.xcodeproj",
-      targets: ["AscendApp"],
+      targets: ["AscendApp", "AscendLiveActivityWidgets"],
       build_configurations: ["Release"],
       code_sign_identity: export_signing_cert
     )
@@ -202,8 +214,10 @@ platform :ios do
     export_plist = write_export_plist(
       signing_certificate: export_signing_cert,
       team_id: production_development_team,
-      bundle_id: production_bundle_identifier,
-      profile_name: production_profile_specifier
+      provisioning_profiles: {
+        production_bundle_identifier => production_profile_specifier,
+        production_widget_bundle_identifier => production_widget_profile_specifier
+      }
     )
 
     output_dir = File.expand_path("build")

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -2,5 +2,10 @@ git_url(ENV.fetch("MATCH_GIT_URL", "git@github.com:tpavay/ascend-match-signing.g
 storage_mode("git")
 type("appstore")
 git_branch(ENV.fetch("MATCH_GIT_BRANCH", "main"))
-app_identifier(["com.TylerPavay.AscendApp.staging", "com.TylerPavay.AscendApp"])
+app_identifier([
+  "com.TylerPavay.AscendApp.staging",
+  "com.TylerPavay.AscendApp.staging.LiveClimbWidgets",
+  "com.TylerPavay.AscendApp",
+  "com.TylerPavay.AscendApp.LiveClimbWidgets"
+])
 team_id("QWGVB7TN4T")


### PR DESCRIPTION
## Summary

Fixes the staging deploy archive failure introduced by the Live Activity widget extension target.

- Requests both app and `AscendLiveActivityWidgets` bundle identifiers from `match` for staging and production lanes.
- Adds the widget extension provisioning profile mapping to the manual export options plist.
- Updates Fastlane signing updates to apply to both app-owned targets: `AscendApp` and `AscendLiveActivityWidgets`.
- Adds explicit widget bundle/profile environment variables to staging and production deploy workflows.
- Adds the staging and production widget bundle IDs to `fastlane/Matchfile`.

## Root Cause

`Deploy Staging` failed during the post-merge archive because CI only installed the app provisioning profile:

```text
MATCH_PROVISIONING_PROFILE_MAPPING = {"com.TylerPavay.AscendApp.staging"=>"match AppStore com.TylerPavay.AscendApp.staging"}
```

The project now embeds `AscendLiveActivityWidgets`, whose staging bundle ID is:

```text
com.TylerPavay.AscendApp.staging.LiveClimbWidgets
```

Xcode therefore failed with:

```text
No profile for team 'QWGVB7TN4T' matching 'match AppStore com.TylerPavay.AscendApp.staging.LiveClimbWidgets' found
```

## Signing Profile Status

Completed in `tpavay/ascend-match-signing` commit `5f02089`.

The match repo now contains encrypted App Store profiles for:

- `profiles/appstore/AppStore_com.TylerPavay.AscendApp.staging.LiveClimbWidgets.mobileprovision`
- `profiles/appstore/AppStore_com.TylerPavay.AscendApp.LiveClimbWidgets.mobileprovision`

The one-off Actions run that created the App IDs and exported the encrypted profiles succeeded here: https://github.com/tpavay/AscendApp/actions/runs/25509337272

## Validation

- `ruby -c fastlane/Fastfile`
- `ruby -c fastlane/Matchfile`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-staging.yml"); YAML.load_file(".github/workflows/deploy-production.yml")'`
- `git diff --check`
- Verified `tpavay/ascend-match-signing` `main` contains both widget `.mobileprovision` files after push.

I could not run `bundle exec fastlane lanes` locally because this machine's system Ruby is missing Bundler `2.5.23` from `Gemfile.lock`.
