### PR TITLE
[codex] Harden workout imports and detail metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,7 +167,9 @@ Workout, WorkoutSourceLink, WorkoutParticipation, LeaderboardStats, Routine, Rou
 ### Import UX
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.
 - Import architecture uses one canonical `Workout` plus local `WorkoutSourceLink` provenance records per provider. New import UI and state should flow through `WorkoutImportCoordinator`, not provider-specific views/services.
+- Workout totals must pass the shared `WorkoutPlausibilityPolicy` before manual save, edit, import, remote backup, and Best Efforts ranking. Keep implausible average-step-rate records out of new data, and independently ignore any legacy implausible rows in Best Efforts.
 - Apple Health is read-only. First connect may backfill historical workouts, but routine checks must stay incremental and sample-only until a workout is actually imported.
+- Apple Health heart-rate chart samples must expand condensed `HKQuantitySample` records using `HKQuantitySeriesSampleQuery` and save the individual quantities. Parent heart-rate samples may represent aggregate blocks and should only be used as a fallback when no series children are returned.
 - Apple Health auto-import is optional and user-controlled from the Apple Health manage sheet.
 - Auto-import only applies to newly finished Apple Health workouts from the moment the user enables it; older pending history remains in the manual review/import flow.
 - If older local settings have auto-import enabled but no stored activation timestamp, use the previous successful HealthKit check as the conservative activation fallback so newly discovered workouts can import without opening older pending history.

