### PR TITLE
Prepare launch catalog and account hydration

### DIFF
--- a/AscendApp/App/RootView.swift
+++ b/AscendApp/App/RootView.swift
@@ -14,6 +14,7 @@ struct RootView: View {
     @Environment(MediaUploadManager.self) private var uploadManager
     @State private var importCoordinator = WorkoutImportCoordinator.shared
     @State private var postAuthOnboardingCoordinator = PostAuthOnboardingCoordinator()
+    @State private var accountDataConflict: AccountDataOwnershipConflict?
 
     var body: some View {
         Group {
@@ -62,51 +63,88 @@ struct RootView: View {
 
     @ViewBuilder
     private var authenticatedContent: some View {
-        switch postAuthOnboardingCoordinator.phase {
-        case .signedOut, .resolving:
-            ProgressView("Setting Up...")
-                .themedBackground()
-
-        case .onboarding(let stage):
-            PostAuthOnboardingFlowView(
-                stage: stage,
-                onBack: postAuthOnboardingCoordinator.moveBack,
-                onContinue: postAuthOnboardingCoordinator.completeCurrentStage
+        if let accountDataConflict {
+            AccountDataConflictView(
+                conflict: accountDataConflict,
+                onSignOut: authVM.signOut
             )
+        } else {
+            switch postAuthOnboardingCoordinator.phase {
+            case .signedOut, .resolving:
+                ProgressView("Setting Up...")
+                    .themedBackground()
 
-        case .complete:
-            MainTabView()
+            case .onboarding(let stage):
+                PostAuthOnboardingFlowView(
+                    stage: stage,
+                    onBack: postAuthOnboardingCoordinator.moveBack,
+                    onContinue: postAuthOnboardingCoordinator.completeCurrentStage
+                )
+
+            case .complete:
+                MainTabView()
+            }
         }
     }
 
     @MainActor
     private func bootstrapAuthenticatedLocalState() async {
-        guard let user = authVM.user else { return }
+        guard let user = authVM.user else {
+            accountDataConflict = nil
+            return
+        }
+        let currentUserId = user.uid
 
         do {
+            switch try AccountDataOwnershipService.evaluateAccess(
+                modelContext: modelContext,
+                signedInUserId: currentUserId
+            ) {
+            case .allowed:
+                accountDataConflict = nil
+            case .blocked(let conflict):
+                accountDataConflict = conflict
+                return
+            }
+
             try WorkoutRemoteSyncMigrationService.runIfNeeded(
                 modelContext: modelContext,
-                currentUserId: user.uid
+                currentUserId: currentUserId
             )
+            AccountDataOwnershipService.recordAuthorizedOwner(signedInUserId: currentUserId)
+
+            do {
+                _ = try await WorkoutHydrationService.hydrateIfNeeded(
+                    modelContext: modelContext,
+                    currentUserId: currentUserId
+                )
+            } catch {
+                print("Workout hydration failed: \(error)")
+            }
 
             await WorkoutSyncCoordinator.shared.processPendingWorkouts(
                 modelContext: modelContext,
-                currentUserId: user.uid
+                currentUserId: currentUserId
             )
 
             let leaderboardService = LeaderboardService.shared
             leaderboardService.configure(modelContext: modelContext)
 
             let workouts = try modelContext.fetch(
-                FetchDescriptor<Workout>(sortBy: [SortDescriptor(\.date, order: .forward)])
+                FetchDescriptor<Workout>(
+                    predicate: #Predicate<Workout> { workout in
+                        workout.ownerUserId == currentUserId
+                    },
+                    sortBy: [SortDescriptor(\.date, order: .forward)]
+                )
             )
             let didRebuild = try leaderboardService.rebuildCurrentStatsIfNeeded(
-                for: user.uid,
+                for: currentUserId,
                 workouts: workouts
             )
 
             if didRebuild {
-                try await leaderboardService.deleteLegacyRemoteStats(userId: user.uid)
+                try await leaderboardService.deleteLegacyRemoteStats(userId: currentUserId)
                 await LeaderboardSessionCache.shared.invalidateAll()
             }
 
@@ -115,13 +153,61 @@ struct RootView: View {
             let photoURL = UserDataRepository.shared.getCachedProfilePictureURL().flatMap(URL.init(string:)) ?? authVM.displayPhotoURL
 
             await LeaderboardSyncCoordinator.shared.enqueueSync(
-                userId: user.uid,
+                userId: currentUserId,
                 displayName: displayName,
                 photoURL: photoURL
             )
         } catch {
             print("Authenticated bootstrap failed: \(error)")
         }
+    }
+}
+
+private struct AccountDataConflictView: View {
+    let conflict: AccountDataOwnershipConflict
+    let onSignOut: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 12) {
+                Image(systemName: "lock.trianglebadge.exclamationmark")
+                    .font(.system(size: 34, weight: .semibold))
+                    .foregroundStyle(Color.accentColor)
+                    .accessibilityHidden(true)
+
+                Text("Account data mismatch")
+                    .font(.montserratBold(size: 28))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.82)
+
+                Text("This device already has Ascend data for another account. Sign in with the original account to protect your workouts and rankings.")
+                    .font(.montserratMedium(size: 15))
+                    .foregroundStyle(.white.opacity(0.68))
+                    .lineSpacing(4)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Button(action: onSignOut) {
+                Text("Sign Out")
+                    .font(.montserratBold(size: 16))
+                    .foregroundStyle(.black)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                            .fill(Color.accentColor)
+                    )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Sign Out")
+
+            Spacer()
+        }
+        .padding(.horizontal, 28)
+        .themedBackground()
     }
 }
 

--- a/AscendApp/Features/Authentication/AccountSessionStore.swift
+++ b/AscendApp/Features/Authentication/AccountSessionStore.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+enum AuthProviderKind: String, Equatable, Sendable {
+    case google
+    case apple
+    case internalQA = "internal_qa"
+}
+
+@MainActor
+final class AccountSessionStore {
+    static let shared = AccountSessionStore()
+
+    private enum Keys {
+        static let lastUsedProvider = "auth.lastUsedProvider"
+        static let localDataOwnerUserId = "accountData.localOwnerUserId"
+    }
+
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    var lastUsedProvider: AuthProviderKind? {
+        guard let rawValue = userDefaults.string(forKey: Keys.lastUsedProvider) else {
+            return nil
+        }
+        return AuthProviderKind(rawValue: rawValue)
+    }
+
+    var localDataOwnerUserId: String? {
+        normalizedUserId(userDefaults.string(forKey: Keys.localDataOwnerUserId))
+    }
+
+    func recordSuccessfulSignIn(provider: AuthProviderKind) {
+        userDefaults.set(provider.rawValue, forKey: Keys.lastUsedProvider)
+    }
+
+    func recordLocalDataOwner(userId: String) {
+        guard let normalized = normalizedUserId(userId) else { return }
+        userDefaults.set(normalized, forKey: Keys.localDataOwnerUserId)
+    }
+
+    func clearLocalDataOwner() {
+        userDefaults.removeObject(forKey: Keys.localDataOwnerUserId)
+    }
+
+    private func normalizedUserId(_ userId: String?) -> String? {
+        guard let userId else { return nil }
+        let trimmed = userId.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/AscendApp/Features/Authentication/AuthenticationViewModel.swift
+++ b/AscendApp/Features/Authentication/AuthenticationViewModel.swift
@@ -44,14 +44,18 @@ class AuthenticationViewModel {
     var isErrorAlertPresented: Bool = false
     var photoURL: URL?
     var customProfilePictureURL: URL?
+    private(set) var lastUsedProvider: AuthProviderKind?
 
     /// Indicates whether the profile data has been loaded from Firestore/cache after auth restore.
     /// Used to avoid showing authenticated UI before profile state is known.
     private(set) var isProfileLoaded: Bool = false
 
     private var authenticationService = AuthenticationService()
+    private let accountSessionStore = AccountSessionStore.shared
 
     init() {
+        lastUsedProvider = accountSessionStore.lastUsedProvider
+
         // Load cached display name immediately for UI responsiveness
         displayName = UserDataRepository.shared.getCachedDisplayName() ?? ""
         
@@ -173,6 +177,7 @@ extension AuthenticationViewModel {
 
         do {
             _ = try await authenticationService.signInWithGoogle()
+            recordSuccessfulSignIn(provider: .google)
             TelemetryManager.shared.log(.authInteractiveSignInSuccess)
         } catch {
             // Don't show error for user cancellation
@@ -214,6 +219,7 @@ extension AuthenticationViewModel {
 
         do {
             _ = try await authenticationService.signInWithEmail(email: trimmedEmail, password: password)
+            recordSuccessfulSignIn(provider: .internalQA)
             TelemetryManager.shared.log(.authInteractiveSignInSuccess)
         } catch {
             TelemetryManager.shared.log(.authSignInFailed)
@@ -234,6 +240,7 @@ extension AuthenticationViewModel {
 
         do {
             _ = try await authenticationService.signInWithApple()
+            recordSuccessfulSignIn(provider: .apple)
             TelemetryManager.shared.log(.authInteractiveSignInSuccess)
         } catch {
             // Don't show error for user cancellation
@@ -282,6 +289,11 @@ extension AuthenticationViewModel {
         }
 
         return .authenticated
+    }
+
+    private func recordSuccessfulSignIn(provider: AuthProviderKind) {
+        accountSessionStore.recordSuccessfulSignIn(provider: provider)
+        lastUsedProvider = provider
     }
     
     private func saveUserToFirestore(user: User) async throws {

--- a/AscendApp/Features/Authentication/Views/SignUpView.swift
+++ b/AscendApp/Features/Authentication/Views/SignUpView.swift
@@ -18,6 +18,7 @@ struct SignUpView: View {
                     errorMessage: hasAttemptedInteractiveSignIn ? authVM.errorMessage : nil,
                     googleIsLoading: authVM.authenticationState == .authenticatingWithGoogle,
                     appleIsLoading: authVM.authenticationState == .authenticatingWithApple,
+                    lastUsedProvider: authVM.lastUsedProvider,
                     showsInternalQA: InternalQASignInAvailability.isEnabled(projectID: FirebaseApp.app()?.options.projectID),
                     isDisabled: authVM.authenticationState.isAuthenticating,
                     onGoogle: signInWithGoogle,
@@ -143,6 +144,7 @@ private struct AuthLandingContent: View {
     let errorMessage: String?
     let googleIsLoading: Bool
     let appleIsLoading: Bool
+    let lastUsedProvider: AuthProviderKind?
     let showsInternalQA: Bool
     let isDisabled: Bool
     let onGoogle: () -> Void
@@ -183,6 +185,7 @@ private struct AuthLandingContent: View {
                         height: layout.buttonHeight,
                         cornerRadius: layout.buttonCornerRadius,
                         fontSize: layout.buttonFontSize,
+                        accessoryTitle: lastUsedProvider == .google ? "Last Used" : nil,
                         icon: {
                             Image("GoogleIcon")
                                 .resizable()
@@ -200,6 +203,7 @@ private struct AuthLandingContent: View {
                         height: layout.buttonHeight,
                         cornerRadius: layout.buttonCornerRadius,
                         fontSize: layout.buttonFontSize,
+                        accessoryTitle: lastUsedProvider == .apple ? "Last Used" : nil,
                         icon: {
                             Image(systemName: "apple.logo")
                                 .font(.system(size: 24, weight: .semibold))
@@ -321,6 +325,24 @@ private enum AuthProviderButtonStyle {
         }
     }
 
+    var accessoryForegroundColor: Color {
+        switch self {
+        case .google:
+            Color(red: 23 / 255, green: 25 / 255, blue: 31 / 255).opacity(0.72)
+        case .apple:
+            .white.opacity(0.76)
+        }
+    }
+
+    var accessoryBackgroundColor: Color {
+        switch self {
+        case .google:
+            Color.black.opacity(0.08)
+        case .apple:
+            .white.opacity(0.12)
+        }
+    }
+
     func background(cornerRadius: CGFloat) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
@@ -375,6 +397,7 @@ private struct AuthProviderButton<Icon: View>: View {
     let height: CGFloat
     let cornerRadius: CGFloat
     let fontSize: CGFloat
+    let accessoryTitle: String?
     @ViewBuilder let icon: () -> Icon
     let action: () -> Void
 
@@ -393,6 +416,20 @@ private struct AuthProviderButton<Icon: View>: View {
                     .font(.montserratSemiBold(size: fontSize))
                     .lineLimit(1)
                     .minimumScaleFactor(0.76)
+
+                if let accessoryTitle, !isLoading {
+                    Text(accessoryTitle.uppercased())
+                        .font(.montserratBold(size: 9))
+                        .foregroundStyle(style.accessoryForegroundColor)
+                        .lineLimit(1)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 5)
+                        .background(
+                            Capsule()
+                                .fill(style.accessoryBackgroundColor)
+                        )
+                        .accessibilityHidden(true)
+                }
             }
             .foregroundStyle(style.foregroundColor)
             .frame(maxWidth: .infinity)
@@ -404,7 +441,12 @@ private struct AuthProviderButton<Icon: View>: View {
         .buttonStyle(.plain)
         .disabled(isDisabled)
         .opacity(isDisabled ? 0.72 : 1)
-        .accessibilityLabel(title)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        guard let accessoryTitle else { return title }
+        return "\(title), \(accessoryTitle)"
     }
 }
 

--- a/AscendApp/Features/Climbs/Models/Climb.swift
+++ b/AscendApp/Features/Climbs/Models/Climb.swift
@@ -22,7 +22,23 @@ struct Climb: Codable, Identifiable, Hashable {
     let funFact: String
     let sourceURL: String
     let imageSetVersion: Int
-    let isPublished: Bool
+    let releaseState: ClimbReleaseState
+
+    var isAvailable: Bool {
+        releaseState.isAvailable
+    }
+
+    var isComingSoon: Bool {
+        releaseState == .comingSoon
+    }
+
+    var isVisibleOnGlobe: Bool {
+        releaseState.isVisibleOnGlobe
+    }
+
+    var isPublished: Bool {
+        releaseState != .hidden && releaseState != .disabled
+    }
 
     var coordinate: CLLocationCoordinate2D {
         CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
@@ -82,7 +98,31 @@ struct Climb: Codable, Identifiable, Hashable {
         funFact: "The Empire State Building opened in 1931 and held the tallest-building title for nearly 40 years.",
         sourceURL: "https://en.wikipedia.org/wiki/Empire_State_Building",
         imageSetVersion: 1,
-        isPublished: true
+        releaseState: .available
+    )
+
+    static let previewComingSoon = Climb(
+        id: "coming-soon-preview",
+        name: "Coming Soon",
+        city: "Unknown",
+        country: "Unknown",
+        continent: "Unknown",
+        latitude: 0,
+        longitude: 0,
+        totalHeightMeters: 100,
+        totalHeightFeet: 328,
+        realClimbableHeightMeters: nil,
+        realClimbableHeightFeet: nil,
+        totalSteps: 500,
+        realStairCount: nil,
+        calculatedFloors: 25,
+        category: "tower",
+        tier: .bronze,
+        tags: ["coming soon"],
+        funFact: "A new First Ascent opens here soon.",
+        sourceURL: "https://ascendstepper.com",
+        imageSetVersion: 1,
+        releaseState: .comingSoon
     )
 
     enum CodingKeys: String, CodingKey {
@@ -106,6 +146,7 @@ struct Climb: Codable, Identifiable, Hashable {
         case funFact
         case sourceURL
         case imageSetVersion
+        case releaseState
         case isPublished
     }
 
@@ -130,7 +171,8 @@ struct Climb: Codable, Identifiable, Hashable {
         funFact: String,
         sourceURL: String,
         imageSetVersion: Int = 1,
-        isPublished: Bool = true
+        releaseState: ClimbReleaseState = .available,
+        isPublished: Bool? = nil
     ) {
         self.id = id
         self.name = name
@@ -152,7 +194,11 @@ struct Climb: Codable, Identifiable, Hashable {
         self.funFact = funFact
         self.sourceURL = sourceURL
         self.imageSetVersion = imageSetVersion
-        self.isPublished = isPublished
+        if isPublished == false {
+            self.releaseState = .hidden
+        } else {
+            self.releaseState = releaseState
+        }
     }
 
     init(from decoder: Decoder) throws {
@@ -177,7 +223,13 @@ struct Climb: Codable, Identifiable, Hashable {
         funFact = try container.decode(String.self, forKey: .funFact)
         sourceURL = try container.decode(String.self, forKey: .sourceURL)
         imageSetVersion = try container.decodeIfPresent(Int.self, forKey: .imageSetVersion) ?? 1
-        isPublished = try container.decodeIfPresent(Bool.self, forKey: .isPublished) ?? true
+        if let decodedReleaseState = try container.decodeIfPresent(ClimbReleaseState.self, forKey: .releaseState) {
+            releaseState = decodedReleaseState
+        } else if try container.decodeIfPresent(Bool.self, forKey: .isPublished) == false {
+            releaseState = .hidden
+        } else {
+            releaseState = .available
+        }
     }
 
     func encode(to encoder: Encoder) throws {
@@ -202,7 +254,7 @@ struct Climb: Codable, Identifiable, Hashable {
         try container.encode(funFact, forKey: .funFact)
         try container.encode(sourceURL, forKey: .sourceURL)
         try container.encode(imageSetVersion, forKey: .imageSetVersion)
-        try container.encode(isPublished, forKey: .isPublished)
+        try container.encode(releaseState, forKey: .releaseState)
     }
 
     private func clampedCameraDistance(

--- a/AscendApp/Features/Climbs/Models/ClimbCatalogSnapshot.swift
+++ b/AscendApp/Features/Climbs/Models/ClimbCatalogSnapshot.swift
@@ -7,7 +7,15 @@ struct ClimbCatalogSnapshot {
     let featuredClimbId: String?
     let updatedAt: Date?
 
-    var publishedClimbs: [Climb] {
-        climbs.filter(\.isPublished)
+    var visibleClimbs: [Climb] {
+        climbs.filter(\.isVisibleOnGlobe)
+    }
+
+    var availableClimbs: [Climb] {
+        climbs.filter(\.isAvailable)
+    }
+
+    var comingSoonClimbs: [Climb] {
+        climbs.filter(\.isComingSoon)
     }
 }

--- a/AscendApp/Features/Climbs/Models/ClimbReleaseState.swift
+++ b/AscendApp/Features/Climbs/Models/ClimbReleaseState.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum ClimbReleaseState: String, Codable, CaseIterable {
+    case available
+    case comingSoon
+    case hidden
+    case disabled
+
+    var isAvailable: Bool {
+        self == .available
+    }
+
+    var isVisibleOnGlobe: Bool {
+        switch self {
+        case .available, .comingSoon:
+            return true
+        case .hidden, .disabled:
+            return false
+        }
+    }
+}

--- a/AscendApp/Features/Climbs/Models/TodayClimbStakeLine.swift
+++ b/AscendApp/Features/Climbs/Models/TodayClimbStakeLine.swift
@@ -14,7 +14,7 @@ enum TodayClimbStakeLine: Equatable {
         case .unavailable:
             return "Climb it. Claim your place on the board."
         case .openFirstAscent:
-            return "Be the first. Earn the First Ascent forever."
+            return "First Ascent open. The first finisher claims it forever."
         case .nextFinisher(let order):
             return "Be the \(Self.ordinalText(for: order)) finisher."
         case .joinFinishers(let count):

--- a/AscendApp/Features/Climbs/Resources/climbs.json
+++ b/AscendApp/Features/Climbs/Resources/climbs.json
@@ -22,7 +22,8 @@
       "torch"
     ],
     "funFact": "France gifted the Statue of Liberty to the United States in 1886.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Statue_of_Liberty"
+    "sourceURL": "https://en.wikipedia.org/wiki/Statue_of_Liberty",
+    "releaseState": "available"
   },
   {
     "id": "washington-monument",
@@ -47,7 +48,8 @@
       "icon"
     ],
     "funFact": "The Washington Monument is the tallest masonry obelisk in the world.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Washington_Monument"
+    "sourceURL": "https://en.wikipedia.org/wiki/Washington_Monument",
+    "releaseState": "comingSoon"
   },
   {
     "id": "gateway-arch",
@@ -72,7 +74,8 @@
       "icon"
     ],
     "funFact": "The Gateway Arch is the tallest arch monument on Earth.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Gateway_Arch"
+    "sourceURL": "https://en.wikipedia.org/wiki/Gateway_Arch",
+    "releaseState": "comingSoon"
   },
   {
     "id": "space-needle",
@@ -97,7 +100,8 @@
       "worlds fair"
     ],
     "funFact": "The Space Needle was built for the 1962 World's Fair.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Space_Needle"
+    "sourceURL": "https://en.wikipedia.org/wiki/Space_Needle",
+    "releaseState": "available"
   },
   {
     "id": "transamerica-pyramid",
@@ -122,7 +126,8 @@
       "icon"
     ],
     "funFact": "The Transamerica Pyramid remained San Francisco's tallest building for decades.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Transamerica_Pyramid"
+    "sourceURL": "https://en.wikipedia.org/wiki/Transamerica_Pyramid",
+    "releaseState": "comingSoon"
   },
   {
     "id": "empire-state-building",
@@ -147,7 +152,8 @@
       "icon"
     ],
     "funFact": "The Empire State Building opened in 1931 during the Great Depression.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Empire_State_Building"
+    "sourceURL": "https://en.wikipedia.org/wiki/Empire_State_Building",
+    "releaseState": "available"
   },
   {
     "id": "chrysler-building",
@@ -172,7 +178,8 @@
       "icon"
     ],
     "funFact": "The Chrysler Building briefly held the world's tallest-building title in 1930.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Chrysler_Building"
+    "sourceURL": "https://en.wikipedia.org/wiki/Chrysler_Building",
+    "releaseState": "comingSoon"
   },
   {
     "id": "one-world-trade-center",
@@ -197,7 +204,8 @@
       "icon"
     ],
     "funFact": "One World Trade Center rises to a symbolic 1,776 feet.",
-    "sourceURL": "https://en.wikipedia.org/wiki/One_World_Trade_Center"
+    "sourceURL": "https://en.wikipedia.org/wiki/One_World_Trade_Center",
+    "releaseState": "comingSoon"
   },
   {
     "id": "willis-tower",
@@ -222,7 +230,8 @@
       "icon"
     ],
     "funFact": "Willis Tower was known as Sears Tower when it became the world's tallest building in 1974.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Willis_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Willis_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "cn-tower",
@@ -247,7 +256,8 @@
       "icon"
     ],
     "funFact": "The CN Tower was the tallest free-standing structure in the world for more than 30 years.",
-    "sourceURL": "https://en.wikipedia.org/wiki/CN_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/CN_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "torre-latinoamericana",
@@ -272,32 +282,8 @@
       "landmark"
     ],
     "funFact": "Torre Latinoamericana is famous for surviving multiple major earthquakes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Torre_Latinoamericana"
-  },
-  {
-    "id": "monument-to-the-revolution",
-    "name": "Monument to the Revolution",
-    "city": "Mexico City",
-    "country": "Mexico",
-    "continent": "North America",
-    "latitude": 19.4363,
-    "longitude": -99.1538,
-    "totalHeightMeters": 67,
-    "totalHeightFeet": 219.8,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 369,
-    "realStairCount": null,
-    "calculatedFloors": 19,
-    "category": "monument",
-    "tier": "bronze",
-    "tags": [
-      "plaza",
-      "history",
-      "icon"
-    ],
-    "funFact": "This monument was built around the abandoned shell of a planned legislative palace.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Monument_to_the_Revolution"
+    "sourceURL": "https://en.wikipedia.org/wiki/Torre_Latinoamericana",
+    "releaseState": "comingSoon"
   },
   {
     "id": "half-dome",
@@ -322,7 +308,8 @@
       "hike"
     ],
     "funFact": "Half Dome's cable route is one of the most famous day hikes in the United States.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Half_Dome"
+    "sourceURL": "https://en.wikipedia.org/wiki/Half_Dome",
+    "releaseState": "comingSoon"
   },
   {
     "id": "denali",
@@ -347,7 +334,8 @@
       "expedition"
     ],
     "funFact": "Denali is the highest mountain peak in North America.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Denali"
+    "sourceURL": "https://en.wikipedia.org/wiki/Denali",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-whitney",
@@ -372,7 +360,8 @@
       "hike"
     ],
     "funFact": "Mount Whitney is the highest summit in the contiguous United States.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Whitney"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Whitney",
+    "releaseState": "comingSoon"
   },
   {
     "id": "pikes-peak",
@@ -397,7 +386,8 @@
       "scenic"
     ],
     "funFact": "Katharine Lee Bates was inspired to write America the Beautiful after visiting Pikes Peak.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Pikes_Peak"
+    "sourceURL": "https://en.wikipedia.org/wiki/Pikes_Peak",
+    "releaseState": "comingSoon"
   },
   {
     "id": "reunion-tower",
@@ -422,32 +412,8 @@
       "skyline"
     ],
     "funFact": "Reunion Tower's glowing geodesic sphere makes it one of Dallas's most recognizable landmarks.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Reunion_Tower"
-  },
-  {
-    "id": "christ-the-redeemer",
-    "name": "Christ the Redeemer",
-    "city": "Rio de Janeiro",
-    "country": "Brazil",
-    "continent": "South America",
-    "latitude": -22.9519,
-    "longitude": -43.2105,
-    "totalHeightMeters": 38,
-    "totalHeightFeet": 124.7,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 209,
-    "realStairCount": null,
-    "calculatedFloors": 11,
-    "category": "monument",
-    "tier": "common",
-    "tags": [
-      "statue",
-      "icon",
-      "viewpoint"
-    ],
-    "funFact": "Christ the Redeemer stands atop Corcovado Mountain overlooking Rio de Janeiro.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Christ_the_Redeemer_(statue)"
+    "sourceURL": "https://en.wikipedia.org/wiki/Reunion_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "machu-picchu",
@@ -472,7 +438,8 @@
       "mountain"
     ],
     "funFact": "Machu Picchu was built in the 15th century and hidden from the outside world for centuries.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Machu_Picchu"
+    "sourceURL": "https://en.wikipedia.org/wiki/Machu_Picchu",
+    "releaseState": "available"
   },
   {
     "id": "sugarloaf-mountain",
@@ -497,7 +464,8 @@
       "viewpoint"
     ],
     "funFact": "Sugarloaf Mountain gets its English name from the cone-shaped molds once used for sugar.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sugarloaf_Mountain"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sugarloaf_Mountain",
+    "releaseState": "comingSoon"
   },
   {
     "id": "gran-torre-santiago",
@@ -522,7 +490,8 @@
       "andes"
     ],
     "funFact": "Gran Torre Santiago is the tallest building in South America.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Gran_Torre_Santiago"
+    "sourceURL": "https://en.wikipedia.org/wiki/Gran_Torre_Santiago",
+    "releaseState": "comingSoon"
   },
   {
     "id": "aconcagua",
@@ -547,7 +516,8 @@
       "expedition"
     ],
     "funFact": "Aconcagua is the highest mountain outside Asia.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Aconcagua"
+    "sourceURL": "https://en.wikipedia.org/wiki/Aconcagua",
+    "releaseState": "comingSoon"
   },
   {
     "id": "monserrate",
@@ -572,32 +542,8 @@
       "city icon"
     ],
     "funFact": "Monserrate rises above Bogota with a church at its summit.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Monserrate"
-  },
-  {
-    "id": "obelisco-buenos-aires",
-    "name": "Obelisco de Buenos Aires",
-    "city": "Buenos Aires",
-    "country": "Argentina",
-    "continent": "South America",
-    "latitude": -34.6037,
-    "longitude": -58.3816,
-    "totalHeightMeters": 67,
-    "totalHeightFeet": 219.8,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 369,
-    "realStairCount": null,
-    "calculatedFloors": 19,
-    "category": "monument",
-    "tier": "bronze",
-    "tags": [
-      "avenue",
-      "city icon",
-      "plaza"
-    ],
-    "funFact": "The Obelisco marks the place where Buenos Aires first flew the national flag.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Obelisco_de_Buenos_Aires"
+    "sourceURL": "https://en.wikipedia.org/wiki/Monserrate",
+    "releaseState": "comingSoon"
   },
   {
     "id": "torres-del-paine",
@@ -622,7 +568,8 @@
       "national park"
     ],
     "funFact": "The granite towers of Torres del Paine are among Patagonia's most famous sights.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Torres_del_Paine"
+    "sourceURL": "https://en.wikipedia.org/wiki/Torres_del_Paine",
+    "releaseState": "comingSoon"
   },
   {
     "id": "el-penon-de-guatape",
@@ -647,7 +594,8 @@
       "viewpoint"
     ],
     "funFact": "A famous zigzag staircase is carved into the side of this giant granite monolith.",
-    "sourceURL": "https://en.wikipedia.org/wiki/El_Penon_de_Guatape"
+    "sourceURL": "https://en.wikipedia.org/wiki/El_Penon_de_Guatape",
+    "releaseState": "comingSoon"
   },
   {
     "id": "palacio-salvo",
@@ -672,7 +620,8 @@
       "plaza"
     ],
     "funFact": "Palacio Salvo dominated Montevideo's skyline when it opened in 1928.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Palacio_Salvo"
+    "sourceURL": "https://en.wikipedia.org/wiki/Palacio_Salvo",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-roraima",
@@ -697,32 +646,8 @@
       "expedition"
     ],
     "funFact": "Mount Roraima's tabletop summit inspired lost world adventure stories.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Roraima"
