### PR TITLE
Polish climb history and replay ranking UX

### DIFF
--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -108,7 +108,6 @@ struct ClimbDetailView: View {
     @State private var showingBrowseClimbs = false
     @State private var showingFlyover = false
     @State private var showingLiveClimbSession = false
-    @State private var selectedHistoryWorkout: Workout?
     @State private var showingHeadphoneHelp = false
     @State private var isHeroCardFlipped = false
     @State private var didTrackDetailViewed = false
@@ -197,9 +196,6 @@ struct ClimbDetailView: View {
         }
         .fullScreenCover(isPresented: $showingFlyover) {
             ClimbFlyoverScreen(climb: viewModel.climb)
-        }
-        .navigationDestination(item: $selectedHistoryWorkout) { workout in
-            WorkoutDetailView(workout: workout)
         }
         .navigationDestination(isPresented: $showingBrowseClimbs) {
             ClimbBrowseView(viewModel: browseViewModel, analyticsEntryPoint: .detailBrowse)
@@ -890,10 +886,6 @@ struct ClimbDetailView: View {
                 communityStatsRow
             }
 
-            if viewModel.hasCompletionHistory {
-                overviewCompletionStatusRow
-            }
-
             primaryActionRow
         }
         .padding(.horizontal, 4)
@@ -911,21 +903,9 @@ struct ClimbDetailView: View {
                 historyMetricsGrid
                     .padding(.vertical, 2)
 
-                Text("RECENT ATTEMPTS")
-                    .font(.montserratSemiBold(size: 12))
-                    .tracking(1.2)
-                    .foregroundStyle(Color.customGray)
-
                 VStack(spacing: 0) {
                     ForEach(viewModel.historySummary.recentEntries) { entry in
-                        Button {
-                            if let workout = workout(forAttemptId: entry.attemptId) {
-                                selectedHistoryWorkout = workout
-                            }
-                        } label: {
-                            historyRow(for: entry)
-                        }
-                        .buttonStyle(.plain)
+                        historyRowLink(for: entry)
                     }
                 }
                 .padding(.top, -2)
@@ -1109,6 +1089,14 @@ struct ClimbDetailView: View {
                                     .fill(Color.accent)
                             )
                     }
+                }
+
+                if let demographicSummaryText = row.demographicSummaryText {
+                    Text(demographicSummaryText)
+                        .font(.montserratSemiBold(size: isFirst ? 11 : 10))
+                        .foregroundStyle(leaderboardSecondaryTextColor)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
                 }
 
                 Text("\(row.finalSteps.formatted()) steps")
@@ -1387,20 +1375,6 @@ struct ClimbDetailView: View {
         return "\(viewModel.communityCompletedCount) completed"
     }
 