--- a/AscendApp/Features/Progress/Models/BestEffortRankings.swift
+++ b/AscendApp/Features/Progress/Models/BestEffortRankings.swift
@@ -667,6 +667,8 @@ enum BestEffortRankingBuilder {
     }
 
     private static func performance(for metric: BestEffortMetric, workout: Workout) -> BestEffortPerformance? {
+        guard WorkoutPlausibilityPolicy.hasPlausibleTotals(workout) else { return nil }
+
         switch metric {
         case .mostSteps:
             guard workout.steps > 0 else { return nil }

--- a/AscendApp/Features/Workouts/Models/WorkoutInputValidation.swift
+++ b/AscendApp/Features/Workouts/Models/WorkoutInputValidation.swift
@@ -12,6 +12,26 @@ enum WorkoutInputValidation {
         return intValue >= 0
     }
 
+    static func isValidWorkoutTotals(
+        metricValue: String,
+        preferredMetric: WorkoutMetric,
+        stepsPerFloor: Int,
+        durationHours: Int,
+        durationMinutes: Int,
+        durationSeconds: Int
+    ) -> Bool {
+        let enteredValue = Int(metricValue) ?? 0
+        let totalDuration = TimeInterval(durationHours * 3_600 + durationMinutes * 60 + durationSeconds)
+        let steps = preferredMetric == .steps
+            ? enteredValue
+            : Workout.floorsToSteps(enteredValue, stepsPerFloor: stepsPerFloor)
+
+        return WorkoutPlausibilityPolicy.hasPlausibleTotals(
+            steps: steps,
+            duration: totalDuration
+        )
+    }
+
     static func isValidWorkoutName(_ value: String) -> Bool {
         value.isEmpty || value.count <= nameMaxLength
     }

--- a/AscendApp/Features/Workouts/Services/WorkoutService.swift
+++ b/AscendApp/Features/Workouts/Services/WorkoutService.swift
@@ -21,6 +21,7 @@ final class WorkoutService {
     @MainActor
     func createWorkout(from request: CreateWorkoutRequest,
                        with photos: [PhotosPickerItem]) async throws -> Workout {
+        try validate(request)
 
         // SAFE: this is an actor hop (MainActor -> PhotoService)
         let uploadedPhotos = try await photoService.uploadPhotos(photos)
@@ -51,6 +52,7 @@ final class WorkoutService {
     @MainActor
     func createWorkout(from request: CreateWorkoutRequest,
                        with selectedPhotos: [SelectedPhotoItem]) async throws -> Workout {
+        try validate(request)
 
         // SAFE: this is an actor hop (MainActor -> PhotoService)
         let uploadedPhotos = try await photoService.uploadSelectedPhotos(selectedPhotos)
@@ -81,6 +83,8 @@ final class WorkoutService {
     /// Photos will be uploaded asynchronously via MediaUploadManager.
     @MainActor
     func createWorkout(from request: CreateWorkoutRequest) async throws -> Workout {
+        try validate(request)
+
         let model = UIDevice.current.model
 
         return Workout(
@@ -100,6 +104,15 @@ final class WorkoutService {
             photos: [],  // Empty - will be populated by MediaUploadManager
             weightConfiguration: request.weightConfiguration
         )
+    }
+
+    private func validate(_ request: CreateWorkoutRequest) throws {
+        guard WorkoutPlausibilityPolicy.hasPlausibleTotals(
+            steps: request.steps,
+            duration: request.duration
+        ) else {
+            throw WorkoutServiceError.invalidWorkoutData
+        }
     }
 }
 

--- a/AscendApp/Features/Workouts/ViewModels/WorkoutFormViewModel.swift
+++ b/AscendApp/Features/Workouts/ViewModels/WorkoutFormViewModel.swift
@@ -126,13 +126,21 @@ class WorkoutFormViewModel {
         let seconds = Int(durationSeconds) ?? 0
         let totalDurationSeconds = hours * 3600 + minutes * 60 + seconds
         let durationValid = totalDurationSeconds > 0
+        let workoutTotalsValid = WorkoutInputValidation.isValidWorkoutTotals(
+            metricValue: metricValue,
+            preferredMetric: settingsManager.preferredWorkoutMetric,
+            stepsPerFloor: settingsManager.stepsPerFloor,
+            durationHours: hours,
+            durationMinutes: minutes,
+            durationSeconds: seconds
+        )
 
         // Validate health metrics if provided
         let avgHRValid = WorkoutInputValidation.isValidOptionalHeartRate(avgHeartRate)
         let maxHRValid = WorkoutInputValidation.isValidOptionalHeartRate(maxHeartRate)
         let caloriesValid = WorkoutInputValidation.isValidOptionalCalories(caloriesBurned)
 
-        return basicValidation && durationValid && avgHRValid && maxHRValid && caloriesValid && !isUploading
+        return basicValidation && durationValid && workoutTotalsValid && avgHRValid && maxHRValid && caloriesValid && !isUploading
     }
 
     // MARK: - Actions

--- a/AscendApp/Features/Workouts/Views/AutoImportedWorkoutReviewView.swift
+++ b/AscendApp/Features/Workouts/Views/AutoImportedWorkoutReviewView.swift
@@ -51,6 +51,14 @@ struct AutoImportedWorkoutReviewView: View {
         let hours = Int(durationHours) ?? 0
         let totalDurationSeconds = hours * 3600 + (minutes ?? 0) * 60 + (seconds ?? 0)
         let stepsValid = stepsValue.isEmpty || Int(stepsValue) != nil
+        let workoutTotalsValid = WorkoutInputValidation.isValidWorkoutTotals(
+            metricValue: stepsValue,
+            preferredMetric: .steps,
+            stepsPerFloor: workout.stepsPerFloor,
+            durationHours: hours,
+            durationMinutes: minutes ?? 0,
+            durationSeconds: seconds ?? 0
+        )
 
         return !isSaving &&
             !isDeleting &&
@@ -60,7 +68,8 @@ struct AutoImportedWorkoutReviewView: View {
             (minutes ?? 0) < 60 &&
             (seconds ?? 0) < 60 &&
             totalDurationSeconds > 0 &&
-            stepsValid
+            stepsValid &&
+            workoutTotalsValid
     }
 
     private var totalDuration: TimeInterval {
@@ -435,6 +444,13 @@ struct AutoImportedWorkoutReviewView: View {
             }
 
             let steps = Int(stepsValue) ?? 0
+            guard WorkoutPlausibilityPolicy.hasPlausibleTotals(
+                steps: steps,
+                duration: totalDuration
+            ) else {
+                throw WorkoutServiceError.invalidWorkoutData
+            }
+
             workout.name = effectiveName
             workout.notes = notes.trimmingCharacters(in: .whitespacesAndNewlines)
             workout.duration = totalDuration

--- a/AscendApp/Features/Workouts/Views/Components/HeroStatsPair.swift
+++ b/AscendApp/Features/Workouts/Views/Components/HeroStatsPair.swift
@@ -8,28 +8,15 @@
 import SwiftUI
 
 /// Large side-by-side hero stats (duration + steps/floors) with a vertical divider.
-/// Supports an optional accent border for highlighted stats.
 struct HeroStatsPair: View {
     let leftLabel: String
     let leftValue: String
     let rightLabel: String
     let rightValue: String
-    let leftIsPR: Bool
-    let rightIsPR: Bool
     let effectiveColorScheme: ColorScheme
 
-    private var hasPR: Bool {
-        leftIsPR || rightIsPR
-    }
-
     private var borderColor: Color {
-        hasPR
-            ? .accent.opacity(0.6)
-            : (effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15))
-    }
-
-    private var borderWidth: CGFloat {
-        hasPR ? 1.5 : 1
+        effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15)
     }
 
     var body: some View {
@@ -49,7 +36,7 @@ struct HeroStatsPair: View {
                 .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
                 .overlay(
                     RoundedRectangle(cornerRadius: 16)
-                        .stroke(borderColor, lineWidth: borderWidth)
+                        .stroke(borderColor, lineWidth: 1)
                 )
         )
     }
@@ -77,8 +64,6 @@ struct HeroStatsPair: View {
             leftValue: "2:00:22",
             rightLabel: "Steps",
             rightValue: "10,849",
-            leftIsPR: false,
-            rightIsPR: true,
             effectiveColorScheme: .dark
         )
 
@@ -87,8 +72,6 @@ struct HeroStatsPair: View {
             leftValue: "30:00",
             rightLabel: "Floors",
             rightValue: "156",
-            leftIsPR: false,
-            rightIsPR: false,
             effectiveColorScheme: .dark
         )
     }

--- a/AscendApp/Features/Workouts/Views/Components/SecondaryStatsRow.swift
+++ b/AscendApp/Features/Workouts/Views/Components/SecondaryStatsRow.swift
@@ -12,11 +12,9 @@ struct SecondaryStatItem: Identifiable {
     let id = UUID()
     let label: String
     let value: String
-    let isPR: Bool
 }
 
 /// Compact row of 1–3 secondary stat cards (pace, calories, METs).
-/// Each card supports an optional accent border.
 struct SecondaryStatsRow: View {
     let items: [SecondaryStatItem]
     let effectiveColorScheme: ColorScheme
@@ -30,10 +28,7 @@ struct SecondaryStatsRow: View {
     }
 
     private func secondaryStatCard(item: SecondaryStatItem) -> some View {
-        let borderColor: Color = item.isPR
-            ? .accent.opacity(0.6)
-            : (effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15))
-        let borderWidth: CGFloat = item.isPR ? 1.5 : 1
+        let borderColor: Color = effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15)
 
         return VStack(spacing: 4) {
             Text(item.value)
@@ -55,7 +50,7 @@ struct SecondaryStatsRow: View {
                 .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
                 .overlay(
                     RoundedRectangle(cornerRadius: 14)
-                        .stroke(borderColor, lineWidth: borderWidth)
+                        .stroke(borderColor, lineWidth: 1)
                 )
         )
     }
@@ -64,9 +59,9 @@ struct SecondaryStatsRow: View {
 #Preview {
     SecondaryStatsRow(
         items: [
-            SecondaryStatItem(label: "Steps/Min", value: "90.1", isPR: true),
-            SecondaryStatItem(label: "Calories", value: "1,692", isPR: false),
-            SecondaryStatItem(label: "METs", value: "10.3", isPR: false)
+            SecondaryStatItem(label: "Steps/Min", value: "90.1"),
+            SecondaryStatItem(label: "Calories", value: "1,692"),
+            SecondaryStatItem(label: "METs", value: "10.3")
         ],
         effectiveColorScheme: .dark
     )

--- a/AscendApp/Features/Workouts/Views/Components/VerticalClimbCard.swift
+++ b/AscendApp/Features/Workouts/Views/Components/VerticalClimbCard.swift
@@ -8,28 +8,28 @@
 import SwiftUI
 
 /// Standalone horizontal card displaying vertical climb with a triangle icon.
-/// Supports an optional accent border.
 struct VerticalClimbCard: View {
     let value: String
     let unit: String
-    let isPR: Bool
     let effectiveColorScheme: ColorScheme
 
     private var borderColor: Color {
-        isPR
-            ? .accent.opacity(0.6)
-            : (effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15))
+        effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15)
     }
 
-    private var borderWidth: CGFloat {
-        isPR ? 1.5 : 1
+    private var primaryTextColor: Color {
+        effectiveColorScheme == .dark ? .white : .black
+    }
+
+    private var secondaryTextColor: Color {
+        effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray
     }
 
     var body: some View {
         HStack(spacing: 16) {
             Image(systemName: "triangle.fill")
                 .font(.system(size: 16, weight: .medium))
-                .foregroundStyle(.accent)
+                .foregroundStyle(secondaryTextColor)
                 .frame(width: 28)
 
             Text("Vertical climb")
@@ -41,11 +41,11 @@ struct VerticalClimbCard: View {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text(value)
                     .font(.montserratBold(size: 20))
-                    .foregroundStyle(.accent)
+                    .foregroundStyle(primaryTextColor)
 
                 Text(unit)
                     .font(.montserratRegular(size: 14))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+                    .foregroundStyle(secondaryTextColor)
             }
         }
         .padding(20)
@@ -54,7 +54,7 @@ struct VerticalClimbCard: View {
                 .fill(effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06))
                 .overlay(
                     RoundedRectangle(cornerRadius: 16)
-                        .stroke(borderColor, lineWidth: borderWidth)
+                        .stroke(borderColor, lineWidth: 1)
                 )
         )
     }
@@ -62,8 +62,8 @@ struct VerticalClimbCard: View {
 
 #Preview {
     VStack(spacing: 12) {
-        VerticalClimbCard(value: "7,232.7", unit: "ft", isPR: true, effectiveColorScheme: .dark)
-        VerticalClimbCard(value: "1,204.5", unit: "m", isPR: false, effectiveColorScheme: .dark)
+        VerticalClimbCard(value: "7,232.7", unit: "ft", effectiveColorScheme: .dark)
+        VerticalClimbCard(value: "1,204.5", unit: "m", effectiveColorScheme: .dark)
     }
     .padding(20)
     .background(Color.black)

--- a/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
+++ b/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
@@ -134,13 +134,21 @@ struct EditWorkoutView: View {
         let seconds = Int(durationSeconds) ?? 0
         let totalDurationSeconds = hours * 3600 + minutes * 60 + seconds
         let durationValid = totalDurationSeconds > 0
+        let workoutTotalsValid = WorkoutInputValidation.isValidWorkoutTotals(
+            metricValue: metricValue,
+            preferredMetric: settingsManager.preferredWorkoutMetric,
+            stepsPerFloor: workout.stepsPerFloor,
+            durationHours: hours,
+            durationMinutes: minutes,
+            durationSeconds: seconds
+        )
         
         // Validate health metrics if provided
         let avgHRValid = WorkoutInputValidation.isValidOptionalHeartRate(avgHeartRate)
         let maxHRValid = WorkoutInputValidation.isValidOptionalHeartRate(maxHeartRate)
         let caloriesValid = WorkoutInputValidation.isValidOptionalCalories(caloriesBurned)
         
-        return basicValidation && durationValid && avgHRValid && maxHRValid && caloriesValid && !isSaving
+        return basicValidation && durationValid && workoutTotalsValid && avgHRValid && maxHRValid && caloriesValid && !isSaving
     }
     
     var body: some View {
@@ -723,6 +731,7 @@ struct EditWorkoutView: View {
         print("🔍 Form valid: \(isFormValid)")
         
         guard !isSaving else { return }
+        guard isFormValid else { return }
         guard let minutes = Int(durationMinutes),
               let seconds = Int(durationSeconds) else {
             print("❌ Guard failed - invalid number conversion")

--- a/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
+++ b/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
@@ -8,105 +8,137 @@
 import SwiftUI
 import Charts
 
+struct HeartRateChartDataSet: Equatable {
+    static let minimumLineSampleCount = 3
+
+    let points: [HeartRateChartPoint]
+    let duration: TimeInterval
+    let heartRateRange: ClosedRange<Int>
+    let heartRateTickValues: [Int]
+
+    var canPlotLine: Bool {
+        let distinctElapsedValues = Set(points.map { Int($0.elapsed.rounded()) })
+        return points.count >= Self.minimumLineSampleCount && distinctElapsedValues.count >= 2
+    }
+
+    init(
+        samples: [HeartRateDataPoint],
+        workoutStartTime: Date,
+        workoutDuration: TimeInterval
+    ) {
+        let visibleDuration = max(workoutDuration, 1)
+        let workoutEndTime = workoutStartTime.addingTimeInterval(visibleDuration)
+        let tolerance: TimeInterval = 60
+        let sortedSamples = samples
+            .filter { sample in
+                sample.heartRate > 0 &&
+                    sample.timestamp >= workoutStartTime.addingTimeInterval(-tolerance) &&
+                    sample.timestamp <= workoutEndTime.addingTimeInterval(tolerance)
+            }
+            .sorted { $0.timestamp < $1.timestamp }
+
+        points = sortedSamples.enumerated().map { index, sample in
+            let elapsed = sample.timestamp.timeIntervalSince(workoutStartTime)
+            return HeartRateChartPoint(
+                id: index,
+                elapsed: min(max(elapsed, 0), visibleDuration),
+                heartRate: sample.heartRate
+            )
+        }
+        duration = visibleDuration
+
+        let rates = points.map(\.heartRate)
+        heartRateRange = Self.range(for: rates)
+        heartRateTickValues = Self.tickValues(for: heartRateRange)
+    }
+
+    private static func range(for heartRates: [Int]) -> ClosedRange<Int> {
+        guard let minRate = heartRates.min(), let maxRate = heartRates.max() else {
+            return 60...180
+        }
+
+        if minRate == maxRate {
+            return max(30, minRate - 5)...(maxRate + 5)
+        }
+
+        let padding = max(3, Int(ceil(Double(maxRate - minRate) * 0.1)))
+        return max(30, minRate - padding)...(maxRate + padding)
+    }
+
+    private static func tickValues(for range: ClosedRange<Int>) -> [Int] {
+        let distance = range.upperBound - range.lowerBound
+        guard distance > 0 else { return [range.lowerBound] }
+
+        let interval = Double(distance) / 4.0
+        var ticks = (0...4).map { index in
+            range.lowerBound + Int(round(Double(index) * interval))
+        }
+        ticks[0] = range.lowerBound
+        ticks[4] = range.upperBound
+        return ticks
+    }
+}
+
+struct HeartRateChartPoint: Identifiable, Equatable {
+    let id: Int
+    let elapsed: TimeInterval
+    let heartRate: Int
+}
+
 struct HeartRateChartView: View {
     let heartRateData: [HeartRateDataPoint]
     let workoutStartTime: Date
     let workoutDuration: TimeInterval
+    let averageHeartRateBpm: Int?
+    let maxHeartRateBpm: Int?
     
     @Environment(\.colorScheme) private var colorScheme
     @State private var themeManager = ThemeManager.shared
     @State private var rawSelectedTime: TimeInterval?
     @State private var stickySelectedTime: TimeInterval?
-    @State private var selectedPoint: HeartRateDataPoint?
-    
-    // Use actual heart rate data timespan instead of workout duration
-    private var actualStartTime: Date {
-        heartRateData.first?.timestamp ?? workoutStartTime
-    }
-    
-    private var actualEndTime: Date {
-        heartRateData.last?.timestamp ?? workoutStartTime.addingTimeInterval(workoutDuration)
-    }
-    
-    private var actualDuration: TimeInterval {
-        actualEndTime.timeIntervalSince(actualStartTime)
+
+    private var dataSet: HeartRateChartDataSet {
+        HeartRateChartDataSet(
+            samples: heartRateData,
+            workoutStartTime: workoutStartTime,
+            workoutDuration: workoutDuration
+        )
     }
     
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
     }
-    
-    // Convert heart rate data to chart-friendly format with elapsed time
-    private var chartData: [(elapsed: TimeInterval, heartRate: Int)] {
-        heartRateData.map { point in
-            (elapsed: point.timestamp.timeIntervalSince(actualStartTime), heartRate: point.heartRate)
-        }
-    }
-    
-    // Computed property to find the selected point — uses active touch or sticky (last-touched) time
-    private var computedSelectedPoint: HeartRateDataPoint? {
+
+    private var computedSelectedPoint: HeartRateChartPoint? {
         guard let activeTime = rawSelectedTime ?? stickySelectedTime else { return nil }
 
-        return heartRateData.min { point1, point2 in
-            let distance1 = abs(point1.timestamp.timeIntervalSince(actualStartTime) - activeTime)
-            let distance2 = abs(point2.timestamp.timeIntervalSince(actualStartTime) - activeTime)
+        return dataSet.points.min { point1, point2 in
+            let distance1 = abs(point1.elapsed - activeTime)
+            let distance2 = abs(point2.elapsed - activeTime)
             return distance1 < distance2
         }
     }
 
-    private var averageHeartRate: Int {
-        guard !heartRateData.isEmpty else { return 0 }
+    private var averageHeartRate: Int? {
+        if let averageHeartRateBpm {
+            return averageHeartRateBpm
+        }
+        guard !heartRateData.isEmpty else { return nil }
         return heartRateData.map(\.heartRate).reduce(0, +) / heartRateData.count
     }
 
-    private var maxHeartRate: Int {
-        heartRateData.map(\.heartRate).max() ?? 0
-    }
-    
-    // Heart rate range for Y-axis scaling
-    private var heartRateRange: ClosedRange<Int> {
-        guard !heartRateData.isEmpty else { return 60...180 }
-        
-        let minRate = heartRateData.map { $0.heartRate }.min() ?? 60
-        let maxRate = heartRateData.map { $0.heartRate }.max() ?? 180
-        
-        return minRate...maxRate
-    }
-    
-    // Y-axis tick values - always includes min, max, and 3 evenly distributed values in between
-    private var heartRateTickValues: [Int] {
-        guard !heartRateData.isEmpty else { return [60, 90, 120, 150, 180] }
-        
-        let minRate = heartRateData.map { $0.heartRate }.min() ?? 60
-        let maxRate = heartRateData.map { $0.heartRate }.max() ?? 180
-        
-        // If min and max are the same, just show that value
-        guard minRate != maxRate else { return [minRate] }
-        
-        // Calculate 3 evenly distributed ticks between min and max
-        let range = maxRate - minRate
-        let interval = Double(range) / 4.0 // 4 intervals to create 5 total ticks
-        
-        var ticks: [Int] = []
-        for i in 0...4 {
-            let tickValue = minRate + Int(round(Double(i) * interval))
-            ticks.append(tickValue)
-        }
-        
-        // Ensure the last tick is exactly the max value
-        ticks[4] = maxRate
-        
-        return ticks
+    private var maxHeartRate: Int? {
+        maxHeartRateBpm ?? heartRateData.map(\.heartRate).max()
     }
     
     var body: some View {
         VStack(spacing: 16) {
             headerView
             
-            if heartRateData.isEmpty {
-                emptyStateView
-            } else {
+            if dataSet.canPlotLine {
                 chartView
+            } else {
+                unavailableChartView
             }
         }
     }
@@ -121,21 +153,25 @@ struct HeartRateChartView: View {
                 Spacer()
 
                 HStack(spacing: 16) {
-                    HStack(spacing: 4) {
-                        Text("Avg")
-                            .font(.montserratRegular(size: 12))
-                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
-                        Text("\(averageHeartRate)")
-                            .font(.montserratBold(size: 14))
-                            .foregroundStyle(.red)
+                    if let averageHeartRate {
+                        HStack(spacing: 4) {
+                            Text("Avg")
+                                .font(.montserratRegular(size: 12))
+                                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+                            Text("\(averageHeartRate)")
+                                .font(.montserratBold(size: 14))
+                                .foregroundStyle(.red)
+                        }
                     }
-                    HStack(spacing: 4) {
-                        Text("Max")
-                            .font(.montserratRegular(size: 12))
-                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
-                        Text("\(maxHeartRate)")
-                            .font(.montserratBold(size: 14))
-                            .foregroundStyle(.red)
+                    if let maxHeartRate {
+                        HStack(spacing: 4) {
+                            Text("Max")
+                                .font(.montserratRegular(size: 12))
+                                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.5) : .gray)
+                            Text("\(maxHeartRate)")
+                                .font(.montserratBold(size: 14))
+                                .foregroundStyle(.red)
+                        }
                     }
                 }
             }
@@ -147,7 +183,7 @@ struct HeartRateChartView: View {
                     Text("\(selected.heartRate) BPM")
                         .font(.montserratBold(size: 16))
                         .foregroundStyle(.red)
-                    Text("at \(formatDuration(selected.timestamp.timeIntervalSince(actualStartTime)))")
+                    Text("at \(formatDuration(selected.elapsed))")
                         .font(.montserratRegular(size: 12))
                         .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
                 }
@@ -157,13 +193,13 @@ struct HeartRateChartView: View {
         .animation(.easeInOut(duration: 0.15), value: computedSelectedPoint != nil)
     }
     
-    private var emptyStateView: some View {
+    private var unavailableChartView: some View {
         VStack(spacing: 12) {
             Image(systemName: "heart.slash")
                 .font(.system(size: 32, weight: .light))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.4) : .gray)
             
-            Text("No heart rate data available")
+            Text(heartRateData.isEmpty ? "No heart-rate samples available" : "Not enough heart-rate samples to chart")
                 .font(.montserratRegular(size: 14))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.7) : .gray)
         }
@@ -181,19 +217,17 @@ struct HeartRateChartView: View {
     
     private var chartView: some View {
         Chart {
-            ForEach(Array(chartData.enumerated()), id: \.offset) { _, data in
+            ForEach(dataSet.points) { data in
                 heartRateLineMark(data: data)
             }
             
-            // Selected point indicators
             if let selected = computedSelectedPoint {
-                let elapsed = selected.timestamp.timeIntervalSince(actualStartTime)
-                selectedPointMarks(elapsed: elapsed, heartRate: selected.heartRate)
+                selectedPointMarks(elapsed: selected.elapsed, heartRate: selected.heartRate)
             }
         }
         .frame(height: 200)
-        .chartXScale(domain: 0...actualDuration)
-        .chartYScale(domain: heartRateRange)
+        .chartXScale(domain: 0...dataSet.duration)
+        .chartYScale(domain: dataSet.heartRateRange)
         .padding(16)
         .chartXAxis { xAxisMarks }
         .chartYAxis { yAxisMarks }
@@ -222,7 +256,7 @@ struct HeartRateChartView: View {
         }
     }
     
-    private func heartRateLineMark(data: (elapsed: TimeInterval, heartRate: Int)) -> some ChartContent {
+    private func heartRateLineMark(data: HeartRateChartPoint) -> some ChartContent {
         LineMark(
             x: .value("Time", data.elapsed),
             y: .value("Heart Rate", data.heartRate)
@@ -246,9 +280,9 @@ struct HeartRateChartView: View {
     }
     
     private var xAxisMarks: some AxisContent {
-        AxisMarks(values: [0, actualDuration / 4, actualDuration / 2, 3 * actualDuration / 4, actualDuration]) { value in
+        AxisMarks(values: [0, dataSet.duration / 4, dataSet.duration / 2, 3 * dataSet.duration / 4, dataSet.duration]) { value in
             if let elapsed = value.as(Double.self) {
-                let anchor: UnitPoint = elapsed == actualDuration ? .topTrailing : (elapsed == 0 ? .topLeading : .top)
+                let anchor: UnitPoint = elapsed == dataSet.duration ? .topTrailing : (elapsed == 0 ? .topLeading : .top)
                 AxisValueLabel(anchor: anchor) {
                     Text(formatDuration(elapsed))
                         .font(.montserratRegular(size: 10))
@@ -263,7 +297,7 @@ struct HeartRateChartView: View {
     }
 
     private var yAxisMarks: some AxisContent {
-        AxisMarks(position: .leading, values: heartRateTickValues) { value in
+        AxisMarks(position: .leading, values: dataSet.heartRateTickValues) { value in
             if let heartRate = value.as(Int.self) {
                 AxisValueLabel {
                     Text("\(heartRate)")
@@ -311,7 +345,9 @@ struct HeartRateChartView: View {
     HeartRateChartView(
         heartRateData: sampleData,
         workoutStartTime: startTime,
-        workoutDuration: 1800
+        workoutDuration: 1800,
+        averageHeartRateBpm: 129,
+        maxHeartRateBpm: 200
     )
     .padding()
 }

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -306,8 +306,6 @@ struct WorkoutDetailView: View {
                 leftValue: workout.durationFormatted,
                 rightLabel: preferredMetric.displayName,
                 rightValue: formattedPrimaryMetric,
-                leftIsPR: false,
-                rightIsPR: false,
                 effectiveColorScheme: effectiveColorScheme
             )
 
@@ -320,11 +318,13 @@ struct WorkoutDetailView: View {
             }
 
             // Heart Rate Chart
-            if !workout.heartRateTimeSeries.isEmpty {
+            if !workout.heartRateTimeSeries.isEmpty || workout.avgHeartRate != nil || workout.maxHeartRate != nil {
                 HeartRateChartView(
                     heartRateData: workout.heartRateTimeSeries,
                     workoutStartTime: workout.date,
-                    workoutDuration: workout.duration
+                    workoutDuration: workout.duration,
+                    averageHeartRateBpm: workout.avgHeartRate,
+                    maxHeartRateBpm: workout.maxHeartRate
                 )
             }
 
@@ -333,7 +333,6 @@ struct WorkoutDetailView: View {
                 VerticalClimbCard(
                     value: verticalClimb.formatted(.number.precision(.fractionLength(1))),
                     unit: workout.verticalClimbUnit(measurementSystem: settingsManager.measurementSystem),
-                    isPR: false,
                     effectiveColorScheme: effectiveColorScheme
                 )
             }
@@ -688,8 +687,7 @@ struct WorkoutDetailView: View {
         if let pace = workout.pace(for: preferredMetric) {
             items.append(SecondaryStatItem(
                 label: "\(preferredMetric.unit)/Min",
-                value: pace.formatted(.number.precision(.fractionLength(1))),
-                isPR: false
+                value: pace.formatted(.number.precision(.fractionLength(1)))
             ))
         }
 
@@ -697,8 +695,7 @@ struct WorkoutDetailView: View {
         if let calories = workout.caloriesBurned {
             items.append(SecondaryStatItem(
                 label: "Calories",
-                value: "\(calories)",
-                isPR: false
+                value: "\(calories)"
             ))
         }
 
@@ -706,8 +703,7 @@ struct WorkoutDetailView: View {
         if let mets = workout.averageMETs {
             items.append(SecondaryStatItem(
                 label: "METs",
-                value: mets.formatted(.number.precision(.fractionLength(1))),
-                isPR: false
+                value: mets.formatted(.number.precision(.fractionLength(1)))
             ))
         }
 

--- a/AscendApp/Features/Workouts/Views/WorkoutImportSheet.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutImportSheet.swift
@@ -477,7 +477,7 @@ struct WorkoutImportSheet: View {
                     failedCount: 0
                 )
                 showingCelebration = true
-            case .updatedExisting, .failed:
+            case .updatedExisting, .skipped, .failed:
                 break
             }
 

--- a/AscendApp/Shared/Models/Workout.swift
+++ b/AscendApp/Shared/Models/Workout.swift
@@ -316,6 +316,11 @@ class Workout {
         remoteSyncStatus = .failed
         lastRemoteSyncError = errorMessage
     }
+
+    func markRemoteSyncRejected(_ errorMessage: String) {
+        remoteSyncStatus = .rejected
+        lastRemoteSyncError = errorMessage
+    }
     
     // Computed properties for convenience
     var durationFormatted: String {

--- a/AscendApp/Shared/Models/WorkoutPlausibilityPolicy.swift
+++ b/AscendApp/Shared/Models/WorkoutPlausibilityPolicy.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+enum WorkoutPlausibilityPolicy {
+    static let maximumAverageStepsPerMinute: Double = 220
+
+    static func averageStepsPerMinute(
+        steps: Int,
+        duration: TimeInterval
+    ) -> Double? {
+        guard steps > 0, duration > 0 else { return nil }
+        return Double(steps) / (duration / 60)
+    }
+
+    static func hasPlausibleTotals(
+        steps: Int,
+        duration: TimeInterval
+    ) -> Bool {
+        guard steps >= 0, duration > 0 else { return false }
+        guard let averageStepsPerMinute = averageStepsPerMinute(
+            steps: steps,
+            duration: duration
+        ) else {
+            return true
+        }
+
+        return averageStepsPerMinute <= maximumAverageStepsPerMinute
+    }
+
+    static func hasPlausibleTotals(_ workout: Workout) -> Bool {
+        hasPlausibleTotals(steps: workout.steps, duration: workout.duration)
+    }
+}

--- a/AscendApp/Shared/Models/WorkoutRemoteSyncStatus.swift
+++ b/AscendApp/Shared/Models/WorkoutRemoteSyncStatus.swift
@@ -4,4 +4,5 @@ enum WorkoutRemoteSyncStatus: String, Codable, Sendable {
     case pendingUpsert
     case synced
     case failed
+    case rejected
 }

--- a/AscendApp/Shared/Repositories/Firebase/GzipCodec.swift
+++ b/AscendApp/Shared/Repositories/Firebase/GzipCodec.swift
@@ -3,22 +3,27 @@ import Foundation
 enum GzipCodec {
     enum Error: LocalizedError {
         case compressionFailed
+        case invalidGzipData
+        case decompressionFailed
 
         var errorDescription: String? {
             switch self {
             case .compressionFailed:
                 return "Failed to compress the heart-rate series."
+            case .invalidGzipData:
+                return "The heart-rate series is not valid gzip data."
+            case .decompressionFailed:
+                return "Failed to decompress the heart-rate series."
             }
         }
     }
 
     static func compress(_ data: Data) throws -> Data {
         guard let compressedNSData = try (data as NSData).compressed(using: .zlib) as Data?,
-              compressedNSData.count >= 6 else {
+              !compressedNSData.isEmpty else {
             throw Error.compressionFailed
         }
 
-        let deflatePayload = compressedNSData.dropFirst(2).dropLast(4)
         var gzipData = Data([
             0x1f, 0x8b, // magic
             0x08,       // deflate
@@ -27,7 +32,7 @@ enum GzipCodec {
             0x00,       // extra flags
             0xff        // OS unknown
         ])
-        gzipData.append(deflatePayload)
+        gzipData.append(compressedNSData)
 
         var crc32 = Self.crc32(for: data).littleEndian
         withUnsafeBytes(of: &crc32) { gzipData.append(contentsOf: $0) }
@@ -36,6 +41,23 @@ enum GzipCodec {
         withUnsafeBytes(of: &inputSize) { gzipData.append(contentsOf: $0) }
 
         return gzipData
+    }
+
+    static func decompress(_ data: Data) throws -> Data {
+        guard data.count >= 18,
+              data[0] == 0x1f,
+              data[1] == 0x8b,
+              data[2] == 0x08,
+              data[3] == 0x00 else {
+            throw Error.invalidGzipData
+        }
+
+        let compressedPayload = data.dropFirst(10).dropLast(8)
+        do {
+            return try (Data(compressedPayload) as NSData).decompressed(using: .zlib) as Data
+        } catch {
+            throw Error.decompressionFailed
+        }
     }
 }
 

--- a/AscendApp/Shared/Services/HealthKitMetricsReader.swift
+++ b/AscendApp/Shared/Services/HealthKitMetricsReader.swift
@@ -8,6 +8,36 @@
 import Foundation
 import HealthKit
 
+struct HeartRateSeriesPoint: Equatable, Sendable {
+    let timestamp: Date
+    let heartRate: Int
+    let parentSampleId: String?
+}
+
+private final class HeartRateSeriesAccumulator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var points: [HeartRateSeriesPoint] = []
+    private var errors: [String] = []
+
+    func append(_ point: HeartRateSeriesPoint) {
+        lock.withLock {
+            points.append(point)
+        }
+    }
+
+    func recordError(_ error: String) {
+        lock.withLock {
+            errors.append(error)
+        }
+    }
+
+    func snapshot() -> (points: [HeartRateSeriesPoint], errors: [String]) {
+        lock.withLock {
+            (points, errors)
+        }
+    }
+}
+
 struct WorkoutMetrics {
     var steps: Int?
     var avgHeartRate: Int?
@@ -54,7 +84,11 @@ final class HealthKitMetricsReader: HealthKitMetricsReading {
         let heartRateData = await fetchHeartRateData(during: dateRange)
         metrics.avgHeartRate = heartRateData.average
         metrics.maxHeartRate = heartRateData.maximum
-        metrics.heartRateTimeSeries = await fetchHeartRateTimeSeries(during: dateRange)
+        metrics.heartRateTimeSeries = await fetchHeartRateTimeSeries(
+            for: workout,
+            during: dateRange,
+            summary: heartRateData
+        )
 
         if let avgMetsQuantity = workout.metadata?["HKAverageMETs"] as? HKQuantity {
             let metsUnit = HKUnit.kilocalorie().unitDivided(
@@ -128,7 +162,11 @@ final class HealthKitMetricsReader: HealthKitMetricsReading {
         }
     }
 
-    private func fetchHeartRateTimeSeries(during dateRange: ClosedRange<Date>) async -> [HeartRateDataPoint] {
+    private func fetchHeartRateTimeSeries(
+        for workout: HKWorkout,
+        during dateRange: ClosedRange<Date>,
+        summary: (average: Int?, maximum: Int?)
+    ) async -> [HeartRateDataPoint] {
         guard let heartRateType = HKQuantityType.quantityType(forIdentifier: .heartRate) else {
             return []
         }
@@ -137,27 +175,198 @@ final class HealthKitMetricsReader: HealthKitMetricsReading {
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
         let unit = HKUnit.count().unitDivided(by: .minute())
 
-        return await withCheckedContinuation { continuation in
+        let parentSamples = await withCheckedContinuation { continuation in
             let query = HKSampleQuery(
                 sampleType: heartRateType,
                 predicate: predicate,
                 limit: HKObjectQueryNoLimit,
                 sortDescriptors: [sortDescriptor]
             ) { _, samples, _ in
-                let dataPoints = (samples as? [HKQuantitySample])?.map { sample in
-                    HeartRateDataPoint(
-                        timestamp: sample.startDate,
-                        heartRate: Int(sample.quantity.doubleValue(for: unit))
-                    )
-                } ?? []
-
-                continuation.resume(returning: dataPoints)
+                continuation.resume(returning: (samples as? [HKQuantitySample]) ?? [])
             }
 
             healthStore.execute(query)
         }
+
+        let parentDataPoints = parentSamples.map { sample in
+            HeartRateDataPoint(
+                timestamp: sample.startDate,
+                heartRate: Int(sample.quantity.doubleValue(for: unit))
+            )
+        }
+
+        let seriesPoints = await fetchHeartRateSeriesPoints(
+            heartRateType: heartRateType,
+            predicate: predicate,
+            unit: unit
+        )
+        let seriesDataPoints = Self.heartRateDataPoints(
+            from: seriesPoints.points,
+            within: dateRange
+        )
+
+        #if DEBUG
+        logHeartRateImportDiagnostics(
+            workout: workout,
+            dateRange: dateRange,
+            parentSamples: parentSamples,
+            parentDataPoints: parentDataPoints,
+            seriesPoints: seriesPoints,
+            importedDataPoints: seriesDataPoints.isEmpty ? parentDataPoints : seriesDataPoints,
+            importedFromSeries: !seriesDataPoints.isEmpty,
+            unit: unit,
+            summary: summary
+        )
+        #endif
+
+        return seriesDataPoints.isEmpty ? parentDataPoints : seriesDataPoints
+    }
+
+    nonisolated static func heartRateDataPoints(
+        from seriesPoints: [HeartRateSeriesPoint],
+        within dateRange: ClosedRange<Date>
+    ) -> [HeartRateDataPoint] {
+        seriesPoints
+            .filter { point in
+                dateRange.contains(point.timestamp) && point.heartRate > 0
+            }
+            .sorted { lhs, rhs in
+                if lhs.timestamp == rhs.timestamp {
+                    return lhs.heartRate < rhs.heartRate
+                }
+                return lhs.timestamp < rhs.timestamp
+            }
+            .map { point in
+                HeartRateDataPoint(timestamp: point.timestamp, heartRate: point.heartRate)
+            }
+    }
+
+    private func fetchHeartRateSeriesPoints(
+        heartRateType: HKQuantityType,
+        predicate: NSPredicate,
+        unit: HKUnit
+    ) async -> (points: [HeartRateSeriesPoint], errors: [String]) {
+        await withCheckedContinuation { continuation in
+            let accumulator = HeartRateSeriesAccumulator()
+            let query = HKQuantitySeriesSampleQuery(
+                quantityType: heartRateType,
+                predicate: predicate
+            ) { _, quantity, dateInterval, quantitySample, done, error in
+                if let error {
+                    accumulator.recordError(error.localizedDescription)
+                }
+
+                if let quantity, let dateInterval {
+                    accumulator.append(
+                        HeartRateSeriesPoint(
+                            timestamp: dateInterval.start,
+                            heartRate: Int(quantity.doubleValue(for: unit)),
+                            parentSampleId: quantitySample?.uuid.uuidString
+                        )
+                    )
+                }
+
+                if done {
+                    continuation.resume(returning: accumulator.snapshot())
+                }
+            }
+            query.includeSample = true
+            query.orderByQuantitySampleStartDate = true
+            healthStore.execute(query)
+        }
     }
 }
+
+#if DEBUG
+private extension HealthKitMetricsReader {
+    func logHeartRateImportDiagnostics(
+        workout: HKWorkout,
+        dateRange: ClosedRange<Date>,
+        parentSamples: [HKQuantitySample],
+        parentDataPoints: [HeartRateDataPoint],
+        seriesPoints: (points: [HeartRateSeriesPoint], errors: [String]),
+        importedDataPoints: [HeartRateDataPoint],
+        importedFromSeries: Bool,
+        unit: HKUnit,
+        summary: (average: Int?, maximum: Int?)
+    ) {
+        let groupedSeriesCounts = Dictionary(grouping: seriesPoints.points, by: \.parentSampleId)
+            .mapValues(\.count)
+        let importedSource = importedFromSeries ? "quantitySeries" : "parentSamples"
+
+        print(
+            """
+            [HK-HR-IMPORT] workout=\(workout.uuid.uuidString) name=\(workout.workoutActivityType.rawValue) \
+            range=\(Self.debugDate(dateRange.lowerBound))...\(Self.debugDate(dateRange.upperBound)) \
+            duration=\(workout.duration) source=\(workout.sourceRevision.source.name) bundle=\(workout.sourceRevision.source.bundleIdentifier) \
+            device=\(workout.device?.name ?? "nil") avg=\(summary.average.map(String.init) ?? "nil") max=\(summary.maximum.map(String.init) ?? "nil") \
+            parentSamples=\(parentSamples.count) parentMappedPoints=\(parentDataPoints.count) seriesChildPoints=\(seriesPoints.points.count) \
+            importedPoints=\(importedDataPoints.count) importedSource=\(importedSource)
+            """
+        )
+
+        if !seriesPoints.errors.isEmpty {
+            print("[HK-HR-IMPORT] seriesErrors=\(seriesPoints.errors.joined(separator: " | "))")
+        }
+
+        logParentSamples(parentSamples, unit: unit, seriesCountsByParentId: groupedSeriesCounts)
+        logSeriesPointSummary(seriesPoints.points)
+    }
+
+    func logParentSamples(
+        _ samples: [HKQuantitySample],
+        unit: HKUnit,
+        seriesCountsByParentId: [String?: Int]
+    ) {
+        let indexes = Self.diagnosticIndexes(totalCount: samples.count)
+        for index in indexes {
+            if index == -1 {
+                print("[HK-HR-IMPORT] parentSamples omitted middle count=\(max(samples.count - 18, 0))")
+                continue
+            }
+
+            let sample = samples[index]
+            let heartRate = Int(sample.quantity.doubleValue(for: unit))
+            let childCount = seriesCountsByParentId[sample.uuid.uuidString] ?? 0
+            print(
+                """
+                [HK-HR-IMPORT] parent[\(index)] uuid=\(sample.uuid.uuidString) bpm=\(heartRate) \
+                count=\(sample.count) childQuantities=\(childCount) \
+                start=\(Self.debugDate(sample.startDate)) end=\(Self.debugDate(sample.endDate)) \
+                source=\(sample.sourceRevision.source.name) bundle=\(sample.sourceRevision.source.bundleIdentifier) \
+                device=\(sample.device?.name ?? "nil")
+                """
+            )
+        }
+    }
+
+    func logSeriesPointSummary(_ points: [HeartRateSeriesPoint]) {
+        guard !points.isEmpty else { return }
+
+        let rates = points.map(\.heartRate)
+        let parentIds = Set(points.compactMap(\.parentSampleId))
+        print(
+            """
+            [HK-HR-IMPORT] seriesSummary count=\(points.count) parentIds=\(parentIds.count) \
+            first=\(Self.debugDate(points[0].timestamp)):\(points[0].heartRate) \
+            last=\(Self.debugDate(points[points.count - 1].timestamp)):\(points[points.count - 1].heartRate) \
+            min=\(rates.min() ?? 0) max=\(rates.max() ?? 0)
+            """
+        )
+    }
+
+    static func diagnosticIndexes(totalCount: Int) -> [Int] {
+        guard totalCount > 18 else { return Array(0..<totalCount) }
+        return Array(0..<12) + [-1] + Array((totalCount - 6)..<totalCount)
+    }
+
+    static func debugDate(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}
+#endif
 
 extension HKWorkout {
     func toAscendWorkout(with metrics: WorkoutMetrics, stepsPerFloor: Int) -> Workout {

--- a/AscendApp/Shared/Services/UserBaselineService.swift
+++ b/AscendApp/Shared/Services/UserBaselineService.swift
@@ -34,7 +34,10 @@ struct UserBaselineService {
     static func validSPMValues(from workouts: [Workout]) -> [Double] {
         workouts.compactMap { workout in
             guard let stepsPerMinute = workout.stepsPerMinute else { return nil }
-            guard workout.duration >= 300, stepsPerMinute < 190, !workout.hasWeights else { return nil }
+            guard workout.duration >= 300,
+                  WorkoutPlausibilityPolicy.hasPlausibleTotals(workout),
+                  stepsPerMinute < 190,
+                  !workout.hasWeights else { return nil }
             return stepsPerMinute
         }
     }

--- a/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
@@ -55,6 +55,7 @@ final class WorkoutImportCoordinator {
     enum ImportOutcome {
         case imported(Workout)
         case updatedExisting(Workout)
+        case skipped(candidateID: String)
         case failed(candidateID: String)
     }
 
@@ -310,6 +311,8 @@ final class WorkoutImportCoordinator {
             } catch {
                 lastErrorMessage = error.localizedDescription
             }
+        case .skipped(let candidateID):
+            pendingCandidates.removeAll { $0.id == candidateID }
         case .failed:
             break
         }
@@ -799,6 +802,8 @@ final class WorkoutImportCoordinator {
             case .updatedExisting(let workout):
                 updatedWorkouts.append(workout)
                 pendingCandidates.removeAll { $0.id == candidate.id }
+            case .skipped(let candidateID):
+                pendingCandidates.removeAll { $0.id == candidateID }
             case .failed(let candidateID):
                 failedCandidateIDs.append(candidateID)
             }
@@ -873,6 +878,10 @@ final class WorkoutImportCoordinator {
         let metrics = await metricsReader.fetchMetrics(for: hkWorkout)
         let settings = SettingsManager.shared
         let workout = hkWorkout.toAscendWorkout(with: metrics, stepsPerFloor: settings.stepsPerFloor)
+        guard WorkoutPlausibilityPolicy.hasPlausibleTotals(workout) else {
+            ignoredAppleHealthWorkoutStore.insert(sample.externalRecordID)
+            return .skipped(candidateID: candidate.id)
+        }
         let appleHealthLink = makeAppleHealthSourceLink(from: sample, workout: workout)
 
         let refreshedIndex = try buildExistingWorkoutIndex(modelContext: modelContext)
@@ -917,6 +926,16 @@ final class WorkoutImportCoordinator {
         } else {
             steps = metricValue
             floors = Workout.stepsToFloors(metricValue, stepsPerFloor: stepsPerFloor)
+        }
+
+        guard WorkoutPlausibilityPolicy.hasPlausibleTotals(
+            steps: steps,
+            duration: candidate.duration
+        ) else {
+            if let externalRecordID = candidate.appleHealthSample?.externalRecordID {
+                ignoredAppleHealthWorkoutStore.insert(externalRecordID)
+            }
+            return .skipped(candidateID: candidate.id)
         }
 
         if let existingWorkoutID = candidate.existingWorkoutID,

--- a/AscendApp/Shared/Services/WorkoutRemoteSyncMapper.swift
+++ b/AscendApp/Shared/Services/WorkoutRemoteSyncMapper.swift
@@ -10,6 +10,10 @@ enum WorkoutRemoteSyncMapper {
             throw WorkoutSyncError.unsupportedSource(workout.source.rawValue)
         }
 
+        guard WorkoutPlausibilityPolicy.hasPlausibleTotals(workout) else {
+            throw WorkoutSyncError.implausibleWorkoutTotals
+        }
+
         let media = workout.photos.isEmpty
             ? nil
             : workout.photos.map { photo in

--- a/AscendApp/Shared/Services/WorkoutSyncCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutSyncCoordinator.swift
@@ -255,15 +255,26 @@ private extension WorkoutSyncCoordinator {
             sortBy: [SortDescriptor(\Workout.lastModifiedAt)]
         )
 
-        return try modelContext.fetch(descriptor)
+        let workouts = try modelContext.fetch(descriptor)
             .filter { workout in
                 guard !pendingDeletionIds.contains(workout.id) else { return false }
                 let status = workout.remoteSyncStatus
                 return status == .pendingUpsert || status == .failed
             }
-            .map { workout in
-                try WorkoutRemoteSyncMapper.snapshot(from: workout)
+
+        var snapshots: [WorkoutRemoteSyncSnapshot] = []
+        for workout in workouts {
+            do {
+                snapshots.append(try WorkoutRemoteSyncMapper.snapshot(from: workout))
+            } catch WorkoutSyncError.implausibleWorkoutTotals {
+                workout.markRemoteSyncRejected(WorkoutSyncError.implausibleWorkoutTotals.localizedDescription)
+                try modelContext.save()
+            } catch {
+                throw error
             }
+        }
+
+        return snapshots
     }
 
     func loadPendingDeletions(

--- a/AscendApp/Shared/Services/WorkoutSyncError.swift
+++ b/AscendApp/Shared/Services/WorkoutSyncError.swift
@@ -5,6 +5,7 @@ enum WorkoutSyncError: LocalizedError {
     case missingOwner
     case unsupportedSource(String)
     case invalidHeartRateSeries
+    case implausibleWorkoutTotals
 
     var errorDescription: String? {
         switch self {
@@ -16,6 +17,8 @@ enum WorkoutSyncError: LocalizedError {
             return "Workout sync does not support source '\(source)' yet."
         case .invalidHeartRateSeries:
             return "Heart-rate samples must include at least one entry."
+        case .implausibleWorkoutTotals:
+            return "Workout totals are outside the supported range."
         }
     }
 }

--- a/AscendAppTests/BestEffortRankingBuilderTests.swift
+++ b/AscendAppTests/BestEffortRankingBuilderTests.swift
@@ -145,9 +145,10 @@ struct BestEffortRankingBuilderTests {
         let liveWorkout = makeLiveClimbWorkout(
             name: "Sampled Live Climb",
             date: referenceDate,
-            duration: 300,
+            duration: 1_800,
             steps: 3_000,
-            splitSteps: [0, 400, 1_000, 2_000, 2_600, 3_000]
+            splitSteps: [0, 1_000, 1_800, 2_400, 2_800, 3_000],
+            intervalSeconds: 300
         )
         let importWithoutTimeline = makeWorkout(
             name: "Apple Health Import",
@@ -168,10 +169,41 @@ struct BestEffortRankingBuilderTests {
         let mostStepsInFive = try #require(board.category(.mostStepsInTime(minutes: 5))?.efforts.first)
 
         #expect(fastestThousand.workout.id == liveWorkout.id)
-        #expect(fastestThousand.valueText == "1:00")
-        #expect(fastestThousand.detailText.contains("2:00-3:00"))
+        #expect(fastestThousand.valueText == "5:00")
+        #expect(fastestThousand.detailText.contains("0:00-5:00"))
         #expect(mostStepsInFive.workout.id == liveWorkout.id)
-        #expect(mostStepsInFive.valueText == "3,000 steps")
+        #expect(mostStepsInFive.valueText == "1,000 steps")
+    }
+
+    @Test
+    func filtersImplausibleWorkoutTotalsFromBestEfforts() throws {
+        let referenceDate = date(year: 2026, month: 5, day: 10)
+        let impossible = makeWorkout(
+            name: "Bad Legacy Import",
+            date: date(year: 2024, month: 8, day: 21),
+            duration: 67.5363039970398,
+            steps: 966,
+            source: .appleHealth
+        )
+        let plausible = makeWorkout(
+            name: "Real Climb",
+            date: referenceDate,
+            duration: 1_200,
+            steps: 2_400
+        )
+
+        let board = BestEffortRankingBuilder.board(
+            from: [impossible, plausible],
+            scope: .allTime,
+            context: .all,
+            referenceDate: referenceDate
+        )
+
+        #expect(board.allEfforts.allSatisfy { $0.workout.id != impossible.id })
+
+        let highestAverageSPM = try #require(board.category(.highestAverageSPM)?.efforts.first)
+        #expect(highestAverageSPM.workout.id == plausible.id)
+        #expect(highestAverageSPM.valueText == "120 SPM")
     }
 
     @Test
@@ -255,14 +287,15 @@ struct BestEffortRankingBuilderTests {
         date: Date,
         duration: TimeInterval,
         steps: Int,
-        splitSteps: [Int]
+        splitSteps: [Int],
+        intervalSeconds: Int = 60
     ) -> Workout {
         let metadata = HeadphoneMotionWorkoutMetadata(
             sampleCount: splitSteps.count,
             climbId: "test-climb",
             targetStepCount: steps,
             stopReason: .targetReached,
-            splitCurve: LiveReplaySplitCurve(intervalSeconds: 60, steps: splitSteps)
+            splitCurve: LiveReplaySplitCurve(intervalSeconds: intervalSeconds, steps: splitSteps)
         )
 
         return Workout(

--- a/AscendAppTests/FirestoreWorkoutDocumentTests.swift
+++ b/AscendAppTests/FirestoreWorkoutDocumentTests.swift
@@ -133,6 +133,27 @@ struct FirestoreWorkoutDocumentTests {
         #expect(decoded.schemaVersion == WorkoutHeartRateStorageBlob.currentSchemaVersion)
     }
 
+    @Test
+    func heartRateStorageBlobCompressionProducesReadableGzip() throws {
+        let start = makeDate(year: 2026, month: 4, day: 10, hour: 6)
+        let blob = WorkoutHeartRateStorageBlob(
+            workoutId: "550e8400-e29b-41d4-a716-446655440000",
+            samples: [
+                HeartRateDataPoint(timestamp: start, heartRate: 118),
+                HeartRateDataPoint(timestamp: start.addingTimeInterval(300), heartRate: 132)
+            ]
+        )
+        let encoded = try JSONEncoder().encode(blob)
+
+        let compressed = try GzipCodec.compress(encoded)
+        let decompressed = try GzipCodec.decompress(compressed)
+        let decoded = try JSONDecoder().decode(WorkoutHeartRateStorageBlob.self, from: decompressed)
+
+        #expect(compressed.starts(with: Data([0x1f, 0x8b, 0x08])))
+        #expect(decompressed == encoded)
+        #expect(decoded == blob)
+    }
+
     private func makeDate(
         year: Int,
         month: Int,

--- a/AscendAppTests/HealthKitMetricsReaderHeartRateSeriesTests.swift
+++ b/AscendAppTests/HealthKitMetricsReaderHeartRateSeriesTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct HealthKitMetricsReaderHeartRateSeriesTests {
+    @Test
+    func mapsQuantitySeriesChildrenIntoSavedHeartRateSamples() {
+        let start = makeDate(year: 2024, month: 4, day: 28, hour: 14, minute: 19)
+        let end = start.addingTimeInterval(668)
+
+        let samples = HealthKitMetricsReader.heartRateDataPoints(
+            from: [
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(30), heartRate: 55, parentSampleId: "parent-1"),
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(300), heartRate: 153, parentSampleId: "parent-1"),
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(660), heartRate: 172, parentSampleId: "parent-1")
+            ],
+            within: start...end
+        )
+
+        #expect(samples == [
+            HeartRateDataPoint(timestamp: start.addingTimeInterval(30), heartRate: 55),
+            HeartRateDataPoint(timestamp: start.addingTimeInterval(300), heartRate: 153),
+            HeartRateDataPoint(timestamp: start.addingTimeInterval(660), heartRate: 172)
+        ])
+    }
+
+    @Test
+    func dropsInvalidAndOutOfWindowQuantitySeriesChildren() {
+        let start = makeDate(year: 2024, month: 5, day: 9, hour: 23, minute: 21)
+        let end = start.addingTimeInterval(1_111)
+
+        let samples = HealthKitMetricsReader.heartRateDataPoints(
+            from: [
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(-1), heartRate: 95, parentSampleId: "before"),
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(10), heartRate: 104, parentSampleId: "parent-1"),
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(900), heartRate: 170, parentSampleId: "parent-2"),
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(1_112), heartRate: 151, parentSampleId: "after"),
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(500), heartRate: 0, parentSampleId: "invalid")
+            ],
+            within: start...end
+        )
+
+        #expect(samples == [
+            HeartRateDataPoint(timestamp: start.addingTimeInterval(10), heartRate: 104),
+            HeartRateDataPoint(timestamp: start.addingTimeInterval(900), heartRate: 170)
+        ])
+    }
+
+    @Test
+    func sortsQuantitySeriesChildrenBeforeSaving() {
+        let start = makeDate(year: 2026, month: 1, day: 3, hour: 14, minute: 47)
+        let end = start.addingTimeInterval(3_609)
+
+        let samples = HealthKitMetricsReader.heartRateDataPoints(
+            from: [
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(1_000), heartRate: 160, parentSampleId: "parent-2"),
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(5), heartRate: 79, parentSampleId: "parent-1"),
+                HeartRateSeriesPoint(timestamp: start.addingTimeInterval(3_600), heartRate: 167, parentSampleId: "parent-4")
+            ],
+            within: start...end
+        )
+
+        #expect(samples.map(\.heartRate) == [79, 160, 167])
+        #expect(samples.map(\.timestamp) == [
+            start.addingTimeInterval(5),
+            start.addingTimeInterval(1_000),
+            start.addingTimeInterval(3_600)
+        ])
+    }
+
+    private func makeDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int = 0
+    ) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return components.date!
+    }
+}

--- a/AscendAppTests/HeartRateChartDataSetTests.swift
+++ b/AscendAppTests/HeartRateChartDataSetTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct HeartRateChartDataSetTests {
+    @Test
+    func oneSampleIsNotEnoughForLineChart() {
+        let start = makeDate(year: 2024, month: 5, day: 12, hour: 14, minute: 17)
+        let dataSet = HeartRateChartDataSet(
+            samples: [
+                HeartRateDataPoint(timestamp: start.addingTimeInterval(5), heartRate: 154)
+            ],
+            workoutStartTime: start,
+            workoutDuration: 1_292
+        )
+
+        #expect(dataSet.points.count == 1)
+        #expect(dataSet.canPlotLine == false)
+        #expect(dataSet.heartRateRange == 149...159)
+    }
+
+    @Test
+    func twoSparseSamplesAreNotEnoughForLineChart() {
+        let start = makeDate(year: 2024, month: 5, day: 9, hour: 23, minute: 21)
+        let dataSet = HeartRateChartDataSet(
+            samples: [
+                HeartRateDataPoint(timestamp: start.addingTimeInterval(10), heartRate: 153),
+                HeartRateDataPoint(timestamp: start.addingTimeInterval(1_010), heartRate: 164)
+            ],
+            workoutStartTime: start,
+            workoutDuration: 1_111
+        )
+
+        #expect(dataSet.points.count == 2)
+        #expect(dataSet.canPlotLine == false)
+        #expect(dataSet.duration == 1_111)
+    }
+
+    @Test
+    func threeSamplesCanPlotAcrossWorkoutDuration() {
+        let start = makeDate(year: 2026, month: 5, day: 10, hour: 15, minute: 5)
+        let dataSet = HeartRateChartDataSet(
+            samples: [
+                HeartRateDataPoint(timestamp: start.addingTimeInterval(5), heartRate: 118),
+                HeartRateDataPoint(timestamp: start.addingTimeInterval(300), heartRate: 132),
+                HeartRateDataPoint(timestamp: start.addingTimeInterval(600), heartRate: 145)
+            ],
+            workoutStartTime: start,
+            workoutDuration: 780
+        )
+
+        #expect(dataSet.canPlotLine)
+        #expect(dataSet.points.map(\.elapsed) == [5.0, 300.0, 600.0])
+        #expect(dataSet.duration == 780)
+    }
+
+    private func makeDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int = 0
+    ) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        components.minute = minute
+        return components.date!
+    }
+}

--- a/AscendAppTests/WorkoutInputValidationTests.swift
+++ b/AscendAppTests/WorkoutInputValidationTests.swift
@@ -31,6 +31,27 @@ struct WorkoutInputValidationTests {
     }
 
     @Test
+    func workoutTotalsRejectImplausibleAverageStepPace() {
+        #expect(WorkoutInputValidation.isValidWorkoutTotals(
+            metricValue: "966",
+            preferredMetric: .steps,
+            stepsPerFloor: 16,
+            durationHours: 0,
+            durationMinutes: 1,
+            durationSeconds: 7
+        ) == false)
+
+        #expect(WorkoutInputValidation.isValidWorkoutTotals(
+            metricValue: "2117",
+            preferredMetric: .steps,
+            stepsPerFloor: 16,
+            durationHours: 0,
+            durationMinutes: 18,
+            durationSeconds: 51
+        ))
+    }
+
+    @Test
     func heartRateNormalizationClampsToSupportedRange() {
         #expect(WorkoutInputValidation.normalizeHeartRateOnSubmit("") == "")
         #expect(WorkoutInputValidation.normalizeHeartRateOnSubmit("12") == "25")

--- a/AscendAppTests/WorkoutPlausibilityPolicyTests.swift
+++ b/AscendAppTests/WorkoutPlausibilityPolicyTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import AscendApp
+
+struct WorkoutPlausibilityPolicyTests {
+    @Test
+    func rejectsImplausibleAverageStepPace() {
+        #expect(WorkoutPlausibilityPolicy.hasPlausibleTotals(
+            steps: 966,
+            duration: 67.5363039970398
+        ) == false)
+    }
+
+    @Test
+    func acceptsStrongButPlausibleAverageStepPace() {
+        #expect(WorkoutPlausibilityPolicy.hasPlausibleTotals(
+            steps: 2_117,
+            duration: 1_131.0771219730375
+        ))
+    }
+
+    @Test
+    func allowsWorkoutsWithoutStepTotals() {
+        #expect(WorkoutPlausibilityPolicy.hasPlausibleTotals(
+            steps: 0,
+            duration: 1_800
+        ))
+    }
+}

--- a/AscendAppTests/WorkoutSyncCoordinatorTests.swift
+++ b/AscendAppTests/WorkoutSyncCoordinatorTests.swift
@@ -106,6 +106,45 @@ struct WorkoutSyncCoordinatorTests {
     }
 
     @Test
+    func implausiblePendingWorkoutIsRejectedAndDoesNotBlockValidSync() async throws {
+        let modelContext = try makeModelContext()
+        let invalidWorkout = makeWorkout(
+            date: makeDate(year: 2024, month: 8, day: 21, hour: 8),
+            duration: 67.5363039970398,
+            steps: 966
+        )
+        invalidWorkout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: invalidWorkout.createdAt)
+        let validWorkout = makeWorkout(date: makeDate(year: 2026, month: 4, day: 13, hour: 9))
+        validWorkout.markPendingRemoteUpsert(ownerUserId: "user-123", modifiedAt: validWorkout.createdAt)
+        modelContext.insert(invalidWorkout)
+        modelContext.insert(validWorkout)
+        try modelContext.save()
+
+        let remoteRepository = FakeWorkoutRemoteRepository()
+        let heartRateRepository = FakeWorkoutHeartRateStorageRepository()
+        let coordinator = WorkoutSyncCoordinator(
+            remoteRepository: remoteRepository,
+            heartRateStorageRepository: heartRateRepository,
+            operationTimeoutSeconds: 1
+        )
+
+        await coordinator.processPendingWorkouts(
+            modelContext: modelContext,
+            currentUserId: "user-123"
+        )
+
+        let workouts = try fetchWorkouts(in: modelContext)
+        let rejectedWorkout = try #require(workouts.first { $0.id == invalidWorkout.id })
+        let syncedWorkout = try #require(workouts.first { $0.id == validWorkout.id })
+        #expect(rejectedWorkout.remoteSyncStatus == .rejected)
+        #expect(rejectedWorkout.lastRemoteSyncError?.isEmpty == false)
+        #expect(syncedWorkout.remoteSyncStatus == .synced)
+
+        let upserts = await remoteRepository.recordedUpserts()
+        #expect(upserts.map(\.workoutId) == [validWorkout.id])
+    }
+
+    @Test
     func heartRateUploadFailureMarksWorkoutFailedWithoutUpsertingDocument() async throws {
         let modelContext = try makeModelContext()
         let workout = makeWorkout(
@@ -452,14 +491,16 @@ struct WorkoutSyncCoordinatorTests {
 
     private func makeWorkout(
         date: Date,
+        duration: TimeInterval = 1_800,
+        steps: Int = 1_000,
         heartRateSamples: [HeartRateDataPoint] = []
     ) -> Workout {
         Workout(
             name: "Workout",
             date: date,
-            duration: 1_800,
-            steps: 1_000,
-            floors: 63,
+            duration: duration,
+            steps: steps,
+            floors: Workout.stepsToFloors(steps, stepsPerFloor: 16),
             stepsPerFloor: 16,
             notes: "Test",
             heartRateTimeSeries: heartRateSamples.isEmpty ? nil : heartRateSamples,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,9 @@ Workout, WorkoutSourceLink, WorkoutParticipation, LeaderboardStats, Routine, Rou
 ### Import UX
 - Workout import supports individual import, selected-batch import, and import-all from the same sheet.
 - Import architecture uses one canonical `Workout` plus local `WorkoutSourceLink` provenance records per provider. New import UI and state should flow through `WorkoutImportCoordinator`, not provider-specific views/services.
+- Workout totals must pass the shared `WorkoutPlausibilityPolicy` before manual save, edit, import, remote backup, and Best Efforts ranking. Keep implausible average-step-rate records out of new data, and independently ignore any legacy implausible rows in Best Efforts.
 - Apple Health is read-only. First connect may backfill historical workouts, but routine checks must stay incremental and sample-only until a workout is actually imported.
+- Apple Health heart-rate chart samples must expand condensed `HKQuantitySample` records using `HKQuantitySeriesSampleQuery` and save the individual quantities. Parent heart-rate samples may represent aggregate blocks and should only be used as a fallback when no series children are returned.
 - Apple Health auto-import is optional and user-controlled from the Apple Health manage sheet.
 - Auto-import only applies to newly finished Apple Health workouts from the moment the user enables it; older pending history remains in the manual review/import flow.
 - If older local settings have auto-import enabled but no stored activation timestamp, use the previous successful HealthKit check as the conservative activation fallback so newly discovered workouts can import without opening older pending history.


### PR DESCRIPTION
## Summary
- Expand Apple Health heart-rate quantity-series child samples before saving chart data, and keep sparse charts from drawing misleading lines.
- Remove the old workout-detail stat accent styling so vertical climb and other stat cards render neutrally.
- Add a shared workout plausibility policy and apply it at manual save/edit, import, auto-import review, remote backup, Best Efforts ranking, and baseline calibration.
- Reject implausible pending remote sync rows without blocking valid workout backups.

## Why
Some Apple Health workouts store detailed heart-rate quantities under aggregate parent samples, so using only the parent sample created missing or misleading charts. Separately, a stale bad workout row with impossible average SPM could still surface in Best Efforts even if current import filtering kept it from being reimported.

## Impact
New impossible workout totals are blocked before they enter normal app flows, and legacy implausible rows are ignored by Best Efforts. No existing Firebase or local workout data is deleted by this change.

## Validation
- XcodeBuildMCP `test_sim` focused suite: 55 passed, 0 failed
- Covered Best Efforts filtering, workout input validation, HealthKit heart-rate series mapping, heart-rate chart sparse-data handling, Firestore heart-rate sidecar encoding, import coordinator behavior, remote sync rejection, and remote sync migration tests.