-  },
-  {
-    "id": "catedral-de-brasilia",
-    "name": "Cathedral of Brasilia",
-    "city": "Brasilia",
-    "country": "Brazil",
-    "continent": "South America",
-    "latitude": -15.7984,
-    "longitude": -47.875,
-    "totalHeightMeters": 90,
-    "totalHeightFeet": 295.3,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 495,
-    "realStairCount": null,
-    "calculatedFloors": 25,
-    "category": "cathedral",
-    "tier": "bronze",
-    "tags": [
-      "modernist",
-      "capital",
-      "icon"
-    ],
-    "funFact": "Oscar Niemeyer designed the Cathedral of Brasilia with a crown-like concrete structure.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Cathedral_of_Brasilia"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Roraima",
+    "releaseState": "comingSoon"
   },
   {
     "id": "farol-santander",
@@ -747,7 +672,8 @@
       "city center"
     ],
     "funFact": "This former bank tower is now an arts and observation space in downtown Sao Paulo.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Farol_Santander"
+    "sourceURL": "https://en.wikipedia.org/wiki/Farol_Santander",
+    "releaseState": "comingSoon"
   },
   {
     "id": "llaima-volcano",
@@ -772,7 +698,8 @@
       "expedition"
     ],
     "funFact": "Llaima is one of Chile's largest and most active volcanoes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Llaima"
+    "sourceURL": "https://en.wikipedia.org/wiki/Llaima",
+    "releaseState": "comingSoon"
   },
   {
     "id": "eiffel-tower",
@@ -797,7 +724,8 @@
       "icon"
     ],
     "funFact": "The Eiffel Tower was built as the entrance arch for the 1889 World's Fair.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Eiffel_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Eiffel_Tower",
+    "releaseState": "available"
   },
   {
     "id": "elizabeth-tower",
@@ -822,7 +750,8 @@
       "icon"
     ],
     "funFact": "Big Ben is the nickname of the tower's Great Bell, not the tower itself.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Elizabeth_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Elizabeth_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "the-shard",
@@ -847,7 +776,8 @@
       "skyline"
     ],
     "funFact": "The Shard was designed by Renzo Piano to look like a shard of glass.",
-    "sourceURL": "https://en.wikipedia.org/wiki/The_Shard"
+    "sourceURL": "https://en.wikipedia.org/wiki/The_Shard",
+    "releaseState": "comingSoon"
   },
   {
     "id": "berlin-tv-tower",
@@ -872,7 +802,8 @@
       "icon"
     ],
     "funFact": "The sphere of the Berlin TV Tower often reflects sunlight in a cross shape nicknamed the Pope's Revenge.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Fernsehturm_Berlin"
+    "sourceURL": "https://en.wikipedia.org/wiki/Fernsehturm_Berlin",
+    "releaseState": "comingSoon"
   },
   {
     "id": "leaning-tower-of-pisa",
@@ -897,32 +828,8 @@
       "icon"
     ],
     "funFact": "The Leaning Tower of Pisa began tilting during construction in the 12th century.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Leaning_Tower_of_Pisa"
-  },
-  {
-    "id": "colosseum",
-    "name": "Colosseum",
-    "city": "Rome",
-    "country": "Italy",
-    "continent": "Europe",
-    "latitude": 41.8902,
-    "longitude": 12.4922,
-    "totalHeightMeters": 48,
-    "totalHeightFeet": 157.5,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 264,
-    "realStairCount": null,
-    "calculatedFloors": 13,
-    "category": "monument",
-    "tier": "common",
-    "tags": [
-      "rome",
-      "amphitheater",
-      "history"
-    ],
-    "funFact": "The Colosseum could hold tens of thousands of spectators for ancient Roman spectacles.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Colosseum"
+    "sourceURL": "https://en.wikipedia.org/wiki/Leaning_Tower_of_Pisa",
+    "releaseState": "comingSoon"
   },
   {
     "id": "sagrada-familia",
@@ -947,57 +854,8 @@
       "basilica"
     ],
     "funFact": "Construction on the Sagrada Familia began in 1882 and is still ongoing.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sagrada_Familia"
-  },
-  {
-    "id": "arc-de-triomphe",
-    "name": "Arc de Triomphe",
-    "city": "Paris",
-    "country": "France",
-    "continent": "Europe",
-    "latitude": 48.8738,
-    "longitude": 2.295,
-    "totalHeightMeters": 50,
-    "totalHeightFeet": 164,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 275,
-    "realStairCount": null,
-    "calculatedFloors": 14,
-    "category": "monument",
-    "tier": "common",
-    "tags": [
-      "paris",
-      "arch",
-      "avenue"
-    ],
-    "funFact": "The Arc de Triomphe honors those who fought and died for France in the French Revolutionary and Napoleonic Wars.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Arc_de_Triomphe"
-  },
-  {
-    "id": "atomium",
-    "name": "Atomium",
-    "city": "Brussels",
-    "country": "Belgium",
-    "continent": "Europe",
-    "latitude": 50.8949,
-    "longitude": 4.3416,
-    "totalHeightMeters": 102,
-    "totalHeightFeet": 334.6,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 561,
-    "realStairCount": null,
-    "calculatedFloors": 28,
-    "category": "monument",
-    "tier": "bronze",
-    "tags": [
-      "expo",
-      "brussels",
-      "icon"
-    ],
-    "funFact": "The Atomium represents an iron crystal magnified 165 billion times.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Atomium"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sagrada_Familia",
+    "releaseState": "comingSoon"
   },
   {
     "id": "matterhorn",
@@ -1022,7 +880,8 @@
       "icon"
     ],
     "funFact": "The Matterhorn's near-symmetrical pyramid shape makes it one of the world's most recognizable mountains.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Matterhorn"
+    "sourceURL": "https://en.wikipedia.org/wiki/Matterhorn",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mont-blanc",
@@ -1047,7 +906,8 @@
       "expedition"
     ],
     "funFact": "Mont Blanc is the highest mountain in the Alps and Western Europe.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mont_Blanc"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mont_Blanc",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-etna",
@@ -1072,7 +932,8 @@
       "expedition"
     ],
     "funFact": "Mount Etna is one of the world's most active stratovolcanoes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Etna"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Etna",
+    "releaseState": "comingSoon"
   },
   {
     "id": "acropolis-of-athens",
@@ -1097,7 +958,8 @@
       "hilltop"
     ],
     "funFact": "The Acropolis has overlooked Athens since classical antiquity.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Acropolis_of_Athens"
+    "sourceURL": "https://en.wikipedia.org/wiki/Acropolis_of_Athens",
+    "releaseState": "comingSoon"
   },
   {
     "id": "st-peters-basilica",
@@ -1122,7 +984,8 @@
       "basilica"
     ],
     "funFact": "St. Peter's Basilica stands over the traditional burial site of Saint Peter.",
-    "sourceURL": "https://en.wikipedia.org/wiki/St._Peter%27s_Basilica"
+    "sourceURL": "https://en.wikipedia.org/wiki/St._Peter%27s_Basilica",
+    "releaseState": "comingSoon"
   },
   {
     "id": "neuschwanstein-castle",
@@ -1147,7 +1010,8 @@
       "icon"
     ],
     "funFact": "Neuschwanstein Castle inspired the look of several fairy-tale castles in popular culture.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Neuschwanstein_Castle"
+    "sourceURL": "https://en.wikipedia.org/wiki/Neuschwanstein_Castle",
+    "releaseState": "comingSoon"
   },
   {
     "id": "moscow-state-university-main-building",
@@ -1172,7 +1036,8 @@
       "university"
     ],
     "funFact": "The main building is one of Moscow's famed Seven Sisters skyscrapers.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Moscow_State_University"
+    "sourceURL": "https://en.wikipedia.org/wiki/Moscow_State_University",
+    "releaseState": "comingSoon"
   },
   {
     "id": "sacre-coeur",
@@ -1197,7 +1062,8 @@
       "paris"
     ],
     "funFact": "Sacre-Coeur sits at the summit of Montmartre, the highest natural point in Paris.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sacre-Coeur,_Paris"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sacre-Coeur,_Paris",
+    "releaseState": "comingSoon"
   },
   {
     "id": "alhambra",
@@ -1222,32 +1088,8 @@
       "andalusia"
     ],
     "funFact": "The Alhambra was the royal court of the Nasrid dynasty in Granada.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Alhambra"
-  },
-  {
-    "id": "torre-de-belem",
-    "name": "Torre de Belem",
-    "city": "Lisbon",
-    "country": "Portugal",
-    "continent": "Europe",
-    "latitude": 38.6916,
-    "longitude": -9.216,
-    "totalHeightMeters": 35,
-    "totalHeightFeet": 114.8,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 193,
-    "realStairCount": null,
-    "calculatedFloors": 10,
-    "category": "tower",
-    "tier": "common",
-    "tags": [
-      "riverfront",
-      "fortress",
-      "lisbon"
-    ],
-    "funFact": "Belem Tower once guarded the entrance to Lisbon's harbor.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Belem_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Alhambra",
+    "releaseState": "comingSoon"
   },
   {
     "id": "hallgrimskirkja",
@@ -1272,7 +1114,8 @@
       "icon"
     ],
     "funFact": "Hallgrimskirkja's design was inspired by Icelandic basalt columns.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Hallgrimskirkja"
+    "sourceURL": "https://en.wikipedia.org/wiki/Hallgrimskirkja",
+    "releaseState": "comingSoon"
   },
   {
     "id": "burj-khalifa",
@@ -1297,7 +1140,8 @@
       "observation"
     ],
     "funFact": "Burj Khalifa has held the tallest-building title since 2010.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Burj_Khalifa"
+    "sourceURL": "https://en.wikipedia.org/wiki/Burj_Khalifa",
+    "releaseState": "available"
   },
   {
     "id": "petronas-towers",
@@ -1322,7 +1166,8 @@
       "icon"
     ],
     "funFact": "The Petronas Towers were the world's tallest buildings from 1998 to 2004.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Petronas_Towers"
+    "sourceURL": "https://en.wikipedia.org/wiki/Petronas_Towers",
+    "releaseState": "comingSoon"
   },
   {
     "id": "taipei-101",
@@ -1347,7 +1192,8 @@
       "icon"
     ],
     "funFact": "Taipei 101 uses a massive tuned-mass damper to steady the tower during typhoons and earthquakes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Taipei_101"
+    "sourceURL": "https://en.wikipedia.org/wiki/Taipei_101",
+    "releaseState": "available"
   },
   {
     "id": "tokyo-skytree",
@@ -1372,7 +1218,8 @@
       "tokyo"
     ],
     "funFact": "Tokyo Skytree is the tallest structure in Japan.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Tokyo_Skytree"
+    "sourceURL": "https://en.wikipedia.org/wiki/Tokyo_Skytree",
+    "releaseState": "comingSoon"
   },
   {
     "id": "tokyo-tower",
@@ -1397,7 +1244,8 @@
       "icon"
     ],
     "funFact": "Tokyo Tower's color scheme follows international air safety rules for tall structures.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Tokyo_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Tokyo_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "shanghai-tower",
@@ -1422,7 +1270,8 @@
       "skyline"
     ],
     "funFact": "Shanghai Tower has one of the world's fastest elevators.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Shanghai_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Shanghai_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "canton-tower",
@@ -1447,7 +1296,8 @@
       "icon"
     ],
     "funFact": "Canton Tower's twisted form is sometimes called the Supermodel Tower.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Canton_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Canton_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "oriental-pearl-tower",
@@ -1472,7 +1322,8 @@
       "icon"
     ],
     "funFact": "The Oriental Pearl Tower became a symbol of modern Shanghai soon after opening in 1994.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Oriental_Pearl_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Oriental_Pearl_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "lotte-world-tower",
@@ -1497,7 +1348,8 @@
       "skyline"
     ],
     "funFact": "Lotte World Tower is the tallest building on the Korean Peninsula.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Lotte_World_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Lotte_World_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "n-seoul-tower",
@@ -1522,32 +1374,8 @@
       "seoul"
     ],
     "funFact": "N Seoul Tower stands atop Namsan and overlooks the South Korean capital.",
-    "sourceURL": "https://en.wikipedia.org/wiki/N_Seoul_Tower"
-  },
-  {
-    "id": "qutub-minar",
-    "name": "Qutub Minar",
-    "city": "Delhi",
-    "country": "India",
-    "continent": "Asia",
-    "latitude": 28.5244,
-    "longitude": 77.1855,
-    "totalHeightMeters": 73,
-    "totalHeightFeet": 239.5,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 402,
-    "realStairCount": null,
-    "calculatedFloors": 20,
-    "category": "tower",
-    "tier": "bronze",
-    "tags": [
-      "minaret",
-      "unesco",
-      "delhi"
-    ],
-    "funFact": "Qutub Minar is the tallest brick minaret in the world.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Qutb_Minar"
+    "sourceURL": "https://en.wikipedia.org/wiki/N_Seoul_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "merdeka-118",
@@ -1572,7 +1400,8 @@
       "skyline"
     ],
     "funFact": "Merdeka 118 became one of the tallest buildings in the world after topping out in 2021.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Merdeka_118"
+    "sourceURL": "https://en.wikipedia.org/wiki/Merdeka_118",
+    "releaseState": "comingSoon"
   },
   {
     "id": "marina-bay-sands",
@@ -1597,7 +1426,8 @@
       "resort"
     ],
     "funFact": "The three towers of Marina Bay Sands are linked by a huge rooftop SkyPark.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Marina_Bay_Sands"
