### PR TITLE
[codex] Simplify live climb headphone interruptions

### DIFF
--- a/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
@@ -203,6 +203,15 @@ final class LiveClimbSessionViewModel {
         phase == .recording && motionSession.status.isRecording
     }
 
+    var shouldShowRankedCompletionSummary: Bool {
+        guard case .saved(.completed) = phase else { return false }
+        return true
+    }
+
+    var shouldShowTrackingRecoveryStatus: Bool {
+        phase == .recording && motionSession.trackingIntegrity.shouldShowRecoveryStatus
+    }
+
     var isBusy: Bool {
         phase == .saving
     }
@@ -474,7 +483,8 @@ final class LiveClimbSessionViewModel {
             targetStepCount: targetRemainingSteps,
             climbTargetStepCount: mode.targetStepCount,
             stopReason: result.stopReason,
-            splitCurve: splitCurve
+            splitCurve: splitCurve,
+            trackingIntegrity: result.trackingIntegrity
         )
 
         let workout = Workout(

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -1317,7 +1317,7 @@ struct ClimbDetailView: View {
     }
 
     private var isPrimaryActionEnabled: Bool {
-        viewModel.isActionEnabled && headphoneMotionService.readiness.canStartLiveClimb
+        viewModel.isActionEnabled
     }
 
     private var liveClimbHeadphoneHelpSheet: some View {
@@ -1422,7 +1422,7 @@ struct ClimbDetailView: View {
                     reason: .headphonesUnavailable
                 )
             )
-            actionErrorMessage = "Live climb attempts require compatible headphones."
+            actionErrorMessage = "Connect compatible headphones to start this live climb."
             return
         }
 

