### PR TITLE
[codex] Fix onboarding analytics telemetry

### DIFF
--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -480,7 +480,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APS_ENVIRONMENT = production;
-				ASCEND_MIXPANEL_TOKEN = 1cc8a5371d862051bc7a04427705b8dd;
+				ASCEND_MIXPANEL_TOKEN = 354ccda8eef57e08d823eebc8598aab7;
 				ASCEND_REVENUECAT_API_KEY = appl_OuhVbQoKshaWOxkeVfELTpsvlHP;
 				ASCEND_REVENUECAT_TEST_API_KEY = "";
 				ASCEND_SUPERWALL_API_KEY = pk_DGywY9Qw39wY_9glnLs8R;
@@ -656,7 +656,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APS_ENVIRONMENT = development;
-				ASCEND_MIXPANEL_TOKEN = 1cc8a5371d862051bc7a04427705b8dd;
+				ASCEND_MIXPANEL_TOKEN = 354ccda8eef57e08d823eebc8598aab7;
 				ASCEND_REVENUECAT_API_KEY = appl_OuhVbQoKshaWOxkeVfELTpsvlHP;
 				ASCEND_REVENUECAT_TEST_API_KEY = "";
 				ASCEND_SUPERWALL_API_KEY = pk_DGywY9Qw39wY_9glnLs8R;
@@ -708,7 +708,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APS_ENVIRONMENT = production;
-				ASCEND_MIXPANEL_TOKEN = 1cc8a5371d862051bc7a04427705b8dd;
+				ASCEND_MIXPANEL_TOKEN = 354ccda8eef57e08d823eebc8598aab7;
 				ASCEND_REVENUECAT_API_KEY = appl_OuhVbQoKshaWOxkeVfELTpsvlHP;
 				ASCEND_REVENUECAT_TEST_API_KEY = "";
 				ASCEND_SUPERWALL_API_KEY = pk_DGywY9Qw39wY_9glnLs8R;