-    private var overviewCompletionStatusRow: some View {
-        HStack(alignment: .center, spacing: 8) {
-            Image(systemName: "checkmark.seal.fill")
-                .font(.system(size: 13, weight: .bold))
-                .foregroundStyle(.accent)
-
-            Text("Completed")
-                .font(.montserratSemiBold(size: 13))
-                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.84) : .black.opacity(0.76))
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .combine)
-    }
-
     private func publicResultSyncStatusRow(
         for status: LiveClimbPublicResultSyncStatus
     ) -> some View {
@@ -1677,7 +1651,21 @@ struct ClimbDetailView: View {
         return (try? modelContext.fetch(descriptor))?.first?.workout
     }
 
-    private func historyRow(for entry: ClimbHistoryEntry) -> some View {
+    @ViewBuilder
+    private func historyRowLink(for entry: ClimbHistoryEntry) -> some View {
+        if let workout = workout(forAttemptId: entry.attemptId) {
+            NavigationLink {
+                WorkoutDetailView(workout: workout, embedsInNavigationStack: false)
+            } label: {
+                historyRow(for: entry, showsChevron: true)
+            }
+            .buttonStyle(.plain)
+        } else {
+            historyRow(for: entry, showsChevron: false)
+        }
+    }
+
+    private func historyRow(for entry: ClimbHistoryEntry, showsChevron: Bool) -> some View {
         HStack(alignment: .center, spacing: 12) {
             VStack(alignment: .leading, spacing: 5) {
                 Text(entry.date.formatted(date: .abbreviated, time: .omitted))
@@ -1709,6 +1697,12 @@ struct ClimbDetailView: View {
                 .font(.montserratBold(size: 17))
                 .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
                 .monospacedDigit()
+
+            if showsChevron {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.32) : .black.opacity(0.28))
+            }
         }
         .padding(.vertical, 14)
         .overlay(alignment: .bottom) {

--- a/AscendApp/Features/Climbs/Views/LiveClimbCompletionSummaryView.swift
+++ b/AscendApp/Features/Climbs/Views/LiveClimbCompletionSummaryView.swift
@@ -25,6 +25,7 @@ struct LiveClimbCompletionSummaryView: View {
     @State private var completionFinisherStatus: LiveReplayFinisherStatus?
     @State private var completionSummary: LiveReplayLeaderboardSummary?
     @State private var isLoadingCompletionRank = false
+    @State private var didFinishCompletionRankLoad = false
     @State private var didTrackSummaryViewed = false
 
     init(
@@ -197,20 +198,6 @@ struct LiveClimbCompletionSummaryView: View {
             }
 
             Spacer(minLength: 0)
-
-            if showsRankingStatusColumn {
-                VStack(alignment: .trailing, spacing: 5) {
-                    Text("STATUS")
-                        .font(.montserratBold(size: 8))
-                        .foregroundStyle(.white.opacity(0.42))
-
-                    Text(rankingStatusText)
-                        .font(.montserratBold(size: 11))
-                        .foregroundStyle(.white.opacity(0.72))
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.72)
-                }
-            }
         }
         .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -424,6 +411,10 @@ struct LiveClimbCompletionSummaryView: View {
             return displayedRank.ordinalText
         }
 
+        if shouldShowRankUnavailableState {
+            return "Unavailable"
+        }
+
         switch publicResultStatus?.phase {
         case .savedOnDevice:
             return "Saved"
@@ -432,7 +423,7 @@ struct LiveClimbCompletionSummaryView: View {
         case .syncingRanking:
             return "Syncing"
         case .pending, .published, nil:
-            return showsPendingRankingState ? "Checking" : unrankedValueText
+            return shouldShowPendingRankCopy ? "Checking" : fallbackUnrankedValueText
         }
     }
 
@@ -445,6 +436,10 @@ struct LiveClimbCompletionSummaryView: View {
             return completedDetailOverride ?? (climb == nil ? "WORKOUT COMPLETE" : "LIVE CLIMB COMPLETE")
         }
 
+        if shouldShowRankUnavailableState {
+            return "CHECK LEADERBOARD LATER"
+        }
+
         switch publicResultStatus?.phase {
         case .savedOnDevice:
             return "RESULT SAVED ON DEVICE"
@@ -453,28 +448,7 @@ struct LiveClimbCompletionSummaryView: View {
         case .syncingRanking:
             return "SYNCING RANKING"
         case .pending, .published, nil:
-            return unrankedDetailText
-        }
-    }
-
-    private var rankingStatusText: String {
-        if isUsingComputedRankFallback {
-            return "CURRENT"
-        }
-
-        if displayedRank != nil {
-            return "COMPLETE"
-        }
-
-        switch publicResultStatus?.phase {
-        case .savedOnDevice:
-            return "SAVED"
-        case .syncFailedRetry:
-            return "FAILED"
-        case .syncingRanking:
-            return "SYNCING"
-        case .pending, .published, nil:
-            return "LOADING"
+            return fallbackUnrankedDetailText
         }
     }
 
@@ -482,11 +456,37 @@ struct LiveClimbCompletionSummaryView: View {
         rankingLabelOverride ?? (climb == nil ? "GLOBAL RANK" : "CLIMB RANK")
     }
 
-    private var showsRankingStatusColumn: Bool {
-        displayedRank != nil ||
-            publicResultStatus?.phase == .savedOnDevice ||
-            publicResultStatus?.phase == .syncFailedRetry ||
-            publicResultStatus?.phase == .syncingRanking
+    private var hasCompletionRankContext: Bool {
+        effectiveLeaderboardContext != nil
+    }
+
+    private var shouldShowPendingRankCopy: Bool {
+        showsPendingRankingState &&
+            hasCompletionRankContext &&
+            !didFinishCompletionRankLoad
+    }
+
+    private var shouldShowRankUnavailableState: Bool {
+        showsPendingRankingState &&
+            hasCompletionRankContext &&
+            didFinishCompletionRankLoad &&
+            displayedRank == nil
+    }
+
+    private var fallbackUnrankedValueText: String {
+        if !hasCompletionRankContext && unrankedValueText == "Checking" {
+            return "Complete"
+        }
+
+        return unrankedValueText
+    }
+
+    private var fallbackUnrankedDetailText: String {
+        if !hasCompletionRankContext && unrankedDetailText == "LOOKING FOR YOUR RANK" {
+            return completedDetailOverride ?? (climb == nil ? "WORKOUT COMPLETE" : "LIVE CLIMB COMPLETE")
+        }
+
+        return unrankedDetailText
     }
 
     private var averageSPMText: String {
@@ -688,14 +688,20 @@ struct LiveClimbCompletionSummaryView: View {
 
     @MainActor
     private func loadCompletionRank() async {
-        guard !isLoadingCompletionRank,
-              let context = effectiveLeaderboardContext else {
+        guard let context = effectiveLeaderboardContext else {
+            didFinishCompletionRankLoad = true
+            return
+        }
+
+        guard !isLoadingCompletionRank else {
             return
         }
 
         isLoadingCompletionRank = true
+        didFinishCompletionRankLoad = false
         defer {
             isLoadingCompletionRank = false
+            didFinishCompletionRankLoad = true
         }
         computedCompletionRank = nil
 

--- a/AscendApp/Features/Routines/Views/Components/RoutineHeroVisualization.swift
+++ b/AscendApp/Features/Routines/Views/Components/RoutineHeroVisualization.swift
@@ -47,8 +47,8 @@ struct RoutineHeroVisualization: View {
             LinearGradient(
                 colors: [
                     .clear,
-                    accentColor.opacity(0.06),
-                    accentColor.opacity(0.12)
+                    ambientColor.opacity(0.06),
+                    ambientColor.opacity(0.12)
                 ],
                 startPoint: .top,
                 endPoint: .bottom
@@ -60,24 +60,30 @@ struct RoutineHeroVisualization: View {
 
     private var silhouetteLayer: some View {
         ZStack {
-            // Filled ridge — gradient from accent at the top to transparent at base
-            TopographicSilhouetteShape(intervals: intervals, totalDuration: totalDuration)
-                .fill(
-                    LinearGradient(
-                        colors: [
-                            accentColor.opacity(0.85),
-                            accentColor.opacity(0.35),
-                            accentColor.opacity(0.05)
-                        ],
-                        startPoint: .top,
-                        endPoint: .bottom
+            ForEach(intervalColorSlices) { slice in
+                TopographicSilhouetteShape(intervals: intervals, totalDuration: totalDuration)
+                    .fill(areaGradient(for: slice))
+                    .clipShape(
+                        RoutineHeroIntervalClipShape(
+                            startRatio: slice.startRatio,
+                            endRatio: slice.endRatio,
+                            horizontalOverscan: 1.5
+                        )
                     )
-                )
+            }
 
-            // Crisp stroke along the ridge line itself
-            TopographicSilhouetteShape(intervals: intervals, totalDuration: totalDuration, strokeOnly: true)
-                .stroke(accentColor.opacity(0.95), lineWidth: 1.5)
-                .shadow(color: accentColor.opacity(0.55), radius: 8, x: 0, y: 0)
+            ForEach(intervalColorSlices) { slice in
+                TopographicSilhouetteShape(intervals: intervals, totalDuration: totalDuration, strokeOnly: true)
+                    .stroke(segmentColor(for: slice).opacity(0.96), lineWidth: 1.7)
+                    .clipShape(
+                        RoutineHeroIntervalClipShape(
+                            startRatio: slice.startRatio,
+                            endRatio: slice.endRatio,
+                            horizontalOverscan: 2
+                        )
+                    )
+                    .shadow(color: segmentColor(for: slice).opacity(0.45), radius: 7, x: 0, y: 0)
+            }
         }
     }
 
@@ -116,8 +122,58 @@ struct RoutineHeroVisualization: View {
 
     // MARK: - Helpers
 
-    private var accentColor: Color {
-        Color(red: 0.706, green: 0.8, blue: 0)
+    private var intervalColorSlices: [RoutineHeroColorSlice] {
+        guard !intervals.isEmpty, totalDuration > 0 else { return [] }
+
+        var cumulativeDuration: TimeInterval = 0
+
+        return intervals.enumerated().map { index, interval in
+            let startRatio = cumulativeDuration / totalDuration
+            cumulativeDuration += max(interval.duration, 0)
+            let endRatio = index == intervals.count - 1 ? 1 : cumulativeDuration / totalDuration
+
+            return RoutineHeroColorSlice(
+                id: interval.id,
+                interval: interval,
+                startRatio: min(max(startRatio, 0), 1),
+                endRatio: min(max(endRatio, startRatio), 1)
+            )
+        }
+    }
+
+    private var ambientColor: Color {
+        guard !intervals.isEmpty else {
+            return Color(red: 0.706, green: 0.8, blue: 0)
+        }
+
+        let weightedScore = intervals.reduce(0.0) { total, interval in
+            total + interval.intensityTier.heatMapScore * max(interval.duration, 0)
+        }
+        let measuredDuration = intervals.reduce(0.0) { $0 + max($1.duration, 0) }
+        let averageScore = measuredDuration > 0 ? weightedScore / measuredDuration : 0.5
+
+        return Color.heatMapColor(for: averageScore, colorScheme: colorScheme)
+    }
+
+    private func segmentColor(for slice: RoutineHeroColorSlice) -> Color {
+        Color.heatMapColor(
+            for: slice.interval.intensityTier.heatMapScore,
+            colorScheme: colorScheme
+        )
+    }
+
+    private func areaGradient(for slice: RoutineHeroColorSlice) -> LinearGradient {
+        let color = segmentColor(for: slice)
+
+        return LinearGradient(
+            colors: [
+                color.opacity(0.82),
+                color.opacity(0.34),
+                color.opacity(0.05)
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
     }
 
     private var totalDurationLabel: String {
@@ -125,6 +181,37 @@ struct RoutineHeroVisualization: View {
         let minutes = totalSeconds / 60
         let seconds = totalSeconds % 60
         return "\(minutes):\(seconds.formatted(.number.precision(.integerLength(2))))"
+    }
+}
+
+private struct RoutineHeroColorSlice: Identifiable {
+    let id: UUID
+    let interval: RoutineInterval
+    let startRatio: Double
+    let endRatio: Double
+}
+
+private struct RoutineHeroIntervalClipShape: Shape {
+    let startRatio: Double
+    let endRatio: Double
+    var horizontalOverscan: CGFloat = 0
+
+    func path(in rect: CGRect) -> Path {
+        let startX = rect.minX + rect.width * CGFloat(startRatio)
+        let endX = rect.minX + rect.width * CGFloat(endRatio)
+        let expandedStartX = max(rect.minX, startX - horizontalOverscan)
+        let expandedEndX = min(rect.maxX, endX + horizontalOverscan)
+
+        var path = Path()
+        path.addRect(
+            CGRect(
+                x: expandedStartX,
+                y: rect.minY,
+                width: max(expandedEndX - expandedStartX, 0),
+                height: rect.height
+            )
+        )
+        return path
     }
 }
 

--- a/AscendApp/Features/Workouts/Views/Components/WorkoutHeartRateRecoveryCard.swift
+++ b/AscendApp/Features/Workouts/Views/Components/WorkoutHeartRateRecoveryCard.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+struct WorkoutHeartRateRecoveryCard: View {
+    let connectionState: AppleHealthConnectionState
+    let isFetching: Bool
+    let message: String?
+    let effectiveColorScheme: ColorScheme
+    let onFetch: () -> Void
+
+    private var primaryTextColor: Color {
+        effectiveColorScheme == .dark ? .white : .black
+    }
+
+    private var secondaryTextColor: Color {
+        effectiveColorScheme == .dark ? .white.opacity(0.62) : .black.opacity(0.58)
+    }
+
+    private var cardFill: Color {
+        effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06)
+    }
+
+    private var borderColor: Color {
+        effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15)
+    }
+
+    private var title: String {
+        switch connectionState {
+        case .connected:
+            return "Waiting for heart-rate data"
+        case .neverConnected:
+            return "Connect Apple Health"
+        case .revoked:
+            return "Apple Health access is off"
+        case .unavailable:
+            return "Apple Health unavailable"
+        }
+    }
+
+    private var detail: String {
+        if let message, !message.isEmpty {
+            return message
+        }
+
+        switch connectionState {
+        case .connected:
+            return "Apple Watch workouts can take a few minutes to sync. Fetch again after Health finishes writing the workout."
+        case .neverConnected:
+            return "Connect Apple Health to pull heart-rate data from your Watch workout."
+        case .revoked:
+            return "Re-enable Ascend in Health permissions, then return here to fetch heart-rate data."
+        case .unavailable:
+            return "This device cannot read Apple Health data."
+        }
+    }
+
+    private var actionTitle: String? {
+        switch connectionState {
+        case .connected:
+            return "Fetch"
+        case .neverConnected:
+            return "Connect"
+        case .revoked, .unavailable:
+            return nil
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Heart Rate")
+                    .font(.montserratSemiBold(size: 20))
+                    .foregroundStyle(primaryTextColor)
+
+                Spacer()
+
+                if isFetching {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(.red)
+                }
+            }
+
+            HStack(alignment: .top, spacing: 14) {
+                Image(systemName: "heart")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(.red)
+                    .frame(width: 34, height: 34)
+                    .background(
+                        Circle()
+                            .fill(.red.opacity(effectiveColorScheme == .dark ? 0.16 : 0.1))
+                    )
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(title)
+                        .font(.montserratSemiBold(size: 15))
+                        .foregroundStyle(primaryTextColor)
+
+                    Text(detail)
+                        .font(.montserratMedium(size: 12))
+                        .foregroundStyle(secondaryTextColor)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let actionTitle {
+                        Button(action: onFetch) {
+                            Label(actionTitle, systemImage: "arrow.clockwise")
+                                .font(.montserratBold(size: 12))
+                                .foregroundStyle(.black)
+                                .padding(.horizontal, 14)
+                                .frame(height: 34)
+                                .background(
+                                    Capsule(style: .continuous)
+                                        .fill(Color.accent)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(isFetching)
+                        .opacity(isFetching ? 0.62 : 1)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(cardFill)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(borderColor, lineWidth: 1)
+                    )
+            )
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        WorkoutHeartRateRecoveryCard(
+            connectionState: .connected,
+            isFetching: false,
+            message: nil,
+            effectiveColorScheme: .dark,
+            onFetch: {}
+        )
+
+        WorkoutHeartRateRecoveryCard(
+            connectionState: .neverConnected,
+            isFetching: true,
+            message: nil,
+            effectiveColorScheme: .dark,
+            onFetch: {}
+        )
+    }
+    .padding(20)
+    .background(Color.black)
+}

--- a/AscendApp/Features/Workouts/Views/Components/WorkoutPaceSplitsSection.swift
+++ b/AscendApp/Features/Workouts/Views/Components/WorkoutPaceSplitsSection.swift
@@ -1,0 +1,212 @@
+import SwiftUI
+
+struct WorkoutPaceSplitsSection: View {
+    let splits: [LiveClimbPaceSplit]
+    let averageStepsPerMinute: Double?
+    let effectiveColorScheme: ColorScheme
+
+    private var primaryTextColor: Color {
+        effectiveColorScheme == .dark ? .white : .black
+    }
+
+    private var secondaryTextColor: Color {
+        effectiveColorScheme == .dark ? .white.opacity(0.54) : .black.opacity(0.52)
+    }
+
+    private var cardFill: Color {
+        effectiveColorScheme == .dark ? .jetLighter.opacity(0.2) : .gray.opacity(0.06)
+    }
+
+    private var borderColor: Color {
+        effectiveColorScheme == .dark ? .white.opacity(0.1) : .gray.opacity(0.15)
+    }
+
+    private var minStepsPerMinute: Double {
+        splits.map(\.stepsPerMinute).min() ?? 0
+    }
+
+    private var maxStepsPerMinute: Double {
+        splits.map(\.stepsPerMinute).max() ?? 0
+    }
+
+    private var averageText: String {
+        let average: Double
+        if let averageStepsPerMinute {
+            average = averageStepsPerMinute
+        } else if splits.isEmpty {
+            average = 0
+        } else {
+            average = splits.map(\.stepsPerMinute).reduce(0, +) / Double(splits.count)
+        }
+
+        return Int(average.rounded()).formatted()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Splits")
+                    .font(.montserratSemiBold(size: 20))
+                    .foregroundStyle(primaryTextColor)
+
+                HStack(spacing: 5) {
+                    Text("\(splits.count.formatted()) \(splits.count == 1 ? "segment" : "segments")")
+                    Text("·")
+                        .foregroundStyle(.accent)
+                    Text("Avg \(averageText) SPM")
+                }
+                .font(.montserratMedium(size: 12))
+                .foregroundStyle(secondaryTextColor)
+                .lineLimit(1)
+                .minimumScaleFactor(0.74)
+            }
+
+            VStack(spacing: 0) {
+                ForEach(splits) { split in
+                    WorkoutPaceSplitRow(
+                        split: split,
+                        minStepsPerMinute: minStepsPerMinute,
+                        maxStepsPerMinute: maxStepsPerMinute,
+                        primaryTextColor: primaryTextColor,
+                        secondaryTextColor: secondaryTextColor
+                    )
+
+                    if split.id != (splits.last?.id ?? split.id) {
+                        Divider()
+                            .background(borderColor)
+                            .padding(.leading, 44)
+                    }
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 8)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(cardFill)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(borderColor, lineWidth: 1)
+                    )
+            )
+        }
+    }
+}
+
+private struct WorkoutPaceSplitRow: View {
+    let split: LiveClimbPaceSplit
+    let minStepsPerMinute: Double
+    let maxStepsPerMinute: Double
+    let primaryTextColor: Color
+    let secondaryTextColor: Color
+
+    private var timeRangeText: String {
+        "\(clockTime(split.startElapsedSeconds))-\(clockTime(split.endElapsedSeconds))"
+    }
+
+    private var barProgress: Double {
+        guard maxStepsPerMinute > minStepsPerMinute else { return 1 }
+
+        let range = maxStepsPerMinute - minStepsPerMinute
+        let normalizedValue = min(max((split.stepsPerMinute - minStepsPerMinute) / range, 0), 1)
+        return 0.25 + (normalizedValue * 0.75)
+    }
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Text("\(split.index + 1)")
+                .font(.montserratBold(size: 12))
+                .foregroundStyle(secondaryTextColor)
+                .monospacedDigit()
+                .frame(width: 24, alignment: .center)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(timeRangeText)
+                        .font(.montserratBold(size: 13))
+                        .foregroundStyle(primaryTextColor)
+                        .frame(width: 104, alignment: .leading)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .monospacedDigit()
+
+                    Text("\(split.steps.formatted()) steps")
+                        .font(.montserratMedium(size: 12))
+                        .foregroundStyle(secondaryTextColor)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.78)
+
+                    Spacer(minLength: 0)
+
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Text("\(Int(split.stepsPerMinute.rounded()).formatted())")
+                            .font(.montserratBold(size: 20))
+                            .foregroundStyle(primaryTextColor)
+                            .monospacedDigit()
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+
+                        Text("SPM")
+                            .font(.montserratBold(size: 8))
+                            .foregroundStyle(secondaryTextColor)
+                    }
+                    .frame(width: 64, alignment: .trailing)
+                }
+
+                GeometryReader { proxy in
+                    ZStack(alignment: .leading) {
+                        Capsule()
+                            .fill(secondaryTextColor.opacity(0.15))
+
+                        Capsule()
+                            .fill(splitBarGradient)
+                            .frame(width: max(proxy.size.width * barProgress, 12))
+                            .shadow(color: .accent.opacity(0.22), radius: 8, x: 0, y: 0)
+                    }
+                }
+                .frame(height: 8)
+            }
+        }
+        .padding(.vertical, 12)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(timeRangeText), \(split.steps.formatted()) steps, \(Int(split.stepsPerMinute.rounded()).formatted()) steps per minute")
+    }
+
+    private var splitBarGradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                Color.accent.opacity(0.42),
+                Color.accent.opacity(0.82),
+                Color.accent
+            ],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    }
+}
+
+private func clockTime(_ seconds: Int) -> String {
+    let totalSeconds = max(seconds, 0)
+    let hours = totalSeconds / 3600
+    let minutes = (totalSeconds % 3600) / 60
+    let seconds = totalSeconds % 60
+
+    if hours > 0 {
+        return "\(hours):\(minutes < 10 ? "0" : "")\(minutes):\(seconds < 10 ? "0" : "")\(seconds)"
+    }
+
+    return "\(minutes):\(seconds < 10 ? "0" : "")\(seconds)"
+}
+
+#Preview {
+    WorkoutPaceSplitsSection(
+        splits: [
+            LiveClimbPaceSplit(index: 0, startElapsedSeconds: 0, endElapsedSeconds: 300, steps: 394, stepsPerMinute: 78.8),
+            LiveClimbPaceSplit(index: 1, startElapsedSeconds: 300, endElapsedSeconds: 600, steps: 417, stepsPerMinute: 83.4),
+            LiveClimbPaceSplit(index: 2, startElapsedSeconds: 600, endElapsedSeconds: 900, steps: 390, stepsPerMinute: 78)
+        ],
+        averageStepsPerMinute: 80,
+        effectiveColorScheme: .dark
+    )
+    .padding(20)
+    .background(Color.black)
+}

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -11,6 +11,8 @@ import UIKit
 
 struct WorkoutDetailView: View {
     let workout: Workout
+    private let embedsInNavigationStack: Bool
+
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
@@ -18,6 +20,7 @@ struct WorkoutDetailView: View {
     @Query(sort: \BestEffortCacheEntry.sortKey) private var bestEffortCacheEntries: [BestEffortCacheEntry]
     @State private var themeManager = ThemeManager.shared
     @State private var settingsManager = SettingsManager.shared
+    @State private var importCoordinator = WorkoutImportCoordinator.shared
     @State private var showingEditWorkout = false
     @State private var showingShareWorkoutView = false
     @State private var showingDeleteConfirmation = false
@@ -30,6 +33,8 @@ struct WorkoutDetailView: View {
     @State private var liveClimbCompletionRank: LiveReplayCompletionRank?
     @State private var isLoadingLiveClimbRank = false
     @State private var copyConfirmationText: String?
+    @State private var isFetchingAppleHealthHeartRate = false
+    @State private var appleHealthHeartRateMessage: String?
 
     // Media layout state
     @State private var sheetPosition: SheetPosition = .middle
@@ -40,6 +45,11 @@ struct WorkoutDetailView: View {
     // Scroll tracking for traditional layout nav bar title
     @State private var scrolledPastTitle = false
     @State private var scrollContentOffset: CGFloat = 0
+
+    init(workout: Workout, embedsInNavigationStack: Bool = true) {
+        self.workout = workout
+        self.embedsInNavigationStack = embedsInNavigationStack
+    }
 
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
@@ -54,105 +64,121 @@ struct WorkoutDetailView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                (effectiveColorScheme == .dark ? Color.black : Color.white)
-                    .ignoresSafeArea()
+        if embedsInNavigationStack {
+            NavigationStack {
+                content
+            }
+        } else {
+            content
+        }
+    }
 
-                if hasMedia {
-                    workoutMediaLayout
-                } else {
-                    traditionalLayout
-                }
+    private var content: some View {
+        ZStack {
+            (effectiveColorScheme == .dark ? Color.black : Color.white)
+                .ignoresSafeArea()
+
+            if hasMedia {
+                workoutMediaLayout
+            } else {
+                traditionalLayout
             }
-            .navigationBarHidden(true)
-            .overlay(alignment: .top) {
-                adaptiveHeader
-            }
-            .sheet(isPresented: $showingEditWorkout) {
-                EditWorkoutView(
+        }
+        .navigationBarHidden(true)
+        .overlay(alignment: .top) {
+            adaptiveHeader
+        }
+        .sheet(isPresented: $showingEditWorkout) {
+            EditWorkoutView(
+                workout: workout,
+                showingEditWorkout: $showingEditWorkout
+            )
+            .interactiveDismissDisabled()
+        }
+        .fullScreenCover(isPresented: $showingShareWorkoutView) {
+            ShareComposerView(workout: workout, climb: liveClimbDetailClimb)
+        }
+        .fullScreenCover(isPresented: $showingLiveClimbSummaryPreview) {
+            if liveClimbSummaryMetadata?.climbId == nil || liveClimbDetailClimb != nil {
+                LiveClimbCompletionSummaryView(
+                    climb: liveClimbDetailClimb,
                     workout: workout,
-                    showingEditWorkout: $showingEditWorkout
-                )
-                .interactiveDismissDisabled()
-            }
-            .fullScreenCover(isPresented: $showingShareWorkoutView) {
-                ShareComposerView(workout: workout, climb: liveClimbDetailClimb)
-            }
-            .fullScreenCover(isPresented: $showingLiveClimbSummaryPreview) {
-                if liveClimbSummaryMetadata?.climbId == nil || liveClimbDetailClimb != nil {
-                    LiveClimbCompletionSummaryView(
-                        climb: liveClimbDetailClimb,
-                        workout: workout,
-                        leaderboardRank: liveClimbCompletionRank?.rank,
-                        leaderboardTotal: liveClimbCompletionRank?.completedCount,
-                        allowsRatingPrompt: false,
-                        onDone: {
-                            showingLiveClimbSummaryPreview = false
-                        }
-                    )
-                } else {
-                    LiveClimbSummaryPreviewUnavailableView {
+                    leaderboardRank: liveClimbCompletionRank?.rank,
+                    leaderboardTotal: liveClimbCompletionRank?.completedCount,
+                    allowsRatingPrompt: false,
+                    leaderboardContext: liveClimbSummaryLeaderboardContext,
+                    rankingLabelOverride: liveClimbSummaryRankingLabelOverride,
+                    completedDetailOverride: liveClimbSummaryCompletedDetailText,
+                    unrankedValueText: liveClimbSummaryLeaderboardContext == nil ? "Complete" : "Checking",
+                    unrankedDetailText: liveClimbSummaryLeaderboardContext == nil ?
+                        liveClimbSummaryCompletedDetailText :
+                        "LOOKING FOR YOUR RANK",
+                    showsPendingRankingState: liveClimbSummaryLeaderboardContext != nil,
+                    onDone: {
                         showingLiveClimbSummaryPreview = false
                     }
+                )
+            } else {
+                LiveClimbSummaryPreviewUnavailableView {
+                    showingLiveClimbSummaryPreview = false
                 }
             }
-            .onAppear {
-                if hasMedia {
-                    currentPhotoIndex = 0
-                }
+        }
+        .onAppear {
+            if hasMedia {
+                currentPhotoIndex = 0
             }
-            .task(id: workout.id) {
-                await loadLiveClimbCompletionRankIfNeeded()
+        }
+        .task(id: workout.id) {
+            await loadLiveClimbCompletionRankIfNeeded()
+            await retryAppleHealthEnrichmentIfNeeded()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
+            Task {
                 await retryAppleHealthEnrichmentIfNeeded()
             }
-            .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-                Task {
-                    await retryAppleHealthEnrichmentIfNeeded()
-                }
+        }
+        .onChange(of: showingEditWorkout) { _, isShowing in
+            if !isShowing && hasMedia {
+                currentPhotoIndex = 0
             }
-            .onChange(of: showingEditWorkout) { _, isShowing in
-                if !isShowing && hasMedia {
-                    currentPhotoIndex = 0
-                }
-            }
-            .sheet(isPresented: $showingDeleteConfirmation) {
-                SingleWorkoutDeleteConfirmationView(
-                    workout: workout,
-                    isLoading: isDeleting,
-                    isCancelling: isCancelling,
-                    onConfirm: {
-                        guard deleteTask == nil else { return }
-                        deleteTask = Task {
-                            await deleteWorkout()
-                            deleteTask = nil
-                        }
-                    },
-                    onCancel: {
-                        if isDeleting {
-                            isCancelling = true
-                            deleteTask?.cancel()
-                            deleteTask = nil
-                            isDeleting = false
-                            isCancelling = false
-                        }
-                        showingDeleteConfirmation = false
+        }
+        .sheet(isPresented: $showingDeleteConfirmation) {
+            SingleWorkoutDeleteConfirmationView(
+                workout: workout,
+                isLoading: isDeleting,
+                isCancelling: isCancelling,
+                onConfirm: {
+                    guard deleteTask == nil else { return }
+                    deleteTask = Task {
+                        await deleteWorkout()
+                        deleteTask = nil
                     }
-                )
-                .interactiveDismissDisabled(isDeleting || isCancelling)
-                .onDisappear {
-                    deleteTask?.cancel()
-                    deleteTask = nil
+                },
+                onCancel: {
+                    if isDeleting {
+                        isCancelling = true
+                        deleteTask?.cancel()
+                        deleteTask = nil
+                        isDeleting = false
+                        isCancelling = false
+                    }
+                    showingDeleteConfirmation = false
                 }
+            )
+            .interactiveDismissDisabled(isDeleting || isCancelling)
+            .onDisappear {
+                deleteTask?.cancel()
+                deleteTask = nil
             }
-            .fullScreenCover(item: $selectedPhoto) { photo in
-                FullScreenPhotoView(photo: photo) {
-                    selectedPhoto = nil
-                }
+        }
+        .fullScreenCover(item: $selectedPhoto) { photo in
+            FullScreenPhotoView(photo: photo) {
+                selectedPhoto = nil
             }
-            .overlay(alignment: .top) {
-                copyConfirmationOverlay
-            }
+        }
+        .overlay(alignment: .top) {
+            copyConfirmationOverlay
         }
     }
 
@@ -326,14 +352,15 @@ struct WorkoutDetailView: View {
                 )
             }
 
-            // Heart Rate Chart
-            if !workout.heartRateTimeSeries.isEmpty || workout.avgHeartRate != nil || workout.maxHeartRate != nil {
-                HeartRateChartView(
-                    heartRateData: workout.heartRateTimeSeries,
-                    workoutStartTime: workout.date,
-                    workoutDuration: workout.duration,
-                    averageHeartRateBpm: workout.avgHeartRate,
-                    maxHeartRateBpm: workout.maxHeartRate
+            if shouldShowHeartRateSection {
+                heartRateSection
+            }
+
+            if shouldShowPaceSplitsSection {
+                WorkoutPaceSplitsSection(
+                    splits: workoutPaceSplits,
+                    averageStepsPerMinute: workout.stepsPerMinute,
+                    effectiveColorScheme: effectiveColorScheme
                 )
             }
 
@@ -513,6 +540,133 @@ struct WorkoutDetailView: View {
 
     private var liveClimbSummaryMetadata: HeadphoneMotionWorkoutMetadata? {
         LiveClimbWorkoutSummaryData.metadata(for: workout)
+    }
+
+    @MainActor
+    private var liveClimbSummaryLeaderboardContext: LiveReplayLeaderboardContext? {
+        guard let metadata = liveClimbSummaryMetadata else { return nil }
+
+        switch metadata.trackingMode {
+        case .liveClimb:
+            guard let climb = liveClimbDetailClimb else { return nil }
+            return .liveClimb(
+                climbId: climb.id,
+                targetSteps: climb.referenceStepCount
+            )
+
+        case .justClimb:
+            return .justClimbGlobal(targetSteps: justClimbSummaryTargetSteps(metadata: metadata))
+
+        case .routine:
+            guard let templateId = metadata.routineTemplateId,
+                  !templateId.isEmpty else {
+                return nil
+            }
+
+            return .routineTemplate(
+                templateId: templateId,
+                targetSteps: summaryTargetSteps(metadata: metadata)
+            )
+
+        case nil:
+            guard metadata.climbId == nil else { return nil }
+            return .justClimbGlobal(targetSteps: justClimbSummaryTargetSteps(metadata: metadata))
+        }
+    }
+
+    @MainActor
+    private var liveClimbSummaryRankingLabelOverride: String? {
+        guard liveClimbSummaryMetadata?.trackingMode == .routine else { return nil }
+        return liveClimbSummaryLeaderboardContext == nil ? "ROUTINE" : "ROUTINE RANK"
+    }
+
+    private var liveClimbSummaryCompletedDetailText: String {
+        switch liveClimbSummaryMetadata?.trackingMode {
+        case .routine:
+            return "ROUTINE COMPLETE"
+        case .liveClimb:
+            return "LIVE CLIMB COMPLETE"
+        case .justClimb, nil:
+            return "WORKOUT COMPLETE"
+        }
+    }
+
+    private func summaryTargetSteps(metadata: HeadphoneMotionWorkoutMetadata) -> Int {
+        max(metadata.targetStepCount ?? workout.steps, workout.steps, 1)
+    }
+
+    private func justClimbSummaryTargetSteps(metadata: HeadphoneMotionWorkoutMetadata) -> Int {
+        max(
+            metadata.targetStepCount ?? JustClimbGoal.defaultOpenStepScale,
+            JustClimbGoal.defaultOpenStepScale,
+            workout.steps,
+            1
+        )
+    }
+
+    @ViewBuilder
+    private var heartRateSection: some View {
+        if hasHeartRateData {
+            HeartRateChartView(
+                heartRateData: workout.heartRateTimeSeries,
+                workoutStartTime: workout.date,
+                workoutDuration: workout.duration,
+                averageHeartRateBpm: workout.avgHeartRate,
+                maxHeartRateBpm: workout.maxHeartRate
+            )
+        } else if shouldShowAppleHealthHeartRateRecovery {
+            WorkoutHeartRateRecoveryCard(
+                connectionState: importCoordinator.appleHealthConnectionState,
+                isFetching: isFetchingAppleHealthHeartRate,
+                message: appleHealthHeartRateMessage,
+                effectiveColorScheme: effectiveColorScheme,
+                onFetch: fetchAppleHealthHeartRate
+            )
+        }
+    }
+
+    private var hasHeartRateData: Bool {
+        !workout.heartRateTimeSeries.isEmpty ||
+            workout.avgHeartRate != nil ||
+            workout.maxHeartRate != nil
+    }
+
+    private var shouldShowHeartRateSection: Bool {
+        hasHeartRateData || shouldShowAppleHealthHeartRateRecovery
+    }
+
+    private var shouldShowAppleHealthHeartRateRecovery: Bool {
+        workout.isInAppSensorWorkout && !hasHeartRateData
+    }
+
+    private var workoutPaceSplits: [LiveClimbPaceSplit] {
+        guard let metadata = liveClimbSummaryMetadata else { return [] }
+
+        return LiveClimbWorkoutSummaryData.paceSplits(
+            for: workout,
+            targetSteps: summaryTargetSteps(metadata: metadata)
+        )
+    }
+
+    private var shouldShowPaceSplitsSection: Bool {
+        workout.isInAppSensorWorkout &&
+            hasRecordedPaceSplitData &&
+            workoutPaceSplits.count > 1
+    }
+
+    private var hasRecordedPaceSplitData: Bool {
+        guard let metadata = liveClimbSummaryMetadata,
+              let intervalSeconds = metadata.splitIntervalSeconds,
+              intervalSeconds > 0,
+              let splitSteps = metadata.splitSteps,
+              splitSteps.count > 2 else {
+            return false
+        }
+
+        let finalSteps = max(workout.steps, 0)
+        return splitSteps.dropLast().contains { step in
+            step > 0 && step < finalSteps
+        }
     }
 
     // MARK: - Weights Section (unchanged)
@@ -756,7 +910,7 @@ struct WorkoutDetailView: View {
     private func loadLiveClimbCompletionRankIfNeeded() async {
         guard liveClimbCompletionRank == nil,
               !isLoadingLiveClimbRank,
-              let climb = liveClimbDetailClimb else {
+              let context = liveClimbSummaryLeaderboardContext else {
             return
         }
 
@@ -764,11 +918,6 @@ struct WorkoutDetailView: View {
         defer {
             isLoadingLiveClimbRank = false
         }
-
-        let context = LiveReplayLeaderboardContext.liveClimb(
-            climbId: climb.id,
-            targetSteps: climb.referenceStepCount
-        )
 
         do {
             liveClimbCompletionRank = try await LiveReplayLeaderboardService.shared.fetchCompletionRank(
@@ -784,10 +933,63 @@ struct WorkoutDetailView: View {
 
     @MainActor
     private func retryAppleHealthEnrichmentIfNeeded() async {
-        await WorkoutImportCoordinator.shared.enrichInAppWorkoutWithAppleHealthIfPossible(
+        await importCoordinator.enrichInAppWorkoutWithAppleHealthIfPossible(
             workout,
             modelContext: modelContext
         )
+    }
+
+    private func fetchAppleHealthHeartRate() {
+        guard !isFetchingAppleHealthHeartRate else { return }
+
+        Task { @MainActor in
+            isFetchingAppleHealthHeartRate = true
+            appleHealthHeartRateMessage = nil
+            defer {
+                isFetchingAppleHealthHeartRate = false
+            }
+
+            if importCoordinator.appleHealthConnectionState == .neverConnected {
+                let didConnect = await importCoordinator.requestAppleHealthAuthorizationIfNeeded()
+                guard didConnect else {
+                    appleHealthHeartRateMessage = importCoordinator.lastErrorMessage ??
+                        "Apple Health could not be connected."
+                    return
+                }
+            }
+
+            guard importCoordinator.appleHealthConnectionState == .connected else {
+                appleHealthHeartRateMessage = appleHealthUnavailableMessage
+                return
+            }
+
+            _ = await importCoordinator.enrichInAppWorkoutWithAppleHealthIfPossible(
+                workout,
+                modelContext: modelContext,
+                forceRangeDiscovery: true
+            )
+
+            if hasHeartRateData {
+                appleHealthHeartRateMessage = nil
+                HapticsManager.shared.trigger(.success)
+            } else {
+                appleHealthHeartRateMessage = "No matching heart-rate samples found yet. Try again after Apple Watch finishes syncing."
+                HapticsManager.shared.trigger(.warning)
+            }
+        }
+    }
+
+    private var appleHealthUnavailableMessage: String {
+        switch importCoordinator.appleHealthConnectionState {
+        case .unavailable:
+            return "Apple Health is not available on this device."
+        case .revoked:
+            return "Apple Health access is off. Re-enable Ascend in Health permissions."
+        case .neverConnected:
+            return "Connect Apple Health to fetch heart-rate data."
+        case .connected:
+            return "Apple Health is connected, but no heart-rate data was found yet."
+        }
     }
 
     private func deleteWorkout() async {

--- a/AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift
+++ b/AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift
@@ -199,11 +199,21 @@ private struct LiveReplayLeaderboardRowView: View {
 
                 avatarView
 
-                Text(row.displayName)
-                    .font(.montserratBold(size: 17))
-                    .foregroundStyle(primaryColor)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.78)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(row.isCurrentUser ? "You" : row.displayName)
+                        .font(.montserratBold(size: 17))
+                        .foregroundStyle(primaryColor)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.78)
+
+                    if let demographicSummaryText = row.demographicSummaryText {
+                        Text(demographicSummaryText)
+                            .font(.montserratSemiBold(size: 10))
+                            .foregroundStyle(secondaryColor)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.75)
+                    }
+                }
 
                 Spacer(minLength: 0)
 

--- a/AscendApp/Shared/Components/ReplayLeaderboard/ReplayCompletionLeaderboardView.swift
+++ b/AscendApp/Shared/Components/ReplayLeaderboard/ReplayCompletionLeaderboardView.swift
@@ -221,6 +221,14 @@ private struct ReplayCompletionLeaderboardRowView: View {
                     }
                 }
 
+                if let demographicSummaryText = row.demographicSummaryText {
+                    Text(demographicSummaryText)
+                        .font(.montserratSemiBold(size: rank == 1 ? 11 : 10))
+                        .foregroundStyle(secondaryColor)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.75)
+                }
+
                 Text("\(displaySteps.formatted()) steps")
                     .font(.montserratMedium(size: rank == 1 ? 12 : 11))
                     .foregroundStyle(secondaryColor)

--- a/AscendApp/Shared/Repositories/Firebase/FirestoreLiveReplayLeaderboardRepository.swift
+++ b/AscendApp/Shared/Repositories/Firebase/FirestoreLiveReplayLeaderboardRepository.swift
@@ -479,7 +479,10 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
             isCurrentUser: false,
             isPersonalBest: (data["isPersonalBest"] as? Bool) ?? false,
             completionDurationSeconds: doubleValue(for: "completionDurationSeconds", in: data),
-            userId: userId
+            userId: userId,
+            gender: stringValue(for: "gender", in: data),
+            age: intValue(for: "age", in: data),
+            locationCity: stringValue(for: "locationCity", in: data)
         )
     }
 
@@ -516,7 +519,10 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
             isCurrentUser: userId == currentUserId,
             isPersonalBest: userId == currentUserId,
             completionDurationSeconds: completionDurationSeconds,
-            userId: userId
+            userId: userId,
+            gender: stringValue(for: "gender", in: data),
+            age: intValue(for: "age", in: data),
+            locationCity: stringValue(for: "locationCity", in: data)
         )
     }
 
@@ -560,7 +566,10 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
             isCurrentUser: row.isCurrentUser,
             isPersonalBest: row.isPersonalBest,
             completionDurationSeconds: row.completionDurationSeconds,
-            userId: row.userId
+            userId: row.userId,
+            gender: row.gender,
+            age: row.age,
+            locationCity: row.locationCity
         )
     }
 

--- a/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
+++ b/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
@@ -261,6 +261,9 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
     let isPersonalBest: Bool
     let completionDurationSeconds: TimeInterval?
     let userId: String?
+    let gender: String?
+    let age: Int?
+    let locationCity: String?
 
     init(
         id: String,
@@ -274,7 +277,10 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
         isCurrentUser: Bool,
         isPersonalBest: Bool,
         completionDurationSeconds: TimeInterval?,
-        userId: String? = nil
+        userId: String? = nil,
+        gender: String? = nil,
+        age: Int? = nil,
+        locationCity: String? = nil
     ) {
         self.id = id
         self.rank = rank
@@ -288,6 +294,9 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
         self.isPersonalBest = isPersonalBest
         self.completionDurationSeconds = completionDurationSeconds
         self.userId = userId
+        self.gender = Self.cleanedString(gender)
+        self.age = Self.validAge(age)
+        self.locationCity = Self.cleanedString(locationCity)
     }
 
     var averageStepsPerMinute: Double? {
@@ -301,12 +310,36 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
         return value.isFinite ? value : nil
     }
 
+    var demographicSummaryText: String? {
+        let parts = [
+            genderAbbreviation,
+            age.map(String.init),
+            locationCity
+        ].compactMap { $0 }
+
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private var genderAbbreviation: String? {
+        switch gender?.lowercased() {
+        case "man", "male", "m":
+            return "M"
+        case "woman", "female", "f":
+            return "F"
+        default:
+            return nil
+        }
+    }
+
     static func currentUser(
         rank: Int?,
         steps: Int,
         avatarToken: String = "YOU",
         photoURL: URL? = nil,
-        isPersonalBest: Bool = false
+        isPersonalBest: Bool = false,
+        gender: String? = nil,
+        age: Int? = nil,
+        locationCity: String? = nil
     ) -> LiveReplayLeaderboardRow {
         LiveReplayLeaderboardRow(
             id: "current-user",
@@ -320,7 +353,10 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
             isCurrentUser: true,
             isPersonalBest: isPersonalBest,
             completionDurationSeconds: nil,
-            userId: nil
+            userId: nil,
+            gender: gender,
+            age: age,
+            locationCity: locationCity
         )
     }
 
@@ -372,7 +408,10 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
             isCurrentUser: isCurrentUser,
             isPersonalBest: isPersonalBest,
             completionDurationSeconds: completionDurationSeconds,
-            userId: userId
+            userId: userId,
+            gender: gender,
+            age: age,
+            locationCity: locationCity
         )
     }
 
@@ -386,6 +425,24 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
 
         let defaultSyntheticSPM = 72.0
         return max(Double(finalSteps) / defaultSyntheticSPM * 60, 90)
+    }
+
+    private static func cleanedString(_ value: String?) -> String? {
+        guard let cleaned = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !cleaned.isEmpty else {
+            return nil
+        }
+
+        return cleaned
+    }
+
+    private static func validAge(_ value: Int?) -> Int? {
+        guard let value,
+              (13...120).contains(value) else {
+            return nil
+        }
+
+        return value
     }
 }
 

--- a/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardService.swift
+++ b/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardService.swift
@@ -112,27 +112,36 @@ actor LiveReplayLeaderboardService: LiveReplayLeaderboardServicing {
     func fetchSummary(
         context: LiveReplayLeaderboardContext
     ) async throws -> LiveReplayLeaderboardSummary {
-        try await repository.fetchSummary(context: context)
+        let repository = repository
+        return try await withLiveReplayLeaderboardTimeout(seconds: fetchTimeoutSeconds) {
+            try await repository.fetchSummary(context: context)
+        }
     }
 
     func fetchCompletionRank(
         context: LiveReplayLeaderboardContext,
         completionDurationSeconds: TimeInterval
     ) async throws -> LiveReplayCompletionRank {
-        try await repository.fetchCompletionRank(
-            context: context,
-            completionDurationSeconds: completionDurationSeconds
-        )
+        let repository = repository
+        return try await withLiveReplayLeaderboardTimeout(seconds: fetchTimeoutSeconds) {
+            try await repository.fetchCompletionRank(
+                context: context,
+                completionDurationSeconds: completionDurationSeconds
+            )
+        }
     }
 
     func fetchCompletionRankSnapshot(
         context: LiveReplayLeaderboardContext,
         workoutId: String
     ) async throws -> LiveReplayCompletionRankSnapshot? {
-        try await repository.fetchCompletionRankSnapshot(
-            context: context,
-            workoutId: workoutId
-        )
+        let repository = repository
+        return try await withLiveReplayLeaderboardTimeout(seconds: fetchTimeoutSeconds) {
+            try await repository.fetchCompletionRankSnapshot(
+                context: context,
+                workoutId: workoutId
+            )
+        }
     }
 
     func fetchPublishStatus(
@@ -150,7 +159,10 @@ actor LiveReplayLeaderboardService: LiveReplayLeaderboardServicing {
     func fetchCurrentUserFinisherStatus(
         context: LiveReplayLeaderboardContext
     ) async throws -> LiveReplayFinisherStatus? {
-        try await repository.fetchCurrentUserFinisherStatus(context: context)
+        let repository = repository
+        return try await withLiveReplayLeaderboardTimeout(seconds: fetchTimeoutSeconds) {
+            try await repository.fetchCurrentUserFinisherStatus(context: context)
+        }
     }
 
     func fetchCompletionLeaderboard(

--- a/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
@@ -457,27 +457,44 @@ final class WorkoutImportCoordinator {
         await syncAppleHealthAutomationServices()
     }
 
+    @discardableResult
     func enrichInAppWorkoutWithAppleHealthIfPossible(
         _ workout: Workout,
-        modelContext: ModelContext
-    ) async {
-        guard canAttemptAppleHealthEnrichment(workout) else { return }
-        let shouldUseRangeDiscovery = enrichmentRetryStore.isRetryDue(for: workout)
+        modelContext: ModelContext,
+        forceRangeDiscovery: Bool = false
+    ) async -> Bool {
+        guard workout.isInAppSensorWorkout,
+              needsAppleHealthEnrichment(workout) else {
+            return false
+        }
+
+        let shouldUseRangeDiscovery = forceRangeDiscovery || enrichmentRetryStore.isRetryDue(for: workout)
         guard shouldUseRangeDiscovery || hasCachedAppleHealthEnrichmentSample(for: workout) else {
-            return
+            return false
         }
 
         await authorizationController.refreshAuthorizationRequestStatus()
 
         do {
+            if let externalRecordID = appleHealthExternalRecordID(for: workout) {
+                return try await enrichLinkedInAppWorkoutWithAppleHealthIfPossible(
+                    workout,
+                    externalRecordID: externalRecordID,
+                    modelContext: modelContext
+                )
+            }
+
             let existingIndex = try buildExistingWorkoutIndex(modelContext: modelContext)
-            _ = try await enrichInAppWorkoutsWithAppleHealthIfPossible(
+            let enrichedWorkouts = try await enrichInAppWorkoutsWithAppleHealthIfPossible(
                 existingIndex: existingIndex,
                 modelContext: modelContext,
-                eligibleWorkoutIDs: [workout.id]
+                eligibleWorkoutIDs: [workout.id],
+                forceRangeDiscovery: forceRangeDiscovery
             )
+            return enrichedWorkouts.contains { $0.id == workout.id }
         } catch {
             lastErrorMessage = error.localizedDescription
+            return false
         }
     }
 
@@ -599,7 +616,8 @@ final class WorkoutImportCoordinator {
     private func enrichInAppWorkoutsWithAppleHealthIfPossible(
         existingIndex: ExistingWorkoutIndex,
         modelContext: ModelContext,
-        eligibleWorkoutIDs: Set<UUID>? = nil
+        eligibleWorkoutIDs: Set<UUID>? = nil,
+        forceRangeDiscovery: Bool = false
     ) async throws -> [Workout] {
         guard authorizationController.connectionState == .connected else { return [] }
 
@@ -614,7 +632,8 @@ final class WorkoutImportCoordinator {
 
         let appleSamples = await appleHealthSamplesForEnrichment(
             eligibleWorkouts: eligibleWorkouts,
-            existingIndex: existingIndex
+            existingIndex: existingIndex,
+            forceRangeDiscovery: forceRangeDiscovery
         )
         guard !appleSamples.isEmpty else { return [] }
 
@@ -663,13 +682,16 @@ final class WorkoutImportCoordinator {
 
     private func appleHealthSamplesForEnrichment(
         eligibleWorkouts: [Workout],
-        existingIndex: ExistingWorkoutIndex
+        existingIndex: ExistingWorkoutIndex,
+        forceRangeDiscovery: Bool = false
     ) async -> [HealthKitWorkoutSample] {
         let ignoredAppleHealthWorkoutIDs = ignoredAppleHealthWorkoutStore.load()
         var samplesByID: [String: HealthKitWorkoutSample] = [:]
-        let retryableWorkouts = eligibleWorkouts.filter { workout in
-            enrichmentRetryStore.isRetryDue(for: workout)
-        }
+        let retryableWorkouts = forceRangeDiscovery
+            ? eligibleWorkouts
+            : eligibleWorkouts.filter { workout in
+                enrichmentRetryStore.isRetryDue(for: workout)
+            }
 
         func addIfEligible(_ sample: HealthKitWorkoutSample) {
             guard !ignoredAppleHealthWorkoutIDs.contains(sample.externalRecordID),
@@ -699,6 +721,42 @@ final class WorkoutImportCoordinator {
         return samplesByID.values.sorted { lhs, rhs in
             lhs.startDate > rhs.startDate
         }
+    }
+
+    @discardableResult
+    private func enrichLinkedInAppWorkoutWithAppleHealthIfPossible(
+        _ workout: Workout,
+        externalRecordID: String,
+        modelContext: ModelContext
+    ) async throws -> Bool {
+        guard authorizationController.connectionState == .connected,
+              let hkWorkout = try await workoutReader.fetchWorkout(withExternalRecordID: externalRecordID) else {
+            return false
+        }
+
+        let sample = healthKitWorkoutSample(from: hkWorkout)
+        let metricWindow = AppleHealthWorkoutEnrichmentPolicy.inAppSensorWorkout.metricWindow(
+            for: workout,
+            sample: sample
+        ) ?? (sample.startDate...sample.endDate)
+        let metrics = await metricsReader.fetchMetrics(for: hkWorkout, during: metricWindow)
+        let before = LeaderboardWorkoutSnapshot(workout: workout)
+        let didChangeMetrics = applyAppleHealthEnrichmentMetrics(metrics, from: sample, to: workout)
+        ensureAppleHealthLinkExists(sample: sample, for: workout, modelContext: modelContext)
+
+        guard didChangeMetrics else {
+            try modelContext.save()
+            return false
+        }
+
+        try WorkoutMutationHandler.shared.workoutsDidChange(
+            modelContext: modelContext,
+            mutation: WorkoutMutation(updated: [
+                .init(before: before, after: LeaderboardWorkoutSnapshot(workout: workout))
+            ]),
+            changedWorkouts: [workout]
+        )
+        return true
     }
 
     private func appleHealthEnrichmentDiscoveryRange(
@@ -941,6 +999,10 @@ final class WorkoutImportCoordinator {
         workout.hasSourceLink(provider: .appleHealth) || workout.healthKitUUID != nil
     }
 
+    private func appleHealthExternalRecordID(for workout: Workout) -> String? {
+        workout.sourceLink(for: .appleHealth)?.externalRecordID ?? workout.healthKitUUID
+    }
+
     private func canAttemptAppleHealthEnrichment(_ workout: Workout) -> Bool {
         AppleHealthWorkoutEnrichmentPolicy.inAppSessionPolicies.contains { policy in
             policy.isEligible(workout, hasAppleHealthLink: hasAppleHealthLink(workout))
@@ -984,29 +1046,61 @@ final class WorkoutImportCoordinator {
         workout.healthKitUUID = sample.externalRecordID
     }
 
+    @discardableResult
     private func applyAppleHealthEnrichmentMetrics(
         _ metrics: WorkoutMetrics,
         from sample: HealthKitWorkoutSample,
         to workout: Workout
-    ) {
-        if let avgHeartRate = metrics.avgHeartRate {
+    ) -> Bool {
+        var didChange = false
+
+        if let avgHeartRate = metrics.avgHeartRate, workout.avgHeartRate != avgHeartRate {
             workout.avgHeartRate = avgHeartRate
+            didChange = true
         }
-        if let maxHeartRate = metrics.maxHeartRate {
+        if let maxHeartRate = metrics.maxHeartRate, workout.maxHeartRate != maxHeartRate {
             workout.maxHeartRate = maxHeartRate
+            didChange = true
         }
         if !metrics.heartRateTimeSeries.isEmpty {
-            workout.heartRateData = metrics.heartRateTimeSeries.encoded
+            let encodedHeartRateData = metrics.heartRateTimeSeries.encoded
+            if workout.heartRateData != encodedHeartRateData {
+                workout.heartRateData = encodedHeartRateData
+                didChange = true
+            }
         }
-        if let caloriesBurned = metrics.caloriesBurned {
+        if let caloriesBurned = metrics.caloriesBurned, workout.caloriesBurned != caloriesBurned {
             workout.caloriesBurned = caloriesBurned
+            didChange = true
         }
-        if let averageMETs = metrics.averageMETs {
+        if let averageMETs = metrics.averageMETs, workout.averageMETs != averageMETs {
             workout.averageMETs = averageMETs
+            didChange = true
         }
 
-        workout.deviceModel = sample.deviceModel ?? sample.displaySourceName
-        workout.healthKitUUID = sample.externalRecordID
+        let deviceModel = sample.deviceModel ?? sample.displaySourceName
+        if workout.deviceModel != deviceModel {
+            workout.deviceModel = deviceModel
+            didChange = true
+        }
+        if workout.healthKitUUID != sample.externalRecordID {
+            workout.healthKitUUID = sample.externalRecordID
+            didChange = true
+        }
+
+        return didChange
+    }
+
+    private func healthKitWorkoutSample(from workout: HKWorkout) -> HealthKitWorkoutSample {
+        HealthKitWorkoutSample(
+            externalRecordID: workout.uuid.uuidString,
+            startDate: workout.startDate,
+            endDate: workout.endDate,
+            duration: workout.duration,
+            sourceName: workout.sourceRevision.source.name,
+            sourceBundleIdentifier: workout.sourceRevision.source.bundleIdentifier,
+            deviceModel: workout.device?.name
+        )
     }
 
     private func ensureAppleHealthLinkExists(

--- a/functions/src/liveReplayLeaderboard.ts
+++ b/functions/src/liveReplayLeaderboard.ts
@@ -34,6 +34,9 @@ interface PublicUserSnapshot {
   displayName: string;
   avatarToken: string;
   photoURL: string | null;
+  age?: number | null;
+  gender?: string | null;
+  locationCity?: string | null;
 }
 
 interface FirstAscentWriteInput {
@@ -839,6 +842,7 @@ function replayEntryWrite(
   input: ReplayEntryWriteInput
 ): Record<string, unknown> {
   return {
+    ...publicUserDemographicFields(input.publicUser),
     avatarToken: input.publicUser.avatarToken,
     completionDurationSeconds: input.payload.finalDurationSeconds,
     contextId: input.payload.contextId,
@@ -923,6 +927,7 @@ function finisherStatusWrite(
   const didImproveBest = existingBestDuration === null ||
     input.payload.finalDurationSeconds < existingBestDuration;
   const write: Record<string, unknown> = {
+    ...publicUserDemographicFields(input.publicUser),
     avatarToken: input.publicUser.avatarToken,
     displayName: input.publicUser.displayName,
     globalCompletionOrder: input.globalCompletionOrder,
@@ -1150,10 +1155,41 @@ async function publicUserSnapshot(userId: string): Promise<PublicUserSnapshot> {
     "Climber";
 
   return {
+    age: ageValue(data?.age),
     avatarToken: avatarToken(displayName),
     displayName,
+    gender: genderValue(data?.gender),
+    locationCity: locationTextValue(data?.location_city),
     photoURL: urlStringValue(data?.profilePictureURL),
   };
+}
+
+/**
+ * Returns the public demographic fields allowed on replay rows.
+ * @param {PublicUserSnapshot} publicUser Public display snapshot.
+ * @return {Record<string, unknown>} Compact demographic fields.
+ */
+function publicUserDemographicFields(
+  publicUser: PublicUserSnapshot
+): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+
+  if (publicUser.age !== null && publicUser.age !== undefined) {
+    fields.age = publicUser.age;
+  }
+
+  if (publicUser.gender !== null && publicUser.gender !== undefined) {
+    fields.gender = publicUser.gender;
+  }
+
+  if (
+    publicUser.locationCity !== null &&
+    publicUser.locationCity !== undefined
+  ) {
+    fields.locationCity = publicUser.locationCity;
+  }
+
+  return fields;
 }
 
 /**
@@ -1218,6 +1254,53 @@ function urlStringValue(value: unknown): string | null {
   }
 
   return /^https?:\/\//i.test(valueString) ? valueString : null;
+}
+
+/**
+ * Returns an age value that is safe to publish.
+ * @param {unknown} value Raw value.
+ * @return {number | null} Age if valid.
+ */
+function ageValue(value: unknown): number | null {
+  const age = nonNegativeIntegerValue(value);
+  if (age === null || age < 13 || age > 120) {
+    return null;
+  }
+
+  return age;
+}
+
+/**
+ * Returns a profile gender raw value that is safe to publish.
+ * @param {unknown} value Raw value.
+ * @return {string | null} Gender raw value if valid.
+ */
+function genderValue(value: unknown): string | null {
+  const gender = stringValue(value);
+  if (
+    gender !== "man" &&
+    gender !== "woman" &&
+    gender !== "non_binary" &&
+    gender !== "prefer_not_to_say"
+  ) {
+    return null;
+  }
+
+  return gender;
+}
+
+/**
+ * Returns a bounded location text value.
+ * @param {unknown} value Raw value.
+ * @return {string | null} Location text if valid.
+ */
+function locationTextValue(value: unknown): string | null {
+  const text = stringValue(value);
+  if (!text || text.length > 120) {
+    return null;
+  }
+
+  return text;
 }
 
 /**

--- a/functions/test/liveReplayLeaderboard.test.ts
+++ b/functions/test/liveReplayLeaderboard.test.ts
@@ -82,8 +82,11 @@ test("builds First Ascent replay summary fields", () => {
     userId: "user-a",
     entryId: "workout-a",
     publicUser: {
+      age: 31,
       avatarToken: "MC",
       displayName: "Maya C.",
+      gender: "woman",
+      locationCity: "Austin",
       photoURL: null,
     },
     claimedAt,
@@ -155,8 +158,11 @@ test("builds replay entry fields with context identity", () => {
     userId: "user-a",
     entryId: "workout-a",
     publicUser: {
+      age: 31,
       avatarToken: "MC",
       displayName: "Maya C.",
+      gender: "woman",
+      locationCity: "Austin",
       photoURL: null,
     },
     stepsAtBucket: 420,
@@ -164,12 +170,15 @@ test("builds replay entry fields with context identity", () => {
   });
 
   assert.deepEqual(write, {
+    age: 31,
     avatarToken: "MC",
     completionDurationSeconds: 738,
     contextId: "empire-state-building",
     contextType: "live_climb",
     displayName: "Maya C.",
     finalSteps: 2096,
+    gender: "woman",
+    locationCity: "Austin",
     photoURL: "",
     schemaVersion: 1,
     splitIntervalSeconds: 10,
@@ -324,8 +333,11 @@ test("builds first finisher status with permanent completion order", () => {
     userId: "user-a",
     entryId: "workout-a",
     publicUser: {
+      age: 31,
       avatarToken: "MC",
       displayName: "Maya C.",
+      gender: "woman",
+      locationCity: "Austin",
       photoURL: null,
     },
     globalCompletionOrder: 47,
@@ -334,13 +346,16 @@ test("builds first finisher status with permanent completion order", () => {
   });
 
   assert.deepEqual(write, {
+    age: 31,
     avatarToken: "MC",
     bestCompletionDurationSeconds: 738,
     bestWorkoutId: "workout-a",
     displayName: "Maya C.",
     firstCompletedAt: completedAt,
     firstWorkoutId: "workout-a",
+    gender: "woman",
     globalCompletionOrder: 47,
+    locationCity: "Austin",
     photoURL: "",
     schemaVersion: 1,
     updatedAt: completedAt,


### PR DESCRIPTION
## Summary
- clean up climb overview/history status UI and make history rows navigate directly to workout detail
- add headphone workout splits plus a heart-rate recovery/fetch state to workout detail
- add public demographics to live replay leaderboard rows and bounded rank lookup behavior
- color routine hero curves/areas by interval intensity

## Validation
- npm test (functions): 44/44 passing
- XcodeBuildMCP Debug simulator build/run: passed with no diagnostics