### PR TITLE
Prepare iteration checkpoint

### DIFF
--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		9B1000012F22000000100001 /* RevenueCat in Frameworks */ = {isa = PBXBuildFile; productRef = 9B1000052F22000000100005 /* RevenueCat */; };
 		9B1000022F22000000100002 /* SuperwallKit in Frameworks */ = {isa = PBXBuildFile; productRef = 9B1000062F22000000100006 /* SuperwallKit */; };
 		9B2000022F23000000100002 /* FirebaseFunctions in Frameworks */ = {isa = PBXBuildFile; productRef = 9B2000012F23000000100001 /* FirebaseFunctions */; };
+		9C3000012F2A000000100001 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = 9C3000032F2A000000100003 /* Mixpanel */; };
 		A20000012F10000000000001 /* AscendLiveActivityWidgets.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A20000012F10000000000003 /* AscendLiveActivityWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -118,6 +119,7 @@
 				9B2000022F23000000100002 /* FirebaseFunctions in Frameworks */,
 				9B1000012F22000000100001 /* RevenueCat in Frameworks */,
 				9B1000022F22000000100002 /* SuperwallKit in Frameworks */,
+				9C3000012F2A000000100001 /* Mixpanel in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -208,6 +210,7 @@
 				9B2000012F23000000100001 /* FirebaseFunctions */,
 				9B1000052F22000000100005 /* RevenueCat */,
 				9B1000062F22000000100006 /* SuperwallKit */,
+				9C3000032F2A000000100003 /* Mixpanel */,
 			);
 			productName = AscendApp;
 			productReference = 9A5E4D822E2406F8008DE803 /* AscendApp.app */;
@@ -295,6 +298,7 @@
 				9A4D66FB2E49447800EEAE1D /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				9B1000032F22000000100003 /* XCRemoteSwiftPackageReference "purchases-ios" */,
 				9B1000042F22000000100004 /* XCRemoteSwiftPackageReference "Superwall-iOS" */,
+				9C3000022F2A000000100002 /* XCRemoteSwiftPackageReference "mixpanel-swift" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9A5E4D832E2406F8008DE803 /* Products */;
@@ -968,6 +972,14 @@
 				minimumVersion = 4.15.3;
 			};
 		};