+    "sourceURL": "https://en.wikipedia.org/wiki/Marina_Bay_Sands",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-fuji",
@@ -1622,7 +1452,8 @@
       "icon"
     ],
     "funFact": "Mount Fuji is Japan's highest peak and a longstanding cultural icon.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Fuji"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Fuji",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-kinabalu",
@@ -1647,7 +1478,8 @@
       "expedition"
     ],
     "funFact": "Mount Kinabalu is the highest mountain in Malaysia.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kinabalu"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kinabalu",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-everest",
@@ -1672,32 +1504,8 @@
       "expedition"
     ],
     "funFact": "Mount Everest is Earth's highest mountain above sea level.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Everest"
-  },
-  {
-    "id": "lotus-temple",
-    "name": "Lotus Temple",
-    "city": "Delhi",
-    "country": "India",
-    "continent": "Asia",
-    "latitude": 28.5535,
-    "longitude": 77.2588,
-    "totalHeightMeters": 34,
-    "totalHeightFeet": 111.5,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 187,
-    "realStairCount": null,
-    "calculatedFloors": 9,
-    "category": "temple",
-    "tier": "common",
-    "tags": [
-      "bahai",
-      "flower",
-      "modern"
-    ],
-    "funFact": "The Lotus Temple welcomes worshippers of every faith and is shaped like a lotus blossom.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Lotus_Temple"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Everest",
+    "releaseState": "available"
   },
   {
     "id": "charminar",
@@ -1722,7 +1530,8 @@
       "icon"
     ],
     "funFact": "The Charminar has four grand arches and four minarets at a historic crossroads in Hyderabad.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Charminar"
+    "sourceURL": "https://en.wikipedia.org/wiki/Charminar",
+    "releaseState": "comingSoon"
   },
   {
     "id": "osaka-castle",
@@ -1747,32 +1556,8 @@
       "icon"
     ],
     "funFact": "Toyotomi Hideyoshi built Osaka Castle in the late 16th century.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Osaka_Castle"
-  },
-  {
-    "id": "great-pyramid-of-giza",
-    "name": "Great Pyramid of Giza",
-    "city": "Giza",
-    "country": "Egypt",
-    "continent": "Africa",
-    "latitude": 29.9792,
-    "longitude": 31.1342,
-    "totalHeightMeters": 147,
-    "totalHeightFeet": 482.3,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 809,
-    "realStairCount": null,
-    "calculatedFloors": 41,
-    "category": "pyramid",
-    "tier": "silver",
-    "tags": [
-      "ancient wonders",
-      "egypt",
-      "icon"
-    ],
-    "funFact": "The Great Pyramid is the oldest of the Seven Wonders of the Ancient World and the only one still largely intact.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Great_Pyramid_of_Giza"
+    "sourceURL": "https://en.wikipedia.org/wiki/Osaka_Castle",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-kilimanjaro",
@@ -1797,7 +1582,8 @@
       "expedition"
     ],
     "funFact": "Kilimanjaro is Africa's highest mountain and a freestanding volcanic massif.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kilimanjaro"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kilimanjaro",
+    "releaseState": "comingSoon"
   },
   {
     "id": "table-mountain",
@@ -1822,7 +1608,8 @@
       "icon"
     ],
     "funFact": "Table Mountain's flat summit dominates the skyline of Cape Town.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Table_Mountain"
+    "sourceURL": "https://en.wikipedia.org/wiki/Table_Mountain",
+    "releaseState": "available"
   },
   {
     "id": "cairo-tower",
@@ -1847,7 +1634,8 @@
       "icon"
     ],
     "funFact": "The lattice exterior of Cairo Tower was designed to echo a lotus plant.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Cairo_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Cairo_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-kenya",
@@ -1872,32 +1660,8 @@
       "expedition"
     ],
     "funFact": "Mount Kenya is the second-highest mountain in Africa.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kenya"
-  },
-  {
-    "id": "hassan-ii-mosque-minaret",
-    "name": "Hassan II Mosque Minaret",
-    "city": "Casablanca",
-    "country": "Morocco",
-    "continent": "Africa",
-    "latitude": 33.6084,
-    "longitude": -7.6326,
-    "totalHeightMeters": 210,
-    "totalHeightFeet": 689,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 1155,
-    "realStairCount": null,
-    "calculatedFloors": 58,
-    "category": "tower",
-    "tier": "silver",
-    "tags": [
-      "minaret",
-      "mosque",
-      "coast"
-    ],
-    "funFact": "The Hassan II Mosque has one of the tallest minarets in the world.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Hassan_II_Mosque"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kenya",
+    "releaseState": "comingSoon"
   },
   {
     "id": "voortrekker-monument",
@@ -1922,7 +1686,8 @@
       "granite"
     ],
     "funFact": "The Voortrekker Monument commemorates the 19th-century migration known as the Great Trek.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Voortrekker_Monument"
+    "sourceURL": "https://en.wikipedia.org/wiki/Voortrekker_Monument",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-cameroon",
@@ -1947,7 +1712,8 @@
       "expedition"
     ],
     "funFact": "Mount Cameroon is one of Africa's most active volcanoes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Cameroon"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Cameroon",
+    "releaseState": "comingSoon"
   },
   {
     "id": "abuna-yemata-guh",
@@ -1972,7 +1738,8 @@
       "ethiopia"
     ],
     "funFact": "Abuna Yemata Guh is famed for its cliffside approach and painted cave church interior.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Abuna_Yemata_Guh"
+    "sourceURL": "https://en.wikipedia.org/wiki/Abuna_Yemata_Guh",
+    "releaseState": "comingSoon"
   },
   {
     "id": "sky-tower-auckland",
@@ -1997,7 +1764,8 @@
       "icon"
     ],
     "funFact": "Sky Tower is the tallest freestanding structure in the Southern Hemisphere.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sky_Tower_(Auckland)"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sky_Tower_(Auckland)",
+    "releaseState": "comingSoon"
   },
   {
     "id": "eureka-tower",
@@ -2022,7 +1790,8 @@
       "observation"
     ],
     "funFact": "Eureka Tower's top floors are wrapped in gold-plated glass.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Eureka_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Eureka_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "q1-tower",
@@ -2047,7 +1816,8 @@
       "skyline"
     ],
     "funFact": "Q1 Tower's spire was inspired by the Sydney Olympic torch.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Q1_(building)"
+    "sourceURL": "https://en.wikipedia.org/wiki/Q1_(building)",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-kosciuszko",
@@ -2072,32 +1842,8 @@
       "alps"
     ],
     "funFact": "Mount Kosciuszko is the highest mountain on mainland Australia.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kosciuszko"
-  },
-  {
-    "id": "melbourne-arts-centre-spire",
-    "name": "Melbourne Arts Centre Spire",
-    "city": "Melbourne",
-    "country": "Australia",
-    "continent": "Oceania",
-    "latitude": -37.8203,
-    "longitude": 144.9689,
-    "totalHeightMeters": 162,
-    "totalHeightFeet": 531.5,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 891,
-    "realStairCount": null,
-    "calculatedFloors": 45,
-    "category": "tower",
-    "tier": "silver",
-    "tags": [
-      "arts",
-      "melbourne",
-      "icon"
-    ],
-    "funFact": "The Arts Centre spire is lit every night and has become a Melbourne skyline signature.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Arts_Centre_Melbourne"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kosciuszko",
+    "releaseState": "comingSoon"
   },
   {
     "id": "kunanyi-mount-wellington",
@@ -2122,7 +1868,8 @@
       "viewpoint"
     ],
     "funFact": "kunanyi towers above Hobart and can be dusted with snow in winter.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Wellington_(Tasmania)"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Wellington_(Tasmania)",
+    "releaseState": "comingSoon"
   },
   {
     "id": "aoraki-mount-cook",
@@ -2147,7 +1894,8 @@
       "icon"
     ],
     "funFact": "Aoraki / Mount Cook is the highest mountain in New Zealand.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Aoraki_/_Mount_Cook"
+    "sourceURL": "https://en.wikipedia.org/wiki/Aoraki_/_Mount_Cook",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-taranaki",
@@ -2172,7 +1920,8 @@
       "icon"
     ],
     "funFact": "Mount Taranaki's near-perfect cone makes it one of New Zealand's most distinctive mountains.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Taranaki"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Taranaki",
+    "releaseState": "comingSoon"
   },
   {
     "id": "sydney-tower",
@@ -2197,6 +1946,7 @@
       "skyline"
     ],
     "funFact": "Sydney Tower is the tallest structure in the city's central business district.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sydney_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sydney_Tower",
+    "releaseState": "available"
   }
 ]

