### PR TITLE
[codex] Fix HealthKit enrichment and paywall wiring

### DIFF
--- a/AscendApp/App/RootView.swift
+++ b/AscendApp/App/RootView.swift
@@ -163,13 +163,7 @@ struct RootView: View {
                 )
 
             case .paywall:
-                AppAccessPaywallPlaceholderView(
-                    onRestore: {
-                        Task {
-                            try? await monetizationManager.restorePurchases()
-                        }
-                    }
-                )
+                AppAccessPaywallPlaceholderView()
 
             case .mainApp:
                 MainTabView(tabRouter: tabRouter)

--- a/AscendApp/Features/Debug/ViewModels/DebugToolsViewModel.swift
+++ b/AscendApp/Features/Debug/ViewModels/DebugToolsViewModel.swift
@@ -27,6 +27,9 @@ class DebugToolsViewModel {
         static let replayPostAuthOnboarding = "Replay Onboarding Now"
         static let replayFullOnboardingFromLanding = "Replay From Landing"
         static let completePostAuthOnboarding = "Complete Post-Auth Onboarding"
+        static let presentAppAccessPaywall = "Present App Access Paywall"
+        static let refreshEntitlements = "Refresh Entitlements"
+        static let restorePurchases = "Restore Purchases"
     }
 
     var selectedWorkoutPreset: WorkoutSeedPreset = .appStoreScreenshots