--- a/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
+++ b/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
@@ -10,6 +10,10 @@ struct LiveClimbSessionView: View {
     @State private var showingDiscardConfirmation = false
     @State private var countdownValue = 3
     @State private var hasStartedRecording = false
+    @State private var countdownRunID = 0
+    @State private var showingHeadphoneRequirement = false
+    @State private var headphoneMotionService = HeadphoneMotionReadinessService.shared
+    @State private var didTrackHeadphoneRequirement = false
 
     private let liveTick = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -29,7 +33,7 @@ struct LiveClimbSessionView: View {
                 .ignoresSafeArea()
 
             if let savedWorkout = viewModel.savedWorkout,
-               viewModel.phase == .saved(.completed) {
+               viewModel.shouldShowRankedCompletionSummary {
                 LiveClimbCompletionSummaryView(
                     climb: viewModel.mode.climb,
                     workout: savedWorkout,
@@ -44,6 +48,11 @@ struct LiveClimbSessionView: View {
                 if !hasStartedRecording && viewModel.phase == .idle {
                     LiveSessionCountdownOverlay(value: countdownValue)
                 }
+
+                if showingHeadphoneRequirement {
+                    headphoneRequiredOverlay
+                }
+
             }
         }
         .preferredColorScheme(.dark)
@@ -54,7 +63,7 @@ struct LiveClimbSessionView: View {
         .onDisappear {
             LiveClimbActivityCommandCenter.shared.unregister()
         }
-        .task {
+        .task(id: countdownRunID) {
             await runCountdownThenStart()
         }
         .onChange(of: viewModel.motionSession.targetReached) { _, reached in
@@ -94,6 +103,10 @@ struct LiveClimbSessionView: View {
     private var sessionContent: some View {
         VStack(spacing: 0) {
             topChrome
+
+            trackingStatusBanner
+                .padding(.horizontal, 20)
+                .padding(.top, 10)
 
             liveLeaderboardSection
                 .frame(maxHeight: .infinity)
@@ -174,6 +187,40 @@ struct LiveClimbSessionView: View {
             tint: .accent,
             effectiveColorScheme: .dark
         )
+    }
+
+    @ViewBuilder
+    private var trackingStatusBanner: some View {
+        if viewModel.shouldShowTrackingRecoveryStatus {
+            trackingBanner(
+                iconName: "airpodspro",
+                message: "Headphone tracking paused. Reconnect to keep counting steps."
+            )
+        }
+    }
+
+    private func trackingBanner(iconName: String, message: String) -> some View {
+        HStack(spacing: 9) {
+            Image(systemName: iconName)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(.accent)
+
+            Text(message)
+                .font(.montserratSemiBold(size: 12))
+                .foregroundStyle(.white.opacity(0.82))
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(.white.opacity(0.09))
+        )
+        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder
@@ -281,9 +328,25 @@ struct LiveClimbSessionView: View {
     }
 
     private func runCountdownThenStart() async {
-        guard !hasStartedRecording else { return }
+        guard !hasStartedRecording,
+              viewModel.phase == .idle else { return }
+
+        countdownValue = 3
+        headphoneMotionService.refresh()
+        guard headphoneMotionService.readiness.canStartLiveClimb else {
+            showHeadphoneRequirement()
+            return
+        }
+
+        showingHeadphoneRequirement = false
 
         for value in stride(from: 3, through: 1, by: -1) {
+            headphoneMotionService.refresh()
+            guard headphoneMotionService.readiness.canStartLiveClimb else {
+                showHeadphoneRequirement()
+                return
+            }
+
             countdownValue = value
             HapticsManager.shared.trigger(value == 1 ? .heavyImpact : .mediumImpact)
 
@@ -292,11 +355,51 @@ struct LiveClimbSessionView: View {
             } catch {
                 return
             }
+
+            headphoneMotionService.refresh()
+            guard headphoneMotionService.readiness.canStartLiveClimb else {
+                showHeadphoneRequirement()
+                return
+            }
+        }
+
+        headphoneMotionService.refresh()
+        guard headphoneMotionService.readiness.canStartLiveClimb else {
+            showHeadphoneRequirement()
+            return
         }
 
         hasStartedRecording = true
         viewModel.start(modelContext: modelContext)
         await viewModel.refreshReplayLeaderboardIfNeeded(force: true)
+    }
+
+    private func showHeadphoneRequirement() {
+        countdownValue = 3
+        showingHeadphoneRequirement = true
+
+        guard !didTrackHeadphoneRequirement else { return }
+        didTrackHeadphoneRequirement = true
+        TelemetryManager.shared.track(
+            LiveClimbAnalyticsEvent.detailStartBlocked(
+                climb: viewModel.mode.climb,
+                entryPoint: viewModel.analyticsEntryPoint,
+                reason: .headphonesUnavailable
+            )
+        )
+    }
+
+    private func retryHeadphoneCountdown() {
+        headphoneMotionService.refresh()
+        guard headphoneMotionService.readiness.canStartLiveClimb else {
+            showingHeadphoneRequirement = true
+            return
+        }
+
+        showingHeadphoneRequirement = false
+        didTrackHeadphoneRequirement = false
+        countdownValue = 3
+        countdownRunID += 1
     }
 
     private func registerLiveActivityControls() {
@@ -326,6 +429,80 @@ struct LiveClimbSessionView: View {
         case .abandoned:
             return "Attempt Ended"
         }
+    }
+
+    private var headphoneRequiredOverlay: some View {
+        liveClimbFullScreenOverlay(
+            iconName: "airpodspro",
+            title: "Headphones required",
+            message: "Connect compatible headphones to start this live climb.",
+            primaryTitle: "Try Again",
+            primaryAction: retryHeadphoneCountdown,
+            secondaryTitle: "Close",
+            secondaryAction: { dismiss() }
+        )
+    }
+
+    private func liveClimbFullScreenOverlay(
+        iconName: String,
+        title: String,
+        message: String,
+        primaryTitle: String,
+        primaryAction: @escaping () -> Void,
+        secondaryTitle: String,
+        secondaryAction: @escaping () -> Void
+    ) -> some View {
+        ZStack {
+            Color.black
+                .opacity(0.96)
+                .ignoresSafeArea()
+
+            VStack(spacing: 22) {
+                Image(systemName: iconName)
+                    .font(.system(size: 42, weight: .semibold))
+                    .foregroundStyle(.accent)
+                    .frame(width: 72, height: 72)
+                    .background(
+                        Circle()
+                            .fill(.white.opacity(0.08))
+                    )
+
+                VStack(spacing: 10) {
+                    Text(title)
+                        .font(.montserratBold(size: 28))
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+
+                    Text(message)
+                        .font(.montserratMedium(size: 15))
+                        .foregroundStyle(.white.opacity(0.68))
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(spacing: 10) {
+                    liveSessionButton(title: primaryTitle, action: primaryAction)
+
+                    Button(action: secondaryAction) {
+                        Text(secondaryTitle)
+                            .font(.montserratBold(size: 14))
+                            .foregroundStyle(.white.opacity(0.82))
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 42)
+                            .background(
+                                Capsule()
+                                    .fill(.white.opacity(0.10))
+                            )
+                            .contentShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.top, 2)
+            }
+            .padding(.horizontal, 30)
+            .frame(maxWidth: 420)
+        }
+        .accessibilityElement(children: .contain)
     }
 }
 

--- a/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionSessionResult.swift
+++ b/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionSessionResult.swift
@@ -18,6 +18,25 @@ struct HeadphoneMotionSessionResult: Equatable, Sendable {
     let steps: Int
     let sampleCount: Int
     let stopReason: HeadphoneMotionSessionStopReason
+    let trackingIntegrity: HeadphoneMotionTrackingIntegrity
+
+    init(
+        startedAt: Date,
+        endedAt: Date,
+        duration: TimeInterval,
+        steps: Int,
+        sampleCount: Int,
+        stopReason: HeadphoneMotionSessionStopReason,
+        trackingIntegrity: HeadphoneMotionTrackingIntegrity = .verified
+    ) {
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.duration = duration
+        self.steps = steps
+        self.sampleCount = sampleCount
+        self.stopReason = stopReason
+        self.trackingIntegrity = trackingIntegrity
+    }
 
     var hasRecordedSteps: Bool {
         steps > 0
@@ -36,6 +55,9 @@ struct HeadphoneMotionWorkoutMetadata: Codable, Equatable, Sendable {
     let stopReason: HeadphoneMotionSessionStopReason
     let splitIntervalSeconds: Int?
     let splitSteps: [Int]?
+    let trackingUnavailableDurationSeconds: TimeInterval?
+    let longestTrackingUnavailableDurationSeconds: TimeInterval?
+    let trackingInterruptionCount: Int?
 
     init(
         sampleCount: Int,
@@ -44,7 +66,8 @@ struct HeadphoneMotionWorkoutMetadata: Codable, Equatable, Sendable {
         targetStepCount: Int?,
         climbTargetStepCount: Int? = nil,
         stopReason: HeadphoneMotionSessionStopReason,
-        splitCurve: LiveReplaySplitCurve? = nil
+        splitCurve: LiveReplaySplitCurve? = nil,
+        trackingIntegrity: HeadphoneMotionTrackingIntegrity = .verified
     ) {
         self.source = "headphone_motion"
         self.algorithmVersion = HeadphoneMotionStepDetector.algorithmVersion
@@ -57,6 +80,9 @@ struct HeadphoneMotionWorkoutMetadata: Codable, Equatable, Sendable {
         self.stopReason = stopReason
         self.splitIntervalSeconds = splitCurve?.intervalSeconds
         self.splitSteps = splitCurve?.steps
+        self.trackingUnavailableDurationSeconds = trackingIntegrity.totalUnavailableDuration
+        self.longestTrackingUnavailableDurationSeconds = trackingIntegrity.longestUnavailableDuration
+        self.trackingInterruptionCount = trackingIntegrity.interruptionCount
     }
 
     var jsonString: String? {

--- a/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionSessionService.swift
+++ b/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionSessionService.swift
@@ -64,6 +64,10 @@ final class HeadphoneMotionSessionService {
     private var pauseStartedAt: Date?
     private var lastMotionUpdateAt: Date?
     private var lastMotionRecoveryAttemptAt: Date?
+    private var trackingUnavailableStartedAt: Date?
+    private var accumulatedTrackingUnavailableDuration: TimeInterval = 0
+    private var longestTrackingUnavailableDuration: TimeInterval = 0
+    private var trackingInterruptionCount = 0
 
     private(set) var isDeviceMotionAvailable = false
     private(set) var isConnected = false
@@ -73,6 +77,7 @@ final class HeadphoneMotionSessionService {
     private(set) var duration: TimeInterval = 0
     private(set) var currentAcceleration: HeadphoneMotionVector = .zero
     private(set) var targetReached = false
+    private(set) var trackingIntegrity: HeadphoneMotionTrackingIntegrity = .verified
     private var onStepSample: ((LiveClimbStepSample) -> Void)?
 
     init(motionManager: CMHeadphoneMotionManager = CMHeadphoneMotionManager()) {
@@ -130,6 +135,7 @@ final class HeadphoneMotionSessionService {
         pauseStartedAt = nil
         lastMotionUpdateAt = nil
         lastMotionRecoveryAttemptAt = nil
+        resetTrackingIntegrity()
         runner?.startRecording(startedAt: startedAt)
 
         startDurationTimer()
@@ -145,6 +151,7 @@ final class HeadphoneMotionSessionService {
         duration = activeDuration(at: pausedAt)
         pauseStartedAt = pausedAt
         lastMotionUpdateAt = nil
+        markTrackingAvailable(at: pausedAt)
         status = .paused
         durationTimer?.invalidate()
         durationTimer = nil
@@ -165,6 +172,9 @@ final class HeadphoneMotionSessionService {
         lastMotionUpdateAt = nil
         lastMotionRecoveryAttemptAt = nil
         status = isConnected ? .recording : .waitingForMotion
+        if status == .waitingForMotion {
+            markTrackingUnavailable(at: resumedAt)
+        }
         runner?.resumeRecording(resumedAt: resumedAt)
         startDurationTimer()
     }
@@ -176,6 +186,10 @@ final class HeadphoneMotionSessionService {
             throw HeadphoneMotionSessionError.notRecording
         }
 
+        let stoppedAt = Date()
+        refreshTrackingIntegrity(at: stoppedAt)
+        let finalTrackingIntegrity = trackingIntegrity
+
         status = .stopping
         durationTimer?.invalidate()
         durationTimer = nil
@@ -185,7 +199,7 @@ final class HeadphoneMotionSessionService {
                 throw HeadphoneMotionSessionError.notRecording
             }
 
-            let result = try await withCheckedThrowingContinuation { continuation in
+            let sessionResult = try await withCheckedThrowingContinuation { continuation in
                 runner.stopRecording(reason: reason) { result in
                     switch result {
                     case .success(let sessionResult):
@@ -195,6 +209,15 @@ final class HeadphoneMotionSessionService {
                     }
                 }
             }
+            let result = HeadphoneMotionSessionResult(
+                startedAt: sessionResult.startedAt,
+                endedAt: sessionResult.endedAt,
+                duration: sessionResult.duration,
+                steps: sessionResult.steps,
+                sampleCount: sessionResult.sampleCount,
+                stopReason: sessionResult.stopReason,
+                trackingIntegrity: finalTrackingIntegrity
+            )
             stepCount = result.steps
             sampleCount = result.sampleCount
             duration = result.duration
@@ -203,6 +226,7 @@ final class HeadphoneMotionSessionService {
             pauseStartedAt = nil
             lastMotionUpdateAt = nil
             lastMotionRecoveryAttemptAt = nil
+            trackingUnavailableStartedAt = nil
             status = .finished
             return result
         } catch {
@@ -220,18 +244,21 @@ final class HeadphoneMotionSessionService {
         } else if !connected, status == .recording {
             status = .waitingForMotion
             lastMotionUpdateAt = nil
+            markTrackingUnavailable(at: Date())
         }
     }
 
     private func handleSessionUpdate(_ update: HeadphoneMotionSessionUpdate) {
         guard !status.isPaused else { return }
 
+        let now = Date()
         isConnected = true
         if status == .waitingForMotion {
             status = .recording
         }
+        markTrackingAvailable(at: now)
 
-        lastMotionUpdateAt = Date()
+        lastMotionUpdateAt = now
         stepCount = update.stepCount
         sampleCount = update.sampleCount
         currentAcceleration = update.acceleration
@@ -254,6 +281,7 @@ final class HeadphoneMotionSessionService {
     private func handleSessionError(_ message: String) {
         status = .failed(message)
         isConnected = false
+        markTrackingUnavailable(at: Date())
     }
 
     private func startDurationTimer() {
@@ -263,6 +291,7 @@ final class HeadphoneMotionSessionService {
                 guard let self, self.status.isRecording else { return }
                 let now = Date()
                 self.duration = self.activeDuration(at: now)
+                self.refreshTrackingIntegrity(at: now)
                 self.restartStalledMotionIfNeeded(at: now)
             }
         }
@@ -277,6 +306,14 @@ final class HeadphoneMotionSessionService {
 
         let lastUpdateAt = lastMotionUpdateAt ?? recordingStartedAt
         guard now.timeIntervalSince(lastUpdateAt) >= 4 else { return }
+
+        if status == .waitingForMotion {
+            markTrackingUnavailable(at: now)
+        } else if status == .recording {
+            status = .waitingForMotion
+            isConnected = false
+            markTrackingUnavailable(at: now)
+        }
 
         if let lastMotionRecoveryAttemptAt,
            now.timeIntervalSince(lastMotionRecoveryAttemptAt) < 5 {
@@ -294,6 +331,59 @@ final class HeadphoneMotionSessionService {
 
         let currentPauseDuration = pauseStartedAt.map { date.timeIntervalSince($0) } ?? 0
         return max(0, date.timeIntervalSince(recordingStartedAt) - accumulatedPausedDuration - currentPauseDuration)
+    }
+
+    private func resetTrackingIntegrity() {
+        trackingUnavailableStartedAt = nil
+        accumulatedTrackingUnavailableDuration = 0
+        longestTrackingUnavailableDuration = 0
+        trackingInterruptionCount = 0
+        trackingIntegrity = .verified
+    }
+
+    private func markTrackingUnavailable(at date: Date) {
+        if trackingUnavailableStartedAt == nil {
+            trackingUnavailableStartedAt = date
+            trackingInterruptionCount += 1
+        }
+
+        refreshTrackingIntegrity(at: date)
+    }
+
+    private func markTrackingAvailable(at date: Date) {
+        if let trackingUnavailableStartedAt {
+            let unavailableDuration = max(date.timeIntervalSince(trackingUnavailableStartedAt), 0)
+            accumulatedTrackingUnavailableDuration += unavailableDuration
+            longestTrackingUnavailableDuration = max(
+                longestTrackingUnavailableDuration,
+                unavailableDuration
+            )
+            self.trackingUnavailableStartedAt = nil
+        }
+
+        refreshTrackingIntegrity(at: date)
+    }
+
+    private func refreshTrackingIntegrity(at date: Date) {
+        let currentUnavailableDuration = trackingUnavailableStartedAt.map {
+            max(date.timeIntervalSince($0), 0)
+        } ?? 0
+        let totalUnavailableDuration = accumulatedTrackingUnavailableDuration + currentUnavailableDuration
+        let longestUnavailableDuration = max(
+            longestTrackingUnavailableDuration,
+            currentUnavailableDuration
+        )
+
+        let updatedIntegrity = HeadphoneMotionTrackingIntegrity(
+            currentUnavailableDuration: currentUnavailableDuration,
+            totalUnavailableDuration: totalUnavailableDuration,
+            longestUnavailableDuration: longestUnavailableDuration,
+            interruptionCount: trackingInterruptionCount
+        )
+
+        if trackingIntegrity != updatedIntegrity {
+            trackingIntegrity = updatedIntegrity
+        }
     }
 }
 

--- a/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionTrackingIntegrity.swift
+++ b/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionTrackingIntegrity.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+struct HeadphoneMotionTrackingIntegrity: Equatable, Sendable {
+    static let recoveryStatusDelay: TimeInterval = 3
+
+    static let verified = HeadphoneMotionTrackingIntegrity(
+        currentUnavailableDuration: 0,
+        totalUnavailableDuration: 0,
+        longestUnavailableDuration: 0,
+        interruptionCount: 0
+    )
+
+    let currentUnavailableDuration: TimeInterval
+    let totalUnavailableDuration: TimeInterval
+    let longestUnavailableDuration: TimeInterval
+    let interruptionCount: Int
+
+    var isCurrentlyUnavailable: Bool {
+        currentUnavailableDuration > 0
+    }
+
+    var shouldShowRecoveryStatus: Bool {
+        isCurrentlyUnavailable &&
+            currentUnavailableDuration >= Self.recoveryStatusDelay
+    }
+
+    var unavailableSecondsForDisplay: Int {
+        max(Int(currentUnavailableDuration.rounded(.down)), 0)
+    }
+}

--- a/AscendAppTests/ClimbServiceTests.swift
+++ b/AscendAppTests/ClimbServiceTests.swift
@@ -122,6 +122,49 @@ struct ClimbServiceTests {
     }
 
     @Test
+    func liveClimbCompletionWithInterruptedTrackingRemainsLeaderboardEligible() throws {
+        let climb = makeClimb(id: "live-climb-interrupted-complete", requiredSteps: 1_000)
+        let service = ClimbService(catalogRepository: TestClimbCatalogRepository(climbs: [climb]))
+        let modelContext = try makeModelContext()
+        let climbStartedAt = Date(timeIntervalSince1970: 1_775_217_600)
+
+        modelContext.insert(ClimbAttempt(climbId: climb.id, startedAt: climbStartedAt))
+        try modelContext.save()
+
+        let trackingIntegrity = HeadphoneMotionTrackingIntegrity(
+            currentUnavailableDuration: 0,
+            totalUnavailableDuration: 18,
+            longestUnavailableDuration: 18,
+            interruptionCount: 1
+        )
+        let metadata = HeadphoneMotionWorkoutMetadata(
+            sampleCount: 500,
+            climbId: climb.id,
+            targetStepCount: climb.referenceStepCount,
+            stopReason: .targetReached,
+            trackingIntegrity: trackingIntegrity
+        )
+        let workout = Workout(
+            name: "Complete Interrupted Climb",
+            date: climbStartedAt.addingTimeInterval(60),
+            duration: 900,
+            steps: 1_000,
+            floors: 63,
+            stepsPerFloor: 16,
+            source: .headphoneMotion,
+            sourceMetadata: metadata.jsonString
+        )
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        try service.apply(workouts: [workout], modelContext: modelContext)
+
+        let attempt = try #require(try modelContext.fetch(FetchDescriptor<ClimbAttempt>()).first)
+        #expect(attempt.status == .completed)
+        #expect(workout.participations.first?.leaderboardEligible == true)
+    }
+
+    @Test
     func laterWorkoutDoesNotAccumulateTowardPriorAttempt() throws {
         let climb = makeClimb(id: "restart-required-climb", requiredSteps: 1_000)
         let service = ClimbService(catalogRepository: TestClimbCatalogRepository(climbs: [climb]))


### PR DESCRIPTION
## Summary

This PR simplifies Live Climb headphone interruption handling so the product behavior is direct and predictable:

- Compatible headphones are required before a Live Climb can start.
- The session rechecks headphone readiness before and during the countdown, plus immediately before recording begins.
- If headphones are unavailable during countdown, the user sees a full-screen "Headphones required" overlay with Try Again / Close.
- During an active climb, headphone tracking loss does not disqualify the climb. The clock keeps running, step counting pauses while tracking is unavailable, and valid step counting resumes when tracking returns.
- Completed Live Climbs remain leaderboard-eligible as long as the user reaches the target step count.

## Why

The previous direction introduced duration-based interruption disqualification, but that made the flow more complex than needed. If the clock keeps running and steps only come from trusted headphone motion samples, losing tracking is already self-penalizing: rest time still counts, and steps are not inferred during the gap.

## Validation

- Built `AscendApp` for iOS Simulator successfully.
- Ran `AscendAppTests/ClimbServiceTests`: 9 passed, 0 failed.

## Notes

Real-device QA with AirPods / AirPods Max is still needed because simulator builds cannot validate actual headphone motion behavior.