--- a/AscendApp/Features/Climbs/Services/ClimbService.swift
+++ b/AscendApp/Features/Climbs/Services/ClimbService.swift
@@ -7,6 +7,8 @@ final class ClimbService {
 
     private let catalogRepository: any ClimbCatalogRepository
     private var cachedClimbs: [Climb]?
+    private var cachedVisibleClimbs: [Climb] = []
+    private var cachedAvailableClimbs: [Climb] = []
     private var cachedClimbsByID: [String: Climb] = [:]
     private(set) var featuredClimbId: String?
     private(set) var catalogSource: ClimbCatalogSource = .bootstrap
@@ -17,13 +19,37 @@ final class ClimbService {
     }
 
     func loadClimbs() throws -> [Climb] {
-        if let cachedClimbs {
-            return cachedClimbs
+        try loadAvailableClimbs()
+    }
+
+    func loadVisibleClimbs() throws -> [Climb] {
+        if cachedClimbs != nil {
+            return cachedVisibleClimbs
         }
 
         let snapshot = try catalogRepository.loadInitialCatalog()
         cache(snapshot: snapshot)
-        return snapshot.publishedClimbs
+        return snapshot.visibleClimbs
+    }
+
+    func loadAvailableClimbs() throws -> [Climb] {
+        if cachedClimbs != nil {
+            return cachedAvailableClimbs
+        }
+
+        let snapshot = try catalogRepository.loadInitialCatalog()
+        cache(snapshot: snapshot)
+        return snapshot.availableClimbs
+    }
+
+    func loadComingSoonClimbs() throws -> [Climb] {
+        if let cachedClimbs {
+            return cachedClimbs.filter(\.isComingSoon)
+        }
+
+        let snapshot = try catalogRepository.loadInitialCatalog()
+        cache(snapshot: snapshot)
+        return snapshot.comingSoonClimbs
     }
 
     @discardableResult
@@ -37,7 +63,7 @@ final class ClimbService {
 
         let didChange = existingVersion != snapshot.catalogVersion ||
             existingFeaturedClimbId != snapshot.featuredClimbId ||
-            existingClimbs != snapshot.publishedClimbs
+            existingClimbs != snapshot.climbs
 
         if didChange {
             postCatalogChangeNotification()
@@ -54,7 +80,7 @@ final class ClimbService {
     }
 
     func homeCardState(modelContext: ModelContext) throws -> ClimbHomeCardState {
-        let climbs = try loadClimbs()
+        let climbs = try loadAvailableClimbs()
 
         if let lastCompletedSummary = try lastCompletedSummary(modelContext: modelContext) {
             return .inactive(lastCompletedSummary)
@@ -86,7 +112,7 @@ final class ClimbService {
     }
 
     func lastCompletedSummary(modelContext: ModelContext) throws -> CompletedClimbSummary? {
-        let climbs = try loadClimbs()
+        let climbs = try loadAvailableClimbs()
         let totalClimbs = climbs.count
         let completedAttempts = fetchAttempts(modelContext: modelContext)
             .filter { $0.status == .completed }
@@ -322,9 +348,10 @@ final class ClimbService {
     }
 
     private func cache(snapshot: ClimbCatalogSnapshot) {
-        let publishedClimbs = snapshot.publishedClimbs
-        cachedClimbs = publishedClimbs
-        cachedClimbsByID = Dictionary(uniqueKeysWithValues: publishedClimbs.map { ($0.id, $0) })
+        cachedClimbs = snapshot.climbs
+        cachedVisibleClimbs = snapshot.visibleClimbs
+        cachedAvailableClimbs = snapshot.availableClimbs
+        cachedClimbsByID = Dictionary(uniqueKeysWithValues: snapshot.climbs.map { ($0.id, $0) })
         featuredClimbId = snapshot.featuredClimbId
         catalogSource = snapshot.source
         catalogVersion = snapshot.catalogVersion

--- a/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
@@ -47,11 +47,11 @@ final class ClimbDetailViewModel {
     }
 
     var actionTitle: String {
-        "Start Live Climb"
+        climb.isAvailable ? "Start Live Climb" : "Coming Soon"
     }
 
     var isActionEnabled: Bool {
-        true
+        climb.isAvailable
     }
 
     var estimatedTimeText: String {

--- a/AscendApp/Features/Climbs/ViewModels/GlobeViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/GlobeViewModel.swift
@@ -43,7 +43,15 @@ final class GlobeViewModel {
     }
 
     var climbCount: Int {
-        visibleClimbs.count
+        availableClimbs.count
+    }
+
+    var availableClimbs: [Climb] {
+        visibleClimbs.filter(\.isAvailable)
+    }
+
+    var comingSoonClimbs: [Climb] {
+        visibleClimbs.filter(\.isComingSoon)
     }
 
     var liveClimbCommunityCompletedUserCount: Int {
@@ -52,11 +60,11 @@ final class GlobeViewModel {
 
     var firstFeaturedClimb: Climb? {
         if let featuredClimbId,
-           let featuredClimb = visibleClimbs.first(where: { $0.id == featuredClimbId }) {
+           let featuredClimb = availableClimbs.first(where: { $0.id == featuredClimbId }) {
             return featuredClimb
         }
 
-        return visibleClimbs.sorted { lhs, rhs in
+        return availableClimbs.sorted { lhs, rhs in
             if lhs.tier == rhs.tier {
                 return lhs.name < rhs.name
             }
@@ -68,7 +76,7 @@ final class GlobeViewModel {
         let normalizedQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedQuery.isEmpty else { return [] }
 
-        return visibleClimbs
+        return availableClimbs
             .compactMap { climb -> (climb: Climb, rank: Int)? in
                 guard let rank = searchRank(for: climb, query: normalizedQuery) else { return nil }
                 return (climb, rank)
@@ -92,7 +100,7 @@ final class GlobeViewModel {
         }
 
         do {
-            visibleClimbs = try climbService.loadClimbs()
+            visibleClimbs = try climbService.loadVisibleClimbs()
             featuredClimbId = climbService.featuredClimbId
             catalogSource = climbService.catalogSource
             refresh(modelContext: modelContext)
@@ -108,7 +116,7 @@ final class GlobeViewModel {
 
     func reloadCatalog(modelContext: ModelContext) {
         do {
-            visibleClimbs = try climbService.loadClimbs()
+            visibleClimbs = try climbService.loadVisibleClimbs()
             featuredClimbId = climbService.featuredClimbId
             catalogSource = climbService.catalogSource
             refresh(modelContext: modelContext)
@@ -123,7 +131,7 @@ final class GlobeViewModel {
     func refresh(modelContext: ModelContext) {
         completedClimbIds = climbService.completedClimbIds(modelContext: modelContext)
         lastCompletedSummary = try? climbService.lastCompletedSummary(modelContext: modelContext)
-        homeCardState = (try? climbService.homeCardState(modelContext: modelContext)) ?? .neverClimbed(totalClimbs: visibleClimbs.count)
+        homeCardState = (try? climbService.homeCardState(modelContext: modelContext)) ?? .neverClimbed(totalClimbs: availableClimbs.count)
         refreshDailyRecommendedClimb()
 
         if let previewSummary {
@@ -417,16 +425,16 @@ final class GlobeViewModel {
     }
 
     private func nextDailyRecommendedClimb() -> Climb? {
-        let uncompletedClimbs = sortedDailyClimbs(visibleClimbs.filter { !completedClimbIds.contains($0.id) })
+        let uncompletedClimbs = sortedDailyClimbs(availableClimbs.filter { !completedClimbIds.contains($0.id) })
         if let climb = dailyClimb(from: uncompletedClimbs) {
             return climb
         }
 
-        return dailyClimb(from: sortedDailyClimbs(visibleClimbs))
+        return dailyClimb(from: sortedDailyClimbs(availableClimbs))
     }
 
     private func refreshDailyRecommendedClimb() {
-        guard !visibleClimbs.isEmpty else {
+        guard !availableClimbs.isEmpty else {
             dailyRecommendedClimb = nil
             return
         }
@@ -436,7 +444,7 @@ final class GlobeViewModel {
 
         if defaults.string(forKey: Self.dailyRecommendationDayDefaultsKey) == todayKey,
            let storedClimbId = defaults.string(forKey: Self.dailyRecommendationClimbDefaultsKey),
-           let storedClimb = visibleClimbs.first(where: { $0.id == storedClimbId }) {
+           let storedClimb = availableClimbs.first(where: { $0.id == storedClimbId }) {
             dailyRecommendedClimb = storedClimb
             return
         }
@@ -489,7 +497,7 @@ final class GlobeViewModel {
     )
 }
 
-#if DEBUG
+#if DEBUG || STAGING
 extension GlobeViewModel {
     static func debugDailyRecommendedClimbId() -> String? {
         let defaults = UserDefaults.standard

--- a/AscendApp/Features/Climbs/Views/ClimbBrowseHelpSheet.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbBrowseHelpSheet.swift
@@ -79,6 +79,15 @@ struct ClimbBrowseHelpSheet: View {
                             legendRow(
                                 title: "Available",
                                 description: "A climb you can preview and start.",
+                                climb: .preview,
+                                isCompleted: false,
+                                isHighlighted: false
+                            )
+
+                            legendRow(
+                                title: "Coming Soon",
+                                description: "A future climb pinned on the globe but not open yet.",
+                                climb: .previewComingSoon,
                                 isCompleted: false,
                                 isHighlighted: false
                             )
@@ -86,6 +95,7 @@ struct ClimbBrowseHelpSheet: View {
                             legendRow(
                                 title: "Completed",
                                 description: "A climb you have already finished at least once.",
+                                climb: .preview,
                                 isCompleted: true,
                                 isHighlighted: false
                             )
@@ -175,12 +185,13 @@ struct ClimbBrowseHelpSheet: View {
     private func legendRow(
         title: String,
         description: String,
+        climb: Climb,
         isCompleted: Bool,
         isHighlighted: Bool
     ) -> some View {
         HStack(alignment: .top, spacing: 14) {
             ClimbPinView(
-                climb: .preview,
+                climb: climb,
                 isCompleted: isCompleted,
                 isHighlighted: isHighlighted
             )

--- a/AscendApp/Features/Climbs/Views/ClimbBrowseView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbBrowseView.swift
@@ -261,7 +261,7 @@ struct ClimbBrowseView: View {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .stroke(.white.opacity(isSearchFocused ? 0.2 : 0.1), lineWidth: 1)
         )
-        .disabled(viewModel.visibleClimbs.isEmpty)
+        .disabled(viewModel.availableClimbs.isEmpty)
     }
 
     // MARK: - Search Results
@@ -304,15 +304,15 @@ struct ClimbBrowseView: View {
 
     private var browseSectionsContent: some View {
         VStack(alignment: .leading, spacing: 22) {
-            horizontalClimbSection(title: "Popular", climbs: popularClimbs, showsSeeAll: true)
-            horizontalClimbSection(title: "Easiest", climbs: easiestClimbs)
-            horizontalClimbSection(title: "Hardest", climbs: hardestClimbs)
-
-            if !completedClimbs.isEmpty {
-                horizontalClimbSection(title: "Completed", climbs: completedClimbs)
+            if let dailyRecommendedClimb = viewModel.dailyRecommendedClimb {
+                todaysClimbSection(dailyRecommendedClimb)
             }
 
             allClimbsSection
+
+            if !viewModel.comingSoonClimbs.isEmpty {
+                comingSoonSection
+            }
         }
     }
 
@@ -352,13 +352,65 @@ struct ClimbBrowseView: View {
 
     private var allClimbsSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            sectionHeader("All Climbs")
+            sectionHeader("All Climbs (\(allClimbs.count))")
 
             VStack(spacing: 8) {
                 ForEach(allClimbs) { climb in
-                    climbResultRow(for: climb, source: .browseAll)
+                    climbResultRow(
+                        for: climb,
+                        source: .browseAll,
+                        isHighlighted: climb.id == viewModel.dailyRecommendedClimb?.id
+                    )
                 }
             }
+        }
+    }
+
+    private func todaysClimbSection(_ climb: Climb) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader("Today's Climb")
+
+            climbResultRow(for: climb, source: .browseSection, isHighlighted: true)
+        }
+    }
+
+    private var comingSoonSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader("Coming Soon")
+
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "lock")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(.accent)
+                    .frame(width: 28, height: 28)
+                    .background(
+                        Circle()
+                            .fill(Color.accent.opacity(0.14))
+                    )
+
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("\(viewModel.comingSoonClimbs.count.formatted()) First Ascents are still locked.")
+                        .font(.montserratSemiBold(size: 14))
+                        .foregroundStyle(.white.opacity(0.9))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text("New climbs open soon. Ghost pins on the globe show where the next races will land.")
+                        .font(.montserratRegular(size: 12.5))
+                        .foregroundStyle(.white.opacity(0.56))
+                        .lineSpacing(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(14)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(.white.opacity(0.06))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(.white.opacity(0.1), lineWidth: 1)
+            )
         }
     }
 
@@ -433,7 +485,8 @@ struct ClimbBrowseView: View {
 
     private func climbResultRow(
         for climb: Climb,
-        source: LiveClimbAnalyticsEvent.EntryPoint
+        source: LiveClimbAnalyticsEvent.EntryPoint,
+        isHighlighted: Bool = false
     ) -> some View {
         Button {
             openClimbFromDrawer(climb, source: source)
@@ -441,6 +494,10 @@ struct ClimbBrowseView: View {
             ClimbResultRowView(
                 climb: climb,
                 isCompleted: viewModel.isCompleted(climb)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(isHighlighted ? Color.accent.opacity(0.72) : .clear, lineWidth: 1)
             )
         }
         .buttonStyle(.plain)
@@ -525,6 +582,8 @@ struct ClimbBrowseView: View {
         _ climb: Climb,
         source: LiveClimbAnalyticsEvent.EntryPoint
     ) {
+        guard climb.isAvailable else { return }
+
         isSearchFocused = false
         viewModel.previewSummary = nil
         viewModel.userDidInteract()
@@ -539,6 +598,8 @@ struct ClimbBrowseView: View {
     }
 
     private func openPreviewClimb(_ climb: Climb) {
+        guard climb.isAvailable else { return }
+
         isSearchFocused = false
         viewModel.userDidInteract()
         selectedDetailEntryPoint = .browsePreview
@@ -562,7 +623,7 @@ struct ClimbBrowseView: View {
         TelemetryManager.shared.track(
             LiveClimbAnalyticsEvent.browseOpened(
                 entryPoint: analyticsEntryPoint,
-                totalClimbs: viewModel.visibleClimbs.count
+                totalClimbs: viewModel.climbCount
             )
         )
     }
@@ -591,70 +652,12 @@ struct ClimbBrowseView: View {
         !viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private var popularClimbs: [Climb] {
-        let featured = viewModel.firstFeaturedClimb.map { [$0] } ?? []
-        let tiered = viewModel.visibleClimbs.sorted { lhs, rhs in
-            if lhs.tier == rhs.tier {
-                return lhs.referenceStepCount < rhs.referenceStepCount
-            }
-            return lhs.tier > rhs.tier
-        }
-        return Array(uniqueClimbs(featured + tiered).prefix(10))
-    }
-
-    private var easiestClimbs: [Climb] {
-        Array(
-            viewModel.visibleClimbs
-                .sorted { lhs, rhs in
-                    if lhs.referenceStepCount == rhs.referenceStepCount {
-                        return lhs.name < rhs.name
-                    }
-                    return lhs.referenceStepCount < rhs.referenceStepCount
-                }
-                .prefix(10)
-        )
-    }
-
-    private var hardestClimbs: [Climb] {
-        Array(
-            viewModel.visibleClimbs
-                .sorted { lhs, rhs in
-                    if lhs.referenceStepCount == rhs.referenceStepCount {
-                        return lhs.name < rhs.name
-                    }
-                    return lhs.referenceStepCount > rhs.referenceStepCount
-                }
-                .prefix(10)
-        )
-    }
-
-    private var completedClimbs: [Climb] {
-        Array(
-            viewModel.visibleClimbs
-                .filter { viewModel.isCompleted($0) }
-                .sorted { lhs, rhs in
-                    if lhs.tier == rhs.tier {
-                        return lhs.name < rhs.name
-                    }
-                    return lhs.tier > rhs.tier
-                }
-                .prefix(10)
-        )
-    }
-
     private var allClimbs: [Climb] {
-        viewModel.visibleClimbs.sorted { lhs, rhs in
+        viewModel.availableClimbs.sorted { lhs, rhs in
             if lhs.referenceStepCount == rhs.referenceStepCount {
                 return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
             }
             return lhs.referenceStepCount < rhs.referenceStepCount
-        }
-    }
-
-    private func uniqueClimbs(_ climbs: [Climb]) -> [Climb] {
-        var seenIds = Set<String>()
-        return climbs.filter { climb in
-            seenIds.insert(climb.id).inserted
         }
     }
 }

--- a/AscendApp/Features/Climbs/Views/ClimbCardView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbCardView.swift
@@ -140,15 +140,15 @@ struct ClimbCardView: View {
         }
 
         if let featuredClimbId = viewModel.featuredClimbId,
-           let featuredClimb = viewModel.visibleClimbs.first(where: { $0.id == featuredClimbId }) {
+           let featuredClimb = viewModel.availableClimbs.first(where: { $0.id == featuredClimbId }) {
             return featuredClimb
         }
 
-        if let empireState = viewModel.visibleClimbs.first(where: { $0.id == "empire-state-building" }) {
+        if let empireState = viewModel.availableClimbs.first(where: { $0.id == "empire-state-building" }) {
             return empireState
         }
 
-        return viewModel.visibleClimbs.first ?? .preview
+        return viewModel.availableClimbs.first ?? .preview
     }
 
     private func estimatedTimeText(for climb: Climb) -> String {

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -152,7 +152,10 @@ struct ClimbDetailView: View {
                     perspective: 0.72
                 )
 
-            flipCardButton
+            if !isHeroCardFlipped {
+                flipCardButton
+                    .transition(.opacity)
+            }
         }
         .contentShape(heroShape)
         .onTapGesture {
@@ -528,10 +531,6 @@ struct ClimbDetailView: View {
 
     private var historyPage: some View {
         VStack(alignment: .leading, spacing: 20) {
-            Text("Your History")
-                .font(.montserratBold(size: 22))
-                .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-
             if viewModel.historySummary.recentEntries.isEmpty {
                 Text("Attempts and completions for this climb will show up here.")
                     .font(.montserratRegular(size: 15))
@@ -560,19 +559,12 @@ struct ClimbDetailView: View {
 
     private var leaderboardPage: some View {
         VStack(alignment: .leading, spacing: 18) {
-            HStack(alignment: .firstTextBaseline) {
-                Text("Leaderboard")
-                    .font(.montserratBold(size: 22))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-
-                Spacer(minLength: 0)
-
-                if viewModel.completionLeaderboardCompletedCount > 0 {
-                    Text("\(viewModel.completionLeaderboardCompletedCount.formatted()) completed")
-                        .font(.montserratSemiBold(size: 13))
-                        .foregroundStyle(.accent)
-                        .monospacedDigit()
-                }
+            if viewModel.completionLeaderboardCompletedCount > 0 {
+                Text("\(viewModel.completionLeaderboardCompletedCount.formatted()) completed")
+                    .font(.montserratSemiBold(size: 13))
+                    .foregroundStyle(.accent)
+                    .monospacedDigit()
+                    .frame(maxWidth: .infinity, alignment: .trailing)
             }
 
             if let firstAscent = viewModel.leaderboardSummary.firstAscent {
@@ -638,11 +630,11 @@ struct ClimbDetailView: View {
 
     private var leaderboardEmptyState: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("No completed times yet")
+            Text("No completed times yet.")
                 .font(.montserratBold(size: 18))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
 
-            Text("Complete this climb to put the first time on the board.")
+            Text("First Ascent open. The first finisher claims it forever.")
                 .font(.montserratRegular(size: 14))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.66) : .black.opacity(0.58))
                 .fixedSize(horizontal: false, vertical: true)
@@ -971,7 +963,7 @@ struct ClimbDetailView: View {
     private var communityCaption: some View {
         Group {
             if viewModel.communityCompletedCount == 0 {
-                Text("Nobody's finished this climb yet. Be the first.")
+                Text("First Ascent open. The first finisher claims it forever.")
                     .font(.montserratRegular(size: 15))
                     .foregroundStyle(communitySecondaryColor)
                     .lineLimit(2)
@@ -996,7 +988,7 @@ struct ClimbDetailView: View {
 
     private var communityAccessibilityLabel: String {
         if viewModel.communityCompletedCount == 0 {
-            return "Nobody has finished this climb yet. Be the first."
+            return "First Ascent open. The first finisher claims it forever."
         }
         return "\(viewModel.communityCompletedCount) completed"
     }

--- a/AscendApp/Features/Climbs/Views/ClimbPinView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbPinView.swift
@@ -41,19 +41,28 @@ struct ClimbPinView: View {
 
     private var pinIcon: some View {
         AppIcon(
-            token: isCompleted ? .mapPinFill : .mapPin,
+            token: isCompleted || climb.isAvailable ? .mapPinFill : .mapPin,
             pointSize: pinSize
         )
         .foregroundStyle(pinColor)
+        .opacity(climb.isComingSoon ? 0.42 : 1)
     }
 
     private var pinColor: Color {
+        if climb.isComingSoon {
+            return .white.opacity(0.72)
+        }
+
         return tierColor
     }
 
     private var shadowColor: Color {
         if isCompleted {
             return tierColor
+        }
+
+        if climb.isComingSoon {
+            return .white.opacity(0.3)
         }
 
         return tierColor
@@ -84,7 +93,7 @@ struct ClimbPinView: View {
 
     private var availableSelectionGlow: some View {
         Circle()
-            .fill(.white.opacity(0.24))
+            .fill((climb.isComingSoon ? Color.white.opacity(0.12) : Color.white.opacity(0.24)))
             .frame(width: 12, height: 12)
             .blur(radius: 0.8)
             .offset(y: -7)
@@ -101,6 +110,10 @@ struct ClimbPinView: View {
         VStack(spacing: 8) {
             ClimbPinView(climb: .preview, isCompleted: true, isHighlighted: false)
             Text("Completed").font(.caption2)
+        }
+        VStack(spacing: 8) {
+            ClimbPinView(climb: .previewComingSoon, isCompleted: false, isHighlighted: false)
+            Text("Coming").font(.caption2)
         }
         VStack(spacing: 8) {
             ClimbPinView(climb: .preview, isCompleted: false, isHighlighted: true)

--- a/AscendApp/Features/Climbs/Views/ClimbPreviewCardView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbPreviewCardView.swift
@@ -17,50 +17,10 @@ struct ClimbPreviewCardView: View {
                     lineWidth: 1.8,
                     isEmphasizedBorderStyle: summary.climb.tier.usesEmphasizedBorderStyle,
                     leading: {
-                        ClimbLeadingArtworkPanel(climb: summary.climb)
+                        leadingArtwork
                     },
                     content: {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(summary.climb.name)
-                                .font(.montserratBold(size: 14.5))
-                                .foregroundStyle(.white)
-                                .lineLimit(2)
-                                .minimumScaleFactor(0.85)
-
-                            HStack(spacing: 5) {
-                                Image(systemName: "mappin.and.ellipse")
-                                    .font(.system(size: 11, weight: .semibold))
-                                    .foregroundStyle(.white.opacity(0.46))
-
-                                Text(summary.climb.displayLocation)
-                                    .font(.montserratRegular(size: 12))
-                                    .foregroundStyle(.white.opacity(0.62))
-                                    .lineLimit(1)
-                            }
-
-                            HStack(spacing: 10) {
-                                Text("\(summary.climb.referenceStepCount.formatted()) steps")
-                                    .font(.montserratSemiBold(size: 12))
-                                    .foregroundStyle(.white)
-
-                                Text("|")
-                                    .font(.montserratMedium(size: 11))
-                                    .foregroundStyle(.white.opacity(0.26))
-
-                                Text(estimatedTimeText)
-                                    .font(.montserratSemiBold(size: 12))
-                                    .foregroundStyle(.white.opacity(0.88))
-                            }
-
-                            Text("Finish in one live attempt")
-                                .font(.montserratMedium(size: 10))
-                                .italic()
-                                .foregroundStyle(.white.opacity(0.32))
-                                .lineLimit(2)
-                                .lineSpacing(1)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .layoutPriority(1)
-                        }
+                        cardContent
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.leading, 16)
                         .padding(.trailing, 46)
@@ -70,6 +30,7 @@ struct ClimbPreviewCardView: View {
                 .frame(height: 138)
             }
             .buttonStyle(.plain)
+            .disabled(!summary.climb.isAvailable)
 
             Button(action: onClose) {
                 Image(systemName: "xmark")
@@ -83,6 +44,102 @@ struct ClimbPreviewCardView: View {
             }
             .buttonStyle(.plain)
             .padding(12)
+        }
+    }
+
+    @ViewBuilder
+    private var leadingArtwork: some View {
+        if summary.climb.isComingSoon {
+            ClimbLeadingArtworkPanel(climb: summary.climb)
+                .blur(radius: 3)
+                .opacity(0.42)
+                .overlay {
+                    Image(systemName: "lock.fill")
+                        .font(.system(size: 18, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.72))
+                }
+        } else {
+            ClimbLeadingArtworkPanel(climb: summary.climb)
+        }
+    }
+
+    @ViewBuilder
+    private var cardContent: some View {
+        if summary.climb.isComingSoon {
+            comingSoonContent
+        } else {
+            availableContent
+        }
+    }
+
+    private var availableContent: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(summary.climb.name)
+                .font(.montserratBold(size: 14.5))
+                .foregroundStyle(.white)
+                .lineLimit(2)
+                .minimumScaleFactor(0.85)
+
+            HStack(spacing: 5) {
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.46))
+
+                Text(summary.climb.displayLocation)
+                    .font(.montserratRegular(size: 12))
+                    .foregroundStyle(.white.opacity(0.62))
+                    .lineLimit(1)
+            }
+
+            HStack(spacing: 10) {
+                Text("\(summary.climb.referenceStepCount.formatted()) steps")
+                    .font(.montserratSemiBold(size: 12))
+                    .foregroundStyle(.white)
+
+                Text("|")
+                    .font(.montserratMedium(size: 11))
+                    .foregroundStyle(.white.opacity(0.26))
+
+                Text(estimatedTimeText)
+                    .font(.montserratSemiBold(size: 12))
+                    .foregroundStyle(.white.opacity(0.88))
+            }
+
+            Text("Finish in one live attempt")
+                .font(.montserratMedium(size: 10))
+                .italic()
+                .foregroundStyle(.white.opacity(0.32))
+                .lineLimit(2)
+                .lineSpacing(1)
+                .fixedSize(horizontal: false, vertical: true)
+                .layoutPriority(1)
+        }
+    }
+
+    private var comingSoonContent: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("Coming Soon")
+                .font(.montserratBold(size: 15))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+
+            HStack(spacing: 5) {
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.46))
+
+                Text(summary.climb.displayLocation)
+                    .font(.montserratRegular(size: 12))
+                    .foregroundStyle(.white.opacity(0.62))
+                    .lineLimit(1)
+            }
+
+            Text("A new First Ascent opens here soon. Be ready.")
+                .font(.montserratSemiBold(size: 12))
+                .foregroundStyle(.white.opacity(0.86))
+                .lineLimit(3)
+                .lineSpacing(2)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -109,6 +166,17 @@ struct ClimbPreviewCardView: View {
 #Preview("Completed Climb") {
     ClimbPreviewCardView(
         summary: ClimbPreviewSummary(climb: .preview, isCompleted: true),
+        onSelect: {},
+        onClose: {}
+    )
+    .padding(16)
+    .background(.black)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Coming Soon") {
+    ClimbPreviewCardView(
+        summary: ClimbPreviewSummary(climb: .previewComingSoon, isCompleted: false),
         onSelect: {},
         onClose: {}
     )

--- a/AscendApp/Features/Climbs/Views/GlobeView.swift
+++ b/AscendApp/Features/Climbs/Views/GlobeView.swift
@@ -48,8 +48,16 @@ struct GlobeView: View {
             )
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(climb.name), \(climb.displayLocation)")
-        .accessibilityHint("Preview climb details")
+        .accessibilityLabel(accessibilityLabel(for: climb))
+        .accessibilityHint(climb.isAvailable ? "Preview climb details" : "Preview coming soon climb")
+    }
+
+    private func accessibilityLabel(for climb: Climb) -> String {
+        if climb.isComingSoon {
+            return "Coming soon climb, \(climb.displayLocation)"
+        }
+
+        return "\(climb.name), \(climb.displayLocation)"
     }
 }
 

--- a/AscendApp/Features/Home/ViewModels/HomeDashboardViewModel.swift
+++ b/AscendApp/Features/Home/ViewModels/HomeDashboardViewModel.swift
@@ -206,7 +206,7 @@ final class HomeDashboardViewModel {
         case .longestClimb:
             return "LONGEST CLIMB"
         case .highestAverageSPM:
-            return "HIGHEST SPM"
+            return "FASTEST PACE"
         case .mostStepsInTime(let minutes):
             return "BEST \(minutes) MIN"
         case .fastestStepTarget(let steps):
@@ -219,7 +219,9 @@ final class HomeDashboardViewModel {
         switch effort.metric {
         case .longestClimb, .fastestStepTarget:
             return BestEffortFormatting.clockTime(effort.performance.value)
-        case .mostSteps, .mostStepsInTime, .highestAverageSPM:
+        case .highestAverageSPM:
+            return effort.valueText
+        case .mostSteps, .mostStepsInTime:
             return effort.compactValueText
         }
     }

--- a/AscendApp/Features/Home/Views/HomeView.swift
+++ b/AscendApp/Features/Home/Views/HomeView.swift
@@ -102,7 +102,7 @@ struct HomeView: View {
                     HomeRankGlobeRow(
                         weeklyRankSummary: homeDashboard.weeklyRankSummary,
                         completedClimbCount: homeDashboard.completedClimbCount,
-                        totalClimbCount: globeViewModel.visibleClimbs.count,
+                        totalClimbCount: globeViewModel.climbCount,
                         onRankTapped: { tabRouter.selectedTab = .leaderboard },
                         onGlobeTapped: { presentClimbBrowse() }
                     )
@@ -227,7 +227,7 @@ struct HomeView: View {
     private func presentClimbBrowse() {
         TelemetryManager.shared.track(
             LiveClimbAnalyticsEvent.homeExploreTapped(
-                totalClimbs: globeViewModel.visibleClimbs.count
+                totalClimbs: globeViewModel.climbCount
             )
         )
         globeViewModel.prepareForBrowseEntry()
@@ -514,10 +514,21 @@ private struct HomeRankCard: View {
     private var cardBackground: some View {
         RoundedRectangle(cornerRadius: 14, style: .continuous)
             .fill(Color(hex: "111111"))
+            .overlay(alignment: .bottomTrailing) {
+                Image("HomeRankTrophyArtwork")
+                    .resizable()
+                    .renderingMode(.original)
+                    .scaledToFit()
+                    .frame(width: 180, height: 180)
+                    .opacity(0.85)
+                    .offset(x: 40, y: 40)
+                    .accessibilityHidden(true)
+            }
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .stroke(.white.opacity(0.1), lineWidth: 1)
             )
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 }
 
@@ -646,11 +657,7 @@ private struct HomePRCard: View {
                 .lineLimit(1)
                 .minimumScaleFactor(0.82)
 
-            Text(record.value)
-                .font(.montserratBold(size: 22))
-                .foregroundStyle(.white)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
+            valueText
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
@@ -665,6 +672,39 @@ private struct HomePRCard: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(record.label): \(record.value)\(record.isNew ? ", new personal record" : "")")
+    }
+
+    @ViewBuilder
+    private var valueText: some View {
+        switch record.metric {
+        case .highestAverageSPM:
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(paceValueNumber)
+                    .font(.montserratBold(size: 22))
+                    .foregroundStyle(.white)
+
+                Text(paceValueUnit)
+                    .font(.montserratBold(size: 11))
+                    .foregroundStyle(.white.opacity(0.72))
+            }
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+        default:
+            Text(record.value)
+                .font(.montserratBold(size: 22))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+    }
+
+    private var paceValueNumber: String {
+        record.value.split(separator: " ", maxSplits: 1).first.map(String.init) ?? record.value
+    }
+
+    private var paceValueUnit: String {
+        let parts = record.value.split(separator: " ", maxSplits: 1).map(String.init)
+        return parts.dropFirst().first ?? "SPM"
     }
 }
 

--- a/AscendApp/Features/Leaderboards/Services/LeaderboardService.swift
+++ b/AscendApp/Features/Leaderboards/Services/LeaderboardService.swift
@@ -34,6 +34,7 @@ final class LeaderboardService {
     ) throws {
         let context = try requireContext()
         let existingStats = try fetchUserStats(for: userId)
+        let ownedWorkouts = workouts.filter { $0.ownerUserId == userId }
 
         for stat in existingStats {
             context.delete(stat)
@@ -41,7 +42,7 @@ final class LeaderboardService {
 
         for timeFrame in LeaderboardTimeFrame.allCases {
             let period = timeFrame.currentPeriod(referenceDate: referenceDate)
-            let aggregate = aggregate(for: timeFrame, workouts: workouts, referenceDate: referenceDate)
+            let aggregate = aggregate(for: timeFrame, workouts: ownedWorkouts, referenceDate: referenceDate)
             let stats = LeaderboardStats(userId: userId, timeFrame: timeFrame, period: period)
             stats.replaceTotals(with: aggregate, period: period, updatedAt: referenceDate)
             context.insert(stats)
@@ -59,13 +60,13 @@ final class LeaderboardService {
 
         let context = try requireContext()
         if impact == .rebuildAll {
-            let workouts = try fetchAllWorkouts()
+            let workouts = try fetchWorkouts(for: userId)
             try rebuildCurrentStats(for: userId, workouts: workouts, referenceDate: referenceDate)
             return true
         }
 
         if try needsCurrentSchemaRebuild(for: userId, referenceDate: referenceDate) {
-            let workouts = try fetchAllWorkouts()
+            let workouts = try fetchWorkouts(for: userId)
             try rebuildCurrentStats(for: userId, workouts: workouts, referenceDate: referenceDate)
             return true
         }
@@ -128,8 +129,15 @@ final class LeaderboardService {
             stats.userId == userId && stats.needsSync
         }
         let statsToSync = try context.fetch(FetchDescriptor<LeaderboardStats>(predicate: predicate))
+        var clearedNoOpStats = false
 
-        return statsToSync.compactMap { stats in
+        let payloads: [LeaderboardSyncPayload] = statsToSync.compactMap { stats -> LeaderboardSyncPayload? in
+            if stats.hasActivity == false, stats.lastSyncedToFirestore == nil {
+                stats.needsSync = false
+                clearedNoOpStats = true
+                return nil
+            }
+
             guard let timeFrame = LeaderboardTimeFrame(rawValue: stats.timeFrame) else { return nil }
             return LeaderboardSyncPayload(
                 localStatID: stats.id,
@@ -149,6 +157,12 @@ final class LeaderboardService {
                 operation: stats.hasActivity ? .upsert : .delete
             )
         }
+
+        if clearedNoOpStats {
+            try context.save()
+        }
+
+        return payloads
     }
 
     func markSynced(payloads: [LeaderboardSyncPayload], syncedAt: Date = Date()) throws {
@@ -298,10 +312,15 @@ final class LeaderboardService {
         return try context.fetch(FetchDescriptor<LeaderboardStats>())
     }
 
-    private func fetchAllWorkouts() throws -> [Workout] {
+    private func fetchWorkouts(for userId: String) throws -> [Workout] {
         let context = try requireContext()
         return try context.fetch(
-            FetchDescriptor<Workout>(sortBy: [SortDescriptor(\.date, order: .forward)])
+            FetchDescriptor<Workout>(
+                predicate: #Predicate<Workout> { workout in
+                    workout.ownerUserId == userId
+                },
+                sortBy: [SortDescriptor(\.date, order: .forward)]
+            )
         )
     }
 

--- a/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
+++ b/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
@@ -85,14 +85,20 @@ final class LeaderboardViewModel {
         )
 
         guard let syncError else { return }
+        let loadFailedWithoutEntries = errorMessage != nil && leaderboardEntries.isEmpty
+        guard loadFailedWithoutEntries == false else { return }
+
+        let hasUnsyncedActivity = hasUnsyncedActivityForSelectedBoard(userId: userId)
         switch LeaderboardNetworkIssue.classify(syncError) {
         case .offline:
             isOffline = true
             errorMessage = nil
         case .slowConnection:
+            guard hasUnsyncedActivity else { return }
             isOffline = false
             errorMessage = "Latest changes may take a moment to appear."
         case .other:
+            guard hasUnsyncedActivity else { return }
             isOffline = false
             errorMessage = leaderboardEntries.isEmpty
                 ? "Couldn’t publish your latest leaderboard stats yet."
@@ -324,6 +330,14 @@ final class LeaderboardViewModel {
             displayName: userEntry?.displayName ?? "You",
             photoURL: userEntry?.photoURL
         )
+    }
+
+    private func hasUnsyncedActivityForSelectedBoard(userId: String) -> Bool {
+        guard let localStats = try? service.getLocalStats(for: userId, timeFrame: selectedTimeFrame) else {
+            return false
+        }
+
+        return localStats.needsSync && localStats.hasActivity
     }
 
     private func formatValue(_ value: Double, for metric: LeaderboardMetric) -> String {

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardUserRowView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardUserRowView.swift
@@ -28,7 +28,9 @@ struct LeaderboardUserRowView: View {
             Text("\(entry.rank)")
                 .font(.montserratBold(size: 30))
                 .foregroundStyle(.accent)
-                .frame(width: 38, alignment: .leading)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .frame(width: 52, alignment: .leading)
 
             profileImage
                 .frame(width: 42, height: 42)
@@ -130,7 +132,7 @@ struct LeaderboardUserRowView: View {
         entry: LeaderboardEntry(
             userId: "1",
             displayName: "Ryan T.",
-            rank: 4,
+            rank: 43,
             value: 15_872_211,
             formattedValue: "15,872,211",
             isCurrentUser: true

--- a/AscendApp/Features/Progress/Services/BestEffortCacheStore.swift
+++ b/AscendApp/Features/Progress/Services/BestEffortCacheStore.swift
@@ -16,10 +16,11 @@ enum BestEffortCacheStore {
 
     static func rebuildIfNeeded(
         modelContext: ModelContext,
+        userId: String? = nil,
         referenceDate: Date = Date(),
         calendar: Calendar = .current
     ) throws {
-        let workouts = try fetchWorkouts(modelContext: modelContext)
+        let workouts = try fetchWorkouts(modelContext: modelContext, userId: userId)
         let referenceYear = calendar.component(.year, from: referenceDate)
         let signature = workoutSignature(for: workouts, referenceYear: referenceYear)
         let metadata = try fetchMetadata(modelContext: modelContext)
@@ -43,10 +44,11 @@ enum BestEffortCacheStore {
 
     static func rebuild(
         modelContext: ModelContext,
+        userId: String? = nil,
         referenceDate: Date = Date(),
         calendar: Calendar = .current
     ) throws {
-        let workouts = try fetchWorkouts(modelContext: modelContext)
+        let workouts = try fetchWorkouts(modelContext: modelContext, userId: userId)
         let referenceYear = calendar.component(.year, from: referenceDate)
         try rebuild(
             modelContext: modelContext,
@@ -150,7 +152,17 @@ enum BestEffortCacheStore {
         try modelContext.save()
     }
 
-    private static func fetchWorkouts(modelContext: ModelContext) throws -> [Workout] {
+    private static func fetchWorkouts(modelContext: ModelContext, userId: String?) throws -> [Workout] {
+        if let userId {
+            let descriptor = FetchDescriptor<Workout>(
+                predicate: #Predicate<Workout> { workout in
+                    workout.ownerUserId == userId
+                },
+                sortBy: [SortDescriptor(\.date, order: .reverse)]
+            )
+            return try modelContext.fetch(descriptor)
+        }
+
         let descriptor = FetchDescriptor<Workout>(
             sortBy: [SortDescriptor(\.date, order: .reverse)]
         )

--- a/AscendApp/Shared/Models/WorkoutParticipation.swift
+++ b/AscendApp/Shared/Models/WorkoutParticipation.swift
@@ -30,6 +30,20 @@ struct WorkoutParticipationMetricsSnapshot: Codable, Equatable, Sendable {
     let floors: Int
     let stepsPerMinute: Double
 
+    init(
+        startedAt: Date,
+        durationSeconds: Double,
+        steps: Int,
+        floors: Int,
+        stepsPerMinute: Double
+    ) {
+        self.startedAt = startedAt
+        self.durationSeconds = durationSeconds
+        self.steps = steps
+        self.floors = floors
+        self.stepsPerMinute = stepsPerMinute
+    }
+
     init(workout: Workout) {
         startedAt = workout.date
         durationSeconds = workout.duration

--- a/AscendApp/Shared/Repositories/Firebase/RemoteWorkoutRecord.swift
+++ b/AscendApp/Shared/Repositories/Firebase/RemoteWorkoutRecord.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+struct RemoteWorkoutRecord: Equatable, Sendable {
+    let workoutId: UUID
+    let document: FirestoreWorkoutDocument
+}

--- a/AscendApp/Shared/Repositories/Firebase/WorkoutRemoteRepository.swift
+++ b/AscendApp/Shared/Repositories/Firebase/WorkoutRemoteRepository.swift
@@ -8,6 +8,21 @@ final class WorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol, @unchecked
 
     private init() {}
 
+    func fetchWorkouts(userId: String) async throws -> [RemoteWorkoutRecord] {
+        let snapshot = try await workoutCollectionReference(userId: userId).getDocuments()
+
+        return try snapshot.documents.compactMap { snapshot in
+            guard let workoutId = UUID(uuidString: snapshot.documentID) else {
+                return nil
+            }
+
+            return RemoteWorkoutRecord(
+                workoutId: workoutId,
+                document: try firestoreDocument(from: snapshot.data())
+            )
+        }
+    }
+
     func upsertWorkout(
         userId: String,
         workoutId: UUID,
@@ -26,10 +41,14 @@ final class WorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol, @unchecked
 }
 
 private extension WorkoutRemoteRepository {
-    func workoutDocumentReference(userId: String, workoutId: UUID) -> DocumentReference {
+    func workoutCollectionReference(userId: String) -> CollectionReference {
         db.collection("users")
             .document(userId)
             .collection("workouts")
+    }
+
+    func workoutDocumentReference(userId: String, workoutId: UUID) -> DocumentReference {
+        workoutCollectionReference(userId: userId)
             .document(workoutId.uuidString)
     }
 
@@ -162,4 +181,188 @@ private extension WorkoutRemoteRepository {
             "stepsPerMinute": snapshot.stepsPerMinute
         ]
     }
+
+    func firestoreDocument(from data: [String: Any]) throws -> FirestoreWorkoutDocument {
+        FirestoreWorkoutDocument(
+            userId: try stringValue("userId", in: data),
+            schemaVersion: optionalIntValue("schemaVersion", in: data) ?? FirestoreWorkoutDocument.currentSchemaVersion,
+            name: try stringValue("name", in: data),
+            startedAt: try dateValue("startedAt", in: data),
+            durationSeconds: try doubleValue("durationSeconds", in: data),
+            steps: try intValue("steps", in: data),
+            floors: try intValue("floors", in: data),
+            stepsPerFloor: try intValue("stepsPerFloor", in: data),
+            notes: try stringValue("notes", in: data),
+            source: try stringValue("source", in: data),
+            integrityLevel: try stringValue("integrityLevel", in: data),
+            createdAt: try dateValue("createdAt", in: data),
+            updatedAt: try dateValue("updatedAt", in: data),
+            avgHeartRateBpm: optionalIntValue("avgHeartRateBpm", in: data),
+            maxHeartRateBpm: optionalIntValue("maxHeartRateBpm", in: data),
+            caloriesBurned: optionalIntValue("caloriesBurned", in: data),
+            effortRating: optionalDoubleValue("effortRating", in: data),
+            averageMETs: optionalDoubleValue("averageMETs", in: data),
+            deviceModel: data["deviceModel"] as? String,
+            sourceMetadata: data["sourceMetadata"] as? String,
+            healthKitUUID: data["healthKitUUID"] as? String,
+            hevyWorkoutId: data["hevyWorkoutId"] as? String,
+            media: try firestoreMediaItems(from: data["media"]),
+            highlightedMediaId: data["highlightedMediaId"] as? String,
+            weightConfiguration: try firestoreWeightConfiguration(from: data["weightConfiguration"]),
+            heartRateSeries: try firestoreHeartRateSeriesReference(from: data["heartRateSeries"]),
+            participations: try firestoreParticipations(from: data["participations"])
+        )
+    }
+
+    func firestoreMediaItems(from value: Any?) throws -> [FirestoreWorkoutMediaItem]? {
+        guard let items = value as? [[String: Any]] else { return nil }
+        return try items.map { item in
+            FirestoreWorkoutMediaItem(
+                id: try stringValue("id", in: item),
+                url: try stringValue("url", in: item),
+                uploadedAt: try dateValue("uploadedAt", in: item),
+                type: try stringValue("type", in: item),
+                durationSeconds: optionalDoubleValue("durationSeconds", in: item)
+            )
+        }
+    }
+
+    func firestoreWeightConfiguration(from value: Any?) throws -> FirestoreWorkoutWeightConfiguration? {
+        guard let data = value as? [String: Any],
+              let entries = data["entries"] as? [[String: Any]] else {
+            return nil
+        }
+
+        return FirestoreWorkoutWeightConfiguration(
+            entries: try entries.map { entry in
+                FirestoreWorkoutWeightEntry(
+                    id: try stringValue("id", in: entry),
+                    equipmentType: try stringValue("equipmentType", in: entry),
+                    weightValue: try doubleValue("weightValue", in: entry),
+                    isEnabled: optionalBoolValue("isEnabled", in: entry) ?? true
+                )
+            }
+        )
+    }
+
+    func firestoreHeartRateSeriesReference(from value: Any?) throws -> FirestoreWorkoutHeartRateSeriesReference? {
+        guard let data = value as? [String: Any] else { return nil }
+
+        return FirestoreWorkoutHeartRateSeriesReference(
+            storagePath: try stringValue("storagePath", in: data),
+            encoding: try stringValue("encoding", in: data),
+            sampleCount: try intValue("sampleCount", in: data),
+            seriesStartAt: try dateValue("seriesStartAt", in: data),
+            seriesEndAt: try dateValue("seriesEndAt", in: data)
+        )
+    }
+
+    func firestoreParticipations(from value: Any?) throws -> [FirestoreWorkoutParticipation]? {
+        guard let participations = value as? [[String: Any]] else { return nil }
+        return try participations.map { participation in
+            FirestoreWorkoutParticipation(
+                id: try stringValue("id", in: participation),
+                workoutId: try stringValue("workoutId", in: participation),
+                userId: try stringValue("userId", in: participation),
+                contextType: try stringValue("contextType", in: participation),
+                contextId: try stringValue("contextId", in: participation),
+                contextVersion: try intValue("contextVersion", in: participation),
+                rulesVersion: try intValue("rulesVersion", in: participation),
+                role: try stringValue("role", in: participation),
+                leaderboardEligible: try boolValue("leaderboardEligible", in: participation),
+                verificationTier: try stringValue("verificationTier", in: participation),
+                metricsSnapshot: try firestoreParticipationMetricsSnapshot(from: participation["metricsSnapshot"]),
+                createdAt: try dateValue("createdAt", in: participation)
+            )
+        }
+    }
+
+    func firestoreParticipationMetricsSnapshot(from value: Any?) throws -> FirestoreWorkoutParticipationMetricsSnapshot {
+        guard let data = value as? [String: Any] else {
+            throw WorkoutRemoteRepositoryDecodingError.missingField("metricsSnapshot")
+        }
+
+        return FirestoreWorkoutParticipationMetricsSnapshot(
+            startedAt: try dateValue("startedAt", in: data),
+            durationSeconds: try doubleValue("durationSeconds", in: data),
+            steps: try intValue("steps", in: data),
+            floors: try intValue("floors", in: data),
+            stepsPerMinute: try doubleValue("stepsPerMinute", in: data)
+        )
+    }
+
+    func stringValue(_ key: String, in data: [String: Any]) throws -> String {
+        guard let value = data[key] as? String else {
+            throw WorkoutRemoteRepositoryDecodingError.missingField(key)
+        }
+        return value
+    }
+
+    func intValue(_ key: String, in data: [String: Any]) throws -> Int {
+        guard let value = optionalIntValue(key, in: data) else {
+            throw WorkoutRemoteRepositoryDecodingError.missingField(key)
+        }
+        return value
+    }
+
+    func optionalIntValue(_ key: String, in data: [String: Any]) -> Int? {
+        if let value = data[key] as? Int {
+            return value
+        }
+        if let value = data[key] as? NSNumber {
+            return value.intValue
+        }
+        return nil
+    }
+
+    func doubleValue(_ key: String, in data: [String: Any]) throws -> Double {
+        guard let value = optionalDoubleValue(key, in: data) else {
+            throw WorkoutRemoteRepositoryDecodingError.missingField(key)
+        }
+        return value
+    }
+
+    func optionalDoubleValue(_ key: String, in data: [String: Any]) -> Double? {
+        if let value = data[key] as? Double {
+            return value
+        }
+        if let value = data[key] as? Int {
+            return Double(value)
+        }
+        if let value = data[key] as? NSNumber {
+            return value.doubleValue
+        }
+        return nil
+    }
+
+    func boolValue(_ key: String, in data: [String: Any]) throws -> Bool {
+        guard let value = optionalBoolValue(key, in: data) else {
+            throw WorkoutRemoteRepositoryDecodingError.missingField(key)
+        }
+        return value
+    }
+
+    func optionalBoolValue(_ key: String, in data: [String: Any]) -> Bool? {
+        if let value = data[key] as? Bool {
+            return value
+        }
+        if let value = data[key] as? NSNumber {
+            return value.boolValue
+        }
+        return nil
+    }
+
+    func dateValue(_ key: String, in data: [String: Any]) throws -> Date {
+        if let timestamp = data[key] as? Timestamp {
+            return timestamp.dateValue()
+        }
+        if let date = data[key] as? Date {
+            return date
+        }
+        throw WorkoutRemoteRepositoryDecodingError.missingField(key)
+    }
+}
+
+enum WorkoutRemoteRepositoryDecodingError: Error, Equatable {
+    case missingField(String)
 }

--- a/AscendApp/Shared/Repositories/Protocols/WorkoutRemoteRepositoryProtocol.swift
+++ b/AscendApp/Shared/Repositories/Protocols/WorkoutRemoteRepositoryProtocol.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 protocol WorkoutRemoteRepositoryProtocol: Sendable {
+    func fetchWorkouts(userId: String) async throws -> [RemoteWorkoutRecord]
+
     func upsertWorkout(
         userId: String,
         workoutId: UUID,

--- a/AscendApp/Shared/Services/AccountDataOwnershipService.swift
+++ b/AscendApp/Shared/Services/AccountDataOwnershipService.swift
@@ -1,0 +1,135 @@
+import Foundation
+import SwiftData
+
+struct AccountDataOwnershipConflict: Equatable {
+    let signedInUserId: String
+    let rememberedOwnerUserId: String?
+    let storedOwnerUserIds: [String]
+    let summary: AccountDataOwnershipSummary
+
+    var hasLocalData: Bool {
+        summary.hasLocalData
+    }
+}
+
+struct AccountDataOwnershipSummary: Equatable {
+    let workoutCount: Int
+    let pendingDeletionCount: Int
+    let leaderboardStatsCount: Int
+    let routineCount: Int
+    let routineFolderCount: Int
+    let climbAttemptCount: Int
+    let pendingMediaUploadCount: Int
+    let bestEffortCacheEntryCount: Int
+
+    var hasLocalData: Bool {
+        [
+            workoutCount,
+            pendingDeletionCount,
+            leaderboardStatsCount,
+            routineCount,
+            routineFolderCount,
+            climbAttemptCount,
+            pendingMediaUploadCount,
+            bestEffortCacheEntryCount
+        ].contains { $0 > 0 }
+    }
+}
+
+enum AccountDataOwnershipDecision: Equatable {
+    case allowed
+    case blocked(AccountDataOwnershipConflict)
+}
+
+@MainActor
+enum AccountDataOwnershipService {
+    static func evaluateAccess(
+        modelContext: ModelContext,
+        signedInUserId: String,
+        sessionStore: AccountSessionStore = .shared
+    ) throws -> AccountDataOwnershipDecision {
+        let normalizedSignedInUserId = signedInUserId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedSignedInUserId.isEmpty else {
+            return .blocked(
+                AccountDataOwnershipConflict(
+                    signedInUserId: signedInUserId,
+                    rememberedOwnerUserId: sessionStore.localDataOwnerUserId,
+                    storedOwnerUserIds: [],
+                    summary: try summary(modelContext: modelContext)
+                )
+            )
+        }
+
+        let rememberedOwnerUserId = sessionStore.localDataOwnerUserId
+        let storedOwnerUserIds = try storedOwnerUserIds(modelContext: modelContext)
+        let summary = try summary(modelContext: modelContext)
+
+        if summary.hasLocalData,
+           let rememberedOwnerUserId,
+           rememberedOwnerUserId != normalizedSignedInUserId {
+            return .blocked(
+                AccountDataOwnershipConflict(
+                    signedInUserId: normalizedSignedInUserId,
+                    rememberedOwnerUserId: rememberedOwnerUserId,
+                    storedOwnerUserIds: storedOwnerUserIds,
+                    summary: summary
+                )
+            )
+        }
+
+        let foreignOwnerIds = storedOwnerUserIds.filter { $0 != normalizedSignedInUserId }
+        guard foreignOwnerIds.isEmpty else {
+            return .blocked(
+                AccountDataOwnershipConflict(
+                    signedInUserId: normalizedSignedInUserId,
+                    rememberedOwnerUserId: rememberedOwnerUserId,
+                    storedOwnerUserIds: storedOwnerUserIds,
+                    summary: summary
+                )
+            )
+        }
+
+        return .allowed
+    }
+
+    static func recordAuthorizedOwner(
+        signedInUserId: String,
+        sessionStore: AccountSessionStore = .shared
+    ) {
+        sessionStore.recordLocalDataOwner(userId: signedInUserId)
+    }
+
+    private static func storedOwnerUserIds(modelContext: ModelContext) throws -> [String] {
+        var ownerIds = Set<String>()
+
+        let workouts = try modelContext.fetch(FetchDescriptor<Workout>())
+        ownerIds.formUnion(workouts.compactMap { normalizedOwnerId($0.ownerUserId) })
+
+        let pendingDeletions = try modelContext.fetch(FetchDescriptor<PendingWorkoutDeletion>())
+        ownerIds.formUnion(pendingDeletions.compactMap { normalizedOwnerId($0.ownerUserId) })
+
+        let leaderboardStats = try modelContext.fetch(FetchDescriptor<LeaderboardStats>())
+        ownerIds.formUnion(leaderboardStats.compactMap { normalizedOwnerId($0.userId) })
+
+        return ownerIds.sorted()
+    }
+
+    private static func summary(modelContext: ModelContext) throws -> AccountDataOwnershipSummary {
+        AccountDataOwnershipSummary(
+            workoutCount: try modelContext.fetchCount(FetchDescriptor<Workout>()),
+            pendingDeletionCount: try modelContext.fetchCount(FetchDescriptor<PendingWorkoutDeletion>()),
+            leaderboardStatsCount: try modelContext.fetchCount(FetchDescriptor<LeaderboardStats>()),
+            routineCount: try modelContext.fetchCount(FetchDescriptor<Routine>()),
+            routineFolderCount: try modelContext.fetchCount(FetchDescriptor<RoutineFolder>()),
+            climbAttemptCount: try modelContext.fetchCount(FetchDescriptor<ClimbAttempt>()),
+            pendingMediaUploadCount: try modelContext.fetchCount(FetchDescriptor<PendingMediaUpload>()),
+            bestEffortCacheEntryCount: try modelContext.fetchCount(FetchDescriptor<BestEffortCacheEntry>())
+        )
+    }
+
+    private static func normalizedOwnerId(_ ownerId: String?) -> String? {
+        guard let ownerId else { return nil }
+        let trimmed = ownerId.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutHydrationService.swift
+++ b/AscendApp/Shared/Services/WorkoutHydrationService.swift
@@ -1,0 +1,301 @@
+import Foundation
+import SwiftData
+
+@MainActor
+enum WorkoutHydrationService {
+    private static var hydratedUserIdsThisSession: Set<String> = []
+    private static var hydratingUserIds: Set<String> = []
+
+    static func hydrateIfNeeded(
+        modelContext: ModelContext,
+        currentUserId: String,
+        remoteRepository: any WorkoutRemoteRepositoryProtocol = WorkoutRemoteRepository.shared
+    ) async throws -> Int {
+        guard !hydratedUserIdsThisSession.contains(currentUserId),
+              !hydratingUserIds.contains(currentUserId) else {
+            return 0
+        }
+
+        hydratingUserIds.insert(currentUserId)
+        defer { hydratingUserIds.remove(currentUserId) }
+
+        let records = try await remoteRepository.fetchWorkouts(userId: currentUserId)
+        hydratedUserIdsThisSession.insert(currentUserId)
+        guard !records.isEmpty else { return 0 }
+
+        let localWorkouts = try fetchLocalWorkouts(modelContext: modelContext, userId: currentUserId)
+        var localByID = Dictionary(uniqueKeysWithValues: localWorkouts.map { ($0.id, $0) })
+        var changedCount = 0
+
+        for record in records.sorted(by: { $0.document.startedAt < $1.document.startedAt }) {
+            if let existingWorkout = localByID[record.workoutId] {
+                guard shouldApplyRemoteDocument(record.document, to: existingWorkout) else { continue }
+                try apply(
+                    record.document,
+                    workoutId: record.workoutId,
+                    userId: currentUserId,
+                    to: existingWorkout,
+                    modelContext: modelContext
+                )
+                changedCount += 1
+            } else {
+                let workout = makeWorkout(
+                    from: record.document,
+                    workoutId: record.workoutId
+                )
+                modelContext.insert(workout)
+                try apply(
+                    record.document,
+                    workoutId: record.workoutId,
+                    userId: currentUserId,
+                    to: workout,
+                    modelContext: modelContext
+                )
+                localByID[workout.id] = workout
+                changedCount += 1
+            }
+        }
+
+        if changedCount > 0 {
+            try modelContext.save()
+        }
+
+        return changedCount
+    }
+
+    private static func shouldApplyRemoteDocument(_ document: FirestoreWorkoutDocument, to workout: Workout) -> Bool {
+        switch workout.remoteSyncStatus {
+        case .pendingUpsert, .failed:
+            return false
+        case .synced, .rejected:
+            return document.updatedAt > workout.lastModifiedAt
+        }
+    }
+
+    private static func fetchLocalWorkouts(modelContext: ModelContext, userId: String) throws -> [Workout] {
+        let descriptor = FetchDescriptor<Workout>(
+            predicate: #Predicate<Workout> { workout in
+                workout.ownerUserId == userId
+            }
+        )
+        return try modelContext.fetch(descriptor)
+    }
+
+    private static func makeWorkout(
+        from document: FirestoreWorkoutDocument,
+        workoutId: UUID
+    ) -> Workout {
+        let workout = Workout(
+            name: document.name,
+            date: document.startedAt,
+            duration: document.durationSeconds,
+            steps: document.steps,
+            floors: document.floors,
+            stepsPerFloor: document.stepsPerFloor,
+            notes: document.notes,
+            avgHeartRate: document.avgHeartRateBpm,
+            maxHeartRate: document.maxHeartRateBpm,
+            caloriesBurned: document.caloriesBurned,
+            effortRating: document.effortRating,
+            averageMETs: document.averageMETs,
+            source: WorkoutSource(rawValue: document.source) ?? .manual,
+            deviceModel: document.deviceModel,
+            sourceMetadata: document.sourceMetadata,
+            healthKitUUID: document.healthKitUUID,
+            hevyWorkoutId: document.hevyWorkoutId,
+            photos: photos(from: document.media),
+            highlightedPhotoId: document.highlightedMediaId.flatMap(UUID.init(uuidString:)),
+            weightConfiguration: weightConfiguration(from: document.weightConfiguration)
+        )
+        workout.id = workoutId
+        return workout
+    }
+
+    private static func apply(
+        _ document: FirestoreWorkoutDocument,
+        workoutId: UUID,
+        userId: String,
+        to workout: Workout,
+        modelContext: ModelContext
+    ) throws {
+        workout.id = workoutId
+        workout.name = document.name
+        workout.date = document.startedAt
+        workout.duration = document.durationSeconds
+        workout.steps = document.steps
+        workout.floors = document.floors
+        workout.stepsPerFloor = document.stepsPerFloor
+        workout.notes = document.notes
+        workout.createdAt = document.createdAt
+        workout.ownerUserId = userId
+        workout.lastModifiedAt = document.updatedAt
+        workout.lastRemoteSyncAt = Date()
+        workout.lastRemoteHeartRateSeriesStoragePath = document.heartRateSeries?.storagePath
+        workout.remoteSyncStatus = .synced
+        workout.lastRemoteSyncError = nil
+        workout.avgHeartRate = document.avgHeartRateBpm
+        workout.maxHeartRate = document.maxHeartRateBpm
+        workout.caloriesBurned = document.caloriesBurned
+        workout.effortRating = document.effortRating
+        workout.averageMETs = document.averageMETs
+        workout.source = WorkoutSource(rawValue: document.source) ?? .manual
+        workout.integrityLevel = DataIntegrityLevel(rawValue: document.integrityLevel) ?? (workout.source.isVerified ? .verified : .unverified)
+        workout.deviceModel = document.deviceModel
+        workout.sourceMetadata = document.sourceMetadata
+        workout.healthKitUUID = document.healthKitUUID
+        workout.hevyWorkoutId = document.hevyWorkoutId
+        workout.photos = photos(from: document.media)
+        workout.highlightedPhotoId = document.highlightedMediaId.flatMap(UUID.init(uuidString:)) ?? workout.photos.first?.id
+        workout.weightConfiguration = weightConfiguration(from: document.weightConfiguration)
+
+        try replaceParticipations(
+            on: workout,
+            with: document.participations ?? [],
+            modelContext: modelContext
+        )
+        try restoreLiveClimbAttemptIfNeeded(
+            for: workout,
+            modelContext: modelContext
+        )
+    }
+
+    private static func replaceParticipations(
+        on workout: Workout,
+        with remoteParticipations: [FirestoreWorkoutParticipation],
+        modelContext: ModelContext
+    ) throws {
+        for participation in workout.participations {
+            modelContext.delete(participation)
+        }
+        workout.participations.removeAll()
+
+        let restored = remoteParticipations.compactMap { remote -> WorkoutParticipation? in
+            guard let id = UUID(uuidString: remote.id),
+                  let contextType = WorkoutParticipationContextType(rawValue: remote.contextType),
+                  let role = WorkoutParticipationRole(rawValue: remote.role),
+                  let verificationTier = WorkoutParticipationVerificationTier(rawValue: remote.verificationTier) else {
+                return nil
+            }
+
+            return WorkoutParticipation(
+                id: id,
+                workout: workout,
+                userId: remote.userId,
+                contextType: contextType,
+                contextId: remote.contextId,
+                contextVersion: remote.contextVersion,
+                rulesVersion: remote.rulesVersion,
+                role: role,
+                leaderboardEligible: remote.leaderboardEligible,
+                verificationTier: verificationTier,
+                metricsSnapshot: WorkoutParticipationMetricsSnapshot(
+                    startedAt: remote.metricsSnapshot.startedAt,
+                    durationSeconds: remote.metricsSnapshot.durationSeconds,
+                    steps: remote.metricsSnapshot.steps,
+                    floors: remote.metricsSnapshot.floors,
+                    stepsPerMinute: remote.metricsSnapshot.stepsPerMinute
+                ),
+                createdAt: remote.createdAt
+            )
+        }
+
+        workout.participations = restored
+        for participation in restored {
+            modelContext.insert(participation)
+        }
+    }
+
+    private static func restoreLiveClimbAttemptIfNeeded(
+        for workout: Workout,
+        modelContext: ModelContext
+    ) throws {
+        guard workout.source == .headphoneMotion,
+              let metadata = LiveClimbWorkoutSummaryData.metadata(for: workout),
+              metadata.trackingMode == .liveClimb,
+              let climbId = metadata.climbId,
+              let attemptId = liveClimbAttemptId(for: workout) else {
+            return
+        }
+
+        let status: ClimbAttemptStatus = metadata.stopReason == .targetReached ? .completed : .failed
+        let endedAt = workout.date.addingTimeInterval(workout.duration)
+        let descriptor = FetchDescriptor<ClimbAttempt>(
+            predicate: #Predicate<ClimbAttempt> { attempt in
+                attempt.id == attemptId
+            }
+        )
+        let existingAttempt = try modelContext.fetch(descriptor).first
+        let attempt = existingAttempt ?? ClimbAttempt(
+            climbId: climbId,
+            status: status,
+            startedAt: workout.date,
+            endedAt: endedAt,
+            completedAt: status == .completed ? endedAt : nil,
+            accumulatedSteps: workout.steps,
+            accumulatedDurationSeconds: Int(workout.duration.rounded()),
+            sessionsCount: 1,
+            appliedWorkoutIds: [workout.id.uuidString],
+            bestCompletionDurationSeconds: status == .completed ? Int(workout.duration.rounded()) : nil
+        )
+
+        attempt.id = attemptId
+        attempt.climbId = climbId
+        attempt.status = status
+        attempt.startedAt = workout.date
+        attempt.endedAt = endedAt
+        attempt.completedAt = status == .completed ? endedAt : nil
+        attempt.accumulatedSteps = workout.steps
+        attempt.accumulatedDurationSeconds = Int(workout.duration.rounded())
+        attempt.sessionsCount = 1
+        attempt.appliedWorkoutIds = [workout.id.uuidString]
+        attempt.bestCompletionDurationSeconds = status == .completed ? Int(workout.duration.rounded()) : nil
+
+        if existingAttempt == nil {
+            modelContext.insert(attempt)
+        }
+    }
+
+    private static func liveClimbAttemptId(for workout: Workout) -> UUID? {
+        workout.participations
+            .first { $0.contextType == .climbAttempt }
+            .flatMap { UUID(uuidString: $0.contextId) }
+    }
+
+    private static func photos(from media: [FirestoreWorkoutMediaItem]?) -> [Photo] {
+        media?.compactMap { item in
+            guard let id = UUID(uuidString: item.id),
+                  let url = URL(string: item.url),
+                  let type = MediaType(rawValue: item.type) else {
+                return nil
+            }
+
+            return Photo(
+                id: id,
+                url: url,
+                uploadedAt: item.uploadedAt,
+                type: type,
+                duration: item.durationSeconds
+            )
+        } ?? []
+    }
+
+    private static func weightConfiguration(from remote: FirestoreWorkoutWeightConfiguration?) -> WeightConfiguration? {
+        guard let remote else { return nil }
+
+        let entries = remote.entries.compactMap { entry -> WeightEntry? in
+            guard let id = UUID(uuidString: entry.id),
+                  let equipmentType = WeightEquipmentType(rawValue: entry.equipmentType) else {
+                return nil
+            }
+
+            return WeightEntry(
+                id: id,
+                equipmentType: equipmentType,
+                weightValue: entry.weightValue,
+                isEnabled: entry.isEnabled
+            )
+        }
+
+        return entries.isEmpty ? nil : WeightConfiguration(entries: entries)
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutMutationHandler.swift
+++ b/AscendApp/Shared/Services/WorkoutMutationHandler.swift
@@ -35,7 +35,7 @@ final class WorkoutMutationHandler {
             let didUpdateLeaderboard = try leaderboardService.applyMutationImpact(impact, for: userId)
 
             try modelContext.save()
-            rebuildBestEffortCacheAfterMutation(modelContext: modelContext)
+            rebuildBestEffortCacheAfterMutation(modelContext: modelContext, userId: userId)
             NotificationCenter.default.post(name: .workoutsDidChange, object: nil)
 
             if !changedWorkouts.isEmpty {
@@ -67,7 +67,7 @@ final class WorkoutMutationHandler {
         }
 
         try modelContext.save()
-        rebuildBestEffortCacheAfterMutation(modelContext: modelContext)
+        rebuildBestEffortCacheAfterMutation(modelContext: modelContext, userId: nil)
         NotificationCenter.default.post(name: .workoutsDidChange, object: nil)
     }
 
@@ -81,9 +81,9 @@ final class WorkoutMutationHandler {
         }
     }
 
-    private func rebuildBestEffortCacheAfterMutation(modelContext: ModelContext) {
+    private func rebuildBestEffortCacheAfterMutation(modelContext: ModelContext, userId: String?) {
         do {
-            try BestEffortCacheStore.rebuild(modelContext: modelContext)
+            try BestEffortCacheStore.rebuild(modelContext: modelContext, userId: userId)
         } catch {
             print("Failed to rebuild Best Effort cache after workout mutation: \(error)")
         }

--- a/AscendApp/Shared/Views/MainTabView.swift
+++ b/AscendApp/Shared/Views/MainTabView.swift
@@ -11,6 +11,7 @@ import SwiftData
 struct MainTabView: View {
     @Environment(\.colorScheme) private var systemColorScheme
     @Environment(\.modelContext) private var modelContext
+    @Environment(AuthenticationViewModel.self) private var authVM
     @Environment(NetworkConnectivityService.self) private var connectivityService
     @State private var themeManager = ThemeManager.shared
     @State private var tabRouter = TabRouter()
@@ -151,7 +152,10 @@ struct MainTabView: View {
 
     private func rebuildBestEffortCacheIfNeeded() {
         do {
-            try BestEffortCacheStore.rebuildIfNeeded(modelContext: modelContext)
+            try BestEffortCacheStore.rebuildIfNeeded(
+                modelContext: modelContext,
+                userId: authVM.user?.uid
+            )
         } catch {
             print("Failed to rebuild Best Effort cache: \(error)")
         }

--- a/AscendAppTests/AccountDataOwnershipServiceTests.swift
+++ b/AscendAppTests/AccountDataOwnershipServiceTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import AscendApp
+
+@MainActor
+struct AccountDataOwnershipServiceTests {
+    @Test
+    func blocksRememberedOwnerMismatchWhenLocalDataExists() throws {
+        let modelContext = try makeModelContext()
+        let defaults = try makeUserDefaults()
+        let sessionStore = AccountSessionStore(userDefaults: defaults)
+        sessionStore.recordLocalDataOwner(userId: "user-a")
+
+        modelContext.insert(Routine(name: "Local Routine"))
+        try modelContext.save()
+
+        let decision = try AccountDataOwnershipService.evaluateAccess(
+            modelContext: modelContext,
+            signedInUserId: "user-b",
+            sessionStore: sessionStore
+        )
+
+        guard case .blocked(let conflict) = decision else {
+            Issue.record("Expected account data ownership to block a remembered owner mismatch.")
+            return
+        }
+
+        #expect(conflict.rememberedOwnerUserId == "user-a")
+        #expect(conflict.summary.routineCount == 1)
+    }
+
+    @Test
+    func allowsRememberedOwnerMismatchWhenLocalStoreIsEmpty() throws {
+        let modelContext = try makeModelContext()
+        let defaults = try makeUserDefaults()
+        let sessionStore = AccountSessionStore(userDefaults: defaults)
+        sessionStore.recordLocalDataOwner(userId: "user-a")
+
+        let decision = try AccountDataOwnershipService.evaluateAccess(
+            modelContext: modelContext,
+            signedInUserId: "user-b",
+            sessionStore: sessionStore
+        )
+
+        #expect(decision == .allowed)
+    }
+
+    @Test
+    func blocksStoredOwnerMismatch() throws {
+        let modelContext = try makeModelContext()
+        let defaults = try makeUserDefaults()
+        let sessionStore = AccountSessionStore(userDefaults: defaults)
+        let workout = Workout(duration: 1_200, steps: 1_000, floors: 63)
+        workout.markPendingRemoteUpsert(ownerUserId: "user-a")
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let decision = try AccountDataOwnershipService.evaluateAccess(
+            modelContext: modelContext,
+            signedInUserId: "user-b",
+            sessionStore: sessionStore
+        )
+
+        guard case .blocked(let conflict) = decision else {
+            Issue.record("Expected account data ownership to block stored owner mismatch.")
+            return
+        }
+
+        #expect(conflict.storedOwnerUserIds == ["user-a"])
+        #expect(conflict.summary.workoutCount == 1)
+    }
+
+    @Test
+    func allowsLegacyOwnerlessDataForFirstPostUpgradeSignIn() throws {
+        let modelContext = try makeModelContext()
+        let defaults = try makeUserDefaults()
+        let sessionStore = AccountSessionStore(userDefaults: defaults)
+        modelContext.insert(Workout(duration: 1_200, steps: 1_000, floors: 63))
+        try modelContext.save()
+
+        let decision = try AccountDataOwnershipService.evaluateAccess(
+            modelContext: modelContext,
+            signedInUserId: "user-a",
+            sessionStore: sessionStore
+        )
+
+        #expect(decision == .allowed)
+    }
+
+    private func makeModelContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            PendingWorkoutDeletion.self,
+            LeaderboardStats.self,
+            Routine.self,
+            RoutineFolder.self,
+            ClimbAttempt.self,
+            PendingMediaUpload.self,
+            BestEffortCacheEntry.self,
+            BestEffortCacheMetadata.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func makeUserDefaults() throws -> UserDefaults {
+        let suiteName = "AccountDataOwnershipServiceTests-\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/AscendAppTests/BestEffortCacheStoreTests.swift
+++ b/AscendAppTests/BestEffortCacheStoreTests.swift
@@ -101,6 +101,45 @@ struct BestEffortCacheStoreTests {
         #expect(cachedProgression.map(\.compactValueText) == ["1,000", "1,500"])
     }
 
+    @Test
+    @MainActor
+    func rebuildWithUserIdIgnoresOtherUsersWorkouts() throws {
+        let modelContext = try makeModelContext()
+        let referenceDate = makeDate(year: 2026, month: 5, day: 10)
+        let ownedWorkout = makeWorkout(
+            name: "Owned Record",
+            date: referenceDate,
+            duration: 600,
+            steps: 1_000,
+            ownerUserId: "user-1"
+        )
+        let foreignWorkout = makeWorkout(
+            name: "Foreign Record",
+            date: referenceDate,
+            duration: 600,
+            steps: 4_000,
+            ownerUserId: "user-2"
+        )
+
+        modelContext.insert(ownedWorkout)
+        modelContext.insert(foreignWorkout)
+        try modelContext.save()
+
+        try BestEffortCacheStore.rebuild(
+            modelContext: modelContext,
+            userId: "user-1",
+            referenceDate: referenceDate
+        )
+
+        let snapshot = BestEffortCacheSnapshot(
+            entries: try fetchCacheEntries(in: modelContext),
+            workouts: try fetchWorkouts(in: modelContext)
+        )
+
+        #expect(snapshot.primaryEffort(for: ownedWorkout) != nil)
+        #expect(snapshot.primaryEffort(for: foreignWorkout) == nil)
+    }
+
     private func makeModelContext() throws -> ModelContext {
         let container = try ModelContainer(
             for: Workout.self,
@@ -133,9 +172,10 @@ struct BestEffortCacheStoreTests {
         name: String,
         date: Date,
         duration: TimeInterval,
-        steps: Int
+        steps: Int,
+        ownerUserId: String? = nil
     ) -> Workout {
-        Workout(
+        let workout = Workout(
             name: name,
             date: date,
             duration: duration,
@@ -144,6 +184,10 @@ struct BestEffortCacheStoreTests {
             stepsPerFloor: 16,
             source: .manual
         )
+        if let ownerUserId {
+            workout.markPendingRemoteUpsert(ownerUserId: ownerUserId, modifiedAt: date)
+        }
+        return workout
     }
 
     private func makeDate(year: Int, month: Int, day: Int) -> Date {

--- a/AscendAppTests/ClimbServiceTests.swift
+++ b/AscendAppTests/ClimbServiceTests.swift
@@ -246,6 +246,26 @@ struct ClimbServiceTests {
         #expect(workout.participations.isEmpty)
     }
 
+    @Test
+    func releaseStatesSeparateAvailableFromVisibleCatalogClimbs() throws {
+        let available = makeClimb(id: "available-climb", requiredSteps: 1_000)
+        let comingSoon = makeClimb(
+            id: "coming-soon-climb",
+            requiredSteps: 2_000,
+            releaseState: .comingSoon
+        )
+        let hidden = makeClimb(
+            id: "hidden-climb",
+            requiredSteps: 3_000,
+            releaseState: .hidden
+        )
+        let service = ClimbService(catalogRepository: TestClimbCatalogRepository(climbs: [available, comingSoon, hidden]))
+
+        #expect(try service.loadClimbs().map(\.id) == [available.id])
+        #expect(try service.loadVisibleClimbs().map(\.id) == [available.id, comingSoon.id])
+        #expect(try service.climb(for: comingSoon.id)?.id == comingSoon.id)
+    }
+
     private func makeModelContext() throws -> ModelContext {
         let container = try ModelContainer(
             for: ClimbAttempt.self,
@@ -257,7 +277,11 @@ struct ClimbServiceTests {
         return ModelContext(container)
     }
 
-    private func makeClimb(id: String, requiredSteps: Int) -> Climb {
+    private func makeClimb(
+        id: String,
+        requiredSteps: Int,
+        releaseState: ClimbReleaseState = .available
+    ) -> Climb {
         Climb(
             id: id,
             name: id,
@@ -279,7 +303,7 @@ struct ClimbServiceTests {
             funFact: "Fact",
             sourceURL: "https://example.com",
             imageSetVersion: 1,
-            isPublished: true
+            releaseState: releaseState
         )
     }
 }

--- a/AscendAppTests/GlobeViewModelTests.swift
+++ b/AscendAppTests/GlobeViewModelTests.swift
@@ -163,6 +163,37 @@ struct GlobeViewModelTests {
         #expect(viewModel.liveClimbCommunityCompletedUserCount == 1)
     }
 
+    @Test
+    func comingSoonClimbsStayOnGlobeButOutOfSearchAndDailyRecommendation() throws {
+        let available = makeClimb(
+            id: "available-climb",
+            category: "tower",
+            heightMeters: 100,
+            steps: 1_000,
+            floors: 50
+        )
+        let comingSoon = makeClimb(
+            id: "coming-soon-climb",
+            category: "tower",
+            heightMeters: 200,
+            steps: 2_000,
+            floors: 100,
+            releaseState: .comingSoon
+        )
+        let viewModel = GlobeViewModel(climbService: makeClimbService(with: [available, comingSoon]))
+        let modelContext = try makeModelContext()
+
+        GlobeViewModel.debugClearDailyRecommendedClimbId()
+        viewModel.loadIfNeeded(modelContext: modelContext)
+        viewModel.searchQuery = "coming"
+
+        #expect(viewModel.visibleClimbs.map(\.id) == [available.id, comingSoon.id])
+        #expect(viewModel.availableClimbs.map(\.id) == [available.id])
+        #expect(viewModel.searchSuggestions.isEmpty)
+        #expect(viewModel.dailyRecommendedClimb?.id == available.id)
+    }
+
+
     private func makeModelContext() throws -> ModelContext {
         let container = try ModelContainer(
             for: ClimbAttempt.self,
@@ -182,7 +213,8 @@ struct GlobeViewModelTests {
         category: String,
         heightMeters: Double,
         steps: Int,
-        floors: Int
+        floors: Int,
+        releaseState: ClimbReleaseState = .available
     ) -> Climb {
         Climb(
             id: id,
@@ -205,7 +237,7 @@ struct GlobeViewModelTests {
             funFact: "Fact",
             sourceURL: "https://example.com",
             imageSetVersion: 1,
-            isPublished: true
+            releaseState: releaseState
         )
     }
 }

--- a/AscendAppTests/LeaderboardServiceTests.swift
+++ b/AscendAppTests/LeaderboardServiceTests.swift
@@ -17,7 +17,8 @@ struct LeaderboardServiceTests {
             date: utcDate(year: 2026, month: 4, day: 8, hour: 7),
             duration: 1_800,
             steps: 900,
-            floors: 60
+            floors: 60,
+            ownerUserId: userId
         )
         modelContext.insert(originalWorkout)
         try modelContext.save()
@@ -83,6 +84,91 @@ struct LeaderboardServiceTests {
         }
     }
 
+    @Test
+    func rebuildCurrentStatsIgnoresWorkoutsOwnedByOtherUsers() throws {
+        let referenceDate = utcDate(year: 2026, month: 4, day: 10, hour: 12)
+        let userId = "user-1"
+        let service = LeaderboardService.shared
+        let modelContext = try makeModelContext()
+        service.configure(modelContext: modelContext)
+
+        let ownedWorkout = makeWorkout(
+            date: utcDate(year: 2026, month: 4, day: 8, hour: 7),
+            duration: 1_800,
+            steps: 900,
+            floors: 60,
+            ownerUserId: userId
+        )
+        let foreignWorkout = makeWorkout(
+            date: utcDate(year: 2026, month: 4, day: 8, hour: 8),
+            duration: 1_800,
+            steps: 2_000,
+            floors: 125,
+            ownerUserId: "user-2"
+        )
+
+        modelContext.insert(ownedWorkout)
+        modelContext.insert(foreignWorkout)
+        try modelContext.save()
+
+        try service.rebuildCurrentStats(
+            for: userId,
+            workouts: [ownedWorkout, foreignWorkout],
+            referenceDate: referenceDate
+        )
+
+        let statsByTimeFrame = try fetchStats(for: userId, in: modelContext)
+        #expect(statsByTimeFrame[.weekly]?.totalSteps == 900)
+        #expect(statsByTimeFrame[.weekly]?.totalWorkouts == 1)
+        #expect(statsByTimeFrame[.allTime]?.totalSteps == 900)
+    }
+
+    @Test
+    func prepareSyncPayloadsSkipsNeverSyncedZeroActivityStats() throws {
+        let referenceDate = utcDate(year: 2026, month: 4, day: 10, hour: 12)
+        let userId = "user-1"
+        let service = LeaderboardService.shared
+        let modelContext = try makeModelContext()
+        service.configure(modelContext: modelContext)
+        let period = LeaderboardTimeFrame.weekly.currentPeriod(referenceDate: referenceDate)
+        let emptyStats = LeaderboardStats(userId: userId, timeFrame: .weekly, period: period)
+        modelContext.insert(emptyStats)
+        try modelContext.save()
+
+        let payloads = try service.prepareSyncPayloads(
+            userId: userId,
+            displayName: "User",
+            photoURL: nil
+        )
+
+        #expect(payloads.isEmpty)
+        #expect(emptyStats.needsSync == false)
+    }
+
+    @Test
+    func prepareSyncPayloadsKeepsDeleteForPreviouslySyncedZeroActivityStats() throws {
+        let referenceDate = utcDate(year: 2026, month: 4, day: 10, hour: 12)
+        let userId = "user-1"
+        let service = LeaderboardService.shared
+        let modelContext = try makeModelContext()
+        service.configure(modelContext: modelContext)
+        let period = LeaderboardTimeFrame.weekly.currentPeriod(referenceDate: referenceDate)
+        let emptyStats = LeaderboardStats(userId: userId, timeFrame: .weekly, period: period)
+        emptyStats.lastSyncedToFirestore = referenceDate.addingTimeInterval(-60)
+        modelContext.insert(emptyStats)
+        try modelContext.save()
+
+        let payloads = try service.prepareSyncPayloads(
+            userId: userId,
+            displayName: "User",
+            photoURL: nil
+        )
+
+        #expect(payloads.count == 1)
+        #expect(payloads.first?.operation == .delete)
+        #expect(emptyStats.needsSync)
+    }
+
     private func makeModelContext() throws -> ModelContext {
         let container = try ModelContainer(
             for: Workout.self,
@@ -105,8 +191,14 @@ struct LeaderboardServiceTests {
         })
     }
 
-    private func makeWorkout(date: Date, duration: TimeInterval, steps: Int, floors: Int) -> Workout {
-        Workout(
+    private func makeWorkout(
+        date: Date,
+        duration: TimeInterval,
+        steps: Int,
+        floors: Int,
+        ownerUserId: String? = nil
+    ) -> Workout {
+        let workout = Workout(
             name: "Workout",
             date: date,
             duration: duration,
@@ -115,6 +207,10 @@ struct LeaderboardServiceTests {
             stepsPerFloor: 16,
             source: .manual
         )
+        if let ownerUserId {
+            workout.markPendingRemoteUpsert(ownerUserId: ownerUserId, modifiedAt: date)
+        }
+        return workout
     }
 
     private func utcDate(year: Int, month: Int, day: Int, hour: Int = 0) -> Date {

--- a/AscendAppTests/WorkoutSyncCoordinatorTests.swift
+++ b/AscendAppTests/WorkoutSyncCoordinatorTests.swift
@@ -570,6 +570,10 @@ private actor FakeWorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol {
         self.onUpsert = onUpsert
     }
 
+    func fetchWorkouts(userId: String) async throws -> [RemoteWorkoutRecord] {
+        []
+    }
+
     func upsertWorkout(
         userId: String,
         workoutId: UUID,
@@ -677,6 +681,10 @@ private actor FlakyWorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol {
 
     init(failingUpsertAttempts: Int) {
         self.remainingFailingUpsertAttempts = failingUpsertAttempts
+    }
+
+    func fetchWorkouts(userId: String) async throws -> [RemoteWorkoutRecord] {
+        []
     }
 
     func upsertWorkout(

--- a/web/public/climbs/catalog-v1.json
+++ b/web/public/climbs/catalog-v1.json
@@ -22,7 +22,8 @@
       "torch"
     ],
     "funFact": "France gifted the Statue of Liberty to the United States in 1886.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Statue_of_Liberty"
+    "sourceURL": "https://en.wikipedia.org/wiki/Statue_of_Liberty",
+    "releaseState": "available"
   },
   {
     "id": "washington-monument",
@@ -47,7 +48,8 @@
       "icon"
     ],
     "funFact": "The Washington Monument is the tallest masonry obelisk in the world.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Washington_Monument"
+    "sourceURL": "https://en.wikipedia.org/wiki/Washington_Monument",
+    "releaseState": "comingSoon"
   },
   {
     "id": "gateway-arch",
@@ -72,7 +74,8 @@
       "icon"
     ],
     "funFact": "The Gateway Arch is the tallest arch monument on Earth.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Gateway_Arch"
+    "sourceURL": "https://en.wikipedia.org/wiki/Gateway_Arch",
+    "releaseState": "comingSoon"
   },
   {
     "id": "space-needle",
@@ -97,7 +100,8 @@
       "worlds fair"
     ],
     "funFact": "The Space Needle was built for the 1962 World's Fair.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Space_Needle"
+    "sourceURL": "https://en.wikipedia.org/wiki/Space_Needle",
+    "releaseState": "available"
   },
   {
     "id": "transamerica-pyramid",
@@ -122,7 +126,8 @@
       "icon"
     ],
     "funFact": "The Transamerica Pyramid remained San Francisco's tallest building for decades.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Transamerica_Pyramid"
+    "sourceURL": "https://en.wikipedia.org/wiki/Transamerica_Pyramid",
+    "releaseState": "comingSoon"
   },
   {
     "id": "empire-state-building",
@@ -147,7 +152,8 @@
       "icon"
     ],
     "funFact": "The Empire State Building opened in 1931 during the Great Depression.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Empire_State_Building"
+    "sourceURL": "https://en.wikipedia.org/wiki/Empire_State_Building",
+    "releaseState": "available"
   },
   {
     "id": "chrysler-building",
@@ -172,7 +178,8 @@
       "icon"
     ],
     "funFact": "The Chrysler Building briefly held the world's tallest-building title in 1930.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Chrysler_Building"
+    "sourceURL": "https://en.wikipedia.org/wiki/Chrysler_Building",
+    "releaseState": "comingSoon"
   },
   {
     "id": "one-world-trade-center",
@@ -197,7 +204,8 @@
       "icon"
     ],
     "funFact": "One World Trade Center rises to a symbolic 1,776 feet.",
-    "sourceURL": "https://en.wikipedia.org/wiki/One_World_Trade_Center"
+    "sourceURL": "https://en.wikipedia.org/wiki/One_World_Trade_Center",
+    "releaseState": "comingSoon"
   },
   {
     "id": "willis-tower",
@@ -222,7 +230,8 @@
       "icon"
     ],
     "funFact": "Willis Tower was known as Sears Tower when it became the world's tallest building in 1974.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Willis_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Willis_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "cn-tower",
@@ -247,7 +256,8 @@
       "icon"
     ],
     "funFact": "The CN Tower was the tallest free-standing structure in the world for more than 30 years.",
-    "sourceURL": "https://en.wikipedia.org/wiki/CN_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/CN_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "torre-latinoamericana",
@@ -272,32 +282,8 @@
       "landmark"
     ],
     "funFact": "Torre Latinoamericana is famous for surviving multiple major earthquakes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Torre_Latinoamericana"
-  },
-  {
-    "id": "monument-to-the-revolution",
-    "name": "Monument to the Revolution",
-    "city": "Mexico City",
-    "country": "Mexico",
-    "continent": "North America",
-    "latitude": 19.4363,
-    "longitude": -99.1538,
-    "totalHeightMeters": 67,
-    "totalHeightFeet": 219.8,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 369,
-    "realStairCount": null,
-    "calculatedFloors": 19,
-    "category": "monument",
-    "tier": "bronze",
-    "tags": [
-      "plaza",
-      "history",
-      "icon"
-    ],
-    "funFact": "This monument was built around the abandoned shell of a planned legislative palace.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Monument_to_the_Revolution"
+    "sourceURL": "https://en.wikipedia.org/wiki/Torre_Latinoamericana",
+    "releaseState": "comingSoon"
   },
   {
     "id": "half-dome",
@@ -322,7 +308,8 @@
       "hike"
     ],
     "funFact": "Half Dome's cable route is one of the most famous day hikes in the United States.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Half_Dome"
+    "sourceURL": "https://en.wikipedia.org/wiki/Half_Dome",
+    "releaseState": "comingSoon"
   },
   {
     "id": "denali",
@@ -347,7 +334,8 @@
       "expedition"
     ],
     "funFact": "Denali is the highest mountain peak in North America.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Denali"
+    "sourceURL": "https://en.wikipedia.org/wiki/Denali",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-whitney",
@@ -372,7 +360,8 @@
       "hike"
     ],
     "funFact": "Mount Whitney is the highest summit in the contiguous United States.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Whitney"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Whitney",
+    "releaseState": "comingSoon"
   },
   {
     "id": "pikes-peak",
@@ -397,7 +386,8 @@
       "scenic"
     ],
     "funFact": "Katharine Lee Bates was inspired to write America the Beautiful after visiting Pikes Peak.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Pikes_Peak"
+    "sourceURL": "https://en.wikipedia.org/wiki/Pikes_Peak",
+    "releaseState": "comingSoon"
   },
   {
     "id": "reunion-tower",
@@ -422,32 +412,8 @@
       "skyline"
     ],
     "funFact": "Reunion Tower's glowing geodesic sphere makes it one of Dallas's most recognizable landmarks.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Reunion_Tower"
-  },
-  {
-    "id": "christ-the-redeemer",
-    "name": "Christ the Redeemer",
-    "city": "Rio de Janeiro",
-    "country": "Brazil",
-    "continent": "South America",
-    "latitude": -22.9519,
-    "longitude": -43.2105,
-    "totalHeightMeters": 38,
-    "totalHeightFeet": 124.7,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 209,
-    "realStairCount": null,
-    "calculatedFloors": 11,
-    "category": "monument",
-    "tier": "common",
-    "tags": [
-      "statue",
-      "icon",
-      "viewpoint"
-    ],
-    "funFact": "Christ the Redeemer stands atop Corcovado Mountain overlooking Rio de Janeiro.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Christ_the_Redeemer_(statue)"
+    "sourceURL": "https://en.wikipedia.org/wiki/Reunion_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "machu-picchu",
@@ -472,7 +438,8 @@
       "mountain"
     ],
     "funFact": "Machu Picchu was built in the 15th century and hidden from the outside world for centuries.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Machu_Picchu"
+    "sourceURL": "https://en.wikipedia.org/wiki/Machu_Picchu",
+    "releaseState": "available"
   },
   {
     "id": "sugarloaf-mountain",
@@ -497,7 +464,8 @@
       "viewpoint"
     ],
     "funFact": "Sugarloaf Mountain gets its English name from the cone-shaped molds once used for sugar.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sugarloaf_Mountain"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sugarloaf_Mountain",
+    "releaseState": "comingSoon"
   },
   {
     "id": "gran-torre-santiago",
@@ -522,7 +490,8 @@
       "andes"
     ],
     "funFact": "Gran Torre Santiago is the tallest building in South America.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Gran_Torre_Santiago"
+    "sourceURL": "https://en.wikipedia.org/wiki/Gran_Torre_Santiago",
+    "releaseState": "comingSoon"
   },
   {
     "id": "aconcagua",
@@ -547,7 +516,8 @@
       "expedition"
     ],
     "funFact": "Aconcagua is the highest mountain outside Asia.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Aconcagua"
+    "sourceURL": "https://en.wikipedia.org/wiki/Aconcagua",
+    "releaseState": "comingSoon"
   },
   {
     "id": "monserrate",
@@ -572,32 +542,8 @@
       "city icon"
     ],
     "funFact": "Monserrate rises above Bogota with a church at its summit.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Monserrate"
-  },
-  {
-    "id": "obelisco-buenos-aires",
-    "name": "Obelisco de Buenos Aires",
-    "city": "Buenos Aires",
-    "country": "Argentina",
-    "continent": "South America",
-    "latitude": -34.6037,
-    "longitude": -58.3816,
-    "totalHeightMeters": 67,
-    "totalHeightFeet": 219.8,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 369,
-    "realStairCount": null,
-    "calculatedFloors": 19,
-    "category": "monument",
-    "tier": "bronze",
-    "tags": [
-      "avenue",
-      "city icon",
-      "plaza"
-    ],
-    "funFact": "The Obelisco marks the place where Buenos Aires first flew the national flag.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Obelisco_de_Buenos_Aires"
+    "sourceURL": "https://en.wikipedia.org/wiki/Monserrate",
+    "releaseState": "comingSoon"
   },
   {
     "id": "torres-del-paine",
@@ -622,7 +568,8 @@
       "national park"
     ],
     "funFact": "The granite towers of Torres del Paine are among Patagonia's most famous sights.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Torres_del_Paine"
+    "sourceURL": "https://en.wikipedia.org/wiki/Torres_del_Paine",
+    "releaseState": "comingSoon"
   },
   {
     "id": "el-penon-de-guatape",
@@ -647,7 +594,8 @@
       "viewpoint"
     ],
     "funFact": "A famous zigzag staircase is carved into the side of this giant granite monolith.",
-    "sourceURL": "https://en.wikipedia.org/wiki/El_Penon_de_Guatape"
+    "sourceURL": "https://en.wikipedia.org/wiki/El_Penon_de_Guatape",
+    "releaseState": "comingSoon"
   },
   {
     "id": "palacio-salvo",
@@ -672,7 +620,8 @@
       "plaza"
     ],
     "funFact": "Palacio Salvo dominated Montevideo's skyline when it opened in 1928.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Palacio_Salvo"
+    "sourceURL": "https://en.wikipedia.org/wiki/Palacio_Salvo",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-roraima",
@@ -697,32 +646,8 @@
       "expedition"
     ],
     "funFact": "Mount Roraima's tabletop summit inspired lost world adventure stories.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Roraima"
-  },
-  {
-    "id": "catedral-de-brasilia",
-    "name": "Cathedral of Brasilia",
-    "city": "Brasilia",
-    "country": "Brazil",
-    "continent": "South America",
-    "latitude": -15.7984,
-    "longitude": -47.875,
-    "totalHeightMeters": 90,
-    "totalHeightFeet": 295.3,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 495,
-    "realStairCount": null,
-    "calculatedFloors": 25,
-    "category": "cathedral",
-    "tier": "bronze",
-    "tags": [
-      "modernist",
-      "capital",
-      "icon"
-    ],
-    "funFact": "Oscar Niemeyer designed the Cathedral of Brasilia with a crown-like concrete structure.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Cathedral_of_Brasilia"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Roraima",
+    "releaseState": "comingSoon"
   },
   {
     "id": "farol-santander",
@@ -747,7 +672,8 @@
       "city center"
     ],
     "funFact": "This former bank tower is now an arts and observation space in downtown Sao Paulo.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Farol_Santander"
+    "sourceURL": "https://en.wikipedia.org/wiki/Farol_Santander",
+    "releaseState": "comingSoon"
   },
   {
     "id": "llaima-volcano",
@@ -772,7 +698,8 @@
       "expedition"
     ],
     "funFact": "Llaima is one of Chile's largest and most active volcanoes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Llaima"
+    "sourceURL": "https://en.wikipedia.org/wiki/Llaima",
+    "releaseState": "comingSoon"
   },
   {
     "id": "eiffel-tower",
@@ -797,7 +724,8 @@
       "icon"
     ],
     "funFact": "The Eiffel Tower was built as the entrance arch for the 1889 World's Fair.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Eiffel_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Eiffel_Tower",
+    "releaseState": "available"
   },
   {
     "id": "elizabeth-tower",
@@ -822,7 +750,8 @@
       "icon"
     ],
     "funFact": "Big Ben is the nickname of the tower's Great Bell, not the tower itself.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Elizabeth_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Elizabeth_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "the-shard",
@@ -847,7 +776,8 @@
       "skyline"
     ],
     "funFact": "The Shard was designed by Renzo Piano to look like a shard of glass.",
-    "sourceURL": "https://en.wikipedia.org/wiki/The_Shard"
+    "sourceURL": "https://en.wikipedia.org/wiki/The_Shard",
+    "releaseState": "comingSoon"
   },
   {
     "id": "berlin-tv-tower",
@@ -872,7 +802,8 @@
       "icon"
     ],
     "funFact": "The sphere of the Berlin TV Tower often reflects sunlight in a cross shape nicknamed the Pope's Revenge.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Fernsehturm_Berlin"
+    "sourceURL": "https://en.wikipedia.org/wiki/Fernsehturm_Berlin",
+    "releaseState": "comingSoon"
   },
   {
     "id": "leaning-tower-of-pisa",
@@ -897,32 +828,8 @@
       "icon"
     ],
     "funFact": "The Leaning Tower of Pisa began tilting during construction in the 12th century.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Leaning_Tower_of_Pisa"
-  },
-  {
-    "id": "colosseum",
-    "name": "Colosseum",
-    "city": "Rome",
-    "country": "Italy",
-    "continent": "Europe",
-    "latitude": 41.8902,
-    "longitude": 12.4922,
-    "totalHeightMeters": 48,
-    "totalHeightFeet": 157.5,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 264,
-    "realStairCount": null,
-    "calculatedFloors": 13,
-    "category": "monument",
-    "tier": "common",
-    "tags": [
-      "rome",
-      "amphitheater",
-      "history"
-    ],
-    "funFact": "The Colosseum could hold tens of thousands of spectators for ancient Roman spectacles.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Colosseum"
+    "sourceURL": "https://en.wikipedia.org/wiki/Leaning_Tower_of_Pisa",
+    "releaseState": "comingSoon"
   },
   {
     "id": "sagrada-familia",
@@ -947,57 +854,8 @@
       "basilica"
     ],
     "funFact": "Construction on the Sagrada Familia began in 1882 and is still ongoing.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sagrada_Familia"
-  },
-  {
-    "id": "arc-de-triomphe",
-    "name": "Arc de Triomphe",
-    "city": "Paris",
-    "country": "France",
-    "continent": "Europe",
-    "latitude": 48.8738,
-    "longitude": 2.295,
-    "totalHeightMeters": 50,
-    "totalHeightFeet": 164,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 275,
-    "realStairCount": null,
-    "calculatedFloors": 14,
-    "category": "monument",
-    "tier": "common",
-    "tags": [
-      "paris",
-      "arch",
-      "avenue"
-    ],
-    "funFact": "The Arc de Triomphe honors those who fought and died for France in the French Revolutionary and Napoleonic Wars.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Arc_de_Triomphe"
-  },
-  {
-    "id": "atomium",
-    "name": "Atomium",
-    "city": "Brussels",
-    "country": "Belgium",
-    "continent": "Europe",
-    "latitude": 50.8949,
-    "longitude": 4.3416,
-    "totalHeightMeters": 102,
-    "totalHeightFeet": 334.6,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 561,
-    "realStairCount": null,
-    "calculatedFloors": 28,
-    "category": "monument",
-    "tier": "bronze",
-    "tags": [
-      "expo",
-      "brussels",
-      "icon"
-    ],
-    "funFact": "The Atomium represents an iron crystal magnified 165 billion times.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Atomium"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sagrada_Familia",
+    "releaseState": "comingSoon"
   },
   {
     "id": "matterhorn",
@@ -1022,7 +880,8 @@
       "icon"
     ],
     "funFact": "The Matterhorn's near-symmetrical pyramid shape makes it one of the world's most recognizable mountains.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Matterhorn"
+    "sourceURL": "https://en.wikipedia.org/wiki/Matterhorn",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mont-blanc",
@@ -1047,7 +906,8 @@
       "expedition"
     ],
     "funFact": "Mont Blanc is the highest mountain in the Alps and Western Europe.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mont_Blanc"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mont_Blanc",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-etna",
@@ -1072,7 +932,8 @@
       "expedition"
     ],
     "funFact": "Mount Etna is one of the world's most active stratovolcanoes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Etna"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Etna",
+    "releaseState": "comingSoon"
   },
   {
     "id": "acropolis-of-athens",
@@ -1097,7 +958,8 @@
       "hilltop"
     ],
     "funFact": "The Acropolis has overlooked Athens since classical antiquity.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Acropolis_of_Athens"
+    "sourceURL": "https://en.wikipedia.org/wiki/Acropolis_of_Athens",
+    "releaseState": "comingSoon"
   },
   {
     "id": "st-peters-basilica",
@@ -1122,7 +984,8 @@
       "basilica"
     ],
     "funFact": "St. Peter's Basilica stands over the traditional burial site of Saint Peter.",
-    "sourceURL": "https://en.wikipedia.org/wiki/St._Peter%27s_Basilica"
+    "sourceURL": "https://en.wikipedia.org/wiki/St._Peter%27s_Basilica",
+    "releaseState": "comingSoon"
   },
   {
     "id": "neuschwanstein-castle",
@@ -1147,7 +1010,8 @@
       "icon"
     ],
     "funFact": "Neuschwanstein Castle inspired the look of several fairy-tale castles in popular culture.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Neuschwanstein_Castle"
+    "sourceURL": "https://en.wikipedia.org/wiki/Neuschwanstein_Castle",
+    "releaseState": "comingSoon"
   },
   {
     "id": "moscow-state-university-main-building",
@@ -1172,7 +1036,8 @@
       "university"
     ],
     "funFact": "The main building is one of Moscow's famed Seven Sisters skyscrapers.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Moscow_State_University"
+    "sourceURL": "https://en.wikipedia.org/wiki/Moscow_State_University",
+    "releaseState": "comingSoon"
   },
   {
     "id": "sacre-coeur",
@@ -1197,7 +1062,8 @@
       "paris"
     ],
     "funFact": "Sacre-Coeur sits at the summit of Montmartre, the highest natural point in Paris.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sacre-Coeur,_Paris"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sacre-Coeur,_Paris",
+    "releaseState": "comingSoon"
   },
   {
     "id": "alhambra",
@@ -1222,32 +1088,8 @@
       "andalusia"
     ],
     "funFact": "The Alhambra was the royal court of the Nasrid dynasty in Granada.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Alhambra"
-  },
-  {
-    "id": "torre-de-belem",
-    "name": "Torre de Belem",
-    "city": "Lisbon",
-    "country": "Portugal",
-    "continent": "Europe",
-    "latitude": 38.6916,
-    "longitude": -9.216,
-    "totalHeightMeters": 35,
-    "totalHeightFeet": 114.8,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 193,
-    "realStairCount": null,
-    "calculatedFloors": 10,
-    "category": "tower",
-    "tier": "common",
-    "tags": [
-      "riverfront",
-      "fortress",
-      "lisbon"
-    ],
-    "funFact": "Belem Tower once guarded the entrance to Lisbon's harbor.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Belem_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Alhambra",
+    "releaseState": "comingSoon"
   },
   {
     "id": "hallgrimskirkja",
@@ -1272,7 +1114,8 @@
       "icon"
     ],
     "funFact": "Hallgrimskirkja's design was inspired by Icelandic basalt columns.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Hallgrimskirkja"
+    "sourceURL": "https://en.wikipedia.org/wiki/Hallgrimskirkja",
+    "releaseState": "comingSoon"
   },
   {
     "id": "burj-khalifa",
@@ -1297,7 +1140,8 @@
       "observation"
     ],
     "funFact": "Burj Khalifa has held the tallest-building title since 2010.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Burj_Khalifa"
+    "sourceURL": "https://en.wikipedia.org/wiki/Burj_Khalifa",
+    "releaseState": "available"
   },
   {
     "id": "petronas-towers",
@@ -1322,7 +1166,8 @@
       "icon"
     ],
     "funFact": "The Petronas Towers were the world's tallest buildings from 1998 to 2004.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Petronas_Towers"
+    "sourceURL": "https://en.wikipedia.org/wiki/Petronas_Towers",
+    "releaseState": "comingSoon"
   },
   {
     "id": "taipei-101",
@@ -1347,7 +1192,8 @@
       "icon"
     ],
     "funFact": "Taipei 101 uses a massive tuned-mass damper to steady the tower during typhoons and earthquakes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Taipei_101"
+    "sourceURL": "https://en.wikipedia.org/wiki/Taipei_101",
+    "releaseState": "available"
   },
   {
     "id": "tokyo-skytree",
@@ -1372,7 +1218,8 @@
       "tokyo"
     ],
     "funFact": "Tokyo Skytree is the tallest structure in Japan.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Tokyo_Skytree"
+    "sourceURL": "https://en.wikipedia.org/wiki/Tokyo_Skytree",
+    "releaseState": "comingSoon"
   },
   {
     "id": "tokyo-tower",
@@ -1397,7 +1244,8 @@
       "icon"
     ],
     "funFact": "Tokyo Tower's color scheme follows international air safety rules for tall structures.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Tokyo_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Tokyo_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "shanghai-tower",
@@ -1422,7 +1270,8 @@
       "skyline"
     ],
     "funFact": "Shanghai Tower has one of the world's fastest elevators.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Shanghai_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Shanghai_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "canton-tower",
@@ -1447,7 +1296,8 @@
       "icon"
     ],
     "funFact": "Canton Tower's twisted form is sometimes called the Supermodel Tower.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Canton_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Canton_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "oriental-pearl-tower",
@@ -1472,7 +1322,8 @@
       "icon"
     ],
     "funFact": "The Oriental Pearl Tower became a symbol of modern Shanghai soon after opening in 1994.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Oriental_Pearl_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Oriental_Pearl_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "lotte-world-tower",
@@ -1497,7 +1348,8 @@
       "skyline"
     ],
     "funFact": "Lotte World Tower is the tallest building on the Korean Peninsula.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Lotte_World_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Lotte_World_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "n-seoul-tower",
@@ -1522,32 +1374,8 @@
       "seoul"
     ],
     "funFact": "N Seoul Tower stands atop Namsan and overlooks the South Korean capital.",
-    "sourceURL": "https://en.wikipedia.org/wiki/N_Seoul_Tower"
-  },
-  {
-    "id": "qutub-minar",
-    "name": "Qutub Minar",
-    "city": "Delhi",
-    "country": "India",
-    "continent": "Asia",
-    "latitude": 28.5244,
-    "longitude": 77.1855,
-    "totalHeightMeters": 73,
-    "totalHeightFeet": 239.5,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 402,
-    "realStairCount": null,
-    "calculatedFloors": 20,
-    "category": "tower",
-    "tier": "bronze",
-    "tags": [
-      "minaret",
-      "unesco",
-      "delhi"
-    ],
-    "funFact": "Qutub Minar is the tallest brick minaret in the world.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Qutb_Minar"
+    "sourceURL": "https://en.wikipedia.org/wiki/N_Seoul_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "merdeka-118",
@@ -1572,7 +1400,8 @@
       "skyline"
     ],
     "funFact": "Merdeka 118 became one of the tallest buildings in the world after topping out in 2021.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Merdeka_118"
+    "sourceURL": "https://en.wikipedia.org/wiki/Merdeka_118",
+    "releaseState": "comingSoon"
   },
   {
     "id": "marina-bay-sands",
@@ -1597,7 +1426,8 @@
       "resort"
     ],
     "funFact": "The three towers of Marina Bay Sands are linked by a huge rooftop SkyPark.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Marina_Bay_Sands"
+    "sourceURL": "https://en.wikipedia.org/wiki/Marina_Bay_Sands",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-fuji",
@@ -1622,7 +1452,8 @@
       "icon"
     ],
     "funFact": "Mount Fuji is Japan's highest peak and a longstanding cultural icon.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Fuji"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Fuji",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-kinabalu",
@@ -1647,7 +1478,8 @@
       "expedition"
     ],
     "funFact": "Mount Kinabalu is the highest mountain in Malaysia.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kinabalu"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kinabalu",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-everest",
@@ -1672,32 +1504,8 @@
       "expedition"
     ],
     "funFact": "Mount Everest is Earth's highest mountain above sea level.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Everest"
-  },
-  {
-    "id": "lotus-temple",
-    "name": "Lotus Temple",
-    "city": "Delhi",
-    "country": "India",
-    "continent": "Asia",
-    "latitude": 28.5535,
-    "longitude": 77.2588,
-    "totalHeightMeters": 34,
-    "totalHeightFeet": 111.5,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 187,
-    "realStairCount": null,
-    "calculatedFloors": 9,
-    "category": "temple",
-    "tier": "common",
-    "tags": [
-      "bahai",
-      "flower",
-      "modern"
-    ],
-    "funFact": "The Lotus Temple welcomes worshippers of every faith and is shaped like a lotus blossom.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Lotus_Temple"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Everest",
+    "releaseState": "available"
   },
   {
     "id": "charminar",
@@ -1722,7 +1530,8 @@
       "icon"
     ],
     "funFact": "The Charminar has four grand arches and four minarets at a historic crossroads in Hyderabad.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Charminar"
+    "sourceURL": "https://en.wikipedia.org/wiki/Charminar",
+    "releaseState": "comingSoon"
   },
   {
     "id": "osaka-castle",
@@ -1747,32 +1556,8 @@
       "icon"
     ],
     "funFact": "Toyotomi Hideyoshi built Osaka Castle in the late 16th century.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Osaka_Castle"
-  },
-  {
-    "id": "great-pyramid-of-giza",
-    "name": "Great Pyramid of Giza",
-    "city": "Giza",
-    "country": "Egypt",
-    "continent": "Africa",
-    "latitude": 29.9792,
-    "longitude": 31.1342,
-    "totalHeightMeters": 147,
-    "totalHeightFeet": 482.3,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 809,
-    "realStairCount": null,
-    "calculatedFloors": 41,
-    "category": "pyramid",
-    "tier": "silver",
-    "tags": [
-      "ancient wonders",
-      "egypt",
-      "icon"
-    ],
-    "funFact": "The Great Pyramid is the oldest of the Seven Wonders of the Ancient World and the only one still largely intact.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Great_Pyramid_of_Giza"
+    "sourceURL": "https://en.wikipedia.org/wiki/Osaka_Castle",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-kilimanjaro",
@@ -1797,7 +1582,8 @@
       "expedition"
     ],
     "funFact": "Kilimanjaro is Africa's highest mountain and a freestanding volcanic massif.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kilimanjaro"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kilimanjaro",
+    "releaseState": "comingSoon"
   },
   {
     "id": "table-mountain",
@@ -1822,7 +1608,8 @@
       "icon"
     ],
     "funFact": "Table Mountain's flat summit dominates the skyline of Cape Town.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Table_Mountain"
+    "sourceURL": "https://en.wikipedia.org/wiki/Table_Mountain",
+    "releaseState": "available"
   },
   {
     "id": "cairo-tower",
@@ -1847,7 +1634,8 @@
       "icon"
     ],
     "funFact": "The lattice exterior of Cairo Tower was designed to echo a lotus plant.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Cairo_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Cairo_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-kenya",
@@ -1872,32 +1660,8 @@
       "expedition"
     ],
     "funFact": "Mount Kenya is the second-highest mountain in Africa.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kenya"
-  },
-  {
-    "id": "hassan-ii-mosque-minaret",
-    "name": "Hassan II Mosque Minaret",
-    "city": "Casablanca",
-    "country": "Morocco",
-    "continent": "Africa",
-    "latitude": 33.6084,
-    "longitude": -7.6326,
-    "totalHeightMeters": 210,
-    "totalHeightFeet": 689,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 1155,
-    "realStairCount": null,
-    "calculatedFloors": 58,
-    "category": "tower",
-    "tier": "silver",
-    "tags": [
-      "minaret",
-      "mosque",
-      "coast"
-    ],
-    "funFact": "The Hassan II Mosque has one of the tallest minarets in the world.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Hassan_II_Mosque"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kenya",
+    "releaseState": "comingSoon"
   },
   {
     "id": "voortrekker-monument",
@@ -1922,7 +1686,8 @@
       "granite"
     ],
     "funFact": "The Voortrekker Monument commemorates the 19th-century migration known as the Great Trek.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Voortrekker_Monument"
+    "sourceURL": "https://en.wikipedia.org/wiki/Voortrekker_Monument",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-cameroon",
@@ -1947,7 +1712,8 @@
       "expedition"
     ],
     "funFact": "Mount Cameroon is one of Africa's most active volcanoes.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Cameroon"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Cameroon",
+    "releaseState": "comingSoon"
   },
   {
     "id": "abuna-yemata-guh",
@@ -1972,7 +1738,8 @@
       "ethiopia"
     ],
     "funFact": "Abuna Yemata Guh is famed for its cliffside approach and painted cave church interior.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Abuna_Yemata_Guh"
+    "sourceURL": "https://en.wikipedia.org/wiki/Abuna_Yemata_Guh",
+    "releaseState": "comingSoon"
   },
   {
     "id": "sky-tower-auckland",
@@ -1997,7 +1764,8 @@
       "icon"
     ],
     "funFact": "Sky Tower is the tallest freestanding structure in the Southern Hemisphere.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sky_Tower_(Auckland)"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sky_Tower_(Auckland)",
+    "releaseState": "comingSoon"
   },
   {
     "id": "eureka-tower",
@@ -2022,7 +1790,8 @@
       "observation"
     ],
     "funFact": "Eureka Tower's top floors are wrapped in gold-plated glass.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Eureka_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Eureka_Tower",
+    "releaseState": "comingSoon"
   },
   {
     "id": "q1-tower",
@@ -2047,7 +1816,8 @@
       "skyline"
     ],
     "funFact": "Q1 Tower's spire was inspired by the Sydney Olympic torch.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Q1_(building)"
+    "sourceURL": "https://en.wikipedia.org/wiki/Q1_(building)",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-kosciuszko",
@@ -2072,32 +1842,8 @@
       "alps"
     ],
     "funFact": "Mount Kosciuszko is the highest mountain on mainland Australia.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kosciuszko"
-  },
-  {
-    "id": "melbourne-arts-centre-spire",
-    "name": "Melbourne Arts Centre Spire",
-    "city": "Melbourne",
-    "country": "Australia",
-    "continent": "Oceania",
-    "latitude": -37.8203,
-    "longitude": 144.9689,
-    "totalHeightMeters": 162,
-    "totalHeightFeet": 531.5,
-    "realClimbableHeightMeters": null,
-    "realClimbableHeightFeet": null,
-    "totalSteps": 891,
-    "realStairCount": null,
-    "calculatedFloors": 45,
-    "category": "tower",
-    "tier": "silver",
-    "tags": [
-      "arts",
-      "melbourne",
-      "icon"
-    ],
-    "funFact": "The Arts Centre spire is lit every night and has become a Melbourne skyline signature.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Arts_Centre_Melbourne"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Kosciuszko",
+    "releaseState": "comingSoon"
   },
   {
     "id": "kunanyi-mount-wellington",
@@ -2122,7 +1868,8 @@
       "viewpoint"
     ],
     "funFact": "kunanyi towers above Hobart and can be dusted with snow in winter.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Wellington_(Tasmania)"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Wellington_(Tasmania)",
+    "releaseState": "comingSoon"
   },
   {
     "id": "aoraki-mount-cook",
@@ -2147,7 +1894,8 @@
       "icon"
     ],
     "funFact": "Aoraki / Mount Cook is the highest mountain in New Zealand.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Aoraki_/_Mount_Cook"
+    "sourceURL": "https://en.wikipedia.org/wiki/Aoraki_/_Mount_Cook",
+    "releaseState": "comingSoon"
   },
   {
     "id": "mount-taranaki",
@@ -2172,7 +1920,8 @@
       "icon"
     ],
     "funFact": "Mount Taranaki's near-perfect cone makes it one of New Zealand's most distinctive mountains.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Taranaki"
+    "sourceURL": "https://en.wikipedia.org/wiki/Mount_Taranaki",
+    "releaseState": "comingSoon"
   },
   {
     "id": "sydney-tower",
@@ -2197,6 +1946,7 @@
       "skyline"
     ],
     "funFact": "Sydney Tower is the tallest structure in the city's central business district.",
-    "sourceURL": "https://en.wikipedia.org/wiki/Sydney_Tower"
+    "sourceURL": "https://en.wikipedia.org/wiki/Sydney_Tower",
+    "releaseState": "available"
   }
 ]

--- a/web/public/climbs/manifest.json
+++ b/web/public/climbs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "catalogVersion": 3,
+  "catalogVersion": 5,
   "catalogPath": "/climbs/catalog-v1.json",
   "featuredClimbId": "empire-state-building",
-  "updatedAt": "2026-05-24T00:00:00Z"
+  "updatedAt": "2026-05-26T00:00:00Z"
 }


### PR DESCRIPTION
## Summary

This PR packages the current launch-readiness work across account ownership, workout hydration, climb catalog release states, leaderboard fixes, and climb-detail/home copy polish.

### What changed

- Added account-session ownership tracking so a device with existing local data is tied to the owning Firebase UID and blocks unsafe cross-account reuse.
- Added authenticated workout hydration from Firestore backups so fresh installs and returning users can rebuild local workout data from the backend.
- Updated the launch climb catalog model with explicit release states, available/coming-soon filtering, and globe/list UI support for coming-soon climbs.
- Reduced the launch catalog to the selected launch set while keeping coming-soon content visible through the remote catalog flow.
- Fixed leaderboard edge cases, including the pinned `You` row rank rendering and avoiding stalled publish warnings when there is no new workout activity to publish.
- Updated recent personal records copy from highest average SPM to fastest pace and made the `SPM` unit subordinate to the number.
- Cleaned up climb detail copy and UI: canonical First Ascent copy, removed duplicate History/Leaderboard headings, and hid the flip control while the hero card back is showing.

### Validation

- `npm test` in `functions`
- `xcodebuild build-for-testing -project AscendApp.xcodeproj -scheme AscendApp -destination 'generic/platform=iOS Simulator' -quiet`
- `git diff --cached --check`

### Notes

The unrelated local `HomeRankTrophyArtwork.imageset` folder was left uncommitted. The dev climb catalog was already deployed separately to Firebase Hosting during validation.