@@ -39,6 +42,7 @@ class DebugToolsViewModel {
     var sections: [DebugSection] {
         [
             onboardingSection,
+            monetizationSection,
             appleHealthImportSection,
             workoutsSection,
             leaderboardSection
@@ -68,6 +72,35 @@ class DebugToolsViewModel {
                     title: ActionTitle.completePostAuthOnboarding,
                     description: "Marks the current account as having completed the post-auth onboarding flow.",
                     icon: "checkmark.seal.fill",
+                    iconColor: .green
+                )
+            ]
+        )
+    }
+
+    // MARK: - Monetization Section
+
+    private var monetizationSection: DebugSection {
+        DebugSection(
+            title: "Monetization",
+            subtitle: "Exercise the RevenueCat and Superwall app-access flow without waiting for the production gate",
+            actions: [
+                DebugAction(
+                    title: ActionTitle.presentAppAccessPaywall,
+                    description: "Presents the app-access Superwall placement using the RevenueCat purchase controller.",
+                    icon: "creditcard.fill",
+                    iconColor: .accent
+                ),
+                DebugAction(
+                    title: ActionTitle.refreshEntitlements,
+                    description: "Fetches the latest RevenueCat customer info and updates local app-access state.",
+                    icon: "arrow.clockwise.circle.fill",
+                    iconColor: .blue
+                ),
+                DebugAction(
+                    title: ActionTitle.restorePurchases,
+                    description: "Runs RevenueCat restore purchases and updates local entitlement state.",
+                    icon: "arrow.counterclockwise.circle.fill",
                     iconColor: .green
                 )
             ]
@@ -193,6 +226,29 @@ class DebugToolsViewModel {
                 NotificationCenter.default.post(name: .postAuthOnboardingStateDidChange, object: nil)
                 successMessage = "Marked post-auth onboarding complete for this user."
 
+            case ActionTitle.presentAppAccessPaywall:
+                guard MonetizationManager.shared.isSuperwallConfigured else {
+                    throw DebugMonetizationError.superwallUnavailable
+                }
+                MonetizationManager.shared.presentPaywall(
+                    .appAccessGate,
+                    params: ["source": "debug_tools"]
+                )
+
+            case ActionTitle.refreshEntitlements:
+                guard MonetizationManager.shared.isRevenueCatConfigured else {
+                    throw DebugMonetizationError.revenueCatUnavailable
+                }
+                await MonetizationManager.shared.refreshEntitlements()
+                successMessage = "Refreshed RevenueCat entitlements."
+
+            case ActionTitle.restorePurchases:
+                guard MonetizationManager.shared.isRevenueCatConfigured else {
+                    throw DebugMonetizationError.revenueCatUnavailable
+                }
+                try await MonetizationManager.shared.restorePurchases()
+                successMessage = "Restored purchases from RevenueCat."
+
             case ActionTitle.seedWorkouts:
                 let count = try await service.seedWorkoutData(
                     preset: selectedWorkoutPreset,
@@ -241,6 +297,20 @@ private enum DebugOnboardingError: LocalizedError {
 
     var errorDescription: String? {
         "Sign in before changing onboarding debug state."
+    }
+}
+
+private enum DebugMonetizationError: LocalizedError {
+    case superwallUnavailable
+    case revenueCatUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .superwallUnavailable:
+            return "Superwall is not configured for this build."
+        case .revenueCatUnavailable:
+            return "RevenueCat is not configured for this build."
+        }
     }
 }
 #endif

--- a/AscendApp/Features/Monetization/Models/MonetizationConfiguration.swift
+++ b/AscendApp/Features/Monetization/Models/MonetizationConfiguration.swift
@@ -100,7 +100,7 @@ struct MonetizationConfiguration: Equatable {
     }
 
     private static var defaultAllowsUnentitledAppAccess: Bool {
-        #if DEBUG || STAGING
+        #if DEBUG
         true
         #else
         false

--- a/AscendApp/Features/Monetization/Paywall/AppAccessPaywallPlaceholderView.swift
+++ b/AscendApp/Features/Monetization/Paywall/AppAccessPaywallPlaceholderView.swift
@@ -3,8 +3,14 @@ import SwiftUI
 struct AppAccessPaywallPlaceholderView: View {
     @Environment(MonetizationManager.self) private var monetizationManager
 
-    let onRestore: () -> Void
     @State private var didPresentPaywall = false
+    @State private var restoreState: RestoreState?
+
+    private enum RestoreState: Equatable {
+        case restoring
+        case restored
+        case failed
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
@@ -45,8 +51,8 @@ struct AppAccessPaywallPlaceholderView: View {
                 .disabled(!monetizationManager.isSuperwallConfigured)
                 .accessibilityHint("Presents the Ascend subscription paywall.")
 
-                Button(action: onRestore) {
-                    Text("Restore Purchases")
+                Button(action: restorePurchases) {
+                    Text(restoreButtonTitle)
                         .font(.montserratSemiBold(size: 15))
                         .foregroundStyle(.white)
                         .frame(maxWidth: .infinity)
@@ -57,6 +63,7 @@ struct AppAccessPaywallPlaceholderView: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .disabled(restoreState == .restoring || !monetizationManager.isRevenueCatConfigured)
             }
 
             Spacer()
@@ -72,7 +79,7 @@ struct AppAccessPaywallPlaceholderView: View {
         guard monetizationManager.isSuperwallConfigured else { return }
         guard !didPresentPaywall else {
             monetizationManager.presentPaywall(
-                .onboardingPaywall,
+                .appAccessGate,
                 params: ["source": "paywall_placeholder_retry"]
             )
             return
@@ -80,13 +87,48 @@ struct AppAccessPaywallPlaceholderView: View {
 
         didPresentPaywall = true
         monetizationManager.presentPaywall(
-            .onboardingPaywall,
-            params: ["source": "post_auth_onboarding"]
+            .appAccessGate,
+            params: ["source": "app_access_gate"]
         )
+    }
+
+    private var restoreButtonTitle: String {
+        guard monetizationManager.isRevenueCatConfigured else {
+            return "Restore Unavailable"
+        }
+
+        switch restoreState {
+        case .restoring:
+            return "Restoring..."
+        case .restored:
+            return "Restored"
+        case .failed:
+            return "Restore Failed"
+        case nil:
+            return "Restore Purchases"
+        }
+    }
+
+    private func restorePurchases() {
+        guard monetizationManager.isRevenueCatConfigured else {
+            restoreState = .failed
+            return
+        }
+        guard restoreState != .restoring else { return }
+        restoreState = .restoring
+
+        Task {
+            do {
+                try await monetizationManager.restorePurchases()
+                restoreState = .restored
+            } catch {
+                restoreState = .failed
+            }
+        }
     }
 }
 
 #Preview {
-    AppAccessPaywallPlaceholderView(onRestore: {})
+    AppAccessPaywallPlaceholderView()
         .environment(MonetizationManager())
 }

--- a/AscendApp/Features/Monetization/Paywall/RevenueCatPurchaseController.swift
+++ b/AscendApp/Features/Monetization/Paywall/RevenueCatPurchaseController.swift
@@ -22,16 +22,16 @@ final class RevenueCatPurchaseController: PurchaseController {
         guard Purchases.isConfigured else { return }
 
         subscriptionStatusTask?.cancel()
-        subscriptionStatusTask = Task {
-            for await customerInfo in Purchases.shared.customerInfoStream {
-                let entitlements = customerInfo.entitlements.activeInCurrentEnvironment.keys.map {
-                    SuperwallKit.Entitlement(id: $0)
-                }
-
+        subscriptionStatusTask = Task { [weak self] in
+            if let customerInfo = try? await Purchases.shared.customerInfo() {
                 await MainActor.run {
-                    Superwall.shared.subscriptionStatus = entitlements.isEmpty
-                        ? .inactive
-                        : .active(Set(entitlements))
+                    self?.applySubscriptionStatus(from: customerInfo)
+                }
+            }
+
+            for await customerInfo in Purchases.shared.customerInfoStream {
+                await MainActor.run {
+                    self?.applySubscriptionStatus(from: customerInfo)
                 }
             }
         }
@@ -47,6 +47,11 @@ final class RevenueCatPurchaseController: PurchaseController {
             let storeProduct = RevenueCat.StoreProduct(sk2Product: sk2Product)
             let result = try await Purchases.shared.purchase(product: storeProduct)
             let outcome = result.userCancelled ? "cancelled" : "purchased"
+
+            if !result.userCancelled {
+                applySubscriptionStatus(from: result.customerInfo)
+                await RevenueCatEntitlementService.shared.refreshCustomerInfo()
+            }
 
             TelemetryManager.shared.track(
                 PaywallAnalyticsEvent.purchaseControllerCompleted(
@@ -81,7 +86,9 @@ final class RevenueCatPurchaseController: PurchaseController {
     @MainActor
     func restorePurchases() async -> RestorationResult {
         do {
-            _ = try await Purchases.shared.restorePurchases()
+            let customerInfo = try await Purchases.shared.restorePurchases()
+            applySubscriptionStatus(from: customerInfo)
+            await RevenueCatEntitlementService.shared.refreshCustomerInfo()
             TelemetryManager.shared.track(
                 PaywallAnalyticsEvent.restoreControllerCompleted(outcome: "restored")
             )
@@ -92,5 +99,16 @@ final class RevenueCatPurchaseController: PurchaseController {
             )
             return .failed(error)
         }
+    }
+
+    @MainActor
+    private func applySubscriptionStatus(from customerInfo: RevenueCat.CustomerInfo) {
+        let entitlements = customerInfo.entitlements.activeInCurrentEnvironment.keys.map {
+            SuperwallKit.Entitlement(id: $0)
+        }
+
+        Superwall.shared.subscriptionStatus = entitlements.isEmpty
+            ? .inactive
+            : .active(Set(entitlements))
     }
 }

--- a/AscendApp/Shared/Services/AppleHealthWorkoutEnrichmentPolicy.swift
+++ b/AscendApp/Shared/Services/AppleHealthWorkoutEnrichmentPolicy.swift
@@ -47,14 +47,14 @@ enum AppleHealthWorkoutEnrichmentPolicy: CaseIterable {
     private var minimumOverlapRatio: Double {
         switch self {
         case .inAppSensorWorkout:
-            return 0.70
+            return 0.50
         }
     }
 
     private var maximumStartDelta: TimeInterval {
         switch self {
         case .inAppSensorWorkout:
-            return 15 * 60
+            return 30 * 60
         }
     }
 }

--- a/AscendApp/Shared/Services/HealthKitMetricsReader.swift
+++ b/AscendApp/Shared/Services/HealthKitMetricsReader.swift
@@ -52,11 +52,16 @@ struct WorkoutMetrics {
 protocol HealthKitMetricsReading {
     func fetchMetrics(for workout: HKWorkout) async -> WorkoutMetrics
     func fetchMetrics(for workout: HKWorkout, during dateRange: ClosedRange<Date>) async -> WorkoutMetrics
+    func fetchMetrics(during dateRange: ClosedRange<Date>) async -> WorkoutMetrics
 }
 
 extension HealthKitMetricsReading {
     func fetchMetrics(for workout: HKWorkout, during dateRange: ClosedRange<Date>) async -> WorkoutMetrics {
         await fetchMetrics(for: workout)
+    }
+
+    func fetchMetrics(during dateRange: ClosedRange<Date>) async -> WorkoutMetrics {
+        WorkoutMetrics()
     }
 }
 
@@ -75,6 +80,14 @@ final class HealthKitMetricsReader: HealthKitMetricsReading {
     }
 
     func fetchMetrics(for workout: HKWorkout, during dateRange: ClosedRange<Date>) async -> WorkoutMetrics {
+        await fetchMetrics(workout: workout, during: dateRange)
+    }
+
+    func fetchMetrics(during dateRange: ClosedRange<Date>) async -> WorkoutMetrics {
+        await fetchMetrics(workout: nil, during: dateRange)
+    }
+
+    private func fetchMetrics(workout: HKWorkout?, during dateRange: ClosedRange<Date>) async -> WorkoutMetrics {
         var metrics = WorkoutMetrics()
 
         if let stepCount = await fetchQuantityData(for: .stepCount, during: dateRange, unit: .count()) {
@@ -90,7 +103,7 @@ final class HealthKitMetricsReader: HealthKitMetricsReading {
             summary: heartRateData
         )
 
-        if let avgMetsQuantity = workout.metadata?["HKAverageMETs"] as? HKQuantity {
+        if let avgMetsQuantity = workout?.metadata?["HKAverageMETs"] as? HKQuantity {
             let metsUnit = HKUnit.kilocalorie().unitDivided(
                 by: HKUnit.hour().unitMultiplied(by: HKUnit.gramUnit(with: .kilo))
             )
@@ -163,7 +176,7 @@ final class HealthKitMetricsReader: HealthKitMetricsReading {
     }
 
     private func fetchHeartRateTimeSeries(
-        for workout: HKWorkout,
+        for workout: HKWorkout?,
         during dateRange: ClosedRange<Date>,
         summary: (average: Int?, maximum: Int?)
     ) async -> [HeartRateDataPoint] {
@@ -280,7 +293,7 @@ final class HealthKitMetricsReader: HealthKitMetricsReading {
 #if DEBUG
 private extension HealthKitMetricsReader {
     func logHeartRateImportDiagnostics(
-        workout: HKWorkout,
+        workout: HKWorkout?,
         dateRange: ClosedRange<Date>,
         parentSamples: [HKQuantitySample],
         parentDataPoints: [HeartRateDataPoint],
@@ -296,10 +309,10 @@ private extension HealthKitMetricsReader {
 
         debugLog(
             """
-            [HK-HR-IMPORT] workout=\(workout.uuid.uuidString) name=\(workout.workoutActivityType.rawValue) \
+            [HK-HR-IMPORT] workout=\(workout?.uuid.uuidString ?? "time-window") name=\(workout?.workoutActivityType.rawValue.description ?? "none") \
             range=\(Self.debugDate(dateRange.lowerBound))...\(Self.debugDate(dateRange.upperBound)) \
-            duration=\(workout.duration) source=\(workout.sourceRevision.source.name) bundle=\(workout.sourceRevision.source.bundleIdentifier) \
-            device=\(workout.device?.name ?? "nil") avg=\(summary.average.map(String.init) ?? "nil") max=\(summary.maximum.map(String.init) ?? "nil") \
+            duration=\(dateRange.upperBound.timeIntervalSince(dateRange.lowerBound)) source=\(workout?.sourceRevision.source.name ?? "time-window") bundle=\(workout?.sourceRevision.source.bundleIdentifier ?? "none") \
+            device=\(workout?.device?.name ?? "nil") avg=\(summary.average.map(String.init) ?? "nil") max=\(summary.maximum.map(String.init) ?? "nil") \
             parentSamples=\(parentSamples.count) parentMappedPoints=\(parentDataPoints.count) seriesChildPoints=\(seriesPoints.points.count) \
             importedPoints=\(importedDataPoints.count) importedSource=\(importedSource)
             """

--- a/AscendApp/Shared/Services/HealthKitWorkoutReader.swift
+++ b/AscendApp/Shared/Services/HealthKitWorkoutReader.swift
@@ -92,8 +92,7 @@ final class HealthKitWorkoutReader: HealthKitWorkoutReading {
 
         let datePredicate = HKQuery.predicateForSamples(
             withStart: dateRange.lowerBound,
-            end: dateRange.upperBound,
-            options: .strictStartDate
+            end: dateRange.upperBound
         )
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [Self.stairWorkoutPredicate(), datePredicate])
         let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
@@ -118,11 +117,17 @@ final class HealthKitWorkoutReader: HealthKitWorkoutReading {
         }
     }
 
+    nonisolated static var stairWorkoutActivityTypes: [HKWorkoutActivityType] {
+        [
+            .stairClimbing,
+            .stepTraining
+        ]
+    }
+
     nonisolated static func stairWorkoutPredicate() -> NSPredicate {
-        NSCompoundPredicate(orPredicateWithSubpredicates: [
-            HKQuery.predicateForWorkouts(with: .stairClimbing),
-            HKQuery.predicateForWorkouts(with: .stepTraining)
-        ])
+        NSCompoundPredicate(orPredicateWithSubpredicates: stairWorkoutActivityTypes.map {
+            HKQuery.predicateForWorkouts(with: $0)
+        })
     }
 
     nonisolated private static func makeSample(from workout: HKWorkout) -> HealthKitWorkoutSample {

--- a/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
@@ -51,8 +51,8 @@ final class AppleHealthEnrichmentRetryStore {
     init(
         defaults: UserDefaults = .standard,
         key: String = "appleHealth.enrichmentRetry.lastAttemptByWorkoutID",
-        minimumRetryInterval: TimeInterval = 10 * 60,
-        retryWindow: TimeInterval = 24 * 60 * 60,
+        minimumRetryInterval: TimeInterval = 60,
+        retryWindow: TimeInterval = 72 * 60 * 60,
         now: @escaping () -> Date = Date.init
     ) {
         self.defaults = defaults
@@ -630,18 +630,31 @@ final class WorkoutImportCoordinator {
         }
         guard !eligibleWorkouts.isEmpty else { return [] }
 
+        let heartRateFallbackWorkouts = forceRangeDiscovery
+            ? eligibleWorkouts
+            : eligibleWorkouts.filter { enrichmentRetryStore.isRetryDue(for: $0) }
         let appleSamples = await appleHealthSamplesForEnrichment(
             eligibleWorkouts: eligibleWorkouts,
             existingIndex: existingIndex,
             forceRangeDiscovery: forceRangeDiscovery
         )
-        guard !appleSamples.isEmpty else { return [] }
+        guard !appleSamples.isEmpty else {
+            return try await enrichInAppWorkoutsWithAppleHealthHeartRateByTimeWindowIfPossible(
+                heartRateFallbackWorkouts,
+                modelContext: modelContext
+            )
+        }
 
         let matches = resolveAppleHealthEnrichmentMatches(
             eligibleWorkouts: eligibleWorkouts,
             appleSamples: appleSamples
         )
-        guard !matches.isEmpty else { return [] }
+        guard !matches.isEmpty else {
+            return try await enrichInAppWorkoutsWithAppleHealthHeartRateByTimeWindowIfPossible(
+                heartRateFallbackWorkouts,
+                modelContext: modelContext
+            )
+        }
 
         var updatedWorkouts: [Workout] = []
         var updates: [WorkoutMutation.Update] = []
@@ -677,7 +690,12 @@ final class WorkoutImportCoordinator {
             return linkedAppleHealthIDs.contains(externalRecordID)
         }
 
-        return updatedWorkouts
+        let heartRateFallbackUpdates = try await enrichInAppWorkoutsWithAppleHealthHeartRateByTimeWindowIfPossible(
+            heartRateFallbackWorkouts.filter { needsAppleHealthHeartRateEnrichment($0) },
+            modelContext: modelContext
+        )
+
+        return updatedWorkouts + heartRateFallbackUpdates
     }
 
     private func appleHealthSamplesForEnrichment(
@@ -763,14 +781,17 @@ final class WorkoutImportCoordinator {
         for workouts: [Workout]
     ) -> ClosedRange<Date>? {
         let starts = workouts.map(\.date)
+        let ends = workouts.map { workout in
+            workout.date.addingTimeInterval(max(workout.duration, 1))
+        }
         guard let earliestStart = starts.min(),
-              let latestStart = starts.max() else {
+              let latestEnd = ends.max() else {
             return nil
         }
 
-        let startTolerance: TimeInterval = 15 * 60
-        let lowerBound = earliestStart.addingTimeInterval(-startTolerance)
-        let upperBound = latestStart.addingTimeInterval(startTolerance)
+        let tolerance: TimeInterval = 30 * 60
+        let lowerBound = earliestStart.addingTimeInterval(-tolerance)
+        let upperBound = latestEnd.addingTimeInterval(tolerance)
         return lowerBound...upperBound
     }
 
@@ -1017,6 +1038,50 @@ final class WorkoutImportCoordinator {
             workout.averageMETs == nil
     }
 
+    private func needsAppleHealthHeartRateEnrichment(_ workout: Workout) -> Bool {
+        workout.avgHeartRate == nil ||
+            workout.maxHeartRate == nil ||
+            workout.heartRateTimeSeries.isEmpty
+    }
+
+    @discardableResult
+    private func enrichInAppWorkoutsWithAppleHealthHeartRateByTimeWindowIfPossible(
+        _ workouts: [Workout],
+        modelContext: ModelContext
+    ) async throws -> [Workout] {
+        guard authorizationController.connectionState == .connected else { return [] }
+
+        let candidates = workouts.filter { workout in
+            workout.isInAppSensorWorkout && needsAppleHealthHeartRateEnrichment(workout)
+        }
+        guard !candidates.isEmpty else { return [] }
+
+        var updatedWorkouts: [Workout] = []
+        var updates: [WorkoutMutation.Update] = []
+
+        for workout in candidates {
+            let metricWindow = workout.date...workout.date.addingTimeInterval(max(workout.duration, 1))
+            let metrics = await metricsReader.fetchMetrics(during: metricWindow)
+            let before = LeaderboardWorkoutSnapshot(workout: workout)
+            let didChangeMetrics = applyAppleHealthHeartRateMetrics(metrics, to: workout)
+
+            guard didChangeMetrics else { continue }
+
+            updatedWorkouts.append(workout)
+            updates.append(.init(before: before, after: LeaderboardWorkoutSnapshot(workout: workout)))
+            enrichmentRetryStore.clear(workoutID: workout.id)
+        }
+
+        guard !updatedWorkouts.isEmpty else { return [] }
+
+        try WorkoutMutationHandler.shared.workoutsDidChange(
+            modelContext: modelContext,
+            mutation: WorkoutMutation(updated: updates),
+            changedWorkouts: updatedWorkouts
+        )
+        return updatedWorkouts
+    }
+
     private func hasCachedAppleHealthEnrichmentSample(for workout: Workout) -> Bool {
         let ignoredAppleHealthWorkoutIDs = ignoredAppleHealthWorkoutStore.load()
         return HealthKitSyncState.cachedWorkoutSamples.contains { sample in
@@ -1086,6 +1151,32 @@ final class WorkoutImportCoordinator {
         if workout.healthKitUUID != sample.externalRecordID {
             workout.healthKitUUID = sample.externalRecordID
             didChange = true
+        }
+
+        return didChange
+    }
+
+    @discardableResult
+    private func applyAppleHealthHeartRateMetrics(
+        _ metrics: WorkoutMetrics,
+        to workout: Workout
+    ) -> Bool {
+        var didChange = false
+
+        if let avgHeartRate = metrics.avgHeartRate, workout.avgHeartRate != avgHeartRate {
+            workout.avgHeartRate = avgHeartRate
+            didChange = true
+        }
+        if let maxHeartRate = metrics.maxHeartRate, workout.maxHeartRate != maxHeartRate {
+            workout.maxHeartRate = maxHeartRate
+            didChange = true
+        }
+        if !metrics.heartRateTimeSeries.isEmpty {
+            let encodedHeartRateData = metrics.heartRateTimeSeries.encoded
+            if workout.heartRateData != encodedHeartRateData {
+                workout.heartRateData = encodedHeartRateData
+                didChange = true
+            }
         }
 
         return didChange

--- a/AscendAppTests/HealthKitWorkoutReaderTests.swift
+++ b/AscendAppTests/HealthKitWorkoutReaderTests.swift
@@ -1,0 +1,15 @@
+import HealthKit
+import Testing
+
+@testable import AscendApp
+
+struct HealthKitWorkoutReaderTests {
+  @Test
+  func stairWorkoutDiscoveryOnlyIncludesStairStepperActivityTypes() {
+    let activityTypes = Set(HealthKitWorkoutReader.stairWorkoutActivityTypes)
+
+    #expect(activityTypes.contains(.stairClimbing))
+    #expect(activityTypes.contains(.stepTraining))
+    #expect(!activityTypes.contains(.stairs))
+  }
+}

--- a/AscendAppTests/WorkoutImportCoordinatorLiveClimbAppleHealthEnrichmentTests.swift
+++ b/AscendAppTests/WorkoutImportCoordinatorLiveClimbAppleHealthEnrichmentTests.swift
@@ -276,6 +276,126 @@ struct WorkoutImportCoordinatorLiveClimbAppleHealthEnrichmentTests {
   }
 
   @Test
+  func refreshEnrichesWhenAppleHealthWorkoutStartsLateButOverlapsSession() async throws {
+    try await HealthKitImportCoordinatorTestIsolation.shared.run {
+      let modelContext = try makeModelContext()
+      let stateSnapshot = LiveClimbHealthKitSyncStateSnapshot.capture()
+      let settingsSnapshot = LiveClimbSettingsSnapshot.capture()
+      defer {
+        stateSnapshot.restore()
+        settingsSnapshot.restore()
+      }
+      resetHealthKitSyncStateForTest()
+      SettingsManager.shared.appleHealthAutoImportEnabled = false
+
+      let liveStart = Date().addingTimeInterval(-3 * 60 * 60)
+      let liveWorkout = makeLiveClimbWorkout(start: liveStart, duration: 2_400, steps: 3_800)
+      modelContext.insert(liveWorkout)
+      modelContext.insert(makeLiveClimbParticipation(for: liveWorkout, climbId: "late-watch-climb"))
+      try modelContext.save()
+
+      let appleWorkout = HKWorkout(
+        activityType: .stairClimbing,
+        start: liveStart.addingTimeInterval(20 * 60),
+        end: liveStart.addingTimeInterval(2_430)
+      )
+      let appleSample = makeAppleHealthSample(from: appleWorkout)
+      let metricsReader = LiveClimbHealthKitMetricsReader(
+        metrics: WorkoutMetrics(
+          avgHeartRate: 149,
+          maxHeartRate: 171,
+          caloriesBurned: 410,
+          heartRateTimeSeries: [
+            HeartRateDataPoint(timestamp: liveStart.addingTimeInterval(1_300), heartRate: 150)
+          ],
+          averageMETs: 7.1
+        )
+      )
+      let workoutReader = LiveClimbHealthKitWorkoutReader(
+        workouts: [appleWorkout],
+        addedSamples: [],
+        dateRangeSamples: [appleSample]
+      )
+      let coordinator = WorkoutImportCoordinator(
+        authorizationController: LiveClimbHealthKitAuthorizationController(),
+        workoutReader: workoutReader,
+        metricsReader: metricsReader
+      )
+      coordinator.configure(modelContext: modelContext)
+
+      await coordinator.refreshPendingImports(trigger: .backgroundObserver)
+
+      #expect(liveWorkout.healthKitUUID == appleSample.externalRecordID)
+      #expect(liveWorkout.avgHeartRate == 149)
+      #expect(liveWorkout.maxHeartRate == 171)
+      #expect(liveWorkout.heartRateTimeSeries.count == 1)
+      #expect(metricsReader.requestedRanges[appleSample.externalRecordID]?.lowerBound == appleSample.startDate)
+      #expect(
+        metricsReader.requestedRanges[appleSample.externalRecordID]?.upperBound
+          == liveStart.addingTimeInterval(2_400))
+      #expect(workoutReader.requestedDateRanges.count == 1)
+    }
+  }
+
+  @Test
+  func refreshFallsBackToHeartRateSamplesWhenWorkoutMatchIsUnavailable() async throws {
+    try await HealthKitImportCoordinatorTestIsolation.shared.run {
+      let modelContext = try makeModelContext()
+      let stateSnapshot = LiveClimbHealthKitSyncStateSnapshot.capture()
+      let settingsSnapshot = LiveClimbSettingsSnapshot.capture()
+      defer {
+        stateSnapshot.restore()
+        settingsSnapshot.restore()
+      }
+      resetHealthKitSyncStateForTest()
+      SettingsManager.shared.appleHealthAutoImportEnabled = false
+
+      let liveStart = Date().addingTimeInterval(-45 * 60)
+      let liveWorkout = makeLiveClimbWorkout(start: liveStart, duration: 2_603, steps: 4_134)
+      modelContext.insert(liveWorkout)
+      modelContext.insert(makeLiveClimbParticipation(for: liveWorkout, climbId: "window-fallback"))
+      try modelContext.save()
+
+      let metricsReader = LiveClimbHealthKitMetricsReader(
+        timeWindowMetrics: WorkoutMetrics(
+          avgHeartRate: 154,
+          maxHeartRate: 181,
+          heartRateTimeSeries: [
+            HeartRateDataPoint(timestamp: liveStart.addingTimeInterval(300), heartRate: 146),
+            HeartRateDataPoint(timestamp: liveStart.addingTimeInterval(2_100), heartRate: 174)
+          ]
+        )
+      )
+      let coordinator = WorkoutImportCoordinator(
+        authorizationController: LiveClimbHealthKitAuthorizationController(),
+        workoutReader: LiveClimbHealthKitWorkoutReader(
+          workouts: [],
+          addedSamples: [],
+          dateRangeSamples: []
+        ),
+        metricsReader: metricsReader
+      )
+      coordinator.configure(modelContext: modelContext)
+
+      await coordinator.refreshPendingImports(trigger: .backgroundObserver)
+
+      #expect(liveWorkout.source == .headphoneMotion)
+      #expect(liveWorkout.duration == 2_603)
+      #expect(liveWorkout.steps == 4_134)
+      #expect(liveWorkout.healthKitUUID == nil)
+      #expect(liveWorkout.sourceLink(for: .appleHealth) == nil)
+      #expect(liveWorkout.avgHeartRate == 154)
+      #expect(liveWorkout.maxHeartRate == 181)
+      #expect(liveWorkout.heartRateTimeSeries.count == 2)
+      #expect(metricsReader.requestedTimeWindows.count == 1)
+      #expect(metricsReader.requestedTimeWindows.first?.lowerBound == liveStart)
+      #expect(
+        metricsReader.requestedTimeWindows.first?.upperBound
+          == liveStart.addingTimeInterval(2_603))
+    }
+  }
+
+  @Test
   func detailRetryDoesNotRepeatHealthKitLookupInsideThrottleWindow() async throws {
     try await HealthKitImportCoordinatorTestIsolation.shared.run {
       let modelContext = try makeModelContext()
@@ -333,7 +453,7 @@ struct WorkoutImportCoordinatorLiveClimbAppleHealthEnrichmentTests {
       resetHealthKitSyncStateForTest()
       SettingsManager.shared.appleHealthAutoImportEnabled = false
 
-      let liveStart = Date().addingTimeInterval(-(26 * 60 * 60))
+      let liveStart = Date().addingTimeInterval(-(80 * 60 * 60))
       let liveWorkout = makeLiveClimbWorkout(start: liveStart, duration: 1_200, steps: 1_500)
       modelContext.insert(liveWorkout)
       modelContext.insert(makeLiveClimbParticipation(for: liveWorkout, climbId: "expired-climb"))
@@ -595,13 +715,17 @@ private final class LiveClimbHealthKitWorkoutReader: HealthKitWorkoutReading {
 @MainActor
 private final class LiveClimbHealthKitMetricsReader: HealthKitMetricsReading {
   private let metrics: WorkoutMetrics
+  private let timeWindowMetrics: WorkoutMetrics?
   private(set) var requestedRanges: [String: ClosedRange<Date>] = [:]
+  private(set) var requestedTimeWindows: [ClosedRange<Date>] = []
 
   init(
     metrics: WorkoutMetrics = WorkoutMetrics(
-      avgHeartRate: 135, maxHeartRate: 165, caloriesBurned: 75)
+      avgHeartRate: 135, maxHeartRate: 165, caloriesBurned: 75),
+    timeWindowMetrics: WorkoutMetrics? = nil
   ) {
     self.metrics = metrics
+    self.timeWindowMetrics = timeWindowMetrics
   }
 
   func fetchMetrics(for workout: HKWorkout) async -> WorkoutMetrics {
@@ -613,6 +737,11 @@ private final class LiveClimbHealthKitMetricsReader: HealthKitMetricsReading {
   {
     requestedRanges[workout.uuid.uuidString] = dateRange
     return metrics
+  }
+
+  func fetchMetrics(during dateRange: ClosedRange<Date>) async -> WorkoutMetrics {
+    requestedTimeWindows.append(dateRange)
+    return timeWindowMetrics ?? WorkoutMetrics()
   }
 }
 

--- a/docs/superwall-paywall-setup.md
+++ b/docs/superwall-paywall-setup.md
@@ -6,7 +6,8 @@ Date: 2026-06-10
 
 - Project: `24464`
 - iOS application: `47442`
-- App placement already used by the iOS app: `onboarding_paywall`
+- App placement used by the iOS hard gate: `app_access_gate`
+- App placement reserved for onboarding-specific paywall tests: `onboarding_paywall`
 - Existing default campaign: `90307`
 - Existing default example paywall: `232089`
 
@@ -67,6 +68,11 @@ Product reference names expected by the self-hosted page:
 - `primary`: yearly free-trial product
 - `secondary`: monthly product
 
+Superwall product identifiers currently present in project `24464`:
+
+- `ascend_yearly`
+- `ascend_monthly`
+
 ## One-time Offer Paywall
 
 Copy:
@@ -94,13 +100,21 @@ Superwall accepted the organization API key and asset uploads, but the paywall c
 
 This is not an authorization issue: the same key successfully wrote assets. Use the dashboard editor or Superwall support for the paywall record creation failure, or deploy the self-hosted pages and retry URL-based creation.
 
+API check on 2026-06-19:
+
+- Paywalls: `232127`, `232372`, and `232373` are all draft `New Paywall` records with no attached products.
+- Existing campaign `90307` is still `Example Campaign` and only listens to placement `campaign_trigger`.
+- The campaign variant still references archived example paywall `232089`.
+- The iOS app hard gate now registers placement `app_access_gate`, so no live Superwall campaign will present until a campaign owns that placement.
+
 ## Remaining Setup
 
-1. Confirm App Store product identifiers for yearly trial, monthly, and optional discount offer.
+1. Confirm App Store Connect and RevenueCat both use product identifiers `ascend_yearly` and `ascend_monthly`, or update Superwall product identifiers to match the final App Store IDs.
 2. Create or repair the two Superwall paywall records.
 3. Attach product references:
-   - yearly trial as `primary`
-   - monthly as `secondary`
+   - `ascend_yearly` as `primary`
+   - `ascend_monthly` as `secondary`
    - discount offer as `primary` on the one-time offer paywall
-4. Wire the main paywall to `onboarding_paywall`.
-5. Keep the campaign disabled until the editor preview renders correctly and RevenueCat entitlements are verified.
+4. Wire the main hard-gate paywall to `app_access_gate`.
+5. Optionally wire onboarding-specific experiments to `onboarding_paywall` once the onboarding paywall stage exists.
+6. Keep the campaign disabled until the editor preview renders correctly and RevenueCat entitlements are verified.


### PR DESCRIPTION
## Summary
- Improves Apple Health workout matching for Live Climb heart-rate enrichment by allowing overlapping stair-stepper workouts and adding time-window heart-rate fallback.
- Keeps HealthKit stair-stepper discovery scoped to stair-stepper workout types only.
- Wires the app-access Superwall placement through the hard gate/debug tools and refreshes RevenueCat/Superwall entitlement state after purchase/restore.
- Updates Superwall setup notes for the app-access placement and product wiring.

## Why
Users were seeing missing heart-rate enrichment when Apple Watch workout timing did not exactly match the in-app Live Climb window. The app also needed the current RevenueCat/Superwall hard-gate wiring committed so staging can verify purchases before launch.

## Validation
- Ran `git diff --cached --check` before commit.
- CI will run the staging iOS build and test suite on this PR.

## Notes
- Left local Xcode `xcuserdata` scheme metadata out of the commit.
- Superwall dashboard/editor layout changes are not represented in git; dashboard campaign/product wiring still needs to be verified in Superwall.
