### PR TITLE
Persist Best Effort cache for performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ functions/src/                  # Cloud Functions (TypeScript)
 ### Tab Architecture
 - `MainTabView` should use SwiftUI's native `TabView(selection:)` as the tab content owner and keep Ascend's custom `MainTabBarView` as the visible bottom chrome via `safeAreaInset`.
 - `TabItem` is metadata only. Do not store eager `AnyView` tab roots in tab configuration, and do not reintroduce a manual `ZStack` that keeps every tab mounted with opacity.
+- `MainTabView` should render only the selected tab root inside the `TabView` so hidden tabs stay unmounted and do not run SwiftData queries, refreshes, or animations. Per-tab navigation/scroll state loss is acceptable for now.
 - Each tab root owns its own `NavigationStack`; keep tab-specific work scoped to the selected tab where possible so hidden tabs do not run expensive queries, refreshes, or animations.
 
 ### Branding
@@ -92,6 +93,7 @@ Workout, WorkoutSourceLink, WorkoutParticipation, LeaderboardStats, Routine, Rou
 ### Best Efforts Architecture
 - Best Efforts are the only workout achievement layer. Do not reintroduce a parallel Personal Records system.
 - Workouts remain the source of truth. Best Efforts are derived from workout history for all-time and this-year scopes across all, bodyweight, weighted, and exact weight-loadout contexts.
+- Best Effort rankings are persisted as derived SwiftData cache rows. Views should read cheap cache snapshots/lookups and must not rebuild rankings from all workouts in `body`; rebuild the cache through `BestEffortCacheStore` after workout create/edit/delete/import mutations and during startup repair if the persisted signature is stale.
 - Weighted Best Efforts must distinguish exact loadouts using the full enabled equipment configuration, such as `20 lb Vest` versus `20 lb Vest + 5 lb each Ankle`.
 - Best Effort metrics are stepper-specific and step-first: most steps, longest climb, highest average SPM, sampled time windows, and sampled fastest step targets. Do not add floors-based Best Efforts unless product explicitly changes direction.
 - Timeline efforts require real sampled Live Climb progress data. Manual entries and total-only imports can contribute whole-workout efforts, but not rolling-window or fastest-segment efforts.

--- a/AscendApp/App/AscendApp.swift
+++ b/AscendApp/App/AscendApp.swift
@@ -68,10 +68,12 @@ struct AscendApp: App {
                 RoutineFolder.self,
                 ClimbAttempt.self,
                 PendingMediaUpload.self,
-                PendingWorkoutDeletion.self
+                PendingWorkoutDeletion.self,
+                BestEffortCacheEntry.self,
+                BestEffortCacheMetadata.self
             ]))
             return try ModelContainer(
-                for: Workout.self, WorkoutSourceLink.self, WorkoutParticipation.self, LeaderboardStats.self, Routine.self, RoutineFolder.self, ClimbAttempt.self, PendingMediaUpload.self, PendingWorkoutDeletion.self,
+                for: Workout.self, WorkoutSourceLink.self, WorkoutParticipation.self, LeaderboardStats.self, Routine.self, RoutineFolder.self, ClimbAttempt.self, PendingMediaUpload.self, PendingWorkoutDeletion.self, BestEffortCacheEntry.self, BestEffortCacheMetadata.self,
                 configurations: config
             )
         } catch {
@@ -100,10 +102,12 @@ struct AscendApp: App {
                     RoutineFolder.self,
                     ClimbAttempt.self,
                     PendingMediaUpload.self,
-                    PendingWorkoutDeletion.self
+                    PendingWorkoutDeletion.self,
+                    BestEffortCacheEntry.self,
+                    BestEffortCacheMetadata.self
                 ]))
                 return try ModelContainer(
-                    for: Workout.self, WorkoutSourceLink.self, WorkoutParticipation.self, LeaderboardStats.self, Routine.self, RoutineFolder.self, ClimbAttempt.self, PendingMediaUpload.self, PendingWorkoutDeletion.self,
+                    for: Workout.self, WorkoutSourceLink.self, WorkoutParticipation.self, LeaderboardStats.self, Routine.self, RoutineFolder.self, ClimbAttempt.self, PendingMediaUpload.self, PendingWorkoutDeletion.self, BestEffortCacheEntry.self, BestEffortCacheMetadata.self,
                     configurations: config
                 )
             } catch {

--- a/AscendApp/Features/Climbs/Views/LiveClimbCompletionSummaryView.swift
+++ b/AscendApp/Features/Climbs/Views/LiveClimbCompletionSummaryView.swift
@@ -8,7 +8,7 @@ struct LiveClimbCompletionSummaryView: View {
     let leaderboardTotal: Int?
     let onDone: () -> Void
 
-    @Query(sort: \Workout.date, order: .reverse) private var allWorkouts: [Workout]
+    @Query(sort: \BestEffortCacheEntry.sortKey) private var bestEffortCacheEntries: [BestEffortCacheEntry]
     @State private var showingShareSheet = false
     @State private var completionRank: LiveReplayCompletionRank?
     @State private var isLoadingCompletionRank = false
@@ -22,7 +22,11 @@ struct LiveClimbCompletionSummaryView: View {
     }
 
     private var primaryBestEffort: RankedBestEffort? {
-        BestEffortRankingBuilder.primaryEffort(for: workout, from: allWorkouts)
+        BestEffortCacheSnapshot(
+            entries: bestEffortCacheEntries,
+            workouts: [workout]
+        )
+        .primaryEffort(for: workout)
     }
 
     var body: some View {
@@ -687,4 +691,5 @@ private extension Int {
         leaderboardTotal: 2_460,
         onDone: {}
     )
+    .modelContainer(for: [Workout.self, BestEffortCacheEntry.self, BestEffortCacheMetadata.self], inMemory: true)
 }

--- a/AscendApp/Features/Home/Views/ProgressSheet.swift
+++ b/AscendApp/Features/Home/Views/ProgressSheet.swift
@@ -5,12 +5,14 @@
 //  Created by Tyler Pavay on 8/28/25.
 //
 
+import SwiftData
 import SwiftUI
 
 struct ProgressSheet: View {
     let workouts: [Workout]
 
     @Environment(\.colorScheme) private var colorScheme
+    @Query(sort: \BestEffortCacheEntry.sortKey) private var bestEffortCacheEntries: [BestEffortCacheEntry]
     @State private var themeManager = ThemeManager.shared
     @State private var settingsManager = SettingsManager.shared
     @State private var selectedDate = Date()
@@ -89,9 +91,12 @@ struct ProgressSheet: View {
     }
 
     // MARK: - Best Efforts
+    private var cacheSnapshot: BestEffortCacheSnapshot {
+        BestEffortCacheSnapshot(entries: bestEffortCacheEntries, workouts: workouts)
+    }
+
     private var bestEffortBoard: BestEffortBoard {
-        BestEffortRankingBuilder.board(
-            from: workouts,
+        cacheSnapshot.board(
             scope: .allTime,
             context: .all
         )
@@ -1026,8 +1031,9 @@ struct CalendarDay {
         Workout(name: "Two days ago", date: Calendar.current.date(byAdding: .day, value: -2, to: Date())!, duration: 2000, steps: 2000, floors: 125, stepsPerFloor: 16),
         Workout(name: "Week ago", date: Calendar.current.date(byAdding: .day, value: -7, to: Date())!, duration: 1500, steps: 1800, floors: 113, stepsPerFloor: 16)
     ]
-    
+
     ProgressSheet(workouts: sampleWorkouts)
+        .modelContainer(for: [Workout.self, BestEffortCacheEntry.self, BestEffortCacheMetadata.self], inMemory: true)
 }
 
 #Preview("Dark Mode") {
@@ -1036,7 +1042,8 @@ struct CalendarDay {
         Workout(name: "Yesterday", date: Calendar.current.date(byAdding: .day, value: -1, to: Date())!, duration: 1200, steps: 1500, floors: 94, stepsPerFloor: 16),
         Workout(name: "Two days ago", date: Calendar.current.date(byAdding: .day, value: -2, to: Date())!, duration: 2000, steps: 2000, floors: 125, stepsPerFloor: 16)
     ]
-    
+
     ProgressSheet(workouts: sampleWorkouts)
         .preferredColorScheme(.dark)
+        .modelContainer(for: [Workout.self, BestEffortCacheEntry.self, BestEffortCacheMetadata.self], inMemory: true)
 }

--- a/AscendApp/Features/Progress/Models/BestEffortCacheEntry.swift
+++ b/AscendApp/Features/Progress/Models/BestEffortCacheEntry.swift
@@ -1,0 +1,179 @@
+//
+//  BestEffortCacheEntry.swift
+//  AscendApp
+//
+//  Created by Codex on 5/15/26.
+//
+
+import Foundation
+import SwiftData
+
+enum BestEffortCacheEntryKind: String {
+    case ranked
+    case progression
+}
+
+@Model
+final class BestEffortCacheEntry {
+    var id: String
+    var kindRawValue: String
+    var metricID: String
+    var scopeRawValue: String
+    var contextID: String
+    var contextKindRawValue: String
+    var rank: Int
+    var workoutID: UUID
+    var value: Double
+    var steps: Int?
+    var duration: TimeInterval?
+    var segmentStartElapsedSeconds: Int?
+    var segmentEndElapsedSeconds: Int?
+    var generatedAt: Date
+    var cacheVersion: Int
+    var sortKey: String
+
+    init(
+        kind: BestEffortCacheEntryKind,
+        effort: RankedBestEffort,
+        generatedAt: Date,
+        cacheVersion: Int
+    ) {
+        let contextKind = effort.context.cacheKindRawValue
+        let entryID = [
+            kind.rawValue,
+            effort.metric.id,
+            effort.scope.rawValue,
+            effort.context.id,
+            "\(effort.rank)",
+            effort.workout.id.uuidString,
+            "\(effort.performance.segmentStartElapsedSeconds ?? -1)",
+            "\(effort.performance.segmentEndElapsedSeconds ?? -1)"
+        ].joined(separator: "|")
+
+        self.id = entryID
+        self.kindRawValue = kind.rawValue
+        self.metricID = effort.metric.id
+        self.scopeRawValue = effort.scope.rawValue
+        self.contextID = effort.context.id
+        self.contextKindRawValue = contextKind
+        self.rank = effort.rank
+        self.workoutID = effort.workout.id
+        self.value = effort.performance.value
+        self.steps = effort.performance.steps
+        self.duration = effort.performance.duration
+        self.segmentStartElapsedSeconds = effort.performance.segmentStartElapsedSeconds
+        self.segmentEndElapsedSeconds = effort.performance.segmentEndElapsedSeconds
+        self.generatedAt = generatedAt
+        self.cacheVersion = cacheVersion
+        self.sortKey = [
+            kind.rawValue,
+            effort.scope.rawValue,
+            effort.context.id,
+            effort.metric.id,
+            String(format: "%05d", effort.rank),
+            effort.workout.id.uuidString
+        ].joined(separator: "|")
+    }
+
+    var kind: BestEffortCacheEntryKind? {
+        BestEffortCacheEntryKind(rawValue: kindRawValue)
+    }
+
+    func rankedEffort(using workout: Workout) -> RankedBestEffort? {
+        guard let metric = BestEffortMetric.definition(for: metricID),
+              let scope = BestEffortScope(rawValue: scopeRawValue),
+              let context = BestEffortContext.cacheContext(
+                kindRawValue: contextKindRawValue,
+                id: contextID,
+                workout: workout
+              ) else {
+            return nil
+        }
+
+        let performance = BestEffortPerformance(
+            metric: metric,
+            workout: workout,
+            value: value,
+            steps: steps,
+            duration: duration,
+            segmentStartElapsedSeconds: segmentStartElapsedSeconds,
+            segmentEndElapsedSeconds: segmentEndElapsedSeconds
+        )
+
+        return RankedBestEffort(
+            metric: metric,
+            rank: rank,
+            scope: scope,
+            context: context,
+            performance: performance
+        )
+    }
+}
+
+@Model
+final class BestEffortCacheMetadata {
+    var id: String
+    var cacheVersion: Int
+    var workoutSignature: String
+    var referenceYear: Int
+    var generatedAt: Date
+    var entryCount: Int
+
+    init(
+        id: String,
+        cacheVersion: Int,
+        workoutSignature: String,
+        referenceYear: Int,
+        generatedAt: Date,
+        entryCount: Int
+    ) {
+        self.id = id
+        self.cacheVersion = cacheVersion
+        self.workoutSignature = workoutSignature
+        self.referenceYear = referenceYear
+        self.generatedAt = generatedAt
+        self.entryCount = entryCount
+    }
+}
+
+private extension BestEffortContext {
+    var cacheKindRawValue: String {
+        switch self {
+        case .all:
+            return "all"
+        case .bodyweight:
+            return "bodyweight"
+        case .weighted:
+            return "weighted"
+        case .exactWeight:
+            return "exactWeight"
+        }
+    }
+
+    static func cacheContext(
+        kindRawValue: String,
+        id: String,
+        workout: Workout
+    ) -> BestEffortContext? {
+        switch kindRawValue {
+        case "all":
+            return id == BestEffortContext.all.id ? .all : nil
+        case "bodyweight":
+            return id == BestEffortContext.bodyweight.id ? .bodyweight : nil
+        case "weighted":
+            return id == BestEffortContext.weighted.id ? .weighted : nil
+        case "exactWeight":
+            guard let loadout = workout.weightLoadoutKey else { return nil }
+            let context = BestEffortContext.exactWeight(loadout)
+            return context.id == id ? context : nil
+        default:
+            return nil
+        }
+    }
+}
+
+extension BestEffortMetric {
+    static func definition(for id: String) -> BestEffortMetric? {
+        allDefinitions.first { $0.id == id }
+    }
+}

--- a/AscendApp/Features/Progress/Models/BestEffortCacheSnapshot.swift
+++ b/AscendApp/Features/Progress/Models/BestEffortCacheSnapshot.swift
@@ -1,0 +1,119 @@
+//
+//  BestEffortCacheSnapshot.swift
+//  AscendApp
+//
+//  Created by Codex on 5/15/26.
+//
+
+import Foundation
+
+struct BestEffortCacheSnapshot {
+    private let rankedEntries: [BestEffortCacheEntry]
+    private let progressionEntries: [BestEffortCacheEntry]
+    private let workoutsByID: [UUID: Workout]
+
+    init(entries: [BestEffortCacheEntry], workouts: [Workout]) {
+        self.rankedEntries = entries.filter { $0.kind == .ranked }
+        self.progressionEntries = entries.filter { $0.kind == .progression }
+        self.workoutsByID = Dictionary(uniqueKeysWithValues: workouts.map { ($0.id, $0) })
+    }
+
+    func board(
+        scope: BestEffortScope,
+        context: BestEffortContext
+    ) -> BestEffortBoard {
+        let efforts = rankedEntries
+            .filter {
+                $0.scopeRawValue == scope.rawValue
+                    && $0.contextID == context.id
+                    && $0.rank <= 3
+            }
+            .compactMap(rankedEffort)
+
+        let categories = BestEffortMetric.allDefinitions.compactMap { metric -> BestEffortCategoryRanking? in
+            let metricEfforts = efforts
+                .filter { $0.metric == metric }
+                .sorted { lhs, rhs in
+                    if lhs.rank != rhs.rank {
+                        return lhs.rank < rhs.rank
+                    }
+                    return lhs.id < rhs.id
+                }
+
+            guard !metricEfforts.isEmpty else { return nil }
+            return BestEffortCategoryRanking(metric: metric, efforts: metricEfforts)
+        }
+
+        let sections = BestEffortSectionKind.allCases.compactMap { section -> BestEffortSection? in
+            let sectionCategories = categories.filter { $0.metric.section == section }
+            guard !sectionCategories.isEmpty else { return nil }
+            return BestEffortSection(kind: section, categories: sectionCategories)
+        }
+
+        return BestEffortBoard(scope: scope, context: context, sections: sections)
+    }
+
+    func rankedEfforts(
+        for metric: BestEffortMetric,
+        scope: BestEffortScope = .allTime,
+        context: BestEffortContext = .all
+    ) -> [RankedBestEffort] {
+        rankedEntries
+            .filter {
+                $0.metricID == metric.id
+                    && $0.scopeRawValue == scope.rawValue
+                    && $0.contextID == context.id
+            }
+            .compactMap(rankedEffort)
+            .sorted { lhs, rhs in
+                if lhs.rank != rhs.rank {
+                    return lhs.rank < rhs.rank
+                }
+                return lhs.id < rhs.id
+            }
+    }
+
+    func recordProgression(
+        for metric: BestEffortMetric,
+        scope: BestEffortScope = .allTime,
+        context: BestEffortContext = .all
+    ) -> [RankedBestEffort] {
+        progressionEntries
+            .filter {
+                $0.metricID == metric.id
+                    && $0.scopeRawValue == scope.rawValue
+                    && $0.contextID == context.id
+            }
+            .compactMap(rankedEffort)
+            .sorted { lhs, rhs in
+                if lhs.rank != rhs.rank {
+                    return lhs.rank < rhs.rank
+                }
+                return lhs.id < rhs.id
+            }
+    }
+
+    func efforts(for workout: Workout) -> [RankedBestEffort] {
+        let efforts = rankedEntries
+            .filter { $0.workoutID == workout.id }
+            .compactMap(rankedEffort)
+
+        return BestEffortRankingBuilder.sortedForSignificance(efforts)
+    }
+
+    func primaryEffort(for workout: Workout) -> RankedBestEffort? {
+        efforts(for: workout).first
+    }
+
+    func primaryEffortsByWorkoutID() -> [UUID: RankedBestEffort] {
+        let efforts = rankedEntries.compactMap(rankedEffort)
+        return BestEffortRankingBuilder.sortedForSignificance(efforts).reduce(into: [:]) { result, effort in
+            result[effort.workout.id] = result[effort.workout.id] ?? effort
+        }
+    }
+
+    private func rankedEffort(from entry: BestEffortCacheEntry) -> RankedBestEffort? {
+        guard let workout = workoutsByID[entry.workoutID] else { return nil }
+        return entry.rankedEffort(using: workout)
+    }
+}

--- a/AscendApp/Features/Progress/Services/BestEffortCacheStore.swift
+++ b/AscendApp/Features/Progress/Services/BestEffortCacheStore.swift
@@ -1,0 +1,199 @@
+//
+//  BestEffortCacheStore.swift
+//  AscendApp
+//
+//  Created by Codex on 5/15/26.
+//
+
+import CryptoKit
+import Foundation
+import SwiftData
+
+@MainActor
+enum BestEffortCacheStore {
+    static let currentVersion = 1
+    private static let metadataID = "best-effort-cache"
+
+    static func rebuildIfNeeded(
+        modelContext: ModelContext,
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) throws {
+        let workouts = try fetchWorkouts(modelContext: modelContext)
+        let referenceYear = calendar.component(.year, from: referenceDate)
+        let signature = workoutSignature(for: workouts, referenceYear: referenceYear)
+        let metadata = try fetchMetadata(modelContext: modelContext)
+        let entryCount = try modelContext.fetchCount(FetchDescriptor<BestEffortCacheEntry>())
+
+        guard metadata?.cacheVersion == currentVersion,
+              metadata?.workoutSignature == signature,
+              metadata?.referenceYear == referenceYear,
+              metadata?.entryCount == entryCount else {
+            try rebuild(
+                modelContext: modelContext,
+                workouts: workouts,
+                referenceDate: referenceDate,
+                calendar: calendar,
+                precomputedSignature: signature,
+                referenceYear: referenceYear
+            )
+            return
+        }
+    }
+
+    static func rebuild(
+        modelContext: ModelContext,
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) throws {
+        let workouts = try fetchWorkouts(modelContext: modelContext)
+        let referenceYear = calendar.component(.year, from: referenceDate)
+        try rebuild(
+            modelContext: modelContext,
+            workouts: workouts,
+            referenceDate: referenceDate,
+            calendar: calendar,
+            precomputedSignature: workoutSignature(for: workouts, referenceYear: referenceYear),
+            referenceYear: referenceYear
+        )
+    }
+
+    static func rebuild(
+        modelContext: ModelContext,
+        workouts: [Workout],
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) throws {
+        let referenceYear = calendar.component(.year, from: referenceDate)
+        try rebuild(
+            modelContext: modelContext,
+            workouts: workouts,
+            referenceDate: referenceDate,
+            calendar: calendar,
+            precomputedSignature: workoutSignature(for: workouts, referenceYear: referenceYear),
+            referenceYear: referenceYear
+        )
+    }
+
+    private static func rebuild(
+        modelContext: ModelContext,
+        workouts: [Workout],
+        referenceDate: Date,
+        calendar: Calendar,
+        precomputedSignature: String,
+        referenceYear: Int
+    ) throws {
+        try deleteExistingCache(modelContext: modelContext)
+
+        let generatedAt = Date()
+        let contexts = BestEffortRankingBuilder.availableContexts(from: workouts)
+        var entryCount = 0
+
+        for scope in BestEffortScope.allCases {
+            for context in contexts {
+                let board = BestEffortRankingBuilder.board(
+                    from: workouts,
+                    scope: scope,
+                    context: context,
+                    referenceDate: referenceDate,
+                    calendar: calendar
+                )
+
+                for effort in board.allEfforts {
+                    modelContext.insert(
+                        BestEffortCacheEntry(
+                            kind: .ranked,
+                            effort: effort,
+                            generatedAt: generatedAt,
+                            cacheVersion: currentVersion
+                        )
+                    )
+                    entryCount += 1
+                }
+
+                for metric in BestEffortMetric.allDefinitions {
+                    let progression = BestEffortRankingBuilder.recordProgression(
+                        for: metric,
+                        from: workouts,
+                        scope: scope,
+                        context: context,
+                        referenceDate: referenceDate,
+                        calendar: calendar
+                    )
+
+                    for effort in progression {
+                        modelContext.insert(
+                            BestEffortCacheEntry(
+                                kind: .progression,
+                                effort: effort,
+                                generatedAt: generatedAt,
+                                cacheVersion: currentVersion
+                            )
+                        )
+                        entryCount += 1
+                    }
+                }
+            }
+        }
+
+        modelContext.insert(
+            BestEffortCacheMetadata(
+                id: metadataID,
+                cacheVersion: currentVersion,
+                workoutSignature: precomputedSignature,
+                referenceYear: referenceYear,
+                generatedAt: generatedAt,
+                entryCount: entryCount
+            )
+        )
+
+        try modelContext.save()
+    }
+
+    private static func fetchWorkouts(modelContext: ModelContext) throws -> [Workout] {
+        let descriptor = FetchDescriptor<Workout>(
+            sortBy: [SortDescriptor(\.date, order: .reverse)]
+        )
+        return try modelContext.fetch(descriptor)
+    }
+
+    private static func fetchMetadata(modelContext: ModelContext) throws -> BestEffortCacheMetadata? {
+        var descriptor = FetchDescriptor<BestEffortCacheMetadata>(
+            predicate: #Predicate { $0.id == metadataID }
+        )
+        descriptor.fetchLimit = 1
+        return try modelContext.fetch(descriptor).first
+    }
+
+    private static func deleteExistingCache(modelContext: ModelContext) throws {
+        let entries = try modelContext.fetch(FetchDescriptor<BestEffortCacheEntry>())
+        for entry in entries {
+            modelContext.delete(entry)
+        }
+
+        let metadata = try modelContext.fetch(FetchDescriptor<BestEffortCacheMetadata>())
+        for item in metadata {
+            modelContext.delete(item)
+        }
+    }
+
+    private static func workoutSignature(for workouts: [Workout], referenceYear: Int) -> String {
+        let components = workouts
+            .sorted { lhs, rhs in lhs.id.uuidString < rhs.id.uuidString }
+            .map { workout in
+                [
+                    workout.id.uuidString,
+                    "\(workout.date.timeIntervalSinceReferenceDate)",
+                    "\(workout.duration)",
+                    "\(workout.steps)",
+                    workout.weightLoadoutKey?.id ?? "bodyweight",
+                    workout.sourceMetadata ?? ""
+                ].joined(separator: ";")
+            }
+            .joined(separator: "|")
+
+        let payload = "v\(currentVersion)|year:\(referenceYear)|\(components)"
+        let digest = SHA256.hash(data: Data(payload.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/AscendApp/Features/Progress/Views/BestEffortsListView.swift
+++ b/AscendApp/Features/Progress/Views/BestEffortsListView.swift
@@ -5,21 +5,26 @@
 //  Created by GPT-5.1 on 11/20/25.
 //
 
+import SwiftData
 import SwiftUI
 
 struct BestEffortsListView: View {
     let workouts: [Workout]
 
     @Environment(\.colorScheme) private var colorScheme
+    @Query(sort: \BestEffortCacheEntry.sortKey) private var bestEffortCacheEntries: [BestEffortCacheEntry]
     @State private var themeManager = ThemeManager.shared
 
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
     }
 
+    private var cacheSnapshot: BestEffortCacheSnapshot {
+        BestEffortCacheSnapshot(entries: bestEffortCacheEntries, workouts: workouts)
+    }
+
     private var board: BestEffortBoard {
-        BestEffortRankingBuilder.board(
-            from: workouts,
+        cacheSnapshot.board(
             scope: .allTime,
             context: .all
         )
@@ -215,6 +220,7 @@ private struct BestEffortRecordDetailView: View {
     let workouts: [Workout]
 
     @Environment(\.colorScheme) private var colorScheme
+    @Query(sort: \BestEffortCacheEntry.sortKey) private var bestEffortCacheEntries: [BestEffortCacheEntry]
     @State private var themeManager = ThemeManager.shared
     @State private var selectedMode: BestEffortRecordDetailMode = .chart
 
@@ -222,19 +228,21 @@ private struct BestEffortRecordDetailView: View {
         themeManager.effectiveColorScheme(for: colorScheme)
     }
 
+    private var cacheSnapshot: BestEffortCacheSnapshot {
+        BestEffortCacheSnapshot(entries: bestEffortCacheEntries, workouts: workouts)
+    }
+
     private var rankedEfforts: [RankedBestEffort] {
-        BestEffortRankingBuilder.rankedEfforts(
+        cacheSnapshot.rankedEfforts(
             for: metric,
-            from: workouts,
             scope: .allTime,
             context: .all
         )
     }
 
     private var progressionEfforts: [RankedBestEffort] {
-        BestEffortRankingBuilder.recordProgression(
+        cacheSnapshot.recordProgression(
             for: metric,
-            from: workouts,
             scope: .allTime,
             context: .all
         )
@@ -866,4 +874,5 @@ private extension BestEffortBoard {
     NavigationStack {
         BestEffortsListView(workouts: sampleWorkouts)
     }
+    .modelContainer(for: [Workout.self, BestEffortCacheEntry.self, BestEffortCacheMetadata.self], inMemory: true)
 }

--- a/AscendApp/Features/Progress/Views/ProgressTabView.swift
+++ b/AscendApp/Features/Progress/Views/ProgressTabView.swift
@@ -22,5 +22,14 @@ struct ProgressTabView: View {
     NavigationStack {
         ProgressTabView()
     }
-    .modelContainer(for: [Workout.self, WorkoutSourceLink.self, WorkoutParticipation.self], inMemory: true)
+    .modelContainer(
+        for: [
+            Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            BestEffortCacheEntry.self,
+            BestEffortCacheMetadata.self
+        ],
+        inMemory: true
+    )
 }

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -14,7 +14,7 @@ struct WorkoutDetailView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
     @Environment(AuthenticationViewModel.self) private var authVM
-    @Query(sort: \Workout.date, order: .reverse) private var allWorkouts: [Workout]
+    @Query(sort: \BestEffortCacheEntry.sortKey) private var bestEffortCacheEntries: [BestEffortCacheEntry]
     @State private var themeManager = ThemeManager.shared
     @State private var settingsManager = SettingsManager.shared
     @State private var showingEditWorkout = false
@@ -744,7 +744,11 @@ struct WorkoutDetailView: View {
     }
 
     private var workoutBestEfforts: [RankedBestEffort] {
-        BestEffortRankingBuilder.efforts(for: workout, from: allWorkouts)
+        BestEffortCacheSnapshot(
+            entries: bestEffortCacheEntries,
+            workouts: [workout]
+        )
+        .efforts(for: workout)
     }
 
     // MARK: - Formatting
@@ -1108,6 +1112,16 @@ struct SingleWorkoutDeleteConfirmationView: View {
     )
 
     WorkoutDetailView(workout: sampleWorkout)
+        .modelContainer(
+            for: [
+                Workout.self,
+                WorkoutSourceLink.self,
+                WorkoutParticipation.self,
+                BestEffortCacheEntry.self,
+                BestEffortCacheMetadata.self
+            ],
+            inMemory: true
+        )
 }
 
 #Preview("No Health Metrics") {
@@ -1127,4 +1141,14 @@ struct SingleWorkoutDeleteConfirmationView: View {
 
     WorkoutDetailView(workout: sampleWorkout)
         .preferredColorScheme(.dark)
+        .modelContainer(
+            for: [
+                Workout.self,
+                WorkoutSourceLink.self,
+                WorkoutParticipation.self,
+                BestEffortCacheEntry.self,
+                BestEffortCacheMetadata.self
+            ],
+            inMemory: true
+        )
 }

--- a/AscendApp/Features/Workouts/Views/WorkoutListView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutListView.swift
@@ -491,5 +491,14 @@ struct WorkoutListView: View {
     NavigationStack {
         WorkoutListView()
     }
-    .modelContainer(for: [Workout.self, WorkoutSourceLink.self, WorkoutParticipation.self], inMemory: true)
+    .modelContainer(
+        for: [
+            Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            BestEffortCacheEntry.self,
+            BestEffortCacheMetadata.self
+        ],
+        inMemory: true
+    )
 }

--- a/AscendApp/Features/Workouts/Views/WorkoutResultsListView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutResultsListView.swift
@@ -5,6 +5,7 @@
 //  Created by Codex on 3/14/24.
 //
 
+import SwiftData
 import SwiftUI
 
 struct WorkoutResultsListView: View {
@@ -14,9 +15,14 @@ struct WorkoutResultsListView: View {
     let effectiveColorScheme: ColorScheme
     let selectedWorkouts: Set<UUID>
     let toggleSelection: (UUID) -> Void
+    @Query(sort: \BestEffortCacheEntry.sortKey) private var bestEffortCacheEntries: [BestEffortCacheEntry]
 
     var body: some View {
-        let primaryBestEffortsByWorkoutID = BestEffortRankingBuilder.primaryEffortsByWorkoutID(from: allWorkouts)
+        let primaryBestEffortsByWorkoutID = BestEffortCacheSnapshot(
+            entries: bestEffortCacheEntries,
+            workouts: allWorkouts
+        )
+        .primaryEffortsByWorkoutID()
 
         ScrollView {
             LazyVStack(spacing: 12) {

--- a/AscendApp/Features/Workouts/Views/WorkoutShareCarouselView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutShareCarouselView.swift
@@ -15,7 +15,7 @@ import UIKit
 struct WorkoutShareCarouselView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
-    @Query(sort: \Workout.date, order: .reverse) private var allWorkouts: [Workout]
+    @Query(sort: \BestEffortCacheEntry.sortKey) private var bestEffortCacheEntries: [BestEffortCacheEntry]
     
     @State private var viewModel: WorkoutShareCarouselViewModel
     @State private var themeManager = ThemeManager.shared
@@ -33,7 +33,11 @@ struct WorkoutShareCarouselView: View {
     }
 
     private var primaryBestEffort: RankedBestEffort? {
-        BestEffortRankingBuilder.primaryEffort(for: viewModel.workout, from: allWorkouts)
+        BestEffortCacheSnapshot(
+            entries: bestEffortCacheEntries,
+            workouts: [viewModel.workout]
+        )
+        .primaryEffort(for: viewModel.workout)
     }
     
     // MARK: - Initializers
@@ -663,6 +667,7 @@ private extension Int {
         workoutCount: 535,
         onDismiss: {}
     )
+    .modelContainer(for: [Workout.self, BestEffortCacheEntry.self, BestEffortCacheMetadata.self], inMemory: true)
 }
 
 #Preview("Share Flow") {
@@ -676,6 +681,7 @@ private extension Int {
             caloriesBurned: 450
         )
     )
+    .modelContainer(for: [Workout.self, BestEffortCacheEntry.self, BestEffortCacheMetadata.self], inMemory: true)
 }
 
 #Preview("With Photo - Dark") {
@@ -691,4 +697,5 @@ private extension Int {
         onDismiss: {}
     )
     .preferredColorScheme(.dark)
+    .modelContainer(for: [Workout.self, BestEffortCacheEntry.self, BestEffortCacheMetadata.self], inMemory: true)
 }

--- a/AscendApp/Shared/Services/WorkoutMutationHandler.swift
+++ b/AscendApp/Shared/Services/WorkoutMutationHandler.swift
@@ -35,6 +35,7 @@ final class WorkoutMutationHandler {
             let didUpdateLeaderboard = try leaderboardService.applyMutationImpact(impact, for: userId)
 
             try modelContext.save()
+            rebuildBestEffortCacheAfterMutation(modelContext: modelContext)
 
             if !changedWorkouts.isEmpty {
                 Task { @MainActor in
@@ -65,6 +66,7 @@ final class WorkoutMutationHandler {
         }
 
         try modelContext.save()
+        rebuildBestEffortCacheAfterMutation(modelContext: modelContext)
     }
 
     func markChangedWorkoutsForRemoteSync(
@@ -74,6 +76,14 @@ final class WorkoutMutationHandler {
     ) {
         for workout in changedWorkouts {
             workout.markPendingRemoteUpsert(ownerUserId: userId, modifiedAt: modifiedAt)
+        }
+    }
+
+    private func rebuildBestEffortCacheAfterMutation(modelContext: ModelContext) {
+        do {
+            try BestEffortCacheStore.rebuild(modelContext: modelContext)
+        } catch {
+            print("Failed to rebuild Best Effort cache after workout mutation: \(error)")
         }
     }
 }

--- a/AscendApp/Shared/Views/MainTabView.swift
+++ b/AscendApp/Shared/Views/MainTabView.swift
@@ -32,12 +32,15 @@ struct MainTabView: View {
     var body: some View {
         TabView(selection: $tabRouter.selectedTab) {
             ForEach(tabs) { tab in
-                tabContent(for: tab.identifier)
-                    .tag(tab.identifier)
-                    .tabItem {
-                        Text(tab.title)
-                    }
-                    .toolbar(.hidden, for: .tabBar)
+                if tab.identifier == tabRouter.selectedTab {
+                    // Keep hidden tabs unmounted so inactive tab roots do not run SwiftData queries or animations.
+                    tabContent(for: tab.identifier)
+                        .tag(tab.identifier)
+                        .tabItem {
+                            Text(tab.title)
+                        }
+                        .toolbar(.hidden, for: .tabBar)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -49,6 +52,9 @@ struct MainTabView: View {
         .onAppear {
             checkForRatingPromptOnLaunch()
             syncBaseLevelOnboardingPresentation()
+        }
+        .task {
+            rebuildBestEffortCacheIfNeeded()
         }
         .onChange(of: connectivityService.isConnected) { oldValue, newValue in
             handleConnectivityChange(from: oldValue, to: newValue)
@@ -152,6 +158,14 @@ struct MainTabView: View {
         showingBaseLevelOnboarding = settingsManager.shouldPresentBaseLevelOnboarding
     }
 
+    private func rebuildBestEffortCacheIfNeeded() {
+        do {
+            try BestEffortCacheStore.rebuildIfNeeded(modelContext: modelContext)
+        } catch {
+            print("Failed to rebuild Best Effort cache: \(error)")
+        }
+    }
+
     private func handleConnectivityChange(from oldValue: Bool, to newValue: Bool) {
         guard oldValue != newValue else { return }
 
@@ -183,6 +197,16 @@ struct MainTabView: View {
     MainTabView()
         .environment(AuthenticationViewModel())
         .environment(NetworkConnectivityService.shared)
+        .modelContainer(
+            for: [
+                Workout.self,
+                WorkoutSourceLink.self,
+                WorkoutParticipation.self,
+                BestEffortCacheEntry.self,
+                BestEffortCacheMetadata.self
+            ],
+            inMemory: true
+        )
 }
 
 #Preview("Offline Connectivity Banner") {

--- a/AscendAppTests/BestEffortCacheStoreTests.swift
+++ b/AscendAppTests/BestEffortCacheStoreTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import AscendApp
+
+struct BestEffortCacheStoreTests {
+    @Test
+    @MainActor
+    func rebuildPersistsPrimaryEffortLookup() throws {
+        let modelContext = try makeModelContext()
+        let referenceDate = makeDate(year: 2026, month: 5, day: 10)
+        let fastWorkout = makeWorkout(
+            name: "Fast Climb",
+            date: referenceDate,
+            duration: 600,
+            steps: 1_800
+        )
+        let longWorkout = makeWorkout(
+            name: "Long Climb",
+            date: makeDate(year: 2025, month: 3, day: 1),
+            duration: 3_600,
+            steps: 3_000
+        )
+
+        modelContext.insert(fastWorkout)
+        modelContext.insert(longWorkout)
+        try modelContext.save()
+
+        try BestEffortCacheStore.rebuild(
+            modelContext: modelContext,
+            referenceDate: referenceDate
+        )
+
+        let workouts = try fetchWorkouts(in: modelContext)
+        let entries = try fetchCacheEntries(in: modelContext)
+        let snapshot = BestEffortCacheSnapshot(entries: entries, workouts: workouts)
+        let cachedPrimary = try #require(snapshot.primaryEffort(for: fastWorkout))
+        let builderPrimary = try #require(BestEffortRankingBuilder.primaryEffort(
+            for: fastWorkout,
+            from: workouts,
+            referenceDate: referenceDate
+        ))
+
+        #expect(cachedPrimary.id == builderPrimary.id)
+        #expect(cachedPrimary.sentence == "Highest average SPM ever")
+    }
+
+    @Test
+    @MainActor
+    func rebuildPersistsRecordProgression() throws {
+        let modelContext = try makeModelContext()
+        let referenceDate = makeDate(year: 2026, month: 5, day: 10)
+        let workouts = [
+            makeWorkout(
+                name: "First Record",
+                date: makeDate(year: 2026, month: 1, day: 1),
+                duration: 1_200,
+                steps: 1_000
+            ),
+            makeWorkout(
+                name: "Second Record",
+                date: makeDate(year: 2026, month: 2, day: 1),
+                duration: 1_200,
+                steps: 1_500
+            ),
+            makeWorkout(
+                name: "Not A Record",
+                date: makeDate(year: 2026, month: 3, day: 1),
+                duration: 1_200,
+                steps: 1_300
+            )
+        ]
+
+        for workout in workouts {
+            modelContext.insert(workout)
+        }
+        try modelContext.save()
+
+        try BestEffortCacheStore.rebuild(
+            modelContext: modelContext,
+            referenceDate: referenceDate
+        )
+
+        let fetchedWorkouts = try fetchWorkouts(in: modelContext)
+        let entries = try fetchCacheEntries(in: modelContext)
+        let snapshot = BestEffortCacheSnapshot(entries: entries, workouts: fetchedWorkouts)
+        let cachedProgression = snapshot.recordProgression(
+            for: .mostSteps,
+            scope: .allTime,
+            context: .all
+        )
+        let builderProgression = BestEffortRankingBuilder.recordProgression(
+            for: .mostSteps,
+            from: fetchedWorkouts,
+            scope: .allTime,
+            context: .all,
+            referenceDate: referenceDate
+        )
+
+        #expect(cachedProgression.map(\.workout.id) == builderProgression.map(\.workout.id))
+        #expect(cachedProgression.map(\.compactValueText) == ["1,000", "1,500"])
+    }
+
+    private func makeModelContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            BestEffortCacheEntry.self,
+            BestEffortCacheMetadata.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func fetchWorkouts(in modelContext: ModelContext) throws -> [Workout] {
+        try modelContext.fetch(
+            FetchDescriptor<Workout>(
+                sortBy: [SortDescriptor(\.date, order: .forward)]
+            )
+        )
+    }
+
+    private func fetchCacheEntries(in modelContext: ModelContext) throws -> [BestEffortCacheEntry] {
+        try modelContext.fetch(
+            FetchDescriptor<BestEffortCacheEntry>(
+                sortBy: [SortDescriptor(\.sortKey)]
+            )
+        )
+    }
+
+    private func makeWorkout(
+        name: String,
+        date: Date,
+        duration: TimeInterval,
+        steps: Int
+    ) -> Workout {
+        Workout(
+            name: name,
+            date: date,
+            duration: duration,
+            steps: steps,
+            floors: Workout.stepsToFloors(steps, stepsPerFloor: 16),
+            stepsPerFloor: 16,
+            source: .manual
+        )
+    }
+
+    private func makeDate(year: Int, month: Int, day: Int) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = TimeZone(secondsFromGMT: 0)
+        components.year = year
+        components.month = month
+        components.day = day
+        return components.date ?? Date()
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ functions/src/                  # Cloud Functions (TypeScript)
 ### Tab Architecture
 - `MainTabView` should use SwiftUI's native `TabView(selection:)` as the tab content owner and keep Ascend's custom `MainTabBarView` as the visible bottom chrome via `safeAreaInset`.
 - `TabItem` is metadata only. Do not store eager `AnyView` tab roots in tab configuration, and do not reintroduce a manual `ZStack` that keeps every tab mounted with opacity.
+- `MainTabView` should render only the selected tab root inside the `TabView` so hidden tabs stay unmounted and do not run SwiftData queries, refreshes, or animations. Per-tab navigation/scroll state loss is acceptable for now.
 - Each tab root owns its own `NavigationStack`; keep tab-specific work scoped to the selected tab where possible so hidden tabs do not run expensive queries, refreshes, or animations.
 
 ### Branding
@@ -92,6 +93,7 @@ Workout, WorkoutSourceLink, WorkoutParticipation, LeaderboardStats, Routine, Rou
 ### Best Efforts Architecture
 - Best Efforts are the only workout achievement layer. Do not reintroduce a parallel Personal Records system.
 - Workouts remain the source of truth. Best Efforts are derived from workout history for all-time and this-year scopes across all, bodyweight, weighted, and exact weight-loadout contexts.
+- Best Effort rankings are persisted as derived SwiftData cache rows. Views should read cheap cache snapshots/lookups and must not rebuild rankings from all workouts in `body`; rebuild the cache through `BestEffortCacheStore` after workout create/edit/delete/import mutations and during startup repair if the persisted signature is stale.
 - Weighted Best Efforts must distinguish exact loadouts using the full enabled equipment configuration, such as `20 lb Vest` versus `20 lb Vest + 5 lb each Ankle`.
 - Best Effort metrics are stepper-specific and step-first: most steps, longest climb, highest average SPM, sampled time windows, and sampled fastest step targets. Do not add floors-based Best Efforts unless product explicitly changes direction.
 - Timeline efforts require real sampled Live Climb progress data. Manual entries and total-only imports can contribute whole-workout efforts, but not rolling-window or fastest-segment efforts.


### PR DESCRIPTION
## Summary
- Keep `MainTabView` rendering scoped to the selected tab so inactive tab roots stay unmounted.
- Add persistent SwiftData Best Effort cache rows and metadata, with startup repair when the cache signature is stale.
- Rebuild the derived cache after workout mutations and switch workout/detail/share/progress surfaces to cheap cache snapshot lookups.
- Update shared project instructions for the new mutation-driven Best Effort cache architecture.

## Root cause
Best Effort rankings were being recomputed from all workouts inside SwiftUI view paths. The workout list, workout detail, share surfaces, and progress surfaces could repeatedly scan scopes, contexts, metrics, exact loadouts, and timeline segments during navigation or body invalidation. That made tab switching and workout navigation block on derived ranking work.

## User impact
Workouts tab load and workout detail navigation keep Best Effort labels available without recalculating rankings on every view load. The cache persists across app launches and repairs itself if the workout signature changes.

## Validation
- `build_sim` passed
- `test_sim` passed: 156 passed, 0 failed

## Notes
First launch after the update may build the derived cache once. After that, Best Effort surfaces should use persisted cache reads unless workouts are created, edited, deleted, or imported.