--- a/AscendApp/Features/Debug/Views/TelemetryConsoleView.swift
+++ b/AscendApp/Features/Debug/Views/TelemetryConsoleView.swift
@@ -116,7 +116,7 @@ struct TelemetryConsoleView: View {
             Text(
                 store.isCollectionEnabled
                     ? "Analytics are product events, breadcrumbs are crash-tracing checkpoints, and screens are view opens. Tap the info icon on any row for a plain-English explanation."
-                    : "Telemetry is disabled for this run. Launch Debug with `-TelemetryEnabled` to populate this console."
+                    : "Telemetry is disabled for this run. Launch Debug once with `-TelemetryEnabled` or `ASC_DEBUG_TELEMETRY_ENABLED=1`; that setting sticks for later Debug launches."
             )
             .font(.montserratRegular(size: 14))
             .foregroundStyle(.secondary)
@@ -126,6 +126,17 @@ struct TelemetryConsoleView: View {
                     .font(.system(size: 13, weight: .medium, design: .monospaced))
                     .foregroundStyle(foregroundColor.opacity(0.8))
             }
+
+            Button {
+                sendMixpanelProbe()
+            } label: {
+                Label("Send Mixpanel Probe", systemImage: "paperplane.fill")
+                    .font(.montserratSemiBold(size: 13))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+            .disabled(!store.isCollectionEnabled)
         }
         .padding(16)
         .background(
@@ -182,7 +193,7 @@ struct TelemetryConsoleView: View {
 
     private var emptyStateMessage: String {
         if !store.isCollectionEnabled {
-            return "Launch Debug with `-TelemetryEnabled`, then come back here after using the app."
+            return "Launch Debug once with `-TelemetryEnabled` or `ASC_DEBUG_TELEMETRY_ENABLED=1`, then restart and use the app."
         }
 
         switch selectedFilter {
@@ -340,6 +351,21 @@ struct TelemetryConsoleView: View {
         case .screen:
             return .blue
         }
+    }
+
+    private func sendMixpanelProbe() {
+        TelemetryManager.shared.track(
+            TelemetryRecord(
+                name: "debug_mixpanel_probe_sent",
+                parameters: [
+                    "probe_id": .string(UUID().uuidString),
+                    "source": .string("telemetry_console"),
+                    "sent_at_unix": .int(Int(Date().timeIntervalSince1970))
+                ],
+                destinations: [.analytics]
+            )
+        )
+        selectedFilter = .analytics
     }
 }
 #endif

--- a/AscendApp/Features/Onboarding/Analytics/OnboardingAnalyticsEvent.swift
+++ b/AscendApp/Features/Onboarding/Analytics/OnboardingAnalyticsEvent.swift
@@ -33,16 +33,23 @@ enum OnboardingAnalyticsEvent: TelemetryEvent {
     )
 
     case flowStarted(context: OnboardingAnalyticsContext)
-    case stepViewed(context: OnboardingAnalyticsContext)
-    case screenViewed(context: OnboardingAnalyticsContext, property: String)
-    case stepCompleted(context: OnboardingAnalyticsContext, actionID: String)
-    case backTapped(context: OnboardingAnalyticsContext)
-    case answerSelected(
+    case screenCompleted(
         context: OnboardingAnalyticsContext,
-        questionID: String,
-        answerID: String,
-        answerIndex: Int?
+        eventName: String,
+        inputType: String,
+        properties: [String: TelemetryValue]
     )
+    case questionAnswered(
+        context: OnboardingAnalyticsContext,
+        eventName: String,
+        questionID: String,
+        inputType: String,
+        selectionType: String?,
+        answerID: String,
+        answerIndex: Int?,
+        properties: [String: TelemetryValue]
+    )
+    case backTapped(context: OnboardingAnalyticsContext)
     case notificationPermissionSelected(context: OnboardingAnalyticsContext, status: String)
     case firstClimbSelected(context: OnboardingAnalyticsContext, climbID: String, climbName: String)
     case authStarted(provider: String)
@@ -58,54 +65,83 @@ enum OnboardingAnalyticsEvent: TelemetryEvent {
                 name: "onboarding_flow_started",
                 context: context
             )
-        case .stepViewed(let context):
+        case .screenCompleted(let context, let eventName, let inputType, let properties):
+            var parameters: [String: TelemetryValue] = [
+                "screen_id": .string(context.stepID),
+                "input_type": .string(inputType),
+                "completed": .bool(true)
+            ]
+
+            properties.forEach { parameters[$0.key] = $0.value }
+
             return makeRecord(
-                name: "onboarding_step_viewed",
-                context: context
-            )
-        case .screenViewed(let context, let property):
-            return makeRecord(
-                name: "screen_viewed",
+                name: eventName,
                 context: context,
-                parameters: ["property": .string(property)]
+                parameters: parameters
             )
-        case .stepCompleted(let context, let actionID):
+        case .questionAnswered(
+            let context,
+            let eventName,
+            let questionID,
+            let inputType,
+            let selectionType,
+            let answerID,
+            let answerIndex,
+            let properties
+        ):
+            var parameters: [String: TelemetryValue] = [
+                "question_id": .string(questionID),
+                "screen_id": .string(context.stepID),
+                "input_type": .string(inputType),
+                "answer_id": .string(answerID),
+                "has_answer": .bool(true)
+            ]
+
+            if let selectionType {
+                parameters["selection_type"] = .string(selectionType)
+            }
+
+            if let answerIndex {
+                parameters["answer_index"] = .int(answerIndex)
+            }
+
+            properties.forEach { parameters[$0.key] = $0.value }
+
             return makeRecord(
-                name: "onboarding_step_completed",
+                name: eventName,
                 context: context,
-                parameters: ["action_id": .string(actionID)]
+                parameters: parameters
             )
         case .backTapped(let context):
             return makeRecord(
                 name: "onboarding_back_tapped",
                 context: context
             )
-        case .answerSelected(let context, let questionID, let answerID, let answerIndex):
-            var parameters: [String: TelemetryValue] = [
-                "question_id": .string(questionID),
-                "answer_id": .string(answerID)
-            ]
-
-            if let answerIndex {
-                parameters["answer_index"] = .int(answerIndex)
-            }
-
-            return makeRecord(
-                name: "onboarding_answer_selected",
-                context: context,
-                parameters: parameters
-            )
         case .notificationPermissionSelected(let context, let status):
             return makeRecord(
-                name: "onboarding_notification_permission_selected",
+                name: "notifications_inputted",
                 context: context,
-                parameters: ["status": .string(status)]
+                parameters: [
+                    "question_id": .string("notifications"),
+                    "screen_id": .string(context.stepID),
+                    "input_type": .string("permission_prompt"),
+                    "selection_type": .string("single_select"),
+                    "answer_id": .string(status),
+                    "status": .string(status),
+                    "has_answer": .bool(true)
+                ]
             )
         case .firstClimbSelected(let context, let climbID, let climbName):
             return makeRecord(
-                name: "onboarding_first_climb_selected",
+                name: "first_climb_selected",
                 context: context,
                 parameters: [
+                    "question_id": .string("first_climb"),
+                    "screen_id": .string(context.stepID),
+                    "input_type": .string("single_select"),
+                    "selection_type": .string("single_select"),
+                    "answer_id": .string(climbID),
+                    "has_answer": .bool(true),
                     "climb_id": .string(climbID),
                     "climb_name": .string(climbName)
                 ]

--- a/AscendApp/Features/Onboarding/Models/PostAuthOnboardingStage.swift
+++ b/AscendApp/Features/Onboarding/Models/PostAuthOnboardingStage.swift
@@ -2,6 +2,11 @@ import Foundation
 
 enum PostAuthOnboardingStage: String, CaseIterable, Codable, Identifiable {
     case displayName
+    case stairStepperBaseline = "stair_stepper_baseline"
+    case exerciseLevel = "exercise_level"
+    case goal
+    case motivation
+    case plan
     case gender
     case age
     case weight
@@ -16,6 +21,11 @@ enum PostAuthOnboardingStage: String, CaseIterable, Codable, Identifiable {
     static var allCases: [PostAuthOnboardingStage] {
         [
             .displayName,
+            .stairStepperBaseline,
+            .exerciseLevel,
+            .goal,
+            .motivation,
+            .plan,
             .gender,
             .age,
             .weight,
@@ -52,8 +62,73 @@ enum PostAuthOnboardingStage: String, CaseIterable, Codable, Identifiable {
         )
     }
 
-    var screenViewProperty: String {
-        rawValue
+    var analyticsEventName: String {
+        switch self {
+        case .displayName:
+            return "name_inputted"
+        case .stairStepperBaseline:
+            return "stair_stepper_baseline_answered"
+        case .exerciseLevel:
+            return "exercise_level_answered"
+        case .goal:
+            return "goal_answered"
+        case .motivation:
+            return "motivation_answered"
+        case .plan:
+            return "plan_answered"
+        case .gender:
+            return "division_inputted"
+        case .age:
+            return "age_inputted"
+        case .weight:
+            return "body_metrics_inputted"
+        case .location:
+            return "location_inputted"
+        case .notifications:
+            return "notifications_inputted"
+        case .planLoading:
+            return "plan_loaded"
+        case .firstClimb:
+            return "first_climb_selected"
+        }
+    }
+
+    var analyticsInputType: String {
+        switch self {
+        case .displayName:
+            return "text"
+        case .stairStepperBaseline, .exerciseLevel, .motivation, .plan:
+            return "single_select"
+        case .goal:
+            return "multi_select"
+        case .gender:
+            return "single_select"
+        case .age:
+            return "number"
+        case .weight:
+            return "measurement"
+        case .location:
+            return "location"
+        case .notifications:
+            return "permission_prompt"
+        case .planLoading:
+            return "automatic"
+        case .firstClimb:
+            return "single_select"
+        }
+    }
+
+    var analyticsSelectionType: String? {
+        switch self {
+        case .stairStepperBaseline, .exerciseLevel, .motivation, .plan:
+            return "single_select"
+        case .goal:
+            return "multi_select"
+        case .gender, .notifications, .firstClimb:
+            return "single_select"
+        case .displayName, .age, .weight, .location, .planLoading:
+            return nil
+        }
     }
 }
 

--- a/AscendApp/Features/Onboarding/ViewModels/PostAuthOnboardingCoordinator.swift
+++ b/AscendApp/Features/Onboarding/ViewModels/PostAuthOnboardingCoordinator.swift
@@ -33,7 +33,6 @@ final class PostAuthOnboardingCoordinator {
 
         phase = snapshot.isComplete ? .complete : .onboarding(snapshot.currentStage)
         recordLifecycleSnapshot(snapshot)
-        recordStepViewedIfNeeded(snapshot)
     }
 
     func completeCurrentStage() {
@@ -42,19 +41,12 @@ final class PostAuthOnboardingCoordinator {
 
         var snapshot = store.snapshot(for: userId)
         snapshot.completedStages.insert(stage)
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.stepCompleted(
-                context: stage.analyticsContext,
-                actionID: "continue"
-            )
-        )
 
         if let nextStage = stage.next {
             snapshot.currentStage = nextStage
             store.save(snapshot, for: userId)
             phase = .onboarding(nextStage)
             recordLifecycleSnapshot(snapshot)
-            recordStepViewedIfNeeded(snapshot)
         } else {
             snapshot.isComplete = true
             snapshot.completedAt = Date()
@@ -98,7 +90,6 @@ final class PostAuthOnboardingCoordinator {
         store.save(snapshot, for: userId)
         phase = .onboarding(previousStage)
         recordLifecycleSnapshot(snapshot)
-        recordStepViewedIfNeeded(snapshot)
     }
 
     func resetCurrentUser() {
@@ -107,7 +98,6 @@ final class PostAuthOnboardingCoordinator {
         let snapshot = store.snapshot(for: userId)
         phase = .onboarding(.first)
         recordLifecycleSnapshot(snapshot)
-        recordStepViewedIfNeeded(snapshot)
         NotificationCenter.default.post(name: .postAuthOnboardingStateDidChange, object: nil)
     }
 
@@ -139,21 +129,6 @@ final class PostAuthOnboardingCoordinator {
         }
     }
 
-    private func recordStepViewedIfNeeded(_ snapshot: PostAuthOnboardingSnapshot) {
-        guard !snapshot.isComplete else { return }
-
-        let context = snapshot.currentStage.analyticsContext
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.stepViewed(context: context)
-        )
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.screenViewed(
-                context: context,
-                property: snapshot.currentStage.screenViewProperty
-            )
-        )
-    }
-
     private func normalized(_ snapshot: PostAuthOnboardingSnapshot) -> PostAuthOnboardingSnapshot {
         var normalizedSnapshot = snapshot
         normalizedSnapshot.completedStages = normalizedSnapshot.completedStages.intersection(Set(PostAuthOnboardingStage.allCases))
@@ -169,9 +144,18 @@ final class PostAuthOnboardingCoordinator {
             return normalizedSnapshot
         }
 
+        let hasIncompleteEarlierStage: Bool
+        if let currentIndex = PostAuthOnboardingStage.allCases.firstIndex(of: normalizedSnapshot.currentStage) {
+            let previousStages = PostAuthOnboardingStage.allCases[..<currentIndex]
+            hasIncompleteEarlierStage = previousStages.contains { !normalizedSnapshot.completedStages.contains($0) }
+        } else {
+            hasIncompleteEarlierStage = false
+        }
+
         if !PostAuthOnboardingStage.allCases.contains(normalizedSnapshot.currentStage) ||
             normalizedSnapshot.completedStages.contains(normalizedSnapshot.currentStage) ||
-            !normalizedSnapshot.completedStages.contains(.displayName) {
+            !normalizedSnapshot.completedStages.contains(.displayName) ||
+            hasIncompleteEarlierStage {
             normalizedSnapshot.currentStage = firstIncompleteStage(in: normalizedSnapshot)
         }
 

--- a/AscendApp/Features/Onboarding/Views/OnboardingValueCarouselView.swift
+++ b/AscendApp/Features/Onboarding/Views/OnboardingValueCarouselView.swift
@@ -116,12 +116,6 @@ struct OnboardingValueCarouselView: View {
         }
 
         let context = analyticsContext(for: pages[selectedIndex], index: selectedIndex)
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.stepCompleted(
-                context: context,
-                actionID: "continue"
-            )
-        )
 
         if selectedIndex < pages.count - 1 {
             selectedIndex += 1
@@ -183,17 +177,6 @@ struct OnboardingValueCarouselView: View {
         guard !viewedPageIDs.contains(page.id) else { return }
 
         viewedPageIDs.insert(page.id)
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.stepViewed(
-                context: analyticsContext(for: page, index: selectedIndex)
-            )
-        )
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.screenViewed(
-                context: analyticsContext(for: page, index: selectedIndex),
-                property: page.id
-            )
-        )
     }
 
     private func analyticsContext(for page: OnboardingValuePage, index: Int) -> OnboardingAnalyticsContext {

--- a/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
+++ b/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
@@ -13,6 +13,12 @@ struct PostAuthOnboardingFlowView: View {
                     stage: stage,
                     onContinue: onContinue
                 )
+            case .stairStepperBaseline, .exerciseLevel, .goal, .motivation, .plan:
+                PostAuthSurveyQuestionStageScreen(
+                    stage: stage,
+                    onBack: onBack,
+                    onContinue: onContinue
+                )
             case .gender:
                 PostAuthGenderScreen(
                     stage: stage,
@@ -63,20 +69,90 @@ struct PostAuthOnboardingFlowView: View {
     }
 }
 
-private func trackPostAuthAnswer(
+private func trackPostAuthInput(
     stage: PostAuthOnboardingStage,
-    questionID: String,
-    answerID: String = "provided",
-    answerIndex: Int? = nil
+    properties: [String: TelemetryValue] = [:]
 ) {
     TelemetryManager.shared.track(
-        OnboardingAnalyticsEvent.answerSelected(
+        OnboardingAnalyticsEvent.screenCompleted(
             context: stage.analyticsContext,
-            questionID: questionID,
-            answerID: answerID,
-            answerIndex: answerIndex
+            eventName: stage.analyticsEventName,
+            inputType: stage.analyticsInputType,
+            properties: properties
         )
     )
+}
+
+private struct PostAuthSurveyQuestionStageScreen: View {
+    let stage: PostAuthOnboardingStage
+    let onBack: () -> Void
+    let onContinue: () -> Void
+
+    @State private var selectedOptionIDs: Set<String> = []
+
+    private let surveyStore = PreAuthOnboardingSurveyStore()
+
+    var body: some View {
+        PreAuthSurveyQuestionScreen(
+            question: question,
+            selectedOptionIDs: selectedOptionIDs,
+            isContinueEnabled: !selectedOptionIDs.isEmpty,
+            onSelect: selectAnswer,
+            onBack: onBack,
+            onContinue: continueFromQuestion
+        )
+        .onAppear {
+            loadSavedAnswerIfNeeded()
+        }
+    }
+
+    private var question: PreAuthSurveyQuestion {
+        guard let question = PreAuthSurveyQuestion.question(for: stage.rawValue) else {
+            preconditionFailure("Missing survey question for post-auth onboarding stage: \(stage.rawValue)")
+        }
+
+        return question.withProgressFraction(progressFraction)
+    }
+
+    private var progressFraction: CGFloat {
+        guard PostAuthOnboardingStage.plannedStepCount > 0 else { return 0 }
+        return CGFloat(stage.progressIndex + 1) / CGFloat(PostAuthOnboardingStage.plannedStepCount)
+    }
+
+    private func loadSavedAnswerIfNeeded() {
+        guard selectedOptionIDs.isEmpty else { return }
+        selectedOptionIDs = surveyStore.optionIDs(for: question.id)
+    }
+
+    private func selectAnswer(_ optionID: String) {
+        var optionIDs = selectedOptionIDs
+
+        switch question.selectionMode {
+        case .single:
+            optionIDs = [optionID]
+        case .multiple:
+            if optionIDs.contains(optionID) {
+                optionIDs.remove(optionID)
+            } else {
+                optionIDs.insert(optionID)
+            }
+        }
+
+        selectedOptionIDs = optionIDs
+        surveyStore.save(questionID: question.id, optionIDs: optionIDs)
+    }
+
+    private func continueFromQuestion() {
+        guard !selectedOptionIDs.isEmpty else { return }
+
+        surveyStore.save(questionID: question.id, optionIDs: selectedOptionIDs)
+        trackOnboardingSurveyAnswer(
+            for: question,
+            context: stage.analyticsContext,
+            selectedOptionIDs: selectedOptionIDs
+        )
+        onContinue()
+    }
 }
 
 private struct PostAuthDisplayNameScreen: View {
@@ -196,7 +272,8 @@ private struct PostAuthDisplayNameScreen: View {
             isSaving = false
 
             if didSave {
-                trackPostAuthAnswer(stage: stage, questionID: "display_name")
+                TelemetryManager.shared.setUserProperty("name_inputted", value: "true")
+                trackPostAuthInput(stage: stage)
                 onContinue()
             }
         }
@@ -272,7 +349,8 @@ private struct PostAuthGenderScreen: View {
             isSaving = false
 
             if didSave {
-                trackPostAuthAnswer(stage: stage, questionID: "division")
+                TelemetryManager.shared.setUserProperty("division_inputted", value: "true")
+                trackPostAuthInput(stage: stage)
                 onContinue()
             }
         }
@@ -331,7 +409,8 @@ private struct PostAuthAgeScreen: View {
             isSaving = false
 
             if didSave {
-                trackPostAuthAnswer(stage: stage, questionID: "age")
+                TelemetryManager.shared.setUserProperty("age_inputted", value: "true")
+                trackPostAuthInput(stage: stage)
                 onContinue()
             }
         }
@@ -425,7 +504,8 @@ private struct PostAuthWeightScreen: View {
             isSaving = false
 
             if didSave {
-                trackPostAuthAnswer(stage: stage, questionID: "body_metrics")
+                TelemetryManager.shared.setUserProperty("body_metrics_inputted", value: "true")
+                trackPostAuthInput(stage: stage)
                 onContinue()
             }
         }
@@ -561,7 +641,8 @@ private struct PostAuthLocationScreen: View {
             isSaving = false
 
             if didSave {
-                trackPostAuthAnswer(stage: stage, questionID: "location")
+                TelemetryManager.shared.setUserProperty("location_inputted", value: "true")
+                trackPostAuthInput(stage: stage)
                 onContinue()
             }
         }
@@ -688,6 +769,7 @@ private struct PostAuthNotificationScreen: View {
                     status: isAllowed ? "allow" : "decline"
                 )
             )
+            TelemetryManager.shared.setUserProperty("notifications_inputted", value: "true")
             onContinue()
         }
     }
@@ -706,6 +788,7 @@ private struct PostAuthNotificationScreen: View {
                     status: "skip"
                 )
             )
+            TelemetryManager.shared.setUserProperty("notifications_inputted", value: "true")
             onContinue()
         }
     }
@@ -847,6 +930,7 @@ private struct PostAuthPlanLoadingScreen: View {
         guard !Task.isCancelled else { return }
 
         guard await sleep(milliseconds: 700) else { return }
+        trackPostAuthInput(stage: stage)
         onContinue()
     }
 
@@ -1294,7 +1378,7 @@ private struct PostAuthFirstClimbRevealScreen: View {
                 if let userId = authVM.user?.uid {
                     OnboardingFirstClimbHandoffStore().stage(climbId: firstClimb.id, for: userId)
                 }
-                TelemetryManager.shared.setUserProperty("first_climb", value: firstClimb.id)
+                TelemetryManager.shared.setUserProperty("first_climb_selected", value: "true")
                 TelemetryManager.shared.track(
                     OnboardingAnalyticsEvent.firstClimbSelected(
                         context: stage.analyticsContext,

--- a/AscendApp/Features/Onboarding/Views/PreAuthOnboardingValueCarouselScreen.swift
+++ b/AscendApp/Features/Onboarding/Views/PreAuthOnboardingValueCarouselScreen.swift
@@ -78,12 +78,6 @@ private struct PreAuthOnboardingSurveyFlowScreen: View {
         let question = currentQuestion
         let context = analyticsContext(for: question, index: stepIndex)
         recordSelectedAnswers(for: question, context: context)
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.stepCompleted(
-                context: context,
-                actionID: "continue"
-            )
-        )
 
         if stepIndex < questions.count - 1 {
             stepIndex += 1
@@ -127,16 +121,6 @@ private struct PreAuthOnboardingSurveyFlowScreen: View {
         guard !viewedQuestionIDs.contains(question.id) else { return }
 
         viewedQuestionIDs.insert(question.id)
-        let context = analyticsContext(for: question, index: stepIndex)
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.stepViewed(context: context)
-        )
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.screenViewed(
-                context: context,
-                property: question.id
-            )
-        )
     }
 
     private func recordSelectedAnswers(
@@ -144,17 +128,13 @@ private struct PreAuthOnboardingSurveyFlowScreen: View {
         context: OnboardingAnalyticsContext
     ) {
         let selectedOptionIDs = selectedAnswers[question.id, default: []]
-        for optionID in selectedOptionIDs.sorted() {
-            let answerIndex = question.options.firstIndex { $0.id == optionID }
-            TelemetryManager.shared.track(
-                OnboardingAnalyticsEvent.answerSelected(
-                    context: context,
-                    questionID: question.id,
-                    answerID: optionID,
-                    answerIndex: answerIndex
-                )
-            )
-        }
+        guard !selectedOptionIDs.isEmpty else { return }
+
+        trackOnboardingSurveyAnswer(
+            for: question,
+            context: context,
+            selectedOptionIDs: selectedOptionIDs
+        )
     }
 
     private func analyticsContext(
@@ -170,7 +150,34 @@ private struct PreAuthOnboardingSurveyFlowScreen: View {
     }
 }
 
-private struct PreAuthSurveyQuestionScreen: View {
+func trackOnboardingSurveyAnswer(
+    for question: PreAuthSurveyQuestion,
+    context: OnboardingAnalyticsContext,
+    selectedOptionIDs: Set<String>
+) {
+    guard !selectedOptionIDs.isEmpty else { return }
+
+    let sortedOptionIDs = selectedOptionIDs.sorted()
+    let answerID = sortedOptionIDs.joined(separator: ",")
+    let answerIndex = sortedOptionIDs.count == 1
+        ? question.options.firstIndex { $0.id == sortedOptionIDs[0] }
+        : nil
+
+    TelemetryManager.shared.track(
+        OnboardingAnalyticsEvent.questionAnswered(
+            context: context,
+            eventName: question.analyticsEventName,
+            questionID: question.id,
+            inputType: question.selectionMode.analyticsInputType,
+            selectionType: question.selectionMode.analyticsInputType,
+            answerID: answerID,
+            answerIndex: answerIndex,
+            properties: ["answer_count": .int(sortedOptionIDs.count)]
+        )
+    )
+}
+
+struct PreAuthSurveyQuestionScreen: View {
     let question: PreAuthSurveyQuestion
     let selectedOptionIDs: Set<String>
     let isContinueEnabled: Bool
@@ -224,7 +231,7 @@ private struct PreAuthSurveyQuestionScreen: View {
     }
 }
 
-private struct PreAuthSurveyScreenShell<Content: View>: View {
+struct PreAuthSurveyScreenShell<Content: View>: View {
     let progressFraction: CGFloat
     let onBack: () -> Void
     let primaryTitle: String
@@ -275,7 +282,7 @@ private struct PreAuthSurveyScreenShell<Content: View>: View {
     }
 }
 
-private struct PreAuthSurveyProgressBar: View {
+struct PreAuthSurveyProgressBar: View {
     let progress: CGFloat
 
     var body: some View {
@@ -299,7 +306,7 @@ private struct PreAuthSurveyProgressBar: View {
     }
 }
 
-private struct PreAuthSurveyOptionRow: View {
+struct PreAuthSurveyOptionRow: View {
     let title: String
     let isSelected: Bool
     let metrics: PreAuthSurveyMetrics
@@ -325,7 +332,7 @@ private struct PreAuthSurveyOptionRow: View {
     }
 }
 
-private struct PreAuthSurveyMetrics {
+struct PreAuthSurveyMetrics {
     let size: CGSize
 
     private var scaleX: CGFloat { size.width / 390 }
@@ -357,14 +364,23 @@ private struct PreAuthSurveyMetrics {
     }
 }
 
-private enum PreAuthSurveyPalette {
+enum PreAuthSurveyPalette {
     static let background = Color(red: 0x11 / 255, green: 0x11 / 255, blue: 0x11 / 255)
 }
 
-private struct PreAuthSurveyQuestion {
+struct PreAuthSurveyQuestion {
     enum SelectionMode {
         case single
         case multiple
+
+        var analyticsInputType: String {
+            switch self {
+            case .single:
+                return "single_select"
+            case .multiple:
+                return "multi_select"
+            }
+        }
     }
 
     let id: String
@@ -376,6 +392,26 @@ private struct PreAuthSurveyQuestion {
     let options: [PreAuthSurveyOption]
 
     static let figmaProgressFraction = CGFloat(21.0 / 169.0)
+
+    var analyticsEventName: String {
+        "\(id)_answered"
+    }
+
+    static func question(for id: String) -> PreAuthSurveyQuestion? {
+        all.first { $0.id == id }
+    }
+
+    func withProgressFraction(_ progressFraction: CGFloat) -> PreAuthSurveyQuestion {
+        PreAuthSurveyQuestion(
+            id: id,
+            eyebrow: eyebrow,
+            headline: headline,
+            headlineHeight: headlineHeight,
+            progressFraction: progressFraction,
+            selectionMode: selectionMode,
+            options: options
+        )
+    }
 
     static let all: [PreAuthSurveyQuestion] = [
         PreAuthSurveyQuestion(
@@ -452,7 +488,7 @@ private struct PreAuthSurveyQuestion {
     ]
 }
 
-private struct PreAuthSurveyOption {
+struct PreAuthSurveyOption {
     let id: String
     let title: String
 }
@@ -488,6 +524,10 @@ struct PreAuthOnboardingSurveyStore {
         } else {
             userDefaults.set(Array(optionIDs).sorted(), forKey: key)
         }
+    }
+
+    func optionIDs(for questionID: String) -> Set<String> {
+        Set(userDefaults.stringArray(forKey: storageKey(for: questionID)) ?? [])
     }
 
     private func firstAnswer(for questionID: String) -> String? {
@@ -545,12 +585,6 @@ private struct PreAuthOnboardingGuideFlowScreen: View {
     private func moveForward() {
         let screen = currentScreen
         let context = analyticsContext(for: screen, index: stepIndex)
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.stepCompleted(
-                context: context,
-                actionID: "continue"
-            )
-        )
 
         if stepIndex < screens.count - 1 {
             stepIndex += 1
@@ -576,16 +610,6 @@ private struct PreAuthOnboardingGuideFlowScreen: View {
         guard !viewedScreenIDs.contains(screen.id) else { return }
 
         viewedScreenIDs.insert(screen.id)
-        let context = analyticsContext(for: screen, index: stepIndex)
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.stepViewed(context: context)
-        )
-        TelemetryManager.shared.track(
-            OnboardingAnalyticsEvent.screenViewed(
-                context: context,
-                property: screen.id
-            )
-        )
     }
 
     private func analyticsContext(

--- a/AscendApp/PrivacyInfo.xcprivacy
+++ b/AscendApp/PrivacyInfo.xcprivacy
@@ -86,7 +86,7 @@
             </array>
         </dict>
 
-        <!-- Other Data Types — declared profile demographics and onboarding first-climb preference -->
+        <!-- Other Data Types — onboarding survey choices, declared profile demographics, and onboarding first-climb preference -->
         <dict>
             <key>NSPrivacyCollectedDataType</key>
             <string>NSPrivacyCollectedDataTypeOtherDataTypes</string>
@@ -96,6 +96,7 @@
             <false/>
             <key>NSPrivacyCollectedDataTypePurposes</key>
             <array>
+                <string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
                 <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
             </array>
         </dict>

--- a/AscendApp/Shared/Managers/TelemetryManager.swift
+++ b/AscendApp/Shared/Managers/TelemetryManager.swift
@@ -70,23 +70,56 @@ final class TelemetryManager: @unchecked Sendable {
         sinks.forEach { $0.setCollectionEnabled(enabled) }
     }
 
-    private static func shouldEnableCollection() -> Bool {
-        let args = ProcessInfo.processInfo.arguments
-
-        if args.contains("-TelemetryDisabled") {
+    static func shouldEnableCollection(
+        arguments: [String] = ProcessInfo.processInfo.arguments,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        userDefaults: UserDefaults = .standard
+    ) -> Bool {
+        if arguments.contains("-TelemetryDisabled") {
+            #if DEBUG
+            userDefaults.set(false, forKey: debugCollectionEnabledDefaultsKey)
+            #endif
             return false
         }
 
-        if args.contains("-TelemetryEnabled") {
+        if arguments.contains("-TelemetryEnabled") {
+            #if DEBUG
+            userDefaults.set(true, forKey: debugCollectionEnabledDefaultsKey)
+            #endif
             return true
         }
 
         #if DEBUG
+        if let environmentValue = environment["ASC_DEBUG_TELEMETRY_ENABLED"],
+           let enabled = debugBooleanValue(environmentValue) {
+            userDefaults.set(enabled, forKey: debugCollectionEnabledDefaultsKey)
+            return enabled
+        }
+
+        if userDefaults.object(forKey: debugCollectionEnabledDefaultsKey) != nil {
+            return userDefaults.bool(forKey: debugCollectionEnabledDefaultsKey)
+        }
+
         return false
         #else
         return true
         #endif
     }
+
+    #if DEBUG
+    private static let debugCollectionEnabledDefaultsKey = "debug.telemetry.collectionEnabled"
+
+    private static func debugBooleanValue(_ value: String) -> Bool? {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return nil
+        }
+    }
+    #endif
 
     private static var appEnvironmentName: String {
         #if DEBUG

--- a/AscendApp/Shared/Services/Telemetry/MixpanelTelemetrySink.swift
+++ b/AscendApp/Shared/Services/Telemetry/MixpanelTelemetrySink.swift
@@ -26,7 +26,7 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
         guard let instance = configuredInstance() else { return }
 
         if let userID {
-            instance.identify(distinctId: userID, usePeople: false)
+            instance.identify(distinctId: userID, usePeople: true)
         } else {
             instance.reset()
         }
@@ -36,28 +36,40 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
         guard let instance = configuredInstance() else { return }
 
         if let value {
+            instance.people.set(property: name, to: value)
             instance.registerSuperProperties([name: value])
         } else {
+            instance.people.unset(properties: [name])
             instance.unregisterSuperProperty(name)
         }
+
+        flushAfterDebugEvent(instance)
     }
 
     func record(_ record: TelemetryRecord) {
-        configuredInstance()?.track(
+        guard let instance = configuredInstance() else { return }
+
+        instance.track(
             event: record.name,
             properties: record.parameters.mixpanelProperties
         )
+
+        flushAfterDebugEvent(instance)
     }
 
     func record(screen: TelemetryScreen) {
+        guard let instance = configuredInstance() else { return }
+
         var properties = screen.parameters.mixpanelProperties
         properties["screen_name"] = screen.name
         properties["screen_class"] = screen.screenClass
 
-        configuredInstance()?.track(
+        instance.track(
             event: "screen_view",
             properties: properties
         )
+
+        flushAfterDebugEvent(instance)
     }
 
     private func configuredInstance() -> MixpanelInstance? {
@@ -72,10 +84,28 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
 
         let instance = Mixpanel.initialize(
             token: token,
-            trackAutomaticEvents: false
+            trackAutomaticEvents: false,
+            flushInterval: flushInterval
         )
+        #if DEBUG
+        instance.loggingEnabled = true
+        #endif
         self.instance = instance
         return instance
+    }
+
+    private var flushInterval: Double {
+        #if DEBUG
+        return 5
+        #else
+        return 60
+        #endif
+    }
+
+    private func flushAfterDebugEvent(_ instance: MixpanelInstance) {
+        #if DEBUG
+        instance.flush(performFullFlush: true)
+        #endif
     }
 }
 

--- a/AscendAppTests/OnboardingAnalyticsEventTests.swift
+++ b/AscendAppTests/OnboardingAnalyticsEventTests.swift
@@ -3,44 +3,92 @@ import Testing
 
 struct OnboardingAnalyticsEventTests {
     @Test
-    func stepViewedIncludesStableFunnelContext() {
+    func profileScreenCompletedUsesFigmaEventNameWithoutAnswerProperties() {
         let context = OnboardingAnalyticsContext(
             flowID: "post_auth_onboarding",
-            stepID: "experience",
-            stepIndex: 1,
-            stepCount: 5
+            stepID: "gender",
+            stepIndex: 6,
+            stepCount: 13
         )
 
-        let record = OnboardingAnalyticsEvent.stepViewed(context: context).record
+        let record = OnboardingAnalyticsEvent.screenCompleted(
+            context: context,
+            eventName: "division_inputted",
+            inputType: "single_select",
+            properties: [:]
+        ).record
 
-        #expect(record.name == "onboarding_step_viewed")
+        #expect(record.name == "division_inputted")
         #expect(record.parameters["flow_id"] == .string("post_auth_onboarding"))
         #expect(record.parameters["flow_version"] == .string("v1"))
-        #expect(record.parameters["step_id"] == .string("experience"))
-        #expect(record.parameters["step_index"] == .int(1))
-        #expect(record.parameters["step_count"] == .int(5))
+        #expect(record.parameters["step_id"] == .string("gender"))
+        #expect(record.parameters["screen_id"] == .string("gender"))
+        #expect(record.parameters["input_type"] == .string("single_select"))
+        #expect(record.parameters["completed"] == .bool(true))
+        #expect(record.parameters["question_id"] == nil)
+        #expect(record.parameters["selection_type"] == nil)
+        #expect(record.parameters["answer_id"] == nil)
+        #expect(record.parameters["answer_index"] == nil)
+        #expect(record.parameters["has_answer"] == nil)
     }
 
     @Test
-    func answerSelectedUsesStableQuestionAndAnswerIDs() {
+    func profileTextScreenCompletedDoesNotRecordRawTextAnswer() {
         let context = OnboardingAnalyticsContext(
             flowID: "post_auth_onboarding",
-            stepID: "experience",
-            stepIndex: 1,
-            stepCount: 5
+            stepID: "displayName",
+            stepIndex: 0,
+            stepCount: 13
         )
 
-        let record = OnboardingAnalyticsEvent.answerSelected(
+        let record = OnboardingAnalyticsEvent.screenCompleted(
             context: context,
-            questionID: "stair_stepper_experience",
-            answerID: "regular_stepper",
-            answerIndex: 2
+            eventName: "name_inputted",
+            inputType: "text",
+            properties: [:]
         ).record
 
-        #expect(record.name == "onboarding_answer_selected")
-        #expect(record.parameters["question_id"] == .string("stair_stepper_experience"))
-        #expect(record.parameters["answer_id"] == .string("regular_stepper"))
-        #expect(record.parameters["answer_index"] == .int(2))
+        #expect(record.name == "name_inputted")
+        #expect(record.parameters["input_type"] == .string("text"))
+        #expect(record.parameters["completed"] == .bool(true))
+        #expect(record.parameters["question_id"] == nil)
+        #expect(record.parameters["answer_id"] == nil)
+        #expect(record.parameters["has_answer"] == nil)
+        #expect(record.parameters["selection_type"] == nil)
+        #expect(record.parameters["answer_index"] == nil)
+    }
+
+    @Test
+    func surveyQuestionAnsweredUsesQuestionEventNameAndAnswerProperties() {
+        let context = OnboardingAnalyticsContext(
+            flowID: "post_auth_onboarding",
+            stepID: "stair_stepper_baseline",
+            stepIndex: 1,
+            stepCount: 13
+        )
+
+        let record = OnboardingAnalyticsEvent.questionAnswered(
+            context: context,
+            eventName: "stair_stepper_baseline_answered",
+            questionID: "stair_stepper_baseline",
+            inputType: "single_select",
+            selectionType: "single_select",
+            answerID: "never_tried",
+            answerIndex: 0,
+            properties: ["answer_count": .int(1)]
+        ).record
+
+        #expect(record.name == "stair_stepper_baseline_answered")
+        #expect(record.parameters["flow_id"] == .string("post_auth_onboarding"))
+        #expect(record.parameters["step_id"] == .string("stair_stepper_baseline"))
+        #expect(record.parameters["screen_id"] == .string("stair_stepper_baseline"))
+        #expect(record.parameters["question_id"] == .string("stair_stepper_baseline"))
+        #expect(record.parameters["input_type"] == .string("single_select"))
+        #expect(record.parameters["selection_type"] == .string("single_select"))
+        #expect(record.parameters["answer_id"] == .string("never_tried"))
+        #expect(record.parameters["answer_index"] == .int(0))
+        #expect(record.parameters["answer_count"] == .int(1))
+        #expect(record.parameters["has_answer"] == .bool(true))
     }
 
     @Test
@@ -54,22 +102,26 @@ struct OnboardingAnalyticsEventTests {
     }
 
     @Test
-    func notificationPermissionSelectedUsesStatusWithoutRawPermissionPayload() {
+    func notificationPermissionSelectedUsesStatusAsSingleSelectAnswer() {
         let context = OnboardingAnalyticsContext(
             flowID: "post_auth_onboarding",
             stepID: "notifications",
-            stepIndex: 5,
-            stepCount: 8
+            stepIndex: 10,
+            stepCount: 13
         )
 
         let record = OnboardingAnalyticsEvent.notificationPermissionSelected(
             context: context,
-            status: "skipped"
+            status: "skip"
         ).record
 
-        #expect(record.name == "onboarding_notification_permission_selected")
+        #expect(record.name == "notifications_inputted")
         #expect(record.parameters["step_id"] == .string("notifications"))
-        #expect(record.parameters["status"] == .string("skipped"))
+        #expect(record.parameters["question_id"] == .string("notifications"))
+        #expect(record.parameters["input_type"] == .string("permission_prompt"))
+        #expect(record.parameters["selection_type"] == .string("single_select"))
+        #expect(record.parameters["answer_id"] == .string("skip"))
+        #expect(record.parameters["status"] == .string("skip"))
     }
 
     @Test
@@ -77,8 +129,8 @@ struct OnboardingAnalyticsEventTests {
         let context = OnboardingAnalyticsContext(
             flowID: "post_auth_onboarding",
             stepID: "first_climb",
-            stepIndex: 7,
-            stepCount: 8
+            stepIndex: 12,
+            stepCount: 13
         )
 
         let record = OnboardingAnalyticsEvent.firstClimbSelected(
@@ -87,8 +139,12 @@ struct OnboardingAnalyticsEventTests {
             climbName: "Empire State Building"
         ).record
 
-        #expect(record.name == "onboarding_first_climb_selected")
+        #expect(record.name == "first_climb_selected")
         #expect(record.parameters["flow_id"] == .string("post_auth_onboarding"))
+        #expect(record.parameters["question_id"] == .string("first_climb"))
+        #expect(record.parameters["input_type"] == .string("single_select"))
+        #expect(record.parameters["selection_type"] == .string("single_select"))
+        #expect(record.parameters["answer_id"] == .string("empire-state-building"))
         #expect(record.parameters["climb_id"] == .string("empire-state-building"))
         #expect(record.parameters["climb_name"] == .string("Empire State Building"))
     }

--- a/AscendAppTests/PostAuthOnboardingCoordinatorTests.swift
+++ b/AscendAppTests/PostAuthOnboardingCoordinatorTests.swift
@@ -7,6 +7,11 @@ struct PostAuthOnboardingCoordinatorTests {
     func postAuthStagesStartWithDisplayName() {
         #expect(PostAuthOnboardingStage.allCases == [
             .displayName,
+            .stairStepperBaseline,
+            .exerciseLevel,
+            .goal,
+            .motivation,
+            .plan,
             .gender,
             .age,
             .weight,
@@ -17,12 +22,12 @@ struct PostAuthOnboardingCoordinatorTests {
         ])
         #expect(PostAuthOnboardingStage.first == .displayName)
         #expect(PostAuthOnboardingStage.flowID == "post_auth_onboarding")
-        #expect(PostAuthOnboardingStage.plannedStepCount == 8)
+        #expect(PostAuthOnboardingStage.plannedStepCount == 13)
     }
 
     @MainActor
     @Test
-    func completingDisplayNameAdvancesToGender() {
+    func completingDisplayNameAdvancesToStairStepperBaseline() {
         let defaults = makeDefaults()
         let store = PostAuthOnboardingStore(userDefaults: defaults)
         let userId = "user-1"
@@ -31,7 +36,7 @@ struct PostAuthOnboardingCoordinatorTests {
         coordinator.resolve(userId: userId)
         coordinator.completeCurrentStage()
 
-        #expect(coordinator.phase == .onboarding(.gender))
+        #expect(coordinator.phase == .onboarding(.stairStepperBaseline))
         #expect(!store.snapshot(for: userId).isComplete)
         #expect(store.snapshot(for: userId).completedStages == [.displayName])
     }
@@ -83,7 +88,7 @@ struct PostAuthOnboardingCoordinatorTests {
 
     @MainActor
     @Test
-    func legacyRemovedStageSnapshotWithDisplayNameCompletedResumesAtGender() {
+    func legacyRemovedStageSnapshotWithDisplayNameCompletedResumesAtFirstSurveyQuestion() {
         let defaults = makeDefaults()
         let store = PostAuthOnboardingStore(userDefaults: defaults)
         let userId = "user-3"
@@ -105,7 +110,30 @@ struct PostAuthOnboardingCoordinatorTests {
         let coordinator = PostAuthOnboardingCoordinator(store: store)
         coordinator.resolve(userId: userId)
 
-        #expect(coordinator.phase == .onboarding(.gender))
+        #expect(coordinator.phase == .onboarding(.stairStepperBaseline))
+        #expect(!store.snapshot(for: userId).isComplete)
+        #expect(store.snapshot(for: userId).completedStages == [.displayName])
+    }
+
+    @MainActor
+    @Test
+    func snapshotWithCurrentStageAfterNewRequiredQuestionsReopensAtFirstMissingQuestion() {
+        let defaults = makeDefaults()
+        let store = PostAuthOnboardingStore(userDefaults: defaults)
+        let userId = "user-4"
+
+        let snapshot = PostAuthOnboardingSnapshot(
+            currentStage: .gender,
+            completedStages: [.displayName],
+            isComplete: false,
+            startedAt: Date(timeIntervalSince1970: 1000)
+        )
+        store.save(snapshot, for: userId)
+
+        let coordinator = PostAuthOnboardingCoordinator(store: store)
+        coordinator.resolve(userId: userId)
+
+        #expect(coordinator.phase == .onboarding(.stairStepperBaseline))
         #expect(!store.snapshot(for: userId).isComplete)
         #expect(store.snapshot(for: userId).completedStages == [.displayName])
     }

--- a/AscendAppTests/TelemetryManagerTests.swift
+++ b/AscendAppTests/TelemetryManagerTests.swift
@@ -5,6 +5,7 @@
 //  Created by Codex on 4/6/26.
 //
 
+import Foundation
 import Testing
 @testable import AscendApp
 
@@ -60,4 +61,87 @@ struct TelemetryManagerTests {
         #expect(analyticsSink.records.isEmpty)
         #expect(analyticsSink.screens.isEmpty)
     }
+
+    #if DEBUG
+    @Test
+    func debugLaunchArgumentPersistsCollectionEnabled() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let enabled = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp", "-TelemetryEnabled"],
+            environment: [:],
+            userDefaults: defaults
+        )
+        let persisted = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp"],
+            environment: [:],
+            userDefaults: defaults
+        )
+
+        #expect(enabled)
+        #expect(persisted)
+    }
+
+    @Test
+    func debugDisabledLaunchArgumentOverridesPersistedCollectionEnabled() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        _ = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp", "-TelemetryEnabled"],
+            environment: [:],
+            userDefaults: defaults
+        )
+
+        let disabled = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp", "-TelemetryDisabled"],
+            environment: [:],
+            userDefaults: defaults
+        )
+        let persisted = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp"],
+            environment: [:],
+            userDefaults: defaults
+        )
+
+        #expect(!disabled)
+        #expect(!persisted)
+    }
+
+    @Test
+    func debugEnvironmentVariableCanEnableCollection() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let enabled = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp"],
+            environment: ["ASC_DEBUG_TELEMETRY_ENABLED": "1"],
+            userDefaults: defaults
+        )
+
+        #expect(enabled)
+    }
+
+    @Test
+    func debugCollectionDefaultsOffWithoutOverride() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let enabled = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp"],
+            environment: [:],
+            userDefaults: defaults
+        )
+
+        #expect(!enabled)
+    }
+
+    private func makeDefaults() throws -> (UserDefaults, String) {
+        let suiteName = "TelemetryManagerTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+    #endif
 }


### PR DESCRIPTION
## Summary
- Replace the Mixpanel SDK credential with the project token so app events reach the Ascend Mixpanel project.
- Align post-auth onboarding analytics with the Figma event taxonomy: one event per screen/question, answer properties only for survey questions, and no raw name/age/weight/height/location values in analytics.
- Add post-auth survey questions to replayed onboarding and add a debug-only Mixpanel probe in the Telemetry Console.
- Extend telemetry tests around debug collection, onboarding event payloads, and post-auth onboarding stage migration.

## Root Cause
The app was compiling the Mixpanel API secret into `ASCEND_MIXPANEL_TOKEN`. The Mixpanel iOS SDK needs the project token. The local telemetry console was showing internal events, but the SDK initialized with the wrong credential.

## Validation
- `test_sim -only-testing:AscendAppTests/OnboardingAnalyticsEventTests -only-testing:AscendAppTests/PostAuthOnboardingCoordinatorTests -only-testing:AscendAppTests/TelemetryManagerTests` passed: 19 tests, 0 failures.
- `build_sim` for `AscendAppDevQA` passed.
- Mixpanel direct probe and app onboarding events appeared in the project Events view.
- Staging seed audit passed for `ascend-staging-fa7d5` after seeding profiles, leaderboard rows, routine templates, and Live Replay fixtures.