+		9C3000022F2A000000100002 /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/mixpanel/mixpanel-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.3.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1020,6 +1032,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9A8E4CE42E2418D200C78912 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseFunctions;
+		};
+		9C3000032F2A000000100003 /* Mixpanel */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9C3000022F2A000000100002 /* XCRemoteSwiftPackageReference "mixpanel-swift" */;
+			productName = Mixpanel;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/AscendApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AscendApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3306231036a5426607182a22d60f06c4004710bfd6aae1fdffe9dcb70e977a3a",
+  "originHash" : "9e19ca4b2ca1cf4ae2cc3dffce71efc0ee8ca2d8de9da942e864b5f1edba725c",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -119,12 +119,39 @@
       }
     },
     {
+      "identity" : "json-logic-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/advantagefse/json-logic-swift",
+      "state" : {
+        "revision" : "9088eed1b26937fe13d248aa24d7632a51be28e2",
+        "version" : "1.2.4"
+      }
+    },
+    {
       "identity" : "leveldb",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/leveldb.git",
       "state" : {
         "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
         "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "mixpanel-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mixpanel/mixpanel-swift",
+      "state" : {
+        "revision" : "aa0638722c88e6923f9faa312ec6372e440034d0",
+        "version" : "6.4.0"
+      }
+    },
+    {
+      "identity" : "mixpanel-swift-common",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mixpanel/mixpanel-swift-common.git",
+      "state" : {
+        "revision" : "ffd168d972a1bea7e86104f253a3e105c69217e5",
+        "version" : "1.0.1"
       }
     },
     {

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -16,6 +16,7 @@ struct ClimbDetailView: View {
     @State private var showingBrowseClimbs = false
     @State private var showingFlyover = false
     @State private var showingLiveClimbSession = false
+    @State private var selectedHistoryWorkout: Workout?
     @State private var showingHeadphoneHelp = false
     @State private var isHeroCardFlipped = false
     @State private var didTrackDetailViewed = false
@@ -95,6 +96,9 @@ struct ClimbDetailView: View {
         }
         .fullScreenCover(isPresented: $showingFlyover) {
             ClimbFlyoverScreen(climb: viewModel.climb)
+        }
+        .navigationDestination(item: $selectedHistoryWorkout) { workout in
+            WorkoutDetailView(workout: workout)
         }
         .navigationDestination(isPresented: $showingBrowseClimbs) {
             ClimbBrowseView(viewModel: browseViewModel, analyticsEntryPoint: .detailBrowse)
@@ -559,7 +563,14 @@ struct ClimbDetailView: View {
 
                 VStack(spacing: 0) {
                     ForEach(viewModel.historySummary.recentEntries) { entry in
-                        historyRow(for: entry)
+                        Button {
+                            if let workout = workout(forAttemptId: entry.attemptId) {
+                                selectedHistoryWorkout = workout
+                            }
+                        } label: {
+                            historyRow(for: entry)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
                 .padding(.top, -2)
@@ -1171,6 +1182,18 @@ struct ClimbDetailView: View {
                 .foregroundStyle(Color.customGray)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Finds the workout backing a climb attempt so a history tap can open it.
+    private func workout(forAttemptId attemptId: UUID) -> Workout? {
+        let attemptKey = attemptId.uuidString
+        let climbAttemptRaw = WorkoutParticipationContextType.climbAttempt.rawValue
+        let descriptor = FetchDescriptor<WorkoutParticipation>(
+            predicate: #Predicate { participation in
+                participation.contextId == attemptKey && participation.contextTypeRawValue == climbAttemptRaw
+            }
+        )
+        return (try? modelContext.fetch(descriptor))?.first?.workout
     }
 
     private func historyRow(for entry: ClimbHistoryEntry) -> some View {

--- a/AscendApp/Features/Climbs/Views/ClimbFlyoverView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbFlyoverView.swift
@@ -13,6 +13,8 @@ struct ClimbFlyoverView: UIViewRepresentable {
     /// When false (default), the camera flies in and holds a centered static
     /// shot. When true, it slowly orbits after arriving.
     var autoOrbit: Bool = false
+    /// Called once the descent reaches the landmark (used to fade the locator pin).
+    var onArrived: () -> Void = {}
 
     func makeCoordinator() -> Coordinator {
         Coordinator()
@@ -41,7 +43,8 @@ struct ClimbFlyoverView: UIViewRepresentable {
             coordinate: climb.coordinate,
             orbitDistance: ClimbCameraFraming.distance(for: climb),
             targetPitch: ClimbCameraFraming.pitch(for: climb),
-            autoOrbit: autoOrbit
+            autoOrbit: autoOrbit,
+            onArrived: onArrived
         )
         return map
     }
@@ -56,19 +59,21 @@ struct ClimbFlyoverView: UIViewRepresentable {
 
     @MainActor
     final class Coordinator: NSObject, UIGestureRecognizerDelegate {
-        private enum Phase { case descending, orbiting }
-
         private weak var mapView: MKMapView?
         private var coordinate = CLLocationCoordinate2D()
         private var orbitDistance: CLLocationDistance = 1_400
         private var targetPitch: CGFloat = 74
         private var heading: CLLocationDirection = 0
 
-        private let globeDistance: CLLocationDistance = 16_000_000
-        private let descentDuration: CFTimeInterval = 5.0
+        // Far enough that the whole globe is visible with margin.
+        private let globeDistance: CLLocationDistance = 40_000_000
+        // Beat to register the location (pin pulses) before the descent.
+        private let holdDuration: CFTimeInterval = 1.3
+        private let descentDuration: CFTimeInterval = 5.5
         private var startTimestamp: CFTimeInterval = 0
-        private var phase: Phase = .descending
         private var autoOrbit = false
+        private var didArrive = false
+        private var onArrived: (() -> Void)?
         private var displayLink: CADisplayLink?
 
         func begin(
@@ -76,15 +81,17 @@ struct ClimbFlyoverView: UIViewRepresentable {
             coordinate: CLLocationCoordinate2D,
             orbitDistance: CLLocationDistance,
             targetPitch: CGFloat,
-            autoOrbit: Bool
+            autoOrbit: Bool,
+            onArrived: @escaping () -> Void
         ) {
             self.mapView = mapView
             self.coordinate = coordinate
             self.orbitDistance = orbitDistance
             self.targetPitch = targetPitch
             self.autoOrbit = autoOrbit
+            self.onArrived = onArrived
 
-            // Open on the globe.
+            // Open fully zoomed out on the globe.
             mapView.camera = MKMapCamera(
                 lookingAtCenter: coordinate,
                 fromDistance: globeDistance,
@@ -101,28 +108,32 @@ struct ClimbFlyoverView: UIViewRepresentable {
             if startTimestamp == 0 { startTimestamp = link.timestamp }
             let elapsed = link.timestamp - startTimestamp
 
-            switch phase {
-            case .descending:
-                let t = min(elapsed / descentDuration, 1)
-                let e = Self.easeInOut(t)
-                // Geometric interpolation so the zoom feels even (Google-Earth swoop).
+            // 1) Hold on the globe so the user can see where in the world it is.
+            if elapsed < holdDuration { return }
+
+            let descentElapsed = elapsed - holdDuration
+            if descentElapsed < descentDuration {
+                // 2) Ease-IN descent: slow at the top, accelerating as it drops.
+                let t = descentElapsed / descentDuration
+                let e = t * t
+                // Geometric interpolation keeps the zoom visually smooth.
                 let distance = globeDistance * pow(orbitDistance / globeDistance, e)
                 let pitch = e * targetPitch
-                heading = e * 80 // gentle quarter-turn on the way down
+                heading = e * 60
                 setCamera(distance: distance, pitch: pitch)
-                if t >= 1 {
-                    if autoOrbit {
-                        phase = .orbiting
-                    } else {
-                        stop() // hold the centered static shot
-                    }
-                }
-
-            case .orbiting:
-                heading += 0.16
-                if heading >= 360 { heading -= 360 }
-                setCamera(distance: orbitDistance, pitch: targetPitch)
+                return
             }
+
+            // 3) Arrived.
+            if !didArrive {
+                didArrive = true
+                setCamera(distance: orbitDistance, pitch: targetPitch)
+                onArrived?()
+                if !autoOrbit { stop(); return }
+            }
+            heading += 0.16
+            if heading >= 360 { heading -= 360 }
+            setCamera(distance: orbitDistance, pitch: targetPitch)
         }
 
         private func setCamera(distance: CLLocationDistance, pitch: CGFloat) {
@@ -132,10 +143,6 @@ struct ClimbFlyoverView: UIViewRepresentable {
                 pitch: pitch,
                 heading: heading
             )
-        }
-
-        private static func easeInOut(_ t: Double) -> Double {
-            t < 0.5 ? 2 * t * t : 1 - pow(-2 * t + 2, 2) / 2
         }
 
         func stop() {
@@ -162,11 +169,39 @@ struct ClimbFlyoverView: UIViewRepresentable {
 struct ClimbFlyoverScreen: View {
     let climb: Climb
     @Environment(\.dismiss) private var dismiss
+    @State private var arrived = false
+    @State private var pulse = false
+
+    private let accent = Color(red: 0.706, green: 0.8, blue: 0)
 
     var body: some View {
         ZStack {
-            ClimbFlyoverView(climb: climb, autoOrbit: true)
-                .ignoresSafeArea()
+            ClimbFlyoverView(climb: climb, autoOrbit: true) {
+                withAnimation(.easeOut(duration: 0.5)) { arrived = true }
+            }
+            .ignoresSafeArea()
+
+            // Pulsing locator pin marking the spot while zoomed out / descending.
+            if !arrived {
+                ZStack {
+                    Circle()
+                        .stroke(accent.opacity(0.85), lineWidth: 2)
+                        .frame(width: 44, height: 44)
+                        .scaleEffect(pulse ? 2.6 : 1)
+                        .opacity(pulse ? 0 : 0.9)
+                    Image(systemName: "mappin.circle.fill")
+                        .font(.system(size: 38))
+                        .foregroundStyle(accent)
+                        .shadow(color: .black.opacity(0.5), radius: 6, x: 0, y: 2)
+                }
+                .allowsHitTesting(false)
+                .transition(.opacity)
+                .onAppear {
+                    withAnimation(.easeOut(duration: 1.5).repeatForever(autoreverses: false)) {
+                        pulse = true
+                    }
+                }
+            }
 
             VStack {
                 HStack {

--- a/AscendApp/Features/Onboarding/Analytics/OnboardingAnalyticsEvent.swift
+++ b/AscendApp/Features/Onboarding/Analytics/OnboardingAnalyticsEvent.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+struct OnboardingAnalyticsContext: Sendable, Hashable {
+    static let currentFlowVersion = "v1"
+
+    let flowID: String
+    let flowVersion: String
+    let stepID: String
+    let stepIndex: Int
+    let stepCount: Int
+
+    init(
+        flowID: String,
+        flowVersion: String = Self.currentFlowVersion,
+        stepID: String,
+        stepIndex: Int,
+        stepCount: Int
+    ) {
+        self.flowID = flowID
+        self.flowVersion = flowVersion
+        self.stepID = stepID
+        self.stepIndex = stepIndex
+        self.stepCount = stepCount
+    }
+}
+
+enum OnboardingAnalyticsEvent: TelemetryEvent {
+    case flowStarted(context: OnboardingAnalyticsContext)
+    case stepViewed(context: OnboardingAnalyticsContext)
+    case stepCompleted(context: OnboardingAnalyticsContext, actionID: String)
+    case backTapped(context: OnboardingAnalyticsContext)
+    case answerSelected(
+        context: OnboardingAnalyticsContext,
+        questionID: String,
+        answerID: String,
+        answerIndex: Int?
+    )
+    case flowCompleted(context: OnboardingAnalyticsContext)
+
+    var record: TelemetryRecord {
+        switch self {
+        case .flowStarted(let context):
+            return makeRecord(
+                name: "onboarding_flow_started",
+                context: context
+            )
+        case .stepViewed(let context):
+            return makeRecord(
+                name: "onboarding_step_viewed",
+                context: context
+            )
+        case .stepCompleted(let context, let actionID):
+            return makeRecord(
+                name: "onboarding_step_completed",
+                context: context,
+                parameters: ["action_id": .string(actionID)]
+            )
+        case .backTapped(let context):
+            return makeRecord(
+                name: "onboarding_back_tapped",
+                context: context
+            )
+        case .answerSelected(let context, let questionID, let answerID, let answerIndex):
+            var parameters: [String: TelemetryValue] = [
+                "question_id": .string(questionID),
+                "answer_id": .string(answerID)
+            ]
+
+            if let answerIndex {
+                parameters["answer_index"] = .int(answerIndex)
+            }
+
+            return makeRecord(
+                name: "onboarding_answer_selected",
+                context: context,
+                parameters: parameters
+            )
+        case .flowCompleted(let context):
+            return makeRecord(
+                name: "onboarding_flow_completed",
+                context: context
+            )
+        }
+    }
+
+    private func makeRecord(
+        name: String,
+        context: OnboardingAnalyticsContext,
+        parameters: [String: TelemetryValue] = [:]
+    ) -> TelemetryRecord {
+        var mergedParameters = context.parameters
+        parameters.forEach { mergedParameters[$0.key] = $0.value }
+
+        return TelemetryRecord(
+            name: name,
+            parameters: mergedParameters
+        )
+    }
+}
+
+private extension OnboardingAnalyticsContext {
+    var parameters: [String: TelemetryValue] {
+        [
+            "flow_id": .string(flowID),
+            "flow_version": .string(flowVersion),
+            "step_id": .string(stepID),
+            "step_index": .int(stepIndex),
+            "step_count": .int(stepCount)
+        ]
+    }
+}

--- a/AscendApp/Features/Onboarding/Models/PostAuthOnboardingStage.swift
+++ b/AscendApp/Features/Onboarding/Models/PostAuthOnboardingStage.swift
@@ -3,6 +3,9 @@ import Foundation
 enum PostAuthOnboardingStage: String, CaseIterable, Codable, Identifiable {
     case displayName
 
+    static let flowID = "post_auth_onboarding"
+    static let plannedStepCount = 5
+
     static var allCases: [PostAuthOnboardingStage] {
         [
             .displayName
@@ -24,6 +27,15 @@ enum PostAuthOnboardingStage: String, CaseIterable, Codable, Identifiable {
 
     static var first: PostAuthOnboardingStage {
         .displayName
+    }
+
+    var analyticsContext: OnboardingAnalyticsContext {
+        OnboardingAnalyticsContext(
+            flowID: Self.flowID,
+            stepID: rawValue,
+            stepIndex: progressIndex,
+            stepCount: Self.plannedStepCount
+        )
     }
 }
 

--- a/AscendApp/Features/Onboarding/ViewModels/PostAuthOnboardingCoordinator.swift
+++ b/AscendApp/Features/Onboarding/ViewModels/PostAuthOnboardingCoordinator.swift
@@ -33,6 +33,7 @@ final class PostAuthOnboardingCoordinator {
 
         phase = snapshot.isComplete ? .complete : .onboarding(snapshot.currentStage)
         recordLifecycleSnapshot(snapshot)
+        recordStepViewedIfNeeded(snapshot)
     }
 
     func completeCurrentStage() {
@@ -41,12 +42,19 @@ final class PostAuthOnboardingCoordinator {
 
         var snapshot = store.snapshot(for: userId)
         snapshot.completedStages.insert(stage)
+        TelemetryManager.shared.track(
+            OnboardingAnalyticsEvent.stepCompleted(
+                context: stage.analyticsContext,
+                actionID: "continue"
+            )
+        )
 
         if let nextStage = stage.next {
             snapshot.currentStage = nextStage
             store.save(snapshot, for: userId)
             phase = .onboarding(nextStage)
             recordLifecycleSnapshot(snapshot)
+            recordStepViewedIfNeeded(snapshot)
         } else {
             snapshot.isComplete = true
             snapshot.completedAt = Date()
@@ -54,6 +62,9 @@ final class PostAuthOnboardingCoordinator {
             SettingsManager.shared.hasCompletedBaseLevelOnboarding = true
             phase = .complete
             recordLifecycleSnapshot(snapshot)
+            TelemetryManager.shared.track(
+                OnboardingAnalyticsEvent.flowCompleted(context: stage.analyticsContext)
+            )
         }
     }
 
@@ -63,6 +74,10 @@ final class PostAuthOnboardingCoordinator {
               let currentIndex = PostAuthOnboardingStage.allCases.firstIndex(of: stage),
               currentIndex > PostAuthOnboardingStage.allCases.startIndex else { return }
 
+        TelemetryManager.shared.track(
+            OnboardingAnalyticsEvent.backTapped(context: stage.analyticsContext)
+        )
+
         let previousIndex = PostAuthOnboardingStage.allCases.index(before: currentIndex)
         let previousStage = PostAuthOnboardingStage.allCases[previousIndex]
         var snapshot = store.snapshot(for: userId)
@@ -70,6 +85,7 @@ final class PostAuthOnboardingCoordinator {
         store.save(snapshot, for: userId)
         phase = .onboarding(previousStage)
         recordLifecycleSnapshot(snapshot)
+        recordStepViewedIfNeeded(snapshot)
     }
 
     func resetCurrentUser() {
@@ -78,6 +94,7 @@ final class PostAuthOnboardingCoordinator {
         let snapshot = store.snapshot(for: userId)
         phase = .onboarding(.first)
         recordLifecycleSnapshot(snapshot)
+        recordStepViewedIfNeeded(snapshot)
         NotificationCenter.default.post(name: .postAuthOnboardingStateDidChange, object: nil)
     }
 
@@ -107,6 +124,14 @@ final class PostAuthOnboardingCoordinator {
                 completedStages: completedStages
             )
         }
+    }
+
+    private func recordStepViewedIfNeeded(_ snapshot: PostAuthOnboardingSnapshot) {
+        guard !snapshot.isComplete else { return }
+
+        TelemetryManager.shared.track(
+            OnboardingAnalyticsEvent.stepViewed(context: snapshot.currentStage.analyticsContext)
+        )
     }
 
     private func normalized(_ snapshot: PostAuthOnboardingSnapshot) -> PostAuthOnboardingSnapshot {

--- a/AscendApp/Features/Onboarding/Views/OnboardingValueCarouselView.swift
+++ b/AscendApp/Features/Onboarding/Views/OnboardingValueCarouselView.swift
@@ -3,8 +3,11 @@ import SwiftUI
 struct OnboardingValueCarouselView: View {
     @Binding var selectedIndex: Int
     @State private var scrollPositionID: String?
+    @State private var didRecordFlowStart = false
+    @State private var viewedPageIDs: Set<String> = []
 
     let pages: [OnboardingValuePage]
+    var analyticsFlowID = "pre_auth_value_onboarding"
     let onFinish: () -> Void
 
     var body: some View {
@@ -45,13 +48,17 @@ struct OnboardingValueCarouselView: View {
                 .onAppear {
                     clampSelectedIndex()
                     syncScrollPositionToSelectedIndex()
+                    recordFlowStartIfNeeded()
+                    recordCurrentPageViewedIfNeeded()
                 }
                 .onChange(of: pages.count) { _, _ in
                     clampSelectedIndex()
                     syncScrollPositionToSelectedIndex()
+                    recordCurrentPageViewedIfNeeded()
                 }
                 .onChange(of: selectedIndex) { _, _ in
                     syncScrollPositionToSelectedIndex()
+                    recordCurrentPageViewedIfNeeded()
                 }
                 .onChange(of: scrollPositionID) { _, newID in
                     updateSelectedIndex(for: newID)
@@ -111,9 +118,20 @@ struct OnboardingValueCarouselView: View {
             return
         }
 
+        let context = analyticsContext(for: pages[selectedIndex], index: selectedIndex)
+        TelemetryManager.shared.track(
+            OnboardingAnalyticsEvent.stepCompleted(
+                context: context,
+                actionID: selectedIndex == pages.count - 1 ? "get_started" : "continue"
+            )
+        )
+
         if selectedIndex < pages.count - 1 {
             selectedIndex += 1
         } else {
+            TelemetryManager.shared.track(
+                OnboardingAnalyticsEvent.flowCompleted(context: context)
+            )
             onFinish()
         }
     }
@@ -147,6 +165,41 @@ struct OnboardingValueCarouselView: View {
         }
 
         selectedIndex = index
+    }
+
+    private func recordFlowStartIfNeeded() {
+        guard !didRecordFlowStart,
+              pages.indices.contains(selectedIndex) else { return }
+
+        didRecordFlowStart = true
+        TelemetryManager.shared.track(
+            OnboardingAnalyticsEvent.flowStarted(
+                context: analyticsContext(for: pages[selectedIndex], index: selectedIndex)
+            )
+        )
+    }
+
+    private func recordCurrentPageViewedIfNeeded() {
+        guard pages.indices.contains(selectedIndex) else { return }
+
+        let page = pages[selectedIndex]
+        guard !viewedPageIDs.contains(page.id) else { return }
+
+        viewedPageIDs.insert(page.id)
+        TelemetryManager.shared.track(
+            OnboardingAnalyticsEvent.stepViewed(
+                context: analyticsContext(for: page, index: selectedIndex)
+            )
+        )
+    }
+
+    private func analyticsContext(for page: OnboardingValuePage, index: Int) -> OnboardingAnalyticsContext {
+        OnboardingAnalyticsContext(
+            flowID: analyticsFlowID,
+            stepID: page.id,
+            stepIndex: index,
+            stepCount: pages.count
+        )
     }
 }
 

--- a/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
+++ b/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
@@ -31,12 +31,10 @@ private struct PostAuthOnboardingDisplayNameScreen: View {
     @State private var isSaving = false
     @State private var validationMessage: String?
 
-    private let plannedQuestionCount = 5
-
     var body: some View {
         OnboardingQuestionScaffold(
             progressIndex: stage.progressIndex,
-            progressCount: plannedQuestionCount,
+            progressCount: PostAuthOnboardingStage.plannedStepCount,
             backgroundImageName: "OnboardingQuestionsBackground",
             eyebrow: "FIRST THINGS FIRST",
             headline: "What Should\nWe Call You?",
@@ -159,6 +157,9 @@ private struct PostAuthOnboardingDisplayNameScreen: View {
     }
 
     private func handleBack() {
+        TelemetryManager.shared.track(
+            OnboardingAnalyticsEvent.backTapped(context: stage.analyticsContext)
+        )
         authVM.signOut()
     }
 }

--- a/AscendApp/Features/Profile/Views/CollectionSection.swift
+++ b/AscendApp/Features/Profile/Views/CollectionSection.swift
@@ -402,15 +402,18 @@ private struct CollectionCard: View {
         .background(Color.black.opacity(0.54))
         .clipShape(RoundedRectangle(cornerRadius: style.cornerRadius, style: .continuous))
         .animatedClimbCardBorder(
-            colors: item.climb.tier.borderColors,
-            shadowColor: item.climb.tier.shadowColor,
+            colors: isClaimed ? item.climb.tier.borderColors : Self.lockedBorderColors,
+            shadowColor: isClaimed ? item.climb.tier.shadowColor : .clear,
             cornerRadius: style.cornerRadius,
             lineWidth: 1,
-            isEmphasized: item.climb.tier.usesEmphasizedBorderStyle,
+            isEmphasized: isClaimed && item.climb.tier.usesEmphasizedBorderStyle,
             animationStyle: .static
         )
         .contentShape(RoundedRectangle(cornerRadius: style.cornerRadius, style: .continuous))
     }
+
+    /// Muted grey border for climbs the user hasn't collected yet.
+    private static let lockedBorderColors: [Color] = [Color.white.opacity(0.16)]
 
     private var claimedBadge: some View {
         Circle()

--- a/AscendApp/Features/ShareComposer/Models/ShareBackgroundFilter.swift
+++ b/AscendApp/Features/ShareComposer/Models/ShareBackgroundFilter.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// A color grade applied to the share *background only* (never the stat
+/// stickers). Each case maps to a combination of SwiftUI image adjustments in
+/// `View.shareBackgroundFilter(_:)`. All cases are resolution-independent, so
+/// the editing preview and the high-res export match exactly.
+///
+/// Geometric effects (zoom blur, motion blur, fisheye) are intentionally out of
+/// scope here — they require Core Image / Metal and per-frame work for video.
+enum ShareBackgroundFilter: String, CaseIterable, Identifiable, Codable, Sendable {
+    // Color grades (SwiftUI image adjustments — resolution-independent)
+    case original
+    case mono
+    case noir
+    case vivid
+    case fade
+    case warm
+    case cool
+    // Geometric grades (Core Image — applied to the source photo)
+    case zoomBlur
+    case motionBlur
+    case fisheye
+
+    var id: String { rawValue }
+
+    /// Geometric filters are rendered through Core Image on the source photo,
+    /// not via SwiftUI color modifiers.
+    var isGeometric: Bool {
+        switch self {
+        case .zoomBlur, .motionBlur, .fisheye: return true
+        default: return false
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .original: return "Original"
+        case .mono: return "Mono"
+        case .noir: return "Noir"
+        case .vivid: return "Vivid"
+        case .fade: return "Fade"
+        case .warm: return "Warm"
+        case .cool: return "Cool"
+        case .zoomBlur: return "Zoom Blur"
+        case .motionBlur: return "Motion Blur"
+        case .fisheye: return "Fisheye"
+        }
+    }
+}

--- a/AscendApp/Features/ShareComposer/Models/ShareStatSticker.swift
+++ b/AscendApp/Features/ShareComposer/Models/ShareStatSticker.swift
@@ -24,6 +24,8 @@ enum ShareStatStickerKind: String, CaseIterable, Identifiable, Codable, Sendable
     case climbRank       // "Nth finisher"
     // Derived achievement (resolved from the Best Effort cache, not the workout)
     case bestEffort
+    // Aggregate (resolved from this-week totals across workouts, not one workout)
+    case totals
 
     var id: String { rawValue }
 
@@ -111,6 +113,26 @@ struct RGBAColor: Equatable, Codable, Sendable {
     static let lime = RGBAColor(r: 0.706, g: 0.8, b: 0, a: 1)
 }
 
+/// Arrangement for a multi-metric (composite) stat sticker. Single-metric
+/// stickers ignore this. `grid` is the 2×2 "cube" (top-left, top-right,
+/// bottom-left, bottom-right).
+enum ShareStatLayout: String, CaseIterable, Identifiable, Codable, Sendable {
+    case row      // metrics side by side
+    case grid     // 2×2 cube
+    case column   // stacked vertically
+
+    var id: String { rawValue }
+}
+
+/// A reference to one resolvable stat: its kind plus, for injected stats
+/// (`.bestEffort` / `.totals`), the key identifying which value. Composite
+/// stickers hold several of these. The value itself is always resolved live
+/// from canonical data — only the reference is stored.
+struct ShareStatRef: Hashable, Codable, Sendable {
+    var kind: ShareStatStickerKind
+    var injectedStatKey: String?
+}
+
 /// One placed sticker on the canvas. Position is normalized (0...1) relative to
 /// the canvas so it survives different export sizes; scale and rotation are the
 /// user's gesture transforms.
@@ -127,6 +149,31 @@ struct ShareStickerInstance: Identifiable, Equatable {
     var font: ShareStickerFont
     var color: RGBAColor
     var textBackground: ShareTextBackground
+    /// When set, this sticker renders the climb's artwork (an image overlay)
+    /// instead of a stat; `kind` is unused in that case.
+    var climbImageVariant: ClimbImageVariant?
+    /// Selector for injected stats whose value isn't resolvable from the workout
+    /// alone (`.bestEffort`, `.totals`). Identifies *which* injected stat this
+    /// sticker shows; the value is still read live from the view model's
+    /// injected lists at render time (never stored on the model).
+    var injectedStatKey: String?
+    /// Extra metrics beyond the primary (`kind` + `injectedStatKey`), making this
+    /// a composite sticker. Empty = single-metric sticker (the common case).
+    var extraStats: [ShareStatRef]
+    /// Arrangement used when the sticker shows more than one metric.
+    var layout: ShareStatLayout
+
+    /// Image stickers (climb artwork) don't take text styling.
+    var isImage: Bool { climbImageVariant != nil }
+
+    /// The primary metric as a reference.
+    var primaryStatRef: ShareStatRef { ShareStatRef(kind: kind, injectedStatKey: injectedStatKey) }
+    /// All metrics in display order (primary first, then extras).
+    var statRefs: [ShareStatRef] { [primaryStatRef] + extraStats }
+    /// True when the sticker renders more than one metric.
+    var isComposite: Bool { !extraStats.isEmpty }
+    /// True when this is a text sticker that includes the climb name (renameable).
+    var containsClimbName: Bool { !isImage && statRefs.contains { $0.kind == .climbName } }
 
     init(
         id: UUID = UUID(),
@@ -137,7 +184,11 @@ struct ShareStickerInstance: Identifiable, Equatable {
         rotationRadians: Double = 0,
         font: ShareStickerFont = .montserrat,
         color: RGBAColor = .white,
-        textBackground: ShareTextBackground = .none
+        textBackground: ShareTextBackground = .none,
+        climbImageVariant: ClimbImageVariant? = nil,
+        injectedStatKey: String? = nil,
+        extraStats: [ShareStatRef] = [],
+        layout: ShareStatLayout = .row
     ) {
         self.id = id
         self.kind = kind
@@ -148,6 +199,10 @@ struct ShareStickerInstance: Identifiable, Equatable {
         self.font = font
         self.color = color
         self.textBackground = textBackground
+        self.climbImageVariant = climbImageVariant
+        self.injectedStatKey = injectedStatKey
+        self.extraStats = extraStats
+        self.layout = layout
     }
 }
 

--- a/AscendApp/Features/ShareComposer/Services/ShareComposerExporter.swift
+++ b/AscendApp/Features/ShareComposer/Services/ShareComposerExporter.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreImage
 import Photos
 import SwiftUI
 import UIKit
@@ -32,24 +33,146 @@ struct ShareComposerExporter {
         return renderer.uiImage
     }
 
-    /// Whether the composed background is a video (full export not yet supported).
+    /// Whether the composed background is a video.
     func isVideoBackground(_ viewModel: ShareComposerViewModel) -> Bool {
         viewModel.background?.isVideo ?? false
     }
 
+    /// Render just the sticker/wordmark overlay (transparent background) at the
+    /// given size — used as the layer composited onto a video.
+    func renderOverlay(viewModel: ShareComposerViewModel, size: CGSize) -> UIImage? {
+        let canvas = ShareExportCanvas(viewModel: viewModel, size: size, overlayOnly: true)
+        let renderer = ImageRenderer(content: canvas)
+        renderer.scale = 1
+        renderer.isOpaque = false
+        return renderer.uiImage
+    }
+
+    /// Bake a recap card (climb artwork + laid-out stats) to a full-resolution
+    /// image, used as a ready-made background. The climb artwork must already be
+    /// in memory (the Recaps tab renders the same card first, warming the cache)
+    /// so this synchronous render captures it.
+    func renderRecap(_ card: ShareRecapCard) -> UIImage? {
+        let sized = card.frame(width: Self.exportSize.width, height: Self.exportSize.height)
+        let renderer = ImageRenderer(content: sized)
+        renderer.scale = 1
+        renderer.isOpaque = true
+        return renderer.uiImage
+    }
+
     // MARK: - Save to Photos
+
+    /// Ferries a non-Sendable `UIImage` into the nonisolated Photos change block.
+    private struct UncheckedImage: @unchecked Sendable { let image: UIImage }
 
     /// Saves the image to the Photos library (add-only permission). Returns true
     /// on success. Requires `NSPhotoLibraryAddUsageDescription` in Info.plist.
     func saveToPhotos(_ image: UIImage) async -> Bool {
         let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
         guard status == .authorized || status == .limited else { return false }
-        return await withCheckedContinuation { continuation in
-            PHPhotoLibrary.shared().performChanges {
-                PHAssetChangeRequest.creationRequestForAsset(from: image)
-            } completionHandler: { success, _ in
-                continuation.resume(returning: success)
+        return await Self.writeToLibrary(image)
+    }
+
+    /// Performs the actual library write OFF the main actor.
+    ///
+    /// `PHPhotoLibrary` runs the change block on its own private serial queue.
+    /// A change block created inside this `@MainActor` type is implicitly
+    /// inferred MainActor-isolated, so running it off-main trips
+    /// `dispatch_assert_queue` and crashes with `EXC_BREAKPOINT`
+    /// (see Apple DTS forum 763665 / swiftlang/swift#75453). Marking this
+    /// helper `nonisolated` keeps the change block free of MainActor isolation
+    /// so Photos can run it on its queue safely.
+    nonisolated private static func writeToLibrary(_ image: UIImage) async -> Bool {
+        let boxed = UncheckedImage(image: image)
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                let request = PHAssetChangeRequest.creationRequestForAsset(from: boxed.image)
+                // Stamp "now" so it sorts as the most recent item.
+                request.creationDate = Date()
             }
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Video export (overlays composited onto the video)
+
+    /// Ferries a non-Sendable `CIImage` into the (`@Sendable`) per-frame handler.
+    private struct UncheckedCIImage: @unchecked Sendable { let image: CIImage }
+
+    /// Exports the video background with the sticker/wordmark overlay burned in,
+    /// returning a temporary file URL (or nil on failure). The overlay is
+    /// rendered once and composited over every frame via Core Image.
+    func exportVideo(viewModel: ShareComposerViewModel) async -> URL? {
+        guard case .video(let url) = viewModel.background else { return nil }
+        let asset = AVURLAsset(url: url)
+        guard let renderSize = await Self.videoRenderSize(asset) else { return nil }
+
+        // Render the overlay at the video's display size so it aligns 1:1.
+        guard let overlay = renderOverlay(viewModel: viewModel, size: renderSize),
+              let overlayCI = CIImage(image: overlay) else {
+            return nil
+        }
+        return await Self.composeVideo(asset: asset, overlay: UncheckedCIImage(image: overlayCI))
+    }
+
+    /// The asset's display (orientation-applied) size.
+    nonisolated private static func videoRenderSize(_ asset: AVURLAsset) async -> CGSize? {
+        guard let track = try? await asset.loadTracks(withMediaType: .video).first,
+              let natural = try? await track.load(.naturalSize),
+              let transform = try? await track.load(.preferredTransform) else {
+            return nil
+        }
+        let rect = CGRect(origin: .zero, size: natural).applying(transform)
+        let size = CGSize(width: abs(rect.width), height: abs(rect.height))
+        return (size.width > 0 && size.height > 0) ? size : natural
+    }
+
+    nonisolated private static func composeVideo(asset: AVURLAsset, overlay: UncheckedCIImage) async -> URL? {
+        // Composite the static overlay over every frame. The source image is
+        // already display-oriented, so the same-size overlay lines up.
+        let videoComposition = AVVideoComposition(asset: asset) { request in
+            let source = request.sourceImage
+            let composited = overlay.image.composited(over: source)
+            request.finish(with: composited.cropped(to: source.extent), context: nil)
+        }
+
+        guard let export = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetHighestQuality) else {
+            return nil
+        }
+        let outURL = FileManager.default.temporaryDirectory
+            .appending(path: "ascend-share-\(UUID().uuidString).mov")
+        export.videoComposition = videoComposition
+        export.outputURL = outURL
+        export.outputFileType = .mov
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            export.exportAsynchronously { continuation.resume() }
+        }
+        return export.status == .completed ? outURL : nil
+    }
+
+    /// Saves an exported video file to Photos (add-only). See `writeToLibrary`
+    /// for why the change block runs off the main actor.
+    func saveVideoToPhotos(_ url: URL) async -> Bool {
+        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        guard status == .authorized || status == .limited else { return false }
+        return await Self.writeVideoToLibrary(url)
+    }
+
+    nonisolated private static func writeVideoToLibrary(_ url: URL) async -> Bool {
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                let request = PHAssetChangeRequest.creationRequestForAssetFromVideo(atFileURL: url)
+                // The exported file carries the source video's date metadata, so
+                // Photos would otherwise file it next to the original. Stamp "now"
+                // so it lands as the most recent item.
+                request?.creationDate = Date()
+            }
+            return true
+        } catch {
+            return false
         }
     }
 
@@ -79,13 +202,16 @@ struct ShareComposerExporter {
 
     // MARK: - System share sheet
 
-    func presentShareSheet(image: UIImage) {
+    func presentShareSheet(image: UIImage) { present(items: [image]) }
+    func presentShareSheet(url: URL) { present(items: [url]) }
+
+    private func present(items: [Any]) {
         guard let scene = UIApplication.shared.connectedScenes
             .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
               let root = scene.keyWindow?.rootViewController else {
             return
         }
-        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+        let activityVC = UIActivityViewController(activityItems: items, applicationActivities: nil)
         // Present from the top-most controller.
         var presenter = root
         while let presented = presenter.presentedViewController {

--- a/AscendApp/Features/ShareComposer/Services/ShareImageFilter.swift
+++ b/AscendApp/Features/ShareComposer/Services/ShareImageFilter.swift
@@ -1,0 +1,61 @@
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import UIKit
+
+/// Applies the geometric (Core Image) share filters — zoom blur, motion blur,
+/// fisheye — to a source photo. Color grades are handled separately by SwiftUI
+/// modifiers (`View.shareBackgroundFilter(_:)`); this only covers effects that
+/// must process pixels.
+///
+/// Pure and `nonisolated` so it can run off the main actor. Results are cached
+/// by the caller (the view model) so each filter is computed once per photo.
+enum ShareImageFilter {
+    /// One GPU-backed context, reused across renders (creating a context is the
+    /// expensive part). `CIContext` is safe to use concurrently for rendering.
+    nonisolated(unsafe) private static let context = CIContext(options: [.useSoftwareRenderer: false])
+
+    nonisolated static func apply(_ filter: ShareBackgroundFilter, to image: UIImage) -> UIImage? {
+        guard filter.isGeometric, let cgInput = image.cgImage else { return nil }
+
+        let input = CIImage(cgImage: cgInput)
+        let extent = input.extent
+        let minSide = min(extent.width, extent.height)
+        let centerPoint = CGPoint(x: extent.midX, y: extent.midY)
+
+        let output: CIImage?
+        switch filter {
+        case .zoomBlur:
+            let f = CIFilter.zoomBlur()
+            f.inputImage = input
+            f.center = centerPoint
+            f.amount = Float(minSide * 0.035)
+            output = f.outputImage
+
+        case .motionBlur:
+            let f = CIFilter.motionBlur()
+            f.inputImage = input
+            f.radius = Float(minSide * 0.02)
+            f.angle = 0
+            output = f.outputImage
+
+        case .fisheye:
+            let f = CIFilter.bumpDistortion()
+            f.inputImage = input
+            f.center = centerPoint
+            f.radius = Float(minSide * 0.6)
+            f.scale = 0.55
+            output = f.outputImage
+
+        default:
+            output = nil
+        }
+
+        // Blur/distortion can grow or soften the extent — crop back to the
+        // original frame so the result stays the same size as the input.
+        guard let cropped = output?.cropped(to: extent),
+              let cg = context.createCGImage(cropped, from: extent) else {
+            return nil
+        }
+        return UIImage(cgImage: cg, scale: image.scale, orientation: image.imageOrientation)
+    }
+}

--- a/AscendApp/Features/ShareComposer/Services/SharePhotoLibrary.swift
+++ b/AscendApp/Features/ShareComposer/Services/SharePhotoLibrary.swift
@@ -19,9 +19,13 @@ final class SharePhotoLibrary {
     private(set) var accessState: AccessState = .unknown
     private(set) var assets: [PHAsset] = []
 
-    private let imageManager = PHCachingImageManager()
+    /// PhotoKit's image manager is thread-safe and its request callbacks fire on
+    /// background queues, so the loading methods below are `nonisolated`. The
+    /// manager is therefore accessed off the main actor — `nonisolated(unsafe)`
+    /// is safe because `PHCachingImageManager` is itself thread-safe.
+    nonisolated(unsafe) private let imageManager = PHCachingImageManager()
 
-    /// Non-Sendable image ferried across a Photos callback boundary.
+    /// Non-Sendable values ferried across a Photos callback boundary.
     private struct SendableImage: @unchecked Sendable { let image: UIImage? }
     private struct SendableURL: @unchecked Sendable { let url: URL? }
 
@@ -67,8 +71,15 @@ final class SharePhotoLibrary {
     }
 
     // MARK: - Loading
+    //
+    // These are `nonisolated` so PhotoKit can invoke their result handlers on
+    // its own background queues without tripping a main-actor executor
+    // assertion (`dispatch_assert_queue`). They take the asset's `localIdentifier`
+    // (a `Sendable` String) rather than the non-Sendable `PHAsset`, re-fetching
+    // the asset off the main actor.
 
-    func thumbnail(for asset: PHAsset, size: CGFloat) async -> UIImage? {
+    nonisolated func thumbnail(forIdentifier id: String, size: CGFloat) async -> UIImage? {
+        guard let asset = Self.fetchAsset(id) else { return nil }
         let target = CGSize(width: size * 2, height: size * 2)
         let options = PHImageRequestOptions()
         options.deliveryMode = .highQualityFormat
@@ -86,7 +97,8 @@ final class SharePhotoLibrary {
         }
     }
 
-    func fullImage(for asset: PHAsset) async -> UIImage? {
+    nonisolated func fullImage(forIdentifier id: String) async -> UIImage? {
+        guard let asset = Self.fetchAsset(id) else { return nil }
         let options = PHImageRequestOptions()
         options.deliveryMode = .highQualityFormat
         options.isNetworkAccessAllowed = true
@@ -103,7 +115,8 @@ final class SharePhotoLibrary {
         }
     }
 
-    func videoURL(for asset: PHAsset) async -> URL? {
+    nonisolated func videoURL(forIdentifier id: String) async -> URL? {
+        guard let asset = Self.fetchAsset(id) else { return nil }
         let options = PHVideoRequestOptions()
         options.deliveryMode = .highQualityFormat
         options.isNetworkAccessAllowed = true
@@ -113,5 +126,9 @@ final class SharePhotoLibrary {
                 continuation.resume(returning: SendableURL(url: url).url)
             }
         }
+    }
+
+    nonisolated private static func fetchAsset(_ id: String) -> PHAsset? {
+        PHAsset.fetchAssets(withLocalIdentifiers: [id], options: nil).firstObject
     }
 }

--- a/AscendApp/Features/ShareComposer/Services/ShareStatResolver.swift
+++ b/AscendApp/Features/ShareComposer/Services/ShareStatResolver.swift
@@ -28,8 +28,12 @@ struct ShareStatResolver {
     func resolve(_ kind: ShareStatStickerKind) -> ResolvedShareStat? {
         switch kind {
         case .workoutName:
+            // For climbs the dedicated climb-name sticker covers this, so don't
+            // offer a duplicate. The "ASCEND" branding lives only in the
+            // always-on bottom wordmark, never tied to a stat.
+            if isClimb { return nil }
             let name = workout.name.isEmpty ? "Stair Workout" : workout.name
-            return ResolvedShareStat(kind: kind, label: "ASCEND", value: name)
+            return ResolvedShareStat(kind: kind, label: "WORKOUT", value: name)
 
         case .date:
             return ResolvedShareStat(kind: kind, label: "DATE", value: Self.dateFormatter.string(from: workout.date))
@@ -79,9 +83,10 @@ struct ShareStatResolver {
             guard let climbRank, climbRank > 0 else { return nil }
             return ResolvedShareStat(kind: kind, label: "FINISHER", value: "#\(climbRank)")
 
-        case .bestEffort:
-            // Best Effort isn't on the Workout — it's injected into the view
-            // model from the Best Effort cache. The resolver can't produce it.
+        case .bestEffort, .totals:
+            // Injected stats: Best Effort comes from the Best Effort cache and
+            // Totals from this-week aggregates. Neither is resolvable from a
+            // single Workout, so the view model supplies them.
             return nil
         }
     }

--- a/AscendApp/Features/ShareComposer/ViewModels/ShareComposerViewModel.swift
+++ b/AscendApp/Features/ShareComposer/ViewModels/ShareComposerViewModel.swift
@@ -13,18 +13,36 @@ final class ShareComposerViewModel {
     let workout: Workout
     let measurementSystem: MeasurementSystem
     let stepHeight: Double
+    let climb: Climb?
     let climbName: String?
     let climbRank: Int?
     let climbRankTotal: Int?
 
     // Editing state
     var background: ShareBackgroundSource?
+    /// Color grade applied to the background only (swipe left/right to cycle).
+    var backgroundFilter: ShareBackgroundFilter = .original
+    /// Background pan/zoom. Scale is unitless (1 = fit); offset is a fraction of
+    /// the canvas, so it maps identically to the high-res export size.
+    var backgroundScale: CGFloat = 1
+    var backgroundOffset: CGSize = .zero
+    /// Core Image-processed background for geometric filters (nil for color grades).
+    var processedBackgroundImage: UIImage?
+    /// Cache so each geometric filter is computed once per chosen photo.
+    @ObservationIgnored private var processedCache: [ShareBackgroundFilter: UIImage] = [:]
     var stickers: [ShareStickerInstance] = []
     var selectedID: UUID?
+    /// User-chosen display name for the climb (stat values stay the truth; only
+    /// the climb's title is renameable). `nil` = use the catalog name.
+    var climbNameOverride: String?
 
-    /// The workout's headline Best Effort, injected from the Best Effort cache
-    /// by the view (the resolver can't compute it from the Workout alone).
-    var primaryBestEffortStat: ResolvedShareStat?
+    /// The workout's Best Efforts, injected from the Best Effort cache by the
+    /// view (the resolver can't compute them from the Workout alone). Each has a
+    /// unique `label` used as the sticker's `injectedStatKey`.
+    var bestEffortStats: [ResolvedShareStat] = []
+    /// This-week aggregate stats (steps, workouts, time, vertical), injected from
+    /// the full workout history. Each has a unique `label` used as the key.
+    var weeklyTotalStats: [ResolvedShareStat] = []
 
     // Transient drag feedback (driven by ShareStickerView callbacks)
     var draggingID: UUID?
@@ -42,6 +60,7 @@ final class ShareComposerViewModel {
         workout: Workout,
         measurementSystem: MeasurementSystem,
         stepHeight: Double,
+        climb: Climb? = nil,
         climbName: String? = nil,
         climbRank: Int? = nil,
         climbRankTotal: Int? = nil,
@@ -50,10 +69,17 @@ final class ShareComposerViewModel {
         self.workout = workout
         self.measurementSystem = measurementSystem
         self.stepHeight = stepHeight
+        self.climb = climb
         self.climbName = climbName
         self.climbRank = climbRank
         self.climbRankTotal = climbRankTotal
         self.background = initialBackground
+    }
+
+    /// Climb artwork offered as an image sticker (when sharing a climb). One
+    /// variant only — the user resizes it freely once placed.
+    var climbImageStickerVariants: [ClimbImageVariant] {
+        climb == nil ? [] : [.thumb]
     }
 
     // MARK: - Stat resolution
@@ -63,7 +89,7 @@ final class ShareComposerViewModel {
             workout: workout,
             measurementSystem: measurementSystem,
             stepHeight: stepHeight,
-            climbName: climbName,
+            climbName: climbNameOverride ?? climbName,
             climbRank: climbRank,
             climbRankTotal: climbRankTotal
         )
@@ -71,18 +97,81 @@ final class ShareComposerViewModel {
 
     var isClimb: Bool { climbName != nil }
 
-    /// Catalog of stats that have a value for this workout, resolved for display.
-    func availableStats() -> [ResolvedShareStat] {
-        var stats = resolver.availableKinds().compactMap { resolver.resolve($0) }
-        if let primaryBestEffortStat {
-            stats.append(primaryBestEffortStat)
-        }
-        return stats
+    /// This-climb / this-workout stats that have a value, resolved for display.
+    /// Best Efforts and Totals are surfaced as their own sections, not here.
+    func climbStats() -> [ResolvedShareStat] {
+        resolver.availableKinds().compactMap { resolver.resolve($0) }
     }
 
-    func resolve(_ kind: ShareStatStickerKind) -> ResolvedShareStat? {
-        if kind == .bestEffort { return primaryBestEffortStat }
-        return resolver.resolve(kind)
+    /// Resolve a single stat reference. Injected kinds (`.bestEffort`, `.totals`)
+    /// look up their value by key; everything else resolves from the workout.
+    func resolved(_ ref: ShareStatRef) -> ResolvedShareStat? {
+        switch ref.kind {
+        case .bestEffort: return injected(ref.injectedStatKey, in: bestEffortStats)
+        case .totals: return injected(ref.injectedStatKey, in: weeklyTotalStats)
+        default: return resolver.resolve(ref.kind)
+        }
+    }
+
+    /// All resolved metrics for a sticker (one for a single sticker, several for
+    /// a composite). Unresolvable refs are dropped.
+    func resolvedStats(for instance: ShareStickerInstance) -> [ResolvedShareStat] {
+        instance.statRefs.compactMap { resolved($0) }
+    }
+
+    /// The sticker's primary resolved value (used for the font-preview sheet).
+    func resolve(_ instance: ShareStickerInstance) -> ResolvedShareStat? {
+        resolved(instance.primaryStatRef)
+    }
+
+    private func injected(_ key: String?, in list: [ResolvedShareStat]) -> ResolvedShareStat? {
+        if let key, let match = list.first(where: { $0.label == key }) { return match }
+        return list.first
+    }
+
+    // MARK: - Structure (composite stickers)
+
+    func setLayout(_ layout: ShareStatLayout, for id: UUID) {
+        guard let i = stickers.firstIndex(where: { $0.id == id }) else { return }
+        stickers[i].layout = layout
+    }
+
+    /// Metrics offered for a sticker's structure sheet — same family as the
+    /// sticker's primary metric (workout/climb stats, best efforts, or totals).
+    func paletteRefs(for instance: ShareStickerInstance) -> [ShareStatRef] {
+        switch instance.kind {
+        case .bestEffort:
+            return bestEffortStats.map { ShareStatRef(kind: .bestEffort, injectedStatKey: $0.label) }
+        case .totals:
+            return weeklyTotalStats.map { ShareStatRef(kind: .totals, injectedStatKey: $0.label) }
+        default:
+            return resolver.availableKinds().map { ShareStatRef(kind: $0, injectedStatKey: nil) }
+        }
+    }
+
+    /// Add/remove a metric on a composite sticker. Keeps at least one metric
+    /// (removing the primary promotes the first extra) and caps the total at 4.
+    func toggleStat(_ ref: ShareStatRef, for id: UUID) {
+        guard let i = stickers.firstIndex(where: { $0.id == id }) else { return }
+        var sticker = stickers[i]
+        if sticker.primaryStatRef == ref {
+            guard !sticker.extraStats.isEmpty else { return } // never remove the last metric
+            let promoted = sticker.extraStats.removeFirst()
+            sticker.kind = promoted.kind
+            sticker.injectedStatKey = promoted.injectedStatKey
+        } else if let idx = sticker.extraStats.firstIndex(of: ref) {
+            sticker.extraStats.remove(at: idx)
+        } else if sticker.statRefs.count < 4 {
+            sticker.extraStats.append(ref)
+        }
+        stickers[i] = sticker
+    }
+
+    // MARK: - Climb rename
+
+    func setClimbName(_ name: String) {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        climbNameOverride = trimmed.isEmpty ? nil : trimmed
     }
 
     // MARK: - Sticker mutations
@@ -97,6 +186,106 @@ final class ShareComposerViewModel {
         )
         stickers.append(instance)
         selectedID = instance.id
+    }
+
+    func addClimbImageSticker(variant: ClimbImageVariant) {
+        let offset = CGFloat(stickers.count % 5) * 0.04
+        let instance = ShareStickerInstance(
+            kind: .climbName, // unused for image stickers
+            position: CGPoint(x: 0.5, y: 0.42 + offset),
+            climbImageVariant: variant
+        )
+        stickers.append(instance)
+        selectedID = instance.id
+    }
+
+    /// Curated stats for the recap card's stat row (duration · steps · calories,
+    /// dropping any that don't resolve for this workout).
+    func recapStats() -> [ResolvedShareStat] {
+        [ShareStatStickerKind.duration, .steps, .calories]
+            .compactMap { resolved(ShareStatRef(kind: $0, injectedStatKey: nil)) }
+    }
+
+    /// Add an injected stat (Best Effort or Totals) as a sticker, keyed so it
+    /// resolves back to the right value from the injected lists.
+    func addInjectedSticker(_ stat: ResolvedShareStat) {
+        let offset = CGFloat(stickers.count % 5) * 0.04
+        let instance = ShareStickerInstance(
+            kind: stat.kind,
+            position: CGPoint(x: 0.5, y: 0.42 + offset),
+            injectedStatKey: stat.label
+        )
+        stickers.append(instance)
+        selectedID = instance.id
+    }
+
+    /// Switch to a freshly chosen background, clearing any placed stickers and
+    /// resetting the filter + transform so the user starts the new canvas clean.
+    func resetForNewBackground(_ source: ShareBackgroundSource) {
+        stickers.removeAll()
+        selectedID = nil
+        backgroundFilter = .original
+        backgroundScale = 1
+        backgroundOffset = .zero
+        processedBackgroundImage = nil
+        processedCache.removeAll()
+        background = source
+    }
+
+    /// Filters available for the current background. Geometric (Core Image)
+    /// filters need a still photo, so presets/videos only get color grades.
+    var availableFilters: [ShareBackgroundFilter] {
+        if case .photo = background { return ShareBackgroundFilter.allCases }
+        return ShareBackgroundFilter.allCases.filter { !$0.isGeometric }
+    }
+
+    /// Cycle the background filter (driven by a horizontal swipe on the canvas).
+    func cycleFilter(forward: Bool) {
+        let all = availableFilters
+        let idx = all.firstIndex(of: backgroundFilter) ?? 0
+        let next = forward ? (idx + 1) % all.count : (idx - 1 + all.count) % all.count
+        backgroundFilter = all[next]
+        refreshProcessedBackground()
+    }
+
+    /// Compute (and cache) the Core Image-processed background for geometric
+    /// filters; color/original grades use the unprocessed photo + SwiftUI modifiers.
+    private func refreshProcessedBackground() {
+        guard backgroundFilter.isGeometric, case .photo(let image) = background else {
+            processedBackgroundImage = nil
+            return
+        }
+        if let cached = processedCache[backgroundFilter] {
+            processedBackgroundImage = cached
+            return
+        }
+        let result = ShareImageFilter.apply(backgroundFilter, to: image)
+        if let result { processedCache[backgroundFilter] = result }
+        processedBackgroundImage = result
+    }
+
+    // MARK: - Background transform (free-form pan / zoom)
+
+    /// The background is "free-form" once scaled or moved away from its default
+    /// fit. In that state a drag repositions it; at the default fit a horizontal
+    /// drag instead cycles the filter (and double-tap returns to this state).
+    var backgroundIsManipulated: Bool {
+        abs(backgroundScale - 1) > 0.01 || backgroundOffset != .zero
+    }
+
+    func commitBackgroundZoom(_ factor: CGFloat) {
+        // Free-form: allow shrinking below fit (zoom out) and growing up to 5×.
+        backgroundScale = min(max(backgroundScale * factor, 0.3), 5)
+    }
+
+    func commitBackgroundPan(dxFraction: CGFloat, dyFraction: CGFloat) {
+        backgroundOffset = CGSize(width: backgroundOffset.width + dxFraction,
+                                  height: backgroundOffset.height + dyFraction)
+    }
+
+    func resetBackgroundTransform() {
+        backgroundScale = 1
+        backgroundOffset = .zero
     }
 
     func deleteSticker(_ id: UUID) {
@@ -164,5 +353,50 @@ final class ShareComposerViewModel {
         isOverTrash = false
         verticalGuideX = nil
         horizontalGuideY = nil
+    }
+
+    // MARK: - Totals injection
+
+    /// Compute this-week aggregates (Monday-based, local week) from the full
+    /// workout history and publish them as Totals stat stickers.
+    func injectWeeklyTotals(from workouts: [Workout], now: Date = Date()) {
+        let calendar = WeekConfiguration.calendar()
+        guard let week = calendar.dateInterval(of: .weekOfYear, for: now) else {
+            weeklyTotalStats = []
+            return
+        }
+        let weekWorkouts = workouts.filter { $0.date >= week.start && $0.date < week.end }
+        guard !weekWorkouts.isEmpty else {
+            weeklyTotalStats = []
+            return
+        }
+
+        let steps = weekWorkouts.reduce(0) { $0 + $1.steps }
+        let count = weekWorkouts.count
+        let duration = weekWorkouts.reduce(0.0) { $0 + $1.duration }
+        let vertical = weekWorkouts.reduce(0.0) {
+            $0 + $1.totalVerticalClimb(stepHeight: stepHeight, measurementSystem: measurementSystem)
+        }
+
+        var stats: [ResolvedShareStat] = []
+        if steps > 0 {
+            stats.append(ResolvedShareStat(kind: .totals, label: "STEPS THIS WEEK",
+                                           value: steps.formatted(.number.grouping(.automatic))))
+        }
+        stats.append(ResolvedShareStat(kind: .totals, label: "WORKOUTS THIS WEEK", value: "\(count)"))
+        stats.append(ResolvedShareStat(kind: .totals, label: "TIME THIS WEEK", value: Self.durationText(duration)))
+        if vertical > 0 {
+            let v = vertical.formatted(.number.precision(.fractionLength(vertical < 100 ? 1 : 0)))
+            stats.append(ResolvedShareStat(kind: .totals, label: "VERTICAL THIS WEEK",
+                                           value: "\(v) \(measurementSystem.distanceAbbreviation)"))
+        }
+        weeklyTotalStats = stats
+    }
+
+    static func durationText(_ seconds: TimeInterval) -> String {
+        let totalMinutes = Int(seconds / 60)
+        let hours = totalMinutes / 60
+        let minutes = totalMinutes % 60
+        return hours > 0 ? "\(hours)h \(minutes)m" : "\(minutes)m"
     }
 }

--- a/AscendApp/Features/ShareComposer/Views/ShareBackgroundPickerView.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareBackgroundPickerView.swift
@@ -5,14 +5,24 @@ import SwiftUI
 struct ShareBackgroundPickerView: View {
     let title: String
     let presets: [ShareComposerPreset]
+    /// Optional one-tap recap card (climb hero + auto-arranged stats).
+    var recap: RecapPreview?
     let onPick: (ShareBackgroundSource) -> Void
+    var onPickRecap: (() -> Void)?
     let onClose: () -> Void
 
     @State private var selectedTab: Tab = .cameraRoll
 
     private let accent = Color(red: 0.706, green: 0.8, blue: 0)
 
-    enum Tab { case cameraRoll, presets }
+    enum Tab { case cameraRoll, presets, recaps }
+
+    /// Data for the Recaps tab card (our pre-made climb card).
+    struct RecapPreview {
+        let climb: Climb
+        let stats: [ResolvedShareStat]
+        let bestEffort: ResolvedShareStat?
+    }
 
     var body: some View {
         ZStack {
@@ -24,10 +34,13 @@ struct ShareBackgroundPickerView: View {
                     .padding(.top, 18)
                     .padding(.bottom, 8)
 
-                if selectedTab == .cameraRoll {
+                switch selectedTab {
+                case .cameraRoll:
                     ShareCameraRollGrid(onPick: onPick)
-                } else {
+                case .presets:
                     presetsContent
+                case .recaps:
+                    recapsContent
                 }
 
                 Spacer(minLength: 0)
@@ -68,6 +81,9 @@ struct ShareBackgroundPickerView: View {
         HStack(spacing: 0) {
             tabButton("Camera Roll", tab: .cameraRoll)
             tabButton("Presets", tab: .presets)
+            if recap != nil {
+                tabButton("Recaps", tab: .recaps)
+            }
         }
         .padding(4)
         .background(.white.opacity(0.06), in: Capsule(style: .continuous))
@@ -97,30 +113,61 @@ struct ShareBackgroundPickerView: View {
 
     // MARK: - Presets
 
+    // MARK: - Presets (backgrounds we offer)
+
     private var presetsContent: some View {
         ScrollView {
-            LazyVGrid(columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)], spacing: 12) {
+            VStack(spacing: 14) {
                 ForEach(presets) { preset in
                     Button {
                         HapticsManager.shared.trigger(.lightImpact)
                         onPick(.preset(preset))
                     } label: {
                         ShareBackgroundView(source: .preset(preset), isStatic: true)
-                            .frame(height: 240)
-                            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                            .overlay(alignment: .bottomLeading) {
-                                Text(preset.displayName.uppercased())
-                                    .font(.montserratSemiBold(size: 11))
-                                    .tracking(1)
-                                    .foregroundStyle(.white)
-                                    .padding(10)
-                            }
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 420)
+                            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
                             .overlay(
-                                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                RoundedRectangle(cornerRadius: 18, style: .continuous)
                                     .stroke(.white.opacity(0.1), lineWidth: 1)
                             )
                     }
                     .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 16)
+        }
+    }
+
+    // MARK: - Recaps (our pre-made climb cards)
+
+    private var recapsContent: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                if let recap, let onPickRecap {
+                    Button {
+                        HapticsManager.shared.trigger(.lightImpact)
+                        onPickRecap()
+                    } label: {
+                        // Color.clear gives the flexible card a concrete 9:16 box.
+                        Color.clear
+                            .aspectRatio(9.0 / 16.0, contentMode: .fit)
+                            .overlay {
+                                ShareRecapCard(climb: recap.climb, stats: recap.stats, bestEffort: recap.bestEffort)
+                            }
+                            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                    .stroke(accent.opacity(0.5), lineWidth: 1.5)
+                            )
+                    }
+                    .buttonStyle(.plain)
+
+                    Text("Your climb, ready to share — tap to use, then add anything on top.")
+                        .font(.montserratRegular(size: 12))
+                        .foregroundStyle(Color.customGray)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
             .padding(.horizontal, 24)

--- a/AscendApp/Features/ShareComposer/Views/ShareBackgroundView.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareBackgroundView.swift
@@ -9,8 +9,24 @@ struct ShareBackgroundView: View {
     /// When true (export), video falls back to a poster frame since the export
     /// pipeline composites video separately.
     var isStatic: Bool = false
+    /// Color grade applied to the background only (stickers are unaffected).
+    var filter: ShareBackgroundFilter = .original
+    /// Core Image-processed photo for geometric filters. When set, it's shown
+    /// directly (the effect is already baked in) instead of the raw source.
+    var processedImage: UIImage? = nil
 
     var body: some View {
+        if let processedImage {
+            Image(uiImage: processedImage)
+                .resizable()
+                .scaledToFill()
+        } else {
+            content.shareBackgroundFilter(filter)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
         switch source {
         case .photo(let image):
             Image(uiImage: image)

--- a/AscendApp/Features/ShareComposer/Views/ShareCameraRollGrid.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareCameraRollGrid.swift
@@ -87,11 +87,11 @@ struct ShareCameraRollGrid: View {
         Task {
             defer { isLoadingSelection = false }
             if asset.mediaType == .video {
-                if let url = await library.videoURL(for: asset) {
+                if let url = await library.videoURL(forIdentifier: asset.localIdentifier) {
                     onPick(.video(url))
                 }
             } else {
-                if let image = await library.fullImage(for: asset) {
+                if let image = await library.fullImage(forIdentifier: asset.localIdentifier) {
                     onPick(.photo(image))
                 }
             }
@@ -129,7 +129,7 @@ private struct PhotoThumbCell: View {
             .clipped()
             .contentShape(Rectangle())
             .task(id: asset.localIdentifier) {
-                thumbnail = await library.thumbnail(for: asset, size: 130)
+                thumbnail = await library.thumbnail(forIdentifier: asset.localIdentifier, size: 130)
             }
     }
 

--- a/AscendApp/Features/ShareComposer/Views/ShareComposerView.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareComposerView.swift
@@ -7,12 +7,25 @@ import SwiftUI
 struct ShareComposerView: View {
     @Environment(\.dismiss) private var dismiss
     @Query(sort: \BestEffortCacheEntry.sortKey) private var bestEffortCacheEntries: [BestEffortCacheEntry]
+    @Query(sort: \Workout.date, order: .reverse) private var allWorkouts: [Workout]
 
     @State private var viewModel: ShareComposerViewModel
     @State private var showAddSheet = false
     @State private var showFontSheet = false
-    @State private var isExporting = false
+    @State private var showStructureSheet = false
+    @State private var showRenameClimb = false
+    @State private var renameText = ""
+    @State private var exportingAction: ExportAction?
     @State private var toast: String?
+    /// Transient filter name shown briefly after a swipe.
+    @State private var filterFlash: String?
+    /// Live background pinch/drag deltas (committed to the view model on end).
+    @GestureState private var bgZoomLive: CGFloat = 1
+    @GestureState private var bgPanLive: CGSize = .zero
+
+    /// Which export is in flight (drives the per-button spinner).
+    private enum ExportAction { case story, save, share }
+    private var isExporting: Bool { exportingAction != nil }
 
     private let exporter = ShareComposerExporter()
     private let presets: [ShareComposerPreset]
@@ -30,18 +43,17 @@ struct ShareComposerView: View {
             workout: workout,
             measurementSystem: settings.measurementSystem,
             stepHeight: settings.stepHeight,
+            climb: climb,
             climbName: climb?.name,
             climbRank: liveClimbRank,
             climbRankTotal: liveClimbRankTotal
         ))
 
+        // Only the hero artwork is offered as a background preset; the card and
+        // thumbnail are addable as stickers (in the Climb tab), not backgrounds.
         var presets: [ShareComposerPreset] = []
         if let climb {
-            presets = [
-                .climbImage(climb, .hero),
-                .climbImage(climb, .card),
-                .climbImage(climb, .thumb)
-            ]
+            presets = [.climbImage(climb, .hero)]
         }
         self.presets = presets
 
@@ -49,6 +61,23 @@ struct ShareComposerView: View {
             self.shareTitle = climb.name
         } else {
             self.shareTitle = workout.name.isEmpty ? "your workout" : workout.name
+        }
+    }
+
+    /// Data for the picker's Recaps tab (only when sharing a climb).
+    private var recapPreview: ShareBackgroundPickerView.RecapPreview? {
+        guard let climb = viewModel.climb else { return nil }
+        return .init(climb: climb, stats: viewModel.recapStats(), bestEffort: viewModel.bestEffortStats.first)
+    }
+
+    /// Bake the recap card to an image and use it as the background (the climb
+    /// artwork is already warm from the Recaps tab preview, so the render
+    /// captures it). The user can then add stickers on top or save as-is.
+    private func applyRecap() {
+        guard let climb = viewModel.climb else { return }
+        let card = ShareRecapCard(climb: climb, stats: viewModel.recapStats(), bestEffort: viewModel.bestEffortStats.first)
+        if let image = exporter.renderRecap(card) {
+            viewModel.resetForNewBackground(.photo(image))
         }
     }
 
@@ -60,12 +89,16 @@ struct ShareComposerView: View {
                 ShareBackgroundPickerView(
                     title: shareTitle,
                     presets: presets,
+                    recap: recapPreview,
                     onPick: { source in
-                        viewModel.background = source
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                        // Re-picking a background starts a clean canvas.
+                        viewModel.resetForNewBackground(source)
+                        Task {
+                            try? await Task.sleep(for: .seconds(0.35))
                             showAddSheet = true
                         }
                     },
+                    onPickRecap: viewModel.climb != nil ? { applyRecap() } : nil,
                     onClose: { dismiss() }
                 )
             } else {
@@ -74,10 +107,24 @@ struct ShareComposerView: View {
         }
         .sheet(isPresented: $showAddSheet) {
             ShareAddStatSheet(
-                stats: viewModel.availableStats(),
-                onPick: { stat in
+                climbStats: viewModel.climbStats(),
+                bestEffortStats: viewModel.bestEffortStats,
+                weeklyTotalStats: viewModel.weeklyTotalStats,
+                climb: viewModel.climb,
+                imageVariants: viewModel.climbImageStickerVariants,
+                onPickStat: { stat in
                     HapticsManager.shared.trigger(.lightImpact)
                     viewModel.addSticker(kind: stat.kind)
+                    showAddSheet = false
+                },
+                onPickInjected: { stat in
+                    HapticsManager.shared.trigger(.lightImpact)
+                    viewModel.addInjectedSticker(stat)
+                    showAddSheet = false
+                },
+                onPickImage: { variant in
+                    HapticsManager.shared.trigger(.lightImpact)
+                    viewModel.addClimbImageSticker(variant: variant)
                     showAddSheet = false
                 }
             )
@@ -86,7 +133,7 @@ struct ShareComposerView: View {
             .presentationBackground(Color(hex: "121212"))
         }
         .sheet(isPresented: $showFontSheet) {
-            if let index = selectedIndex, let stat = viewModel.resolve(viewModel.stickers[index].kind) {
+            if let index = selectedIndex, let stat = viewModel.resolve(viewModel.stickers[index]) {
                 ShareFontPickerSheet(
                     sampleStat: stat,
                     current: viewModel.stickers[index].font,
@@ -100,36 +147,82 @@ struct ShareComposerView: View {
                 .presentationBackground(Color(hex: "121212"))
             }
         }
+        .sheet(isPresented: $showStructureSheet) {
+            if let index = selectedIndex {
+                ShareStructureSheet(viewModel: viewModel, stickerID: viewModel.stickers[index].id)
+                    .presentationDetents([.fraction(0.55), .large])
+                    .presentationDragIndicator(.visible)
+                    .presentationBackground(Color(hex: "121212"))
+            }
+        }
+        .alert("Rename climb", isPresented: $showRenameClimb) {
+            TextField("Climb name", text: $renameText)
+            Button("Cancel", role: .cancel) {}
+            Button("Save") { viewModel.setClimbName(renameText) }
+        } message: {
+            Text("Rename how this climb appears on your share. Stat values can't be changed.")
+        }
         .overlay(alignment: .bottom) { toastView }
         .task {
-            // Inject the workout's headline Best Effort (from the cache) so it
-            // can be added as a sticker.
+            // Inject the workout's Best Efforts (from the cache) so each can be
+            // added as its own sticker — they get their own add-sheet section.
+            // The cache can hold the same metric across multiple scopes/contexts,
+            // so dedupe by label (the list is significance-sorted; keep the first).
             let snapshot = BestEffortCacheSnapshot(entries: bestEffortCacheEntries, workouts: [viewModel.workout])
-            if let effort = snapshot.primaryEffort(for: viewModel.workout) {
-                viewModel.primaryBestEffortStat = ResolvedShareStat(
-                    kind: .bestEffort,
-                    label: effort.metric.title.uppercased(),
-                    value: effort.compactValueText
-                )
+            var seenEffortLabels = Set<String>()
+            viewModel.bestEffortStats = snapshot.efforts(for: viewModel.workout).compactMap { effort in
+                let label = effort.metric.title.uppercased()
+                guard seenEffortLabels.insert(label).inserted else { return nil }
+                return ResolvedShareStat(kind: .bestEffort, label: label, value: effort.compactValueText)
             }
+            // Inject this-week totals for the Totals tab.
+            viewModel.injectWeeklyTotals(from: allWorkouts)
         }
     }
 
     // MARK: - Composer canvas
 
     private var composer: some View {
+        VStack(spacing: 0) {
+            canvasRegion
+            bottomBar
+        }
+        .background(Color.black)
+        .ignoresSafeArea(edges: .top)
+    }
+
+    /// The shareable photo region — everything that gets exported. The action
+    /// bar lives *below* this (in `bottomBar`) so controls never overlap the
+    /// image, matching the Aura layout.
+    private var canvasRegion: some View {
         GeometryReader { geo in
             let canvasSize = geo.size
             let canvasScale = canvasSize.width / 390
 
             ZStack {
-                // Background (live)
+                // Black base so a shrunk (zoomed-out) background floats on black.
+                Color.black
+
+                // Background (live): pinch to zoom (in or out), drag to move it
+                // freely once manipulated, or swipe to change the filter at fit.
+                // Double-tap resets it to fit.
                 if let background = viewModel.background {
-                    ShareBackgroundView(source: background)
-                        .frame(width: canvasSize.width, height: canvasSize.height)
-                        .clipped()
-                        .contentShape(Rectangle())
-                        .onTapGesture { viewModel.deselect() }
+                    let panActive = viewModel.backgroundIsManipulated
+                    let scale = viewModel.backgroundScale * bgZoomLive
+                    let offX = viewModel.backgroundOffset.width * canvasSize.width + (panActive ? bgPanLive.width : 0)
+                    let offY = viewModel.backgroundOffset.height * canvasSize.height + (panActive ? bgPanLive.height : 0)
+                    ShareBackgroundView(
+                        source: background,
+                        filter: viewModel.backgroundFilter,
+                        processedImage: viewModel.processedBackgroundImage
+                    )
+                    .frame(width: canvasSize.width, height: canvasSize.height)
+                    .scaleEffect(scale)
+                    .offset(x: offX, y: offY)
+                    .contentShape(Rectangle())
+                    .onTapGesture(count: 2) { viewModel.resetBackgroundTransform() }
+                    .onTapGesture { viewModel.deselect() }
+                    .gesture(backgroundGesture(canvasSize: canvasSize))
                 }
 
                 // Snap guides (drawn at the active snap line: center or edge)
@@ -146,13 +239,15 @@ struct ShareComposerView: View {
 
                 // Stickers
                 ForEach(Array(viewModel.stickers.enumerated()), id: \.element.id) { index, sticker in
-                    if let stat = viewModel.resolve(sticker.kind) {
+                    if sticker.isImage || !viewModel.resolvedStats(for: sticker).isEmpty {
                         ShareStickerView(
                             instance: $viewModel.stickers[index],
-                            stat: stat,
+                            stats: viewModel.resolvedStats(for: sticker),
+                            climb: viewModel.climb,
                             canvasSize: canvasSize,
                             canvasScale: canvasScale,
                             isSelected: viewModel.selectedID == sticker.id,
+                            isOverTrash: viewModel.isOverTrash && viewModel.draggingID == sticker.id,
                             onSelect: { viewModel.select(sticker.id) },
                             onDragChanged: { center in
                                 viewModel.handleDragChanged(id: sticker.id, center: center, canvasSize: canvasSize)
@@ -172,16 +267,39 @@ struct ShareComposerView: View {
                     trashZone(in: canvasSize)
                 }
 
+                // Transient filter name after a swipe.
+                if let filterFlash {
+                    Text(filterFlash.uppercased())
+                        .font(.montserratBold(size: 15))
+                        .tracking(2)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 18)
+                        .padding(.vertical, 10)
+                        .background(Capsule().fill(.black.opacity(0.55)))
+                        .transition(.opacity)
+                        .allowsHitTesting(false)
+                }
+
+                // Bottom overlay: the + pill (hidden while dragging) above the
+                // always-on Ascend wordmark that's burned into every export.
+                VStack(spacing: 10) {
+                    Spacer()
+                    if viewModel.draggingID == nil { addPill }
+                    AscendWordmark(size: 13 * canvasScale, letterColor: .white.opacity(0.92))
+                        .shadow(color: .black.opacity(0.5), radius: 4, x: 0, y: 1)
+                        .allowsHitTesting(false)
+                        .padding(.bottom, 12)
+                }
+
                 // Chrome
                 topChrome
                 if viewModel.draggingID == nil {
                     editRail
-                    bottomBar
                 }
             }
             .frame(width: canvasSize.width, height: canvasSize.height)
+            .clipped()
         }
-        .ignoresSafeArea()
     }
 
     private func trashZone(in canvasSize: CGSize) -> some View {
@@ -203,9 +321,13 @@ struct ShareComposerView: View {
     private var topChrome: some View {
         VStack {
             HStack {
-                circleButton(systemName: "xmark") { dismiss() }
+                // Back to the background picker (not exit). Exit happens from
+                // the picker's chevron-down.
+                circleButton(systemName: "chevron.left") {
+                    viewModel.deselect()
+                    viewModel.background = nil
+                }
                 Spacer()
-                circleButton(systemName: "photo") { viewModel.background = nil }
             }
             .padding(.horizontal, 12)
             .padding(.top, 52)
@@ -222,8 +344,23 @@ struct ShareComposerView: View {
 
     @ViewBuilder
     private var editRail: some View {
-        if let index = selectedIndex {
+        if let index = selectedIndex, !viewModel.stickers[index].isImage {
             VStack(spacing: 14) {
+                // Structure: arrange multiple metrics (row / grid / column) + toggle which show.
+                railButton(systemName: "square.grid.2x2") {
+                    HapticsManager.shared.trigger(.lightImpact)
+                    showStructureSheet = true
+                }
+
+                // Rename — only when the sticker includes the climb name.
+                if viewModel.stickers[index].containsClimbName {
+                    railButton(systemName: "pencil") {
+                        HapticsManager.shared.trigger(.lightImpact)
+                        renameText = viewModel.resolve(viewModel.stickers[index])?.value ?? ""
+                        showRenameClimb = true
+                    }
+                }
+
                 railButton(systemName: "textformat.size") {
                     HapticsManager.shared.trigger(.lightImpact)
                     viewModel.stickers[index].style = viewModel.stickers[index].style.next()
@@ -270,45 +407,104 @@ struct ShareComposerView: View {
         )
     }
 
-    private var bottomBar: some View {
-        VStack {
-            Spacer()
+    /// Translucent "add sticker" button floating at the bottom of the photo,
+    /// matching the Share button's footprint. Light haptic on tap.
+    private var addPill: some View {
+        Button {
+            HapticsManager.shared.trigger(.lightImpact)
+            showAddSheet = true
+        } label: {
+            Image(systemName: "plus")
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 52, height: 52)
+                .background(.ultraThinMaterial, in: Circle())
+                .overlay(Circle().stroke(.white.opacity(0.18), lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+    }
 
-            // Add sticker pill
-            Button { showAddSheet = true } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 22, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .frame(width: 56, height: 56)
-                    .background(Circle().fill(.black.opacity(0.4)).overlay(Circle().stroke(.white.opacity(0.25), lineWidth: 1)))
+    /// Action strip in its own space below the photo — never overlaps the image.
+    private var bottomBar: some View {
+        HStack(spacing: 12) {
+            actionPill(label: "STORY", systemName: "camera", isLoading: exportingAction == .story) {
+                Task { await exportToStory() }
+            }
+            actionPill(label: "SAVE", systemName: "arrow.down.to.line", isLoading: exportingAction == .save) {
+                Task { await save() }
+            }
+            Button { Task { await shareSheet() } } label: {
+                Group {
+                    if exportingAction == .share {
+                        ProgressView().tint(.black)
+                    } else {
+                        Image(systemName: "square.and.arrow.up").font(.system(size: 20, weight: .semibold))
+                    }
+                }
+                .foregroundStyle(.black)
+                .frame(width: 52, height: 52)
+                .background(Circle().fill(accent))
             }
             .buttonStyle(.plain)
-            .padding(.bottom, 16)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 14)
+        .padding(.bottom, 4)
+        .frame(maxWidth: .infinity)
+        .background(Color.black)
+        .disabled(isExporting)
+    }
 
-            // Action bar
-            HStack(spacing: 12) {
-                actionPill(label: "STORY", systemName: "camera") { Task { await exportToStory() } }
-                actionPill(label: "SAVE", systemName: "arrow.down.to.line") { Task { await save() } }
-                Button { Task { await shareSheet() } } label: {
-                    Image(systemName: "square.and.arrow.up")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(.black)
-                        .frame(width: 52, height: 52)
-                        .background(Circle().fill(accent))
+    // MARK: - Background transform + filter swipe
+
+    /// Pinch zooms the background; dragging repositions it when zoomed, or
+    /// (at fit-scale) a horizontal swipe cycles the filter.
+    private func backgroundGesture(canvasSize: CGSize) -> some Gesture {
+        let zoom = MagnifyGesture()
+            .updating($bgZoomLive) { value, state, _ in state = value.magnification }
+            .onEnded { value in viewModel.commitBackgroundZoom(value.magnification) }
+
+        let pan = DragGesture(minimumDistance: 20)
+            .updating($bgPanLive) { value, state, _ in state = value.translation }
+            .onEnded { value in
+                if viewModel.backgroundIsManipulated {
+                    viewModel.commitBackgroundPan(
+                        dxFraction: value.translation.width / canvasSize.width,
+                        dyFraction: value.translation.height / canvasSize.height
+                    )
+                } else {
+                    handleFilterSwipe(value.translation)
                 }
-                .buttonStyle(.plain)
             }
-            .padding(.horizontal, 20)
-            .padding(.bottom, 36)
-            .opacity(isExporting ? 0.5 : 1)
-            .disabled(isExporting)
+
+        return zoom.simultaneously(with: pan)
+    }
+
+    private func handleFilterSwipe(_ translation: CGSize) {
+        // Only horizontal swipes of meaningful length cycle the filter.
+        guard abs(translation.width) > abs(translation.height), abs(translation.width) > 45 else { return }
+        HapticsManager.shared.trigger(.selection)
+        viewModel.cycleFilter(forward: translation.width < 0)
+        flashFilterName()
+    }
+
+    private func flashFilterName() {
+        let name = viewModel.backgroundFilter.displayName
+        withAnimation { filterFlash = name }
+        Task {
+            try? await Task.sleep(for: .seconds(0.9))
+            withAnimation { if filterFlash == name { filterFlash = nil } }
         }
     }
 
-    private func actionPill(label: String, systemName: String, action: @escaping () -> Void) -> some View {
+    private func actionPill(label: String, systemName: String, isLoading: Bool, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             HStack(spacing: 8) {
-                Image(systemName: systemName).font(.system(size: 16, weight: .semibold))
+                if isLoading {
+                    ProgressView().tint(.white)
+                } else {
+                    Image(systemName: systemName).font(.system(size: 16, weight: .semibold))
+                }
                 Text(label).font(.montserratBold(size: 14)).tracking(1)
             }
             .foregroundStyle(.white)
@@ -348,86 +544,236 @@ struct ShareComposerView: View {
 
     private func showToast(_ message: String) {
         withAnimation { toast = message }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        Task {
+            try? await Task.sleep(for: .seconds(2))
             withAnimation { if toast == message { toast = nil } }
         }
     }
 
-    private func save() async {
-        isExporting = true
-        defer { isExporting = false }
-        guard let image = await exporter.renderImage(viewModel: viewModel) else {
-            showToast("Couldn't render image")
-            return
+    private var isVideoBackground: Bool { viewModel.background?.isVideo ?? false }
+
+    private func finishSave(_ ok: Bool) {
+        if ok {
+            HapticsManager.shared.trigger(.success)
+            showToast("Saved to Photos")
+        } else {
+            showToast("Allow Photos access to save")
         }
-        let ok = await exporter.saveToPhotos(image)
-        showToast(ok ? "Saved to Photos" : "Allow Photos access to save")
+    }
+
+    private func save() async {
+        exportingAction = .save
+        defer { exportingAction = nil }
+        if isVideoBackground {
+            guard let url = await exporter.exportVideo(viewModel: viewModel) else {
+                showToast("Couldn't export video")
+                return
+            }
+            finishSave(await exporter.saveVideoToPhotos(url))
+        } else {
+            guard let image = await exporter.renderImage(viewModel: viewModel) else {
+                showToast("Couldn't render image")
+                return
+            }
+            finishSave(await exporter.saveToPhotos(image))
+        }
     }
 
     private func shareSheet() async {
-        isExporting = true
-        defer { isExporting = false }
-        guard let image = await exporter.renderImage(viewModel: viewModel) else { return }
-        exporter.presentShareSheet(image: image)
+        exportingAction = .share
+        defer { exportingAction = nil }
+        if isVideoBackground {
+            guard let url = await exporter.exportVideo(viewModel: viewModel) else { return }
+            exporter.presentShareSheet(url: url)
+        } else {
+            guard let image = await exporter.renderImage(viewModel: viewModel) else { return }
+            exporter.presentShareSheet(image: image)
+        }
     }
 
     private func exportToStory() async {
-        isExporting = true
-        defer { isExporting = false }
-        guard let image = await exporter.renderImage(viewModel: viewModel) else { return }
-        if !exporter.shareToInstagramStory(image) {
-            exporter.presentShareSheet(image: image)
+        exportingAction = .story
+        defer { exportingAction = nil }
+        if isVideoBackground {
+            // IG Stories video import isn't wired yet — fall back to the share sheet.
+            guard let url = await exporter.exportVideo(viewModel: viewModel) else { return }
+            exporter.presentShareSheet(url: url)
+        } else {
+            guard let image = await exporter.renderImage(viewModel: viewModel) else { return }
+            if !exporter.shareToInstagramStory(image) {
+                exporter.presentShareSheet(image: image)
+            }
         }
     }
 }
 
-/// Bottom sheet listing the stats available to add as stickers.
+/// Bottom sheet for adding stickers. A Climb | Totals toggle (Aura-style)
+/// switches between this-climb content (artwork + stats + Best Efforts) and
+/// this-week totals.
 private struct ShareAddStatSheet: View {
-    let stats: [ResolvedShareStat]
-    let onPick: (ResolvedShareStat) -> Void
+    let climbStats: [ResolvedShareStat]
+    let bestEffortStats: [ResolvedShareStat]
+    let weeklyTotalStats: [ResolvedShareStat]
+    let climb: Climb?
+    let imageVariants: [ClimbImageVariant]
+    let onPickStat: (ResolvedShareStat) -> Void
+    let onPickInjected: (ResolvedShareStat) -> Void
+    let onPickImage: (ClimbImageVariant) -> Void
+
+    @State private var tab: Tab = .primary
+    enum Tab { case primary, totals }
 
     private let columns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
+    private let lime = Color(red: 0.706, green: 0.8, blue: 0)
+
+    /// Left tab is "Climb" when sharing a climb, otherwise "Workout".
+    private var primaryLabel: String { climb == nil ? "Workout" : "Climb" }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text("Add to your share")
-                .font(.montserratBold(size: 18))
-                .foregroundStyle(.white)
+        VStack(spacing: 0) {
+            tabPill
                 .padding(.horizontal, 24)
-                .padding(.top, 24)
+                .padding(.top, 18)
                 .padding(.bottom, 16)
 
             ScrollView {
-                LazyVGrid(columns: columns, spacing: 12) {
-                    ForEach(stats, id: \.kind) { stat in
-                        Button { onPick(stat) } label: {
-                            VStack(spacing: 6) {
-                                Text(stat.value)
-                                    .font(.montserratBold(size: 26))
-                                    .foregroundStyle(.white)
-                                    .lineLimit(1)
-                                    .minimumScaleFactor(0.6)
-                                Text(stat.label)
-                                    .font(.montserratSemiBold(size: 10))
-                                    .tracking(1.5)
-                                    .foregroundStyle(Color(red: 0.706, green: 0.8, blue: 0))
-                            }
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 88)
-                            .background(
-                                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                    .fill(.white.opacity(0.05))
-                                    .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(.white.opacity(0.08), lineWidth: 1))
-                            )
-                        }
-                        .buttonStyle(.plain)
-                    }
+                if tab == .primary {
+                    primaryContent
+                } else {
+                    totalsContent
                 }
-                .padding(.horizontal, 24)
-                .padding(.bottom, 32)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    // MARK: - Tabs
+
+    private var tabPill: some View {
+        HStack(spacing: 0) {
+            tabButton(primaryLabel, tab: .primary)
+            tabButton("Totals", tab: .totals)
+        }
+        .padding(4)
+        .background(.white.opacity(0.06), in: Capsule(style: .continuous))
+        .overlay(Capsule(style: .continuous).stroke(.white.opacity(0.08), lineWidth: 1))
+    }
+
+    private func tabButton(_ label: String, tab destination: Tab) -> some View {
+        Button {
+            guard tab != destination else { return }
+            HapticsManager.shared.trigger(.lightImpact)
+            tab = destination
+        } label: {
+            Text(label)
+                .font(.montserratSemiBold(size: 14))
+                .foregroundStyle(tab == destination ? .white : .white.opacity(0.5))
+                .frame(maxWidth: .infinity)
+                .frame(height: 38)
+                .background {
+                    if tab == destination {
+                        Capsule(style: .continuous).fill(.white.opacity(0.12))
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Climb / Workout tab
+
+    private var primaryContent: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            if let climb, !imageVariants.isEmpty {
+                section("CLIMB") {
+                    HStack(spacing: 12) {
+                        ForEach(imageVariants, id: \.self) { variant in
+                            Button { onPickImage(variant) } label: {
+                                ShareClimbImageVisual(climb: climb, variant: variant)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+
+            if !climbStats.isEmpty {
+                section("STATS") { statGrid(climbStats, onTap: onPickStat) }
+            }
+
+            if !bestEffortStats.isEmpty {
+                section("BEST EFFORTS") { statGrid(bestEffortStats, onTap: onPickInjected) }
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.bottom, 32)
+    }
+
+    // MARK: - Totals tab
+
+    private var totalsContent: some View {
+        VStack(alignment: .leading, spacing: 22) {
+            if weeklyTotalStats.isEmpty {
+                Text("No workouts yet this week.\nLog a session to share your weekly totals.")
+                    .font(.montserratMedium(size: 14))
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(Color.customGray)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.top, 44)
+            } else {
+                section("THIS WEEK") { statGrid(weeklyTotalStats, onTap: onPickInjected) }
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.bottom, 32)
+    }
+
+    // MARK: - Reusable bits
+
+    private func section<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            sectionHeader(title)
+            content()
+        }
+    }
+
+    private func statGrid(_ stats: [ResolvedShareStat], onTap: @escaping (ResolvedShareStat) -> Void) -> some View {
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(stats, id: \.label) { stat in
+                Button { onTap(stat) } label: { statTile(stat) }
+                    .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func statTile(_ stat: ResolvedShareStat) -> some View {
+        VStack(spacing: 6) {
+            Text(stat.value)
+                .font(.montserratBold(size: 24))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+            Text(stat.label)
+                .font(.montserratSemiBold(size: 10))
+                .tracking(1.2)
+                .foregroundStyle(lime)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 88)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(.white.opacity(0.05))
+                .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(.white.opacity(0.08), lineWidth: 1))
+        )
+    }
+
+    private func sectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(.montserratSemiBold(size: 11))
+            .tracking(2)
+            .foregroundStyle(lime)
     }
 }
 
@@ -487,5 +833,142 @@ private struct ShareFontPickerSheet: View {
             Spacer(minLength: 0)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+}
+
+/// Sheet to arrange a stat sticker's metrics: pick a layout (row / 2×2 grid /
+/// column) and select/deselect which metrics appear. Stat *values* aren't
+/// editable here — only the arrangement and which metrics show (they're the
+/// truth). Reads/writes the live view model so the canvas updates as you toggle.
+private struct ShareStructureSheet: View {
+    let viewModel: ShareComposerViewModel
+    let stickerID: UUID
+
+    private let lime = Color(red: 0.706, green: 0.8, blue: 0)
+    private let columns = [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)]
+
+    private var sticker: ShareStickerInstance? {
+        viewModel.stickers.first { $0.id == stickerID }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text("Arrange stats")
+                .font(.montserratBold(size: 16))
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.top, 20)
+                .padding(.bottom, 16)
+
+            if let sticker {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 22) {
+                        layoutSection(current: sticker.layout)
+                        metricSection(sticker: sticker)
+                    }
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 32)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+    }
+
+    // MARK: - Layout
+
+    private func layoutSection(current: ShareStatLayout) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header("LAYOUT")
+            HStack(spacing: 12) {
+                layoutButton(.row, icon: "rectangle.split.3x1", current: current)
+                layoutButton(.grid, icon: "square.grid.2x2", current: current)
+                layoutButton(.column, icon: "rectangle.split.1x2", current: current)
+            }
+        }
+    }
+
+    private func layoutButton(_ layout: ShareStatLayout, icon: String, current: ShareStatLayout) -> some View {
+        let isOn = layout == current
+        return Button {
+            HapticsManager.shared.trigger(.lightImpact)
+            viewModel.setLayout(layout, for: stickerID)
+        } label: {
+            Image(systemName: icon)
+                .font(.system(size: 22, weight: .semibold))
+                .foregroundStyle(isOn ? .black : .white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 56)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(isOn ? lime : .white.opacity(0.06))
+                        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(.white.opacity(0.08), lineWidth: 1))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Metrics
+
+    private func metricSection(sticker: ShareStickerInstance) -> some View {
+        let palette = viewModel.paletteRefs(for: sticker)
+        let selected = Set(sticker.statRefs)
+        return VStack(alignment: .leading, spacing: 10) {
+            header("METRICS")
+            LazyVGrid(columns: columns, spacing: 12) {
+                ForEach(palette, id: \.self) { ref in
+                    let stat = viewModel.resolved(ref)
+                    metricChip(
+                        label: stat?.label ?? "",
+                        value: stat?.value ?? "",
+                        isOn: selected.contains(ref)
+                    ) {
+                        HapticsManager.shared.trigger(.lightImpact)
+                        viewModel.toggleStat(ref, for: stickerID)
+                    }
+                }
+            }
+        }
+    }
+
+    private func metricChip(label: String, value: String, isOn: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: isOn ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(isOn ? lime : .white.opacity(0.4))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(value)
+                        .font(.montserratBold(size: 16))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.6)
+                    Text(label)
+                        .font(.montserratSemiBold(size: 9))
+                        .tracking(1)
+                        .foregroundStyle(Color.customGray)
+                        .lineLimit(1)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 60)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.white.opacity(0.05))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .stroke(isOn ? lime.opacity(0.6) : .white.opacity(0.08), lineWidth: isOn ? 1.5 : 1)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func header(_ text: String) -> some View {
+        Text(text)
+            .font(.montserratSemiBold(size: 11))
+            .tracking(2)
+            .foregroundStyle(lime)
     }
 }

--- a/AscendApp/Features/ShareComposer/Views/ShareExportCanvas.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareExportCanvas.swift
@@ -8,21 +8,25 @@ struct ShareExportCanvas: View {
     let size: CGSize
     /// Poster frame substituted for a video background at export time.
     var backgroundOverride: UIImage?
+    /// When true, render only the stickers + wordmark on a transparent canvas
+    /// (used as the overlay composited onto a video).
+    var overlayOnly: Bool = false
 
     var body: some View {
         let canvasScale = size.width / 390
 
         ZStack {
-            backgroundLayer
+            if !overlayOnly {
+                Color.black
+                backgroundLayer
+            }
 
             ForEach(viewModel.stickers) { sticker in
-                if let stat = viewModel.resolve(sticker.kind) {
-                    ShareStatStickerContent(
-                        stat: stat,
-                        style: sticker.style,
-                        font: sticker.font,
-                        color: sticker.color,
-                        textBackground: sticker.textBackground
+                if sticker.isImage || !viewModel.resolvedStats(for: sticker).isEmpty {
+                    ShareStickerVisual(
+                        instance: sticker,
+                        stats: viewModel.resolvedStats(for: sticker),
+                        climb: viewModel.climb
                     )
                         .scaleEffect(sticker.scale * canvasScale)
                         .rotationEffect(.radians(sticker.rotationRadians))
@@ -45,16 +49,30 @@ struct ShareExportCanvas: View {
 
     @ViewBuilder
     private var backgroundLayer: some View {
+        // Same pan/zoom as the editing canvas (offset is a canvas fraction, so it
+        // maps to the export size). The outer ZStack clip trims any overflow.
+        let scale = viewModel.backgroundScale
+        let offX = viewModel.backgroundOffset.width * size.width
+        let offY = viewModel.backgroundOffset.height * size.height
+
         if let backgroundOverride {
             Image(uiImage: backgroundOverride)
                 .resizable()
                 .scaledToFill()
                 .frame(width: size.width, height: size.height)
-                .clipped()
+                .shareBackgroundFilter(viewModel.backgroundFilter)
+                .scaleEffect(scale)
+                .offset(x: offX, y: offY)
         } else if let background = viewModel.background {
-            ShareBackgroundView(source: background, isStatic: true)
-                .frame(width: size.width, height: size.height)
-                .clipped()
+            ShareBackgroundView(
+                source: background,
+                isStatic: true,
+                filter: viewModel.backgroundFilter,
+                processedImage: viewModel.processedBackgroundImage
+            )
+            .frame(width: size.width, height: size.height)
+            .scaleEffect(scale)
+            .offset(x: offX, y: offY)
         } else {
             Color.black
         }

--- a/AscendApp/Features/ShareComposer/Views/ShareRecapCard.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareRecapCard.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+/// A pre-designed "recap" card: the climb's hero artwork with the name and key
+/// stats laid out for the user. One source of truth, used two ways:
+///   • shown live in the Recaps tab as the tappable preview, and
+///   • rendered to a UIImage (via `ImageRenderer`) to become a baked background.
+///
+/// Scale-aware (everything derives from `width / 390`), so the small preview and
+/// the full-resolution export are visually identical. New recap styles are new
+/// card views — adding one is data/layout, not a new export path.
+struct ShareRecapCard: View {
+    let climb: Climb
+    /// Curated stats for the stat row (typically duration · steps · calories).
+    let stats: [ResolvedShareStat]
+    /// Optional headline best effort shown beneath the stat row.
+    let bestEffort: ResolvedShareStat?
+
+    private let lime = Color(red: 0.706, green: 0.8, blue: 0)
+
+    var body: some View {
+        GeometryReader { geo in
+            let s = geo.size.width / 390
+
+            ZStack {
+                ClimbArtworkView(climb: climb, variant: .hero)
+
+                LinearGradient(
+                    colors: [.black.opacity(0.2), .clear, .black.opacity(0.78)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+
+                VStack(spacing: 0) {
+                    Spacer()
+
+                    Text(climb.name)
+                        .font(.montserratBold(size: 30 * s))
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.5)
+                        .padding(.horizontal, 24 * s)
+
+                    Text("CLIMB")
+                        .font(.montserratSemiBold(size: 11 * s))
+                        .tracking(3 * s)
+                        .foregroundStyle(lime)
+                        .padding(.top, 6 * s)
+
+                    HStack(alignment: .top, spacing: 26 * s) {
+                        ForEach(stats.prefix(3), id: \.label) { stat in
+                            statCell(stat, scale: s)
+                        }
+                    }
+                    .padding(.top, 26 * s)
+
+                    if let bestEffort {
+                        VStack(spacing: 2 * s) {
+                            Text(bestEffort.value)
+                                .font(.montserratBold(size: 34 * s))
+                                .foregroundStyle(.white)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.6)
+                            Text(bestEffort.label)
+                                .font(.montserratSemiBold(size: 11 * s))
+                                .tracking(2 * s)
+                                .foregroundStyle(lime)
+                        }
+                        .padding(.top, 30 * s)
+                    }
+
+                    Spacer()
+                }
+                .padding(.bottom, 70 * s)
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+            .clipped()
+        }
+    }
+
+    private func statCell(_ stat: ResolvedShareStat, scale s: CGFloat) -> some View {
+        VStack(spacing: 2 * s) {
+            Text(stat.value)
+                .font(.montserratBold(size: 22 * s))
+                .foregroundStyle(.white)
+                .lineLimit(1)
+                .minimumScaleFactor(0.6)
+            Text(stat.label)
+                .font(.montserratSemiBold(size: 9 * s))
+                .tracking(1 * s)
+                .foregroundStyle(lime)
+        }
+    }
+}

--- a/AscendApp/Features/ShareComposer/Views/ShareStatStickerContent.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareStatStickerContent.swift
@@ -92,6 +92,92 @@ struct ShareStatStickerContent: View {
     }
 }
 
+/// Renders several resolved stats as one composite block in a chosen layout
+/// (row / 2×2 grid / vertical column). Each cell is a small label-over-value
+/// pair so multiple metrics read cleanly together.
+struct ShareCompositeStatContent: View {
+    let stats: [ResolvedShareStat]
+    var layout: ShareStatLayout = .row
+    var font: ShareStickerFont = .montserrat
+    var color: RGBAColor = .white
+    var textBackground: ShareTextBackground = .none
+    /// Intrinsic size; the canvas/exporter scales the whole sticker via `.scaleEffect`.
+    var baseValueSize: CGFloat = 30
+
+    private let lime = Color(red: 0.706, green: 0.8, blue: 0)
+    private var valueColor: Color { color.color }
+    private var labelColor: Color { color.isWhite ? lime : color.color }
+
+    var body: some View {
+        arrangement
+            .shadow(color: .black.opacity(textBackground == .none ? 0.45 : 0), radius: 6, x: 0, y: 2)
+            .padding(plateInsets)
+            .background(plate)
+            .fixedSize()
+    }
+
+    @ViewBuilder
+    private var arrangement: some View {
+        switch layout {
+        case .row:
+            HStack(alignment: .center, spacing: baseValueSize * 0.6) {
+                ForEach(Array(stats.enumerated()), id: \.offset) { cell($0.element) }
+            }
+        case .column:
+            VStack(spacing: baseValueSize * 0.34) {
+                ForEach(Array(stats.enumerated()), id: \.offset) { cell($0.element) }
+            }
+        case .grid:
+            let rows = stride(from: 0, to: stats.count, by: 2).map { start in
+                Array(stats[start..<min(start + 2, stats.count)])
+            }
+            VStack(spacing: baseValueSize * 0.38) {
+                ForEach(Array(rows.enumerated()), id: \.offset) { _, pair in
+                    HStack(alignment: .center, spacing: baseValueSize * 0.6) {
+                        ForEach(Array(pair.enumerated()), id: \.offset) { cell($0.element) }
+                    }
+                }
+            }
+        }
+    }
+
+    private func cell(_ stat: ResolvedShareStat) -> some View {
+        VStack(spacing: 1) {
+            Text(stat.label)
+                .font(font.swiftUIFont(size: baseValueSize * 0.34))
+                .tracking(1.3)
+                .foregroundStyle(labelColor.opacity(0.9))
+            Text(stat.value)
+                .font(font.swiftUIFont(size: baseValueSize * 0.92))
+                .foregroundStyle(valueColor)
+        }
+    }
+
+    private var plateInsets: EdgeInsets {
+        switch textBackground {
+        case .none:
+            return EdgeInsets()
+        default:
+            return EdgeInsets(top: baseValueSize * 0.45, leading: baseValueSize * 0.55,
+                              bottom: baseValueSize * 0.45, trailing: baseValueSize * 0.55)
+        }
+    }
+
+    @ViewBuilder
+    private var plate: some View {
+        switch textBackground {
+        case .none:
+            EmptyView()
+        case .dark:
+            RoundedRectangle(cornerRadius: baseValueSize * 0.3, style: .continuous)
+                .fill(.black.opacity(0.6))
+        case .grey:
+            RoundedRectangle(cornerRadius: baseValueSize * 0.3, style: .continuous)
+                .fill(.white.opacity(0.18))
+        }
+    }
+}
+
 #Preview {
     ZStack {
         Color.gray
@@ -99,6 +185,14 @@ struct ShareStatStickerContent: View {
             ShareStatStickerContent(stat: .init(kind: .steps, label: "STEPS", value: "2,096"), style: .display, font: .anton)
             ShareStatStickerContent(stat: .init(kind: .duration, label: "DURATION", value: "22:10"), style: .display, font: .playfair, color: .white, textBackground: .dark)
             ShareStatStickerContent(stat: .init(kind: .calories, label: "CAL", value: "317"), style: .chip, font: .spaceMono, color: RGBAColor(r: 0.95, g: 0.26, b: 0.21, a: 1))
+            ShareCompositeStatContent(
+                stats: [
+                    .init(kind: .duration, label: "TIME", value: "20m 17s"),
+                    .init(kind: .avgHeartRate, label: "AVG BPM", value: "131"),
+                    .init(kind: .calories, label: "CAL", value: "255")
+                ],
+                layout: .row, font: .playfair
+            )
         }
     }
     .preferredColorScheme(.dark)

--- a/AscendApp/Features/ShareComposer/Views/ShareStickerStyleResolvers.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareStickerStyleResolvers.swift
@@ -24,6 +24,34 @@ extension ShareStickerFont {
     }
 }
 
+extension View {
+    /// Applies a background filter's color grade. Resolution-independent
+    /// adjustments only, so the editing canvas and the export render identically.
+    @ViewBuilder
+    func shareBackgroundFilter(_ filter: ShareBackgroundFilter) -> some View {
+        switch filter {
+        case .original:
+            self
+        case .mono:
+            grayscale(1).contrast(1.05)
+        case .noir:
+            grayscale(1).contrast(1.4).brightness(-0.06)
+        case .vivid:
+            saturation(1.55).contrast(1.08)
+        case .fade:
+            saturation(0.72).contrast(0.88).brightness(0.07)
+        case .warm:
+            colorMultiply(Color(red: 1.0, green: 0.9, blue: 0.78)).saturation(1.1)
+        case .cool:
+            colorMultiply(Color(red: 0.82, green: 0.9, blue: 1.0)).saturation(1.05)
+        case .zoomBlur, .motionBlur, .fisheye:
+            // Geometric filters are baked into a processed image via Core Image;
+            // no color adjustment here.
+            self
+        }
+    }
+}
+
 extension RGBAColor {
     var color: Color {
         Color(.sRGB, red: r, green: g, blue: b, opacity: a)

--- a/AscendApp/Features/ShareComposer/Views/ShareStickerView.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareStickerView.swift
@@ -8,12 +8,17 @@ import SwiftUI
 /// the canvas via closures so this view stays focused on one sticker.
 struct ShareStickerView: View {
     @Binding var instance: ShareStickerInstance
-    let stat: ResolvedShareStat
+    /// Resolved metrics (one for a single sticker, several for a composite).
+    let stats: [ResolvedShareStat]
+    let climb: Climb?
     let canvasSize: CGSize
     /// Proportional scale (canvasWidth / reference 390) so stickers render at the
     /// same relative size in the editing canvas and the high-res export.
     var canvasScale: CGFloat = 1
     let isSelected: Bool
+    /// True while this sticker is being dragged over the trash zone — it shrinks
+    /// to preview deletion, then springs back if dragged out.
+    var isOverTrash: Bool = false
 
     let onSelect: () -> Void
     /// Live canvas-space center during a drag (for trash-hover + guide feedback).
@@ -26,6 +31,12 @@ struct ShareStickerView: View {
     @GestureState private var dragTranslation: CGSize = .zero
     @GestureState private var gestureScale: CGFloat = 1
     @GestureState private var gestureRotation: Angle = .zero
+    /// Tracks whether rotation is currently inside a 90° snap zone, so the snap
+    /// haptic fires once on entry rather than every frame.
+    @State private var rotationSnapped = false
+
+    /// Capture window around each 90° multiple where rotation snaps (≈5°).
+    private let rotationSnapThreshold = Double.pi / 36
 
     private var baseCenter: CGPoint {
         CGPoint(x: instance.position.x * canvasSize.width,
@@ -38,20 +49,32 @@ struct ShareStickerView: View {
         // Live magnetic snap: the sticker glues to the active guide line while
         // dragging (not just on release), giving the "sticky" feel.
         let displayCenter = snapCenter(rawCenter)
+        // Live rotation snap to 0/90/180/270 so the user can feel alignment.
+        let displayRotation = snappedAngle(instance.rotationRadians + gestureRotation.radians)
 
-        ShareStatStickerContent(
-            stat: stat,
-            style: instance.style,
-            font: instance.font,
-            color: instance.color,
-            textBackground: instance.textBackground
-        )
+        ShareStickerVisual(instance: instance, stats: stats, climb: climb)
             .padding(10)
-            .scaleEffect(instance.scale * gestureScale * canvasScale)
-            .rotationEffect(.radians(instance.rotationRadians) + gestureRotation)
+            .scaleEffect(instance.scale * gestureScale * canvasScale * (isOverTrash ? 0.35 : 1))
+            .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isOverTrash)
+            .rotationEffect(.radians(displayRotation))
             .position(displayCenter)
             .gesture(combinedGesture)
             .onTapGesture { onSelect() }
+    }
+
+    // MARK: - Rotation snapping
+
+    /// Nearest 90° multiple if within the snap threshold, else the raw angle.
+    private func snappedAngle(_ radians: Double) -> Double {
+        let quarter = Double.pi / 2
+        let nearest = (radians / quarter).rounded() * quarter
+        return abs(radians - nearest) <= rotationSnapThreshold ? nearest : radians
+    }
+
+    private func isNearRotationSnap(_ radians: Double) -> Bool {
+        let quarter = Double.pi / 2
+        let nearest = (radians / quarter).rounded() * quarter
+        return abs(radians - nearest) <= rotationSnapThreshold
     }
 
     private var combinedGesture: some Gesture {
@@ -81,8 +104,17 @@ struct ShareStickerView: View {
 
         let rotate = RotateGesture()
             .updating($gestureRotation) { value, state, _ in state = value.rotation }
-            .onChanged { _ in onSelect() }
-            .onEnded { value in instance.rotationRadians += value.rotation.radians }
+            .onChanged { value in
+                onSelect()
+                let live = instance.rotationRadians + value.rotation.radians
+                let near = isNearRotationSnap(live)
+                if near && !rotationSnapped { HapticsManager.shared.trigger(.lightImpact) }
+                rotationSnapped = near
+            }
+            .onEnded { value in
+                rotationSnapped = false
+                instance.rotationRadians = snappedAngle(instance.rotationRadians + value.rotation.radians)
+            }
 
         return drag.simultaneously(with: magnify).simultaneously(with: rotate)
     }

--- a/AscendApp/Features/ShareComposer/Views/ShareStickerVisual.swift
+++ b/AscendApp/Features/ShareComposer/Views/ShareStickerVisual.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// The visual content of a sticker — either a stat (text) or the climb's
+/// artwork (image). Shared by the editing canvas and the export renderer so
+/// both produce identical output.
+struct ShareStickerVisual: View {
+    let instance: ShareStickerInstance
+    /// Resolved metrics for text stickers (empty for image stickers; more than
+    /// one for a composite sticker).
+    let stats: [ResolvedShareStat]
+    /// Climb for image stickers (nil for stat stickers).
+    let climb: Climb?
+
+    var body: some View {
+        if let variant = instance.climbImageVariant, let climb {
+            ShareClimbImageVisual(climb: climb, variant: variant)
+        } else if stats.count > 1 {
+            ShareCompositeStatContent(
+                stats: stats,
+                layout: instance.layout,
+                font: instance.font,
+                color: instance.color,
+                textBackground: instance.textBackground
+            )
+        } else if let stat = stats.first {
+            ShareStatStickerContent(
+                stat: stat,
+                style: instance.style,
+                font: instance.font,
+                color: instance.color,
+                textBackground: instance.textBackground
+            )
+        }
+    }
+}
+
+/// A climb's artwork rendered at sticker scale with rounded corners.
+struct ShareClimbImageVisual: View {
+    let climb: Climb
+    let variant: ClimbImageVariant
+
+    private var size: CGSize {
+        switch variant {
+        case .hero: return CGSize(width: 190, height: 120)
+        case .card: return CGSize(width: 120, height: 165)
+        case .thumb: return CGSize(width: 96, height: 128)
+        }
+    }
+
+    var body: some View {
+        ClimbArtworkView(climb: climb, variant: variant)
+            .frame(width: size.width, height: size.height)
+            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(.white.opacity(0.25), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.4), radius: 8, x: 0, y: 3)
+            .fixedSize()
+    }
+}

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -75,7 +75,7 @@ struct WorkoutDetailView: View {
                 .interactiveDismissDisabled()
             }
             .fullScreenCover(isPresented: $showingShareWorkoutView) {
-                ShareComposerView(workout: workout)
+                ShareComposerView(workout: workout, climb: liveClimbDetailClimb)
             }
             .fullScreenCover(isPresented: $showingLiveClimbSummaryPreview) {
                 if liveClimbSummaryMetadata?.climbId == nil || liveClimbDetailClimb != nil {

--- a/AscendApp/Info.plist
+++ b/AscendApp/Info.plist
@@ -12,6 +12,8 @@
 	<string>$(ASCEND_SUPERWALL_API_KEY)</string>
 	<key>AscendSuperwallTestMode</key>
 	<string>$(ASCEND_SUPERWALL_TEST_MODE)</string>
+	<key>AscendMixpanelToken</key>
+	<string>$(ASCEND_MIXPANEL_TOKEN)</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/AscendApp/PrivacyInfo.xcprivacy
+++ b/AscendApp/PrivacyInfo.xcprivacy
@@ -42,10 +42,10 @@
     <!-- ============================================================ -->
     <!--
       Ascend does not perform cross-app or cross-site tracking as defined by
-      App Tracking Transparency. Firebase Analytics is enabled in
-      Release/TestFlight builds but is configured without IDFA collection
-      (IS_ADS_ENABLED=false) and is used only for first-party app telemetry.
-      No ad networks are integrated.
+      App Tracking Transparency. Firebase Analytics and Mixpanel are enabled in
+      Release/TestFlight builds for first-party app telemetry. Firebase is
+      configured without IDFA collection (IS_ADS_ENABLED=false), Mixpanel does
+      not use IDFA by default, and no ad networks are integrated.
     -->
     <key>NSPrivacyTracking</key>
     <false/>
@@ -169,7 +169,7 @@
             </array>
         </dict>
 
-        <!-- Product Interaction — first-party telemetry breadcrumbs (Release/TestFlight only) -->
+        <!-- Product Interaction — first-party telemetry via Firebase Analytics and Mixpanel (Release/TestFlight only) -->
         <dict>
             <key>NSPrivacyCollectedDataType</key>
             <string>NSPrivacyCollectedDataTypeProductInteraction</string>

--- a/AscendApp/Shared/Managers/TelemetryManager.swift
+++ b/AscendApp/Shared/Managers/TelemetryManager.swift
@@ -35,6 +35,7 @@ final class TelemetryManager: @unchecked Sendable {
         } else {
             var defaultSinks: [any TelemetrySink] = [
                 FirebaseTelemetrySink(),
+                MixpanelTelemetrySink(),
                 CrashlyticsBreadcrumbSink(reporter: reporter)
             ]
 

--- a/AscendApp/Shared/Services/Telemetry/AnalyticsConfiguration.swift
+++ b/AscendApp/Shared/Services/Telemetry/AnalyticsConfiguration.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct AnalyticsConfiguration: Equatable {
+    static let live = AnalyticsConfiguration()
+
+    static let mixpanelTokenInfoKey = "AscendMixpanelToken"
+
+    let mixpanelToken: String?
+
+    var canConfigureMixpanel: Bool {
+        mixpanelToken != nil
+    }
+
+    init(infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:]) {
+        mixpanelToken = Self.normalizedToken(infoDictionary[Self.mixpanelTokenInfoKey])
+    }
+
+    private static func normalizedToken(_ value: Any?) -> String? {
+        guard let rawValue = value as? String else { return nil }
+
+        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty, !trimmedValue.hasPrefix("$(") else {
+            return nil
+        }
+
+        return trimmedValue
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/MixpanelTelemetrySink.swift
+++ b/AscendApp/Shared/Services/Telemetry/MixpanelTelemetrySink.swift
@@ -1,0 +1,93 @@
+import Foundation
+@preconcurrency import Mixpanel
+
+final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
+    let supportedDestinations: Set<TelemetryDestination> = [.analytics]
+
+    private let configuration: AnalyticsConfiguration
+    private let lock = NSLock()
+    private var instance: MixpanelInstance?
+
+    init(configuration: AnalyticsConfiguration = .live) {
+        self.configuration = configuration
+    }
+
+    func setCollectionEnabled(_ enabled: Bool) {
+        guard let instance = configuredInstance() else { return }
+
+        if enabled {
+            instance.optInTracking()
+        } else {
+            instance.optOutTracking()
+        }
+    }
+
+    func setUserID(_ userID: String?) {
+        guard let instance = configuredInstance() else { return }
+
+        if let userID {
+            instance.identify(distinctId: userID, usePeople: false)
+        } else {
+            instance.reset()
+        }
+    }
+
+    func record(_ record: TelemetryRecord) {
+        configuredInstance()?.track(
+            event: record.name,
+            properties: record.parameters.mixpanelProperties
+        )
+    }
+
+    func record(screen: TelemetryScreen) {
+        var properties = screen.parameters.mixpanelProperties
+        properties["screen_name"] = screen.name
+        properties["screen_class"] = screen.screenClass
+
+        configuredInstance()?.track(
+            event: "screen_view",
+            properties: properties
+        )
+    }
+
+    private func configuredInstance() -> MixpanelInstance? {
+        guard let token = configuration.mixpanelToken else { return nil }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        if let instance {
+            return instance
+        }
+
+        let instance = Mixpanel.initialize(
+            token: token,
+            trackAutomaticEvents: false
+        )
+        self.instance = instance
+        return instance
+    }
+}
+
+private extension Dictionary where Key == String, Value == TelemetryValue {
+    var mixpanelProperties: Properties {
+        reduce(into: Properties()) { partialResult, entry in
+            partialResult[entry.key] = entry.value.mixpanelValue
+        }
+    }
+}
+
+private extension TelemetryValue {
+    var mixpanelValue: MixpanelType {
+        switch self {
+        case .string(let value):
+            value
+        case .int(let value):
+            value
+        case .double(let value):
+            value
+        case .bool(let value):
+            value
+        }
+    }
+}

--- a/AscendAppTests/AnalyticsConfigurationTests.swift
+++ b/AscendAppTests/AnalyticsConfigurationTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import AscendApp
+
+struct AnalyticsConfigurationTests {
+    @Test
+    func mixpanelTokenIgnoresUnexpandedBuildSettingPlaceholder() {
+        let configuration = AnalyticsConfiguration(
+            infoDictionary: [
+                AnalyticsConfiguration.mixpanelTokenInfoKey: "$(ASCEND_MIXPANEL_TOKEN)"
+            ]
+        )
+
+        #expect(configuration.mixpanelToken == nil)
+        #expect(!configuration.canConfigureMixpanel)
+    }
+
+    @Test
+    func mixpanelTokenTrimsConfiguredValue() {
+        let configuration = AnalyticsConfiguration(
+            infoDictionary: [
+                AnalyticsConfiguration.mixpanelTokenInfoKey: " token-123 "
+            ]
+        )
+
+        #expect(configuration.mixpanelToken == "token-123")
+        #expect(configuration.canConfigureMixpanel)
+    }
+}

--- a/AscendAppTests/OnboardingAnalyticsEventTests.swift
+++ b/AscendAppTests/OnboardingAnalyticsEventTests.swift
@@ -1,0 +1,45 @@
+import Testing
+@testable import AscendApp
+
+struct OnboardingAnalyticsEventTests {
+    @Test
+    func stepViewedIncludesStableFunnelContext() {
+        let context = OnboardingAnalyticsContext(
+            flowID: "post_auth_onboarding",
+            stepID: "experience",
+            stepIndex: 1,
+            stepCount: 5
+        )
+
+        let record = OnboardingAnalyticsEvent.stepViewed(context: context).record
+
+        #expect(record.name == "onboarding_step_viewed")
+        #expect(record.parameters["flow_id"] == .string("post_auth_onboarding"))
+        #expect(record.parameters["flow_version"] == .string("v1"))
+        #expect(record.parameters["step_id"] == .string("experience"))
+        #expect(record.parameters["step_index"] == .int(1))
+        #expect(record.parameters["step_count"] == .int(5))
+    }
+
+    @Test
+    func answerSelectedUsesStableQuestionAndAnswerIDs() {
+        let context = OnboardingAnalyticsContext(
+            flowID: "post_auth_onboarding",
+            stepID: "experience",
+            stepIndex: 1,
+            stepCount: 5
+        )
+
+        let record = OnboardingAnalyticsEvent.answerSelected(
+            context: context,
+            questionID: "stair_stepper_experience",
+            answerID: "regular_stepper",
+            answerIndex: 2
+        ).record
+
+        #expect(record.name == "onboarding_answer_selected")
+        #expect(record.parameters["question_id"] == .string("stair_stepper_experience"))
+        #expect(record.parameters["answer_id"] == .string("regular_stepper"))
+        #expect(record.parameters["answer_index"] == .int(2))
+    }
+}

--- a/AscendAppTests/PostAuthOnboardingCoordinatorTests.swift
+++ b/AscendAppTests/PostAuthOnboardingCoordinatorTests.swift
@@ -9,6 +9,8 @@ struct PostAuthOnboardingCoordinatorTests {
             .displayName
         ])
         #expect(PostAuthOnboardingStage.first == .displayName)
+        #expect(PostAuthOnboardingStage.flowID == "post_auth_onboarding")
+        #expect(PostAuthOnboardingStage.plannedStepCount == 5)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary
- Adds the current share composer/export iteration, including filters, recap card rendering, sticker visuals, and photo-library/export support updates.
- Adds Mixpanel as a telemetry sink behind the existing telemetry facade, plus typed onboarding funnel events and tests.
- Includes the current climb flyover/detail, profile collection, and workout-detail follow-up changes so the branch is a clean checkpoint.

## Verification
- `git diff --check`
- `xcodebuild -project AscendApp.xcodeproj -scheme AscendApp -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project AscendApp.xcodeproj -scheme AscendApp-Staging -configuration Staging -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/AscendAppMixpanelBuild ENABLE_TESTABILITY=YES build-for-testing`

## Notes
- Mixpanel is configured through the `ASCEND_MIXPANEL_TOKEN` build setting. If that value is unset or still a placeholder, the Mixpanel sink no-ops.
