### PR TITLE
Implement climbs collection page

### DIFF
--- a/AscendApp/Features/Profile/Models/ProfileCollectionSummary.swift
+++ b/AscendApp/Features/Profile/Models/ProfileCollectionSummary.swift
@@ -37,4 +37,6 @@ struct ProfileCollectionSummary: Equatable {
     let collectedCount: Int
     let catalogCount: Int
     let previewCards: [ProfileCollectionCardItem]
+    let launchedCards: [ProfileCollectionCardItem]
+    let comingSoonClimbs: [Climb]
 }

--- a/AscendApp/Features/Profile/Services/ProfileSnapshotBuilder.swift
+++ b/AscendApp/Features/Profile/Services/ProfileSnapshotBuilder.swift
@@ -206,9 +206,14 @@ enum ProfileSnapshotBuilder {
         fitnessLevel: FitnessLevel
     ) -> ProfileCollectionSummary {
         let availableClimbs = climbs.filter(\.isAvailable)
+        let comingSoonClimbs = climbs.filter(\.isComingSoon)
         let completedClimbs = claimedClimbs(
             from: completedAttempts,
             availableClimbs: availableClimbs
+        )
+        let launchedCards = collectionCards(
+            for: collectionOrderedLaunchedClimbs(availableClimbs),
+            claimedClimbs: completedClimbs
         )
         let previewCards = collectionPreviewCards(
             claimedClimbs: completedClimbs,
@@ -219,7 +224,9 @@ enum ProfileSnapshotBuilder {
         return ProfileCollectionSummary(
             collectedCount: completedClimbs.count,
             catalogCount: availableClimbs.count,
-            previewCards: previewCards
+            previewCards: previewCards,
+            launchedCards: launchedCards,
+            comingSoonClimbs: Array(comingSoonClimbs.prefix(6))
         )
     }
 
@@ -228,9 +235,14 @@ enum ProfileSnapshotBuilder {
         climbs: [Climb]
     ) -> ProfileCollectionSummary {
         let availableClimbs = climbs.filter(\.isAvailable)
+        let comingSoonClimbs = climbs.filter(\.isComingSoon)
         let completedClimbs = claimedClimbs(
             from: workoutSummaries,
             availableClimbs: availableClimbs
+        )
+        let launchedCards = collectionCards(
+            for: collectionOrderedLaunchedClimbs(availableClimbs),
+            claimedClimbs: completedClimbs
         )
         let previewCards = collectionPreviewCards(
             claimedClimbs: completedClimbs,
@@ -240,7 +252,9 @@ enum ProfileSnapshotBuilder {
         return ProfileCollectionSummary(
             collectedCount: completedClimbs.count,
             catalogCount: availableClimbs.count,
-            previewCards: previewCards
+            previewCards: previewCards,
+            launchedCards: launchedCards,
+            comingSoonClimbs: Array(comingSoonClimbs.prefix(6))
         )
     }
 
@@ -317,6 +331,57 @@ enum ProfileSnapshotBuilder {
 
         return Array(claimedCards + recommendedCards)
     }
+
+    private static func collectionCards(
+        for climbs: [Climb],
+        claimedClimbs: [ProfileCollectionClaimedClimb]
+    ) -> [ProfileCollectionCardItem] {
+        let claimedByID = Dictionary(uniqueKeysWithValues: claimedClimbs.map { ($0.climb.id, $0) })
+
+        return climbs.map { climb in
+            if let claimedClimb = claimedByID[climb.id] {
+                return .claimed(claimedClimb)
+            }
+
+            return .unclaimed(climb)
+        }
+    }
+
+    private static func collectionOrderedLaunchedClimbs(_ climbs: [Climb]) -> [Climb] {
+        climbs.sorted(by: collectionLaunchSort)
+    }
+
+    private static func collectionLaunchSort(lhs: Climb, rhs: Climb) -> Bool {
+        let lhsRank = collectionLaunchOrder[lhs.id] ?? Int.max
+        let rhsRank = collectionLaunchOrder[rhs.id] ?? Int.max
+
+        if lhsRank != rhsRank {
+            return lhsRank < rhsRank
+        }
+
+        if lhs.tier != rhs.tier {
+            return lhs.tier < rhs.tier
+        }
+
+        if lhs.totalSteps != rhs.totalSteps {
+            return lhs.totalSteps < rhs.totalSteps
+        }
+
+        return lhs.name < rhs.name
+    }
+
+    private static let collectionLaunchOrder: [String: Int] = [
+        "taipei-101": 0,
+        "statue-of-liberty": 1,
+        "space-needle": 2,
+        "empire-state-building": 3,
+        "eiffel-tower": 4,
+        "burj-khalifa": 5,
+        "table-mountain": 6,
+        "machu-picchu": 7,
+        "mount-everest": 8,
+        "sydney-tower": 9
+    ]
 
     private static func recommendedUnclaimedClimbs(
         from climbs: [Climb],

--- a/AscendApp/Features/Profile/Views/CollectionSection.swift
+++ b/AscendApp/Features/Profile/Views/CollectionSection.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import UIKit
+import UserNotifications
 
 struct CollectionSection: View {
     let collection: ProfileCollectionSummary
@@ -12,40 +14,53 @@ struct CollectionSection: View {
         if collection.catalogCount > 0, !previewCards.isEmpty {
             ProfileCardSurfaceView {
                 VStack(alignment: .leading, spacing: 12) {
-                    Text("COLLECTION")
-                        .font(.montserratSemiBold(size: 11))
-                        .tracking(1.2)
-                        .foregroundStyle(Color.accentColor)
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        Text("Climbs Collection")
+                            .font(.montserratBold(size: 21))
+                            .foregroundStyle(.white)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.72)
 
-                    Text("\(collection.collectedCount) of \(collection.catalogCount) climbs collected")
-                        .font(.montserratBold(size: 21))
-                        .foregroundStyle(.white)
-                        .lineLimit(2)
-                        .minimumScaleFactor(0.72)
+                        Spacer(minLength: 0)
 
-                    HStack(alignment: .top, spacing: 10) {
-                        ForEach(previewCards) { item in
-                            NavigationLink {
-                                ClimbDetailView(climb: item.climb, analyticsEntryPoint: .unknown)
-                            } label: {
-                                CollectionPreviewCard(item: item)
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel(accessibilityLabel(for: item))
-                            .accessibilityHint("Open \(item.climb.name)")
-                        }
+                        Text("\(collection.collectedCount) of \(collection.catalogCount)")
+                            .font(.montserratSemiBold(size: 12))
+                            .tracking(0.8)
+                            .foregroundStyle(Color.accentColor)
+                            .lineLimit(1)
+                            .fixedSize()
+                            .accessibilityLabel("\(collection.collectedCount) of \(collection.catalogCount) climbs collected")
                     }
 
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(alignment: .top, spacing: 10) {
+                            ForEach(previewCards) { item in
+                                NavigationLink {
+                                    ClimbDetailView(climb: item.climb, analyticsEntryPoint: .unknown)
+                                } label: {
+                                    CollectionCard(item: item, style: .profilePreview)
+                                        .frame(width: CollectionCardStyle.profilePreview.cardWidth)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel(accessibilityLabel(for: item))
+                                .accessibilityHint("Open \(item.climb.name)")
+                            }
+                        }
+                        .padding(.vertical, 1)
+                        .padding(.trailing, 2)
+                    }
+                    .scrollIndicators(.hidden)
+
                     NavigationLink {
-                        CollectionGalleryPlaceholderView(totalCount: collection.catalogCount)
+                        ClimbsCollectionView(collection: collection, mode: mode)
                     } label: {
-                        Text("View all \(collection.catalogCount) climbs")
+                        Text("View all climbs")
                             .font(.montserratSemiBold(size: 14))
                             .foregroundStyle(Color.accentColor)
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.plain)
-                    .padding(.top, 2)
+                    .padding(.top, 4)
                 }
                 .padding(14)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -63,99 +78,458 @@ struct CollectionSection: View {
     }
 }
 
-private struct CollectionPreviewCard: View {
-    let item: ProfileCollectionCardItem
+private struct ClimbsCollectionView: View {
+    let collection: ProfileCollectionSummary
+    let mode: ProfileViewMode
 
-    private let cornerRadius: CGFloat = 9
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedComingSoonClimb: Climb?
+    @State private var isHandlingNotifications = false
+
+    private let launchedColumns = [
+        GridItem(.flexible(), spacing: 12),
+        GridItem(.flexible(), spacing: 12)
+    ]
+    private let comingSoonColumns = [
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: 8)
+    ]
 
     var body: some View {
-        VStack(spacing: 7) {
-            ClimbArtworkView(climb: item.climb, variant: .card)
-                .aspectRatio(1.02, contentMode: .fill)
-                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                topBar
+                progressSummary
+                launchedGrid
 
-            Text(item.climb.name)
-                .font(.montserratBold(size: 11))
-                .foregroundStyle(.white)
-                .multilineTextAlignment(.center)
-                .lineLimit(2)
-                .minimumScaleFactor(0.78)
-                .frame(height: 28)
-                .frame(maxWidth: .infinity)
+                if !collection.comingSoonClimbs.isEmpty {
+                    comingSoonSection
+                }
 
-            statusStrip
-                .frame(height: 32)
+                if mode == .own {
+                    notificationsCTA
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .padding(.bottom, 34)
         }
-        .padding(7)
-        .frame(maxWidth: .infinity)
-        .background(ProfileVisualStyle.cardFill)
-        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        .animatedClimbCardBorder(
-            colors: item.climb.tier.borderColors,
-            shadowColor: item.climb.tier.shadowColor,
-            cornerRadius: cornerRadius,
-            lineWidth: 1,
-            isEmphasized: item.climb.tier.usesEmphasizedBorderStyle,
-            animationStyle: .ambient
-        )
-        .contentShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+        .scrollIndicators(.hidden)
+        .background(ProfileVisualStyle.background.ignoresSafeArea())
+        .toolbar(.hidden, for: .navigationBar)
+        .sheet(item: $selectedComingSoonClimb) { climb in
+            CollectionComingSoonDetailSheet(climb: climb)
+        }
     }
 
-    @ViewBuilder
-    private var statusStrip: some View {
-        if let claimedAt = item.claimedAt {
-            HStack(spacing: 5) {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 13, weight: .semibold))
+    private var topBar: some View {
+        ZStack {
+            Text("CLIMBS COLLECTION")
+                .font(.montserratSemiBold(size: 18))
+                .tracking(2.4)
+                .foregroundStyle(Color.accentColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
+                .frame(maxWidth: .infinity)
+
+            HStack {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 22, weight: .bold))
+                        .foregroundStyle(Color.accentColor)
+                        .frame(width: 48, height: 48)
+                        .background(
+                            Circle()
+                                .fill(Color.white.opacity(0.045))
+                                .overlay(
+                                    Circle()
+                                        .stroke(Color.white.opacity(0.16), lineWidth: 1)
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Back")
+
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    private var progressSummary: some View {
+        HStack(spacing: 16) {
+            CollectionProgressBar(
+                collectedCount: collection.collectedCount,
+                catalogCount: collection.catalogCount
+            )
+            .frame(height: 10)
+
+            Text("\(collection.collectedCount) / \(collection.catalogCount)")
+                .font(.montserratBold(size: 18))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .fixedSize()
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(collection.collectedCount) of \(collection.catalogCount) climbs collected")
+    }
+
+    private var launchedGrid: some View {
+        LazyVGrid(columns: launchedColumns, spacing: 12) {
+            ForEach(collection.launchedCards) { item in
+                NavigationLink {
+                    ClimbDetailView(climb: item.climb, analyticsEntryPoint: .unknown)
+                } label: {
+                    CollectionCard(item: item, style: .grid)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(accessibilityLabel(for: item))
+                .accessibilityHint("Open \(item.climb.name)")
+            }
+        }
+    }
+
+    private var comingSoonSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("COMING SOON")
+                    .font(.montserratSemiBold(size: 11))
+                    .tracking(2.4)
                     .foregroundStyle(Color.accentColor)
 
-                Text("Claimed \(ProfileDateFormatters.fullDate(claimedAt))")
-                    .font(.montserratMedium(size: 9))
-                    .foregroundStyle(ProfileVisualStyle.secondaryText)
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.72)
+                Text("More climbs are on the way")
+                    .font(.montserratBold(size: 20))
+                    .foregroundStyle(.white)
             }
-            .frame(maxWidth: .infinity, alignment: .center)
-        } else {
-            Text("Climb")
-                .font(.montserratSemiBold(size: 13))
-                .foregroundStyle(Color.accentColor)
+
+            LazyVGrid(columns: comingSoonColumns, spacing: 8) {
+                ForEach(collection.comingSoonClimbs) { climb in
+                    Button {
+                        selectedComingSoonClimb = climb
+                    } label: {
+                        CollectionComingSoonCard(climb: climb)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Coming soon climb")
+                    .accessibilityHint("Reveal the region")
+                }
+            }
+        }
+        .padding(.top, 2)
+    }
+
+    private var notificationsCTA: some View {
+        VStack(spacing: 10) {
+            Text("Be the first to know when new climbs drop.")
+                .font(.montserratMedium(size: 14))
+                .foregroundStyle(.white.opacity(0.9))
+                .multilineTextAlignment(.center)
                 .frame(maxWidth: .infinity)
-                .frame(height: 32)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 7, style: .continuous)
-                        .stroke(Color.accentColor, lineWidth: 1)
-                )
+
+            Button {
+                handleNotificationsTap()
+            } label: {
+                Text("Turn on notifications")
+                    .font(.montserratBold(size: 20))
+                    .foregroundStyle(Color.accentColor)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 46)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.accentColor, lineWidth: 1.5)
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(isHandlingNotifications)
+        }
+        .padding(.top, 2)
+    }
+
+    private func accessibilityLabel(for item: ProfileCollectionCardItem) -> String {
+        if item.claimedAt != nil {
+            return "\(item.climb.name), collected"
+        }
+
+        return "\(item.climb.name), not collected"
+    }
+
+    private func handleNotificationsTap() {
+        guard !isHandlingNotifications else { return }
+        isHandlingNotifications = true
+
+        Task {
+            await CollectionNotificationPermissionHandler.handleTurnOnNotifications()
+            isHandlingNotifications = false
         }
     }
 }
 
-private struct CollectionGalleryPlaceholderView: View {
-    let totalCount: Int
+private struct CollectionProgressBar: View {
+    let collectedCount: Int
+    let catalogCount: Int
+
+    private var progress: CGFloat {
+        guard catalogCount > 0 else { return 0 }
+        return min(max(CGFloat(collectedCount) / CGFloat(catalogCount), 0), 1)
+    }
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 14) {
-                Text("COLLECTION")
-                    .font(.montserratBold(size: 28))
-                    .foregroundStyle(.white)
-                    .tracking(1.4)
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(Color.white.opacity(0.08))
 
-                ProfileCardSurfaceView {
-                    Text("Full collection grid is next. \(totalCount) launched climbs are available.")
-                        .font(.montserratMedium(size: 14))
-                        .foregroundStyle(ProfileVisualStyle.secondaryText)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(16)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+                Capsule()
+                    .fill(Color.accentColor)
+                    .frame(width: max(proxy.size.width * progress, progress > 0 ? 18 : 0))
             }
-            .padding(20)
         }
-        .scrollIndicators(.hidden)
+    }
+}
+
+private struct CollectionCardStyle {
+    let cardWidth: CGFloat
+    let artworkHeight: CGFloat
+    let cardPadding: CGFloat
+    let spacing: CGFloat
+    let cornerRadius: CGFloat
+    let artworkCornerRadius: CGFloat
+    let nameFontSize: CGFloat
+    let nameHeight: CGFloat
+    let buttonFontSize: CGFloat
+    let buttonHeight: CGFloat
+    let badgeSize: CGFloat
+
+    static let profilePreview = CollectionCardStyle(
+        cardWidth: 154,
+        artworkHeight: 138,
+        cardPadding: 7,
+        spacing: 7,
+        cornerRadius: 9,
+        artworkCornerRadius: 7,
+        nameFontSize: 11,
+        nameHeight: 28,
+        buttonFontSize: 13,
+        buttonHeight: 32,
+        badgeSize: 26
+    )
+
+    static let grid = CollectionCardStyle(
+        cardWidth: 0,
+        artworkHeight: 96,
+        cardPadding: 7,
+        spacing: 7,
+        cornerRadius: 10,
+        artworkCornerRadius: 8,
+        nameFontSize: 12,
+        nameHeight: 30,
+        buttonFontSize: 13,
+        buttonHeight: 32,
+        badgeSize: 26
+    )
+}
+
+private struct CollectionCard: View {
+    let item: ProfileCollectionCardItem
+    let style: CollectionCardStyle
+
+    private var isClaimed: Bool {
+        item.claimedAt != nil
+    }
+
+    var body: some View {
+        VStack(spacing: style.spacing) {
+            ClimbArtworkView(climb: item.climb, variant: .card)
+                .frame(height: style.artworkHeight)
+                .clipShape(RoundedRectangle(cornerRadius: style.artworkCornerRadius, style: .continuous))
+                .overlay(alignment: .topTrailing) {
+                    if isClaimed {
+                        claimedBadge
+                            .padding(7)
+                    }
+                }
+
+            Text(item.climb.name)
+                .font(.montserratBold(size: style.nameFontSize))
+                .foregroundStyle(.white)
+                .multilineTextAlignment(.center)
+                .lineLimit(2)
+                .minimumScaleFactor(0.78)
+                .frame(height: style.nameHeight)
+                .frame(maxWidth: .infinity)
+
+            climbAction
+        }
+        .padding(style.cardPadding)
+        .frame(maxWidth: .infinity)
+        .background(Color.black.opacity(0.54))
+        .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius, style: .continuous))
+        .animatedClimbCardBorder(
+            colors: item.climb.tier.borderColors,
+            shadowColor: item.climb.tier.shadowColor,
+            cornerRadius: style.cornerRadius,
+            lineWidth: 1,
+            isEmphasized: item.climb.tier.usesEmphasizedBorderStyle,
+            animationStyle: .ambient
+        )
+        .contentShape(RoundedRectangle(cornerRadius: style.cornerRadius, style: .continuous))
+    }
+
+    private var claimedBadge: some View {
+        Circle()
+            .fill(Color.accentColor)
+            .frame(width: style.badgeSize, height: style.badgeSize)
+            .overlay {
+                Image(systemName: "checkmark")
+                    .font(.system(size: style.badgeSize * 0.48, weight: .bold))
+                    .foregroundStyle(.white)
+            }
+            .shadow(color: Color.black.opacity(0.34), radius: 5, x: 0, y: 2)
+    }
+
+    private var climbAction: some View {
+        Text("Climb")
+            .font(.montserratSemiBold(size: style.buttonFontSize))
+            .foregroundStyle(Color.accentColor)
+            .frame(maxWidth: .infinity)
+            .frame(height: style.buttonHeight)
+            .overlay(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .stroke(Color.accentColor, lineWidth: 1)
+            )
+    }
+}
+
+private struct CollectionComingSoonCard: View {
+    let climb: Climb
+
+    var body: some View {
+        VStack(spacing: 8) {
+            ZStack {
+                ClimbArtworkView(climb: climb, variant: .card)
+                    .frame(height: 76)
+                    .blur(radius: 8)
+                    .saturation(0.25)
+                    .brightness(-0.12)
+                    .overlay(
+                        LinearGradient(
+                            colors: [.clear, .black.opacity(0.72)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+
+                Text("???")
+                    .font(.montserratBold(size: 16))
+                    .foregroundStyle(.white)
+                    .padding(.top, 30)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+
+            HStack(spacing: 6) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 11, weight: .bold))
+
+                Text("Coming soon")
+                    .font(.montserratSemiBold(size: 10))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+            }
+            .foregroundStyle(.white)
+        }
+        .padding(7)
+        .frame(maxWidth: .infinity)
+        .background(Color.white.opacity(0.04))
+        .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
+                .stroke(Color.white.opacity(0.34), lineWidth: 1)
+        )
+        .opacity(0.42)
+    }
+}
+
+private struct CollectionComingSoonDetailSheet: View {
+    let climb: Climb
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            ZStack(alignment: .topTrailing) {
+                ClimbArtworkView(climb: climb, variant: .hero)
+                    .frame(height: 230)
+                    .blur(radius: 12)
+                    .saturation(0.18)
+                    .brightness(-0.16)
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .overlay(
+                        LinearGradient(
+                            colors: [.clear, .black.opacity(0.76)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    )
+
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 34, height: 34)
+                        .background(Circle().fill(Color.black.opacity(0.46)))
+                }
+                .buttonStyle(.plain)
+                .padding(10)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("???")
+                    .font(.montserratBold(size: 30))
+                    .foregroundStyle(.white)
+
+                Text("Coming soon · \(climb.continent)")
+                    .font(.montserratSemiBold(size: 14))
+                    .foregroundStyle(Color.accentColor)
+
+                Text("New First Ascent slot loading. Watch the globe and be ready.")
+                    .font(.montserratMedium(size: 14))
+                    .foregroundStyle(ProfileVisualStyle.secondaryText)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(20)
         .background(ProfileVisualStyle.background.ignoresSafeArea())
-        .navigationTitle("Collection")
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar(.visible, for: .navigationBar)
+        .presentationDetents([.medium])
+    }
+}
+
+@MainActor
+private enum CollectionNotificationPermissionHandler {
+    static func handleTurnOnNotifications() async {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+
+        switch settings.authorizationStatus {
+        case .notDetermined:
+            let granted = (try? await center.requestAuthorization(options: [.alert, .badge, .sound])) ?? false
+            if !granted {
+                openNotificationSettings()
+            }
+        case .denied, .authorized, .provisional, .ephemeral:
+            openNotificationSettings()
+        @unknown default:
+            openNotificationSettings()
+        }
+    }
+
+    private static func openNotificationSettings() {
+        guard let url = URL(string: UIApplication.openNotificationSettingsURLString) else { return }
+        UIApplication.shared.open(url)
     }
 }

--- a/AscendApp/Features/Profile/Views/OtherUserProfileView.swift
+++ b/AscendApp/Features/Profile/Views/OtherUserProfileView.swift
@@ -23,7 +23,7 @@ struct OtherUserProfileView: View {
 
     private var climbs: [Climb] {
         _ = catalogRevision
-        return (try? ClimbService.shared.loadClimbs()) ?? []
+        return (try? ClimbService.shared.loadVisibleClimbs()) ?? []
     }
 
     private var seedIdentity: ProfileUserIdentity {

--- a/AscendApp/Features/Profile/Views/OwnProfileView.swift
+++ b/AscendApp/Features/Profile/Views/OwnProfileView.swift
@@ -48,7 +48,7 @@ struct OwnProfileView: View {
 
     private var climbs: [Climb] {
         _ = catalogRevision
-        return (try? ClimbService.shared.loadClimbs()) ?? []
+        return (try? ClimbService.shared.loadVisibleClimbs()) ?? []
     }
 
     private var snapshot: ProfileSnapshot {

--- a/AscendAppTests/ProfileCollectionSummaryTests.swift
+++ b/AscendAppTests/ProfileCollectionSummaryTests.swift
@@ -19,10 +19,17 @@ struct ProfileCollectionSummaryTests {
 
         #expect(snapshot.collection.catalogCount == 4)
         #expect(snapshot.collection.collectedCount == 0)
+        #expect(snapshot.collection.comingSoonClimbs.map(\.id) == ["coming-soon"])
         #expect(snapshot.collection.previewCards.map(\.climb.id) == [
             "common-low-steps",
             "common-high-steps",
             "bronze-low-steps"
+        ])
+        #expect(snapshot.collection.launchedCards.map(\.climb.id) == [
+            "common-low-steps",
+            "common-high-steps",
+            "bronze-low-steps",
+            "gold-low-steps"
         ])
     }
 
@@ -53,6 +60,51 @@ struct ProfileCollectionSummaryTests {
             recentClaimDate,
             olderClaimDate
         ])
+        #expect(snapshot.collection.launchedCards.map(\.climb.id) == [
+            "common-recommendation",
+            "bronze-recommendation",
+            "silver-claimed",
+            "gold-claimed"
+        ])
+        #expect(snapshot.collection.launchedCards.compactMap(\.claimedAt) == [
+            recentClaimDate,
+            olderClaimDate
+        ])
+    }
+
+    @Test
+    func launchedCollectionUsesProductOrderForKnownLaunchClimbs() {
+        let snapshot = snapshot(
+            attempts: [
+                attempt(climbId: "taipei-101", completedAt: Date(timeIntervalSince1970: 1_000))
+            ],
+            climbs: [
+                climb(id: "mount-everest", tier: .mythic, steps: 48_664),
+                climb(id: "statue-of-liberty", tier: .bronze, steps: 512),
+                climb(id: "taipei-101", tier: .diamond, steps: 2_794),
+                climb(id: "sydney-tower", tier: .gold, steps: 1_700),
+                climb(id: "space-needle", tier: .silver, steps: 1_012),
+                climb(id: "empire-state-building", tier: .gold, steps: 2_096),
+                climb(id: "eiffel-tower", tier: .gold, steps: 1_815),
+                climb(id: "burj-khalifa", tier: .epic, steps: 4_554),
+                climb(id: "table-mountain", tier: .legendary, steps: 6_023),
+                climb(id: "machu-picchu", tier: .mythic, steps: 13_365)
+            ]
+        )
+
+        #expect(snapshot.collection.launchedCards.map(\.climb.id) == [
+            "taipei-101",
+            "statue-of-liberty",
+            "space-needle",
+            "empire-state-building",
+            "eiffel-tower",
+            "burj-khalifa",
+            "table-mountain",
+            "machu-picchu",
+            "mount-everest",
+            "sydney-tower"
+        ])
+        #expect(snapshot.collection.launchedCards.first?.claimedAt != nil)
     }
 
     private func snapshot(attempts: [ClimbAttempt], climbs: [Climb]) -> ProfileSnapshot {

--- a/AscendAppTests/ProfileComparisonSummaryTests.swift
+++ b/AscendAppTests/ProfileComparisonSummaryTests.swift
@@ -48,7 +48,9 @@ struct ProfileComparisonSummaryTests {
             collection: ProfileCollectionSummary(
                 collectedCount: Set(workouts.compactMap(\.climbId)).count,
                 catalogCount: 0,
-                previewCards: []
+                previewCards: [],
+                launchedCards: [],
+                comingSoonClimbs: []
             ),
             achievements: .zero,
             firstAscentsHeld: [],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ functions/src/                  # Cloud Functions (TypeScript)
 - Post-auth onboarding must collect the required profile fields before the user reaches the main app: display name plus declared demographics when that stage is enabled. Age stays bounded from 13 through 120, and gender uses the `ProfileGender` raw values.
 - Smart-default first-climb recommendations should come from the user's declared behavioral baseline: easier starters for new stair-stepper users, larger landmarks for regulars and serious athletes. Defaults route to the climb detail screen, not directly into a live attempt.
 - Notifications opt-in should be anchored to a concrete value prop: never miss a climb drop. Do not ask for notification permission as generic setup housekeeping.
+- Notifications opt-in is the gateway to First Ascent opportunity. Climbers with notifications enabled receive 24-hour advance notice of new climb drops, giving them a fair shot to claim the FA at unlock.
 
 ### Environments
 Three Firebase environments. App selects at compile time via `#if DEBUG / #elseif STAGING`:
@@ -214,6 +215,7 @@ Three distinct concepts. Keep them cleanly separated — don't fold feature-spec
 - Profile sections render in this order: identity hero, other-user comparison, Active Standings, Activity + Streak, Collection, Achievements, First Ascents, Records, Trends, Recent Workouts.
 - Active Standings stays above Activity because active competition is more urgent than long-arc history. First Ascents stay above Records because permanent competitive prestige is more aspirational than personal records. Trends sit between Records and Recent Workouts.
 - Collection on Profile is a 3-card preview, never the full Pokedex. Card composition adapts to claimed climbs: 0 claimed shows 3 recommended unclaimed; 1 claimed shows 1 claimed + 2 recommended unclaimed; 2 claimed shows 2 claimed + 1 recommended unclaimed; 3+ claimed shows the 3 most recent claimed.
+- Claimed climbs retain the Climb action. A small checkmark badge overlay on the thumbnail signals claimed state; the action button is never replaced or hidden by completion.
 - Recommended unclaimed Collection cards sort by tier ascending, then step count ascending, and exclude climbs the user has already claimed. The full collection grid lives behind the `View all` link as a separate page.
 - Public profile reads must use public-safe documents/subcollections such as public profile, cached profile stats, achievements, and public workout summaries. Never read private workout backups to render another user's profile.
 - Business logic for profile section visibility, achievement counting, ranking subtitles, comparison state, and stat derivation belongs in models/services that can be unit tested without a SwiftUI view tree.
@@ -352,6 +354,7 @@ Live Climbs is the hero competitive experience: a user picks a real-world landma
 - Launch composition should be content-driven: available climbs, coming-soon climbs, hidden climbs, and disabled climbs are all catalog data, not app-release code paths.
 - New climb drops should be publishable by changing hosted catalog data and image assets. Avoid adding per-climb code, hardcoded IDs outside smart defaults, or app-store-release dependencies for catalog expansion.
 - First Ascent availability follows release phasing: hidden and disabled climbs do not appear as open First Ascent opportunities; coming-soon climbs can tease future drops but must not accept live attempts until available.
+- Coming Soon climbs follow a cross-surface mystery pattern. The Pokedex shows blurred silhouette only (no name, no location). The Globe shows location only (via dim pin with region revealed on tap). The user pieces together identity by cross-referencing both surfaces; neither reveals everything on its own.
 - All climb tiers use the same rotating tier-border treatment driven by per-tier color tokens. Mythic is the emphasized tier (strongest glow, purple-forward prismatic palette).
 - Persistent idle climb surfaces (e.g. the Home daily card) may use a lighter ambient border treatment with an unblurred moving highlight to reduce per-frame animation work while preserving visible motion.
 


### PR DESCRIPTION
## Summary
- Adds the full Climbs Collection page behind the profile collection preview.
- Shares collection card treatment between the profile preview and full grid, keeping claimed climbs actionable with a thumbnail check badge.
- Adds launched climb ordering, coming-soon teaser cards, notification CTA behavior, and product guidance in CLAUDE.md.

## Validation
- XcodeBuildMCP `build_sim` for `AscendApp` Debug succeeded.
- XcodeBuildMCP `test_sim -only-testing:AscendAppTests/ProfileCollectionSummaryTests` passed: 3 passed, 0 failed.
- XcodeBuildMCP `test_sim -only-testing:AscendAppTests/PostAuthOnboardingCoordinatorTests` passed: 4 passed, 0 failed.
