### PR TITLE
Add Sentry dSYM upload for CI

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -141,6 +141,7 @@ jobs:
           IOS_PRODUCTION_BUNDLE_ID: com.TylerPavay.AscendApp
           IOS_PRODUCTION_WIDGET_BUNDLE_ID: com.TylerPavay.AscendApp.LiveClimbWidgets
           IOS_PRODUCTION_WIDGET_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.LiveClimbWidgets
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
           BUILD_NUMBER: ${{ github.run_number }}
         run: bundle exec fastlane build_production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -114,6 +114,7 @@ jobs:
           IOS_STAGING_BUNDLE_ID: com.TylerPavay.AscendApp.staging
           IOS_STAGING_WIDGET_BUNDLE_ID: com.TylerPavay.AscendApp.staging.LiveClimbWidgets
           IOS_STAGING_WIDGET_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.staging.LiveClimbWidgets
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
           BUILD_NUMBER: ${{ github.run_number }}
         run: bundle exec fastlane build_staging

--- a/AscendApp.xcodeproj/project.pbxproj
+++ b/AscendApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		9C3000012F2A000000100001 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = 9C3000032F2A000000100003 /* Mixpanel */; };
 		9D4000012F60000000100001 /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = 9D4000032F60000000100003 /* MapboxMaps */; };
 		9E5000012F6B000000100001 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 9E5000022F6B000000100002 /* FirebaseMessaging */; };
+		9F6000012F75000000100001 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 9F6000032F75000000100003 /* Sentry */; };
 		A20000012F10000000000001 /* AscendLiveActivityWidgets.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = A20000012F10000000000003 /* AscendLiveActivityWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -124,6 +125,7 @@
 				9B1000022F22000000100002 /* SuperwallKit in Frameworks */,
 				9C3000012F2A000000100001 /* Mixpanel in Frameworks */,
 				9D4000012F60000000100001 /* MapboxMaps in Frameworks */,
+				9F6000012F75000000100001 /* Sentry in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -217,6 +219,7 @@
 				9B1000062F22000000100006 /* SuperwallKit */,
 				9C3000032F2A000000100003 /* Mixpanel */,
 				9D4000032F60000000100003 /* MapboxMaps */,
+				9F6000032F75000000100003 /* Sentry */,
 			);
 			productName = AscendApp;
 			productReference = 9A5E4D822E2406F8008DE803 /* AscendApp.app */;
@@ -311,6 +314,7 @@
 				9B1000042F22000000100004 /* XCRemoteSwiftPackageReference "Superwall-iOS" */,
 				9C3000022F2A000000100002 /* XCRemoteSwiftPackageReference "mixpanel-swift" */,
 				9D4000022F60000000100002 /* XCRemoteSwiftPackageReference "mapbox-maps-ios-binary" */,
+				9F6000022F75000000100002 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 9A5E4D832E2406F8008DE803 /* Products */;
@@ -364,6 +368,7 @@
 				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
 				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
 				"$(SRCROOT)/scripts/link-firebase-plists.sh",
+				"$(SRCROOT)/scripts/upload-sentry-dsyms.sh",
 				"$(SRCROOT)/AscendApp/Info.plist",
 				"$(SRCROOT)/AscendApp/App/Firebase/GoogleService-Info-Dev.plist",
 				"$(SRCROOT)/AscendApp/App/Firebase/GoogleService-Info-Staging.plist",
@@ -376,7 +381,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -eu\n\n# Ensure local Firebase config plists are linked into this worktree.\n\"${SRCROOT}/scripts/link-firebase-plists.sh\"\n\n# Determine which GoogleService-Info plist to use\ncase \"${CONFIGURATION}\" in\n    \"Debug\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Dev.plist\"\n        ;;\n    \"Staging\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Staging.plist\"\n        ;;\n    \"Release\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Production.plist\"\n        ;;\nesac\n\n# Run Crashlytics with the correct plist\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${GOOGLE_SERVICE_PLIST}\"\n";
+			shellScript = "set -eu\n\n# Ensure local Firebase config plists are linked into this worktree.\n\"${SRCROOT}/scripts/link-firebase-plists.sh\"\n\n# Determine which GoogleService-Info plist to use\ncase \"${CONFIGURATION}\" in\n    \"Debug\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Dev.plist\"\n        ;;\n    \"Staging\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Staging.plist\"\n        ;;\n    \"Release\")\n        GOOGLE_SERVICE_PLIST=\"${SRCROOT}/AscendApp/App/Firebase/GoogleService-Info-Production.plist\"\n        ;;\nesac\n\n# Run Crashlytics with the correct plist\n\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\" -gsp \"${GOOGLE_SERVICE_PLIST}\"\n\n# Upload dSYMs to Sentry when CI or the local shell provides SENTRY_AUTH_TOKEN.\n\"${SRCROOT}/scripts/upload-sentry-dsyms.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -483,6 +488,8 @@
 				ASCEND_MIXPANEL_TOKEN = 354ccda8eef57e08d823eebc8598aab7;
 				ASCEND_REVENUECAT_API_KEY = appl_OuhVbQoKshaWOxkeVfELTpsvlHP;
 				ASCEND_REVENUECAT_TEST_API_KEY = "";
+				ASCEND_SENTRY_DSN = "https://8ffadf8996800f8feaaea21ca77ebe5d@o4511621278728192.ingest.us.sentry.io/4511621439815680";
+				ASCEND_SENTRY_ENABLED = YES;
 				ASCEND_SUPERWALL_API_KEY = pk_DGywY9Qw39wY_9glnLs8R;
 				ASCEND_SUPERWALL_TEST_MODE = NO;
 				ASCEND_USE_REVENUECAT_TEST_STORE = NO;
@@ -659,6 +666,8 @@
 				ASCEND_MIXPANEL_TOKEN = 354ccda8eef57e08d823eebc8598aab7;
 				ASCEND_REVENUECAT_API_KEY = appl_OuhVbQoKshaWOxkeVfELTpsvlHP;
 				ASCEND_REVENUECAT_TEST_API_KEY = "";
+				ASCEND_SENTRY_DSN = "https://8ffadf8996800f8feaaea21ca77ebe5d@o4511621278728192.ingest.us.sentry.io/4511621439815680";
+				ASCEND_SENTRY_ENABLED = YES;
 				ASCEND_SUPERWALL_API_KEY = pk_DGywY9Qw39wY_9glnLs8R;
 				ASCEND_SUPERWALL_TEST_MODE = NO;
 				ASCEND_USE_REVENUECAT_TEST_STORE = NO;
@@ -711,6 +720,8 @@
 				ASCEND_MIXPANEL_TOKEN = 354ccda8eef57e08d823eebc8598aab7;
 				ASCEND_REVENUECAT_API_KEY = appl_OuhVbQoKshaWOxkeVfELTpsvlHP;
 				ASCEND_REVENUECAT_TEST_API_KEY = "";
+				ASCEND_SENTRY_DSN = "https://8ffadf8996800f8feaaea21ca77ebe5d@o4511621278728192.ingest.us.sentry.io/4511621439815680";
+				ASCEND_SENTRY_ENABLED = YES;
 				ASCEND_SUPERWALL_API_KEY = pk_DGywY9Qw39wY_9glnLs8R;
 				ASCEND_SUPERWALL_TEST_MODE = NO;
 				ASCEND_USE_REVENUECAT_TEST_STORE = NO;
@@ -1007,6 +1018,14 @@
 				minimumVersion = 11.20.0;
 			};
 		};
+		9F6000022F75000000100002 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.18.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1074,6 +1093,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 9A8E4CE42E2418D200C78912 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
+		};
+		9F6000032F75000000100003 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9F6000022F75000000100002 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/AscendApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AscendApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "02c81269ccc2895fedfbb1900aaab0f1fe483bc46fa0fa3d4142b7def2bc97cd",
+  "originHash" : "232830a369661a2020366ce7d25524c01cb8ba390ddc0be5fc7056524ee5d535",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -206,6 +206,15 @@
       "state" : {
         "revision" : "98435c3d7b0f6210b2303fc7f2ec09510d4790b6",
         "version" : "5.74.0"
+      }
+    },
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa",
+      "state" : {
+        "revision" : "43abfbf9a26089ad34604c718ad0935440caf1d4",
+        "version" : "9.18.0"
       }
     },
     {

--- a/AscendApp/Features/Debug/Services/DebugToolsService.swift
+++ b/AscendApp/Features/Debug/Services/DebugToolsService.swift
@@ -57,9 +57,30 @@ final class DebugToolsService {
             modelContext: modelContext
         )
     }
+
+    func sendSentryTestDiagnostic() {
+        TelemetryManager.shared.debugEnableCollectionForSession()
+        TelemetryManager.shared.recordError(
+            DebugDiagnosticsError.sentryTestEvent,
+            context: .network,
+            code: "debug_sentry_test_event",
+            additionalInfo: [
+                "source": "debug_tools",
+                "expected": "true"
+            ]
+        )
+    }
     
     // MARK: - Future: Add more debug operations
     // func clearAllData() async throws { }
     // func resetUserPreferences() async throws { }
+}
+
+private enum DebugDiagnosticsError: LocalizedError {
+    case sentryTestEvent
+
+    var errorDescription: String? {
+        "Debug Sentry test diagnostic"
+    }
 }
 #endif

--- a/AscendApp/Features/Debug/ViewModels/DebugToolsViewModel.swift
+++ b/AscendApp/Features/Debug/ViewModels/DebugToolsViewModel.swift
@@ -32,6 +32,7 @@ class DebugToolsViewModel {
         static let presentAppAccessPaywall = "Present App Access Paywall"
         static let refreshEntitlements = "Refresh Entitlements"
         static let restorePurchases = "Restore Purchases"
+        static let sendSentryTestDiagnostic = "Send Sentry Test Event"
     }
 
     var selectedWorkoutPreset: WorkoutSeedPreset = .appStoreScreenshots
@@ -43,12 +44,30 @@ class DebugToolsViewModel {
 
     var sections: [DebugSection] {
         [
+            diagnosticsSection,
             onboardingSection,
             monetizationSection,
             appleHealthImportSection,
             workoutsSection,
             leaderboardSection
         ]
+    }
+
+    // MARK: - Diagnostics Section
+
+    private var diagnosticsSection: DebugSection {
+        DebugSection(
+            title: "Diagnostics",
+            subtitle: "Verify crash and non-fatal error reporting",
+            actions: [
+                DebugAction(
+                    title: ActionTitle.sendSentryTestDiagnostic,
+                    description: "Enables telemetry for this Debug session and sends a harmless non-fatal diagnostic event through Crashlytics and Sentry.",
+                    icon: "waveform.path.ecg.rectangle.fill",
+                    iconColor: .red
+                )
+            ]
+        )
     }
 
     // MARK: - Onboarding Section
@@ -270,6 +289,10 @@ class DebugToolsViewModel {
                 }
                 try await MonetizationManager.shared.restorePurchases()
                 successMessage = "Restored purchases from RevenueCat."
+
+            case ActionTitle.sendSentryTestDiagnostic:
+                service.sendSentryTestDiagnostic()
+                successMessage = "Sent a non-fatal Sentry test diagnostic."
 
             case ActionTitle.seedWorkouts:
                 let count = try await service.seedWorkoutData(

--- a/AscendApp/Features/Onboarding/ViewModels/PostAuthOnboardingCoordinator.swift
+++ b/AscendApp/Features/Onboarding/ViewModels/PostAuthOnboardingCoordinator.swift
@@ -130,16 +130,16 @@ final class PostAuthOnboardingCoordinator {
     private func recordLifecycleSnapshot(_ snapshot: PostAuthOnboardingSnapshot) {
         let completedStages = PostAuthOnboardingStage.allCases
             .filter { snapshot.completedStages.contains($0) }
-            .map(\.rawValue)
+            .map(\.lifecycleKey)
 
         if snapshot.isComplete {
             LifecycleEventRecorder.shared.recordOnboardingCompleted(
-                currentStage: snapshot.currentStage.rawValue,
+                currentStage: snapshot.currentStage.lifecycleKey,
                 completedStages: completedStages
             )
         } else {
             LifecycleEventRecorder.shared.recordOnboardingStageReached(
-                stage: snapshot.currentStage.rawValue,
+                stage: snapshot.currentStage.lifecycleKey,
                 completedStages: completedStages
             )
         }
@@ -175,5 +175,16 @@ final class PostAuthOnboardingCoordinator {
 
     private func firstIncompleteStage(in snapshot: PostAuthOnboardingSnapshot) -> PostAuthOnboardingStage {
         PostAuthOnboardingStage.allCases.first { !snapshot.completedStages.contains($0) } ?? .first
+    }
+}
+
+private extension PostAuthOnboardingStage {
+    var lifecycleKey: String {
+        switch self {
+        case .displayName:
+            return "display_name"
+        default:
+            return rawValue
+        }
     }
 }

--- a/AscendApp/Info.plist
+++ b/AscendApp/Info.plist
@@ -14,6 +14,10 @@
 	<string>$(ASCEND_SUPERWALL_TEST_MODE)</string>
 	<key>AscendMixpanelToken</key>
 	<string>$(ASCEND_MIXPANEL_TOKEN)</string>
+	<key>AscendSentryDSN</key>
+	<string>$(ASCEND_SENTRY_DSN)</string>
+	<key>AscendSentryEnabled</key>
+	<string>$(ASCEND_SENTRY_ENABLED)</string>
 	<key>MBXAccessToken</key>
 	<string>$(MAPBOX_ACCESS_TOKEN)</string>
 	<key>CFBundleURLTypes</key>

--- a/AscendApp/PrivacyInfo.xcprivacy
+++ b/AscendApp/PrivacyInfo.xcprivacy
@@ -229,7 +229,7 @@
             </array>
         </dict>
 
-        <!-- Crash Data — Firebase Crashlytics -->
+        <!-- Crash Data — Firebase Crashlytics and Sentry diagnostics -->
         <dict>
             <key>NSPrivacyCollectedDataType</key>
             <string>NSPrivacyCollectedDataTypeCrashData</string>
@@ -243,7 +243,7 @@
             </array>
         </dict>
 
-        <!-- Performance Data — non-fatal error logging via Crashlytics.recordError -->
+        <!-- Performance Data — non-fatal error logging via Crashlytics.recordError and Sentry.capture(error:) -->
         <dict>
             <key>NSPrivacyCollectedDataType</key>
             <string>NSPrivacyCollectedDataTypePerformanceData</string>

--- a/AscendApp/Shared/Managers/TelemetryManager.swift
+++ b/AscendApp/Shared/Managers/TelemetryManager.swift
@@ -27,7 +27,12 @@ final class TelemetryManager: @unchecked Sendable {
         crashlyticsReporter: (any CrashlyticsReporting)? = nil,
         collectionEnabledOverride: Bool? = nil
     ) {
-        let reporter = crashlyticsReporter ?? FirebaseCrashlyticsReporter()
+        let reporter = crashlyticsReporter ?? CompositeCrashlyticsReporter(
+            reporters: [
+                FirebaseCrashlyticsReporter(),
+                SentryDiagnosticsReporter()
+            ]
+        )
         self.crashlyticsReporter = reporter
         self.collectionEnabledOverride = collectionEnabledOverride
         if let sinks {
@@ -118,6 +123,13 @@ final class TelemetryManager: @unchecked Sendable {
         default:
             return nil
         }
+    }
+
+    func debugEnableCollectionForSession() {
+        lock.withLock { $0.isCollectionEnabled = true }
+        crashlyticsReporter.setCollectionEnabled(true)
+        sinks.forEach { $0.setCollectionEnabled(true) }
+        setAppMetadata()
     }
     #endif
 

--- a/AscendApp/Shared/Services/Telemetry/CompositeCrashlyticsReporter.swift
+++ b/AscendApp/Shared/Services/Telemetry/CompositeCrashlyticsReporter.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+final class CompositeCrashlyticsReporter: CrashlyticsReporting, @unchecked Sendable {
+    private let reporters: [any CrashlyticsReporting]
+
+    init(reporters: [any CrashlyticsReporting]) {
+        self.reporters = reporters
+    }
+
+    func setCollectionEnabled(_ enabled: Bool) {
+        reporters.forEach { $0.setCollectionEnabled(enabled) }
+    }
+
+    func setUserID(_ userID: String?) {
+        reporters.forEach { $0.setUserID(userID) }
+    }
+
+    func setCustomValue(_ value: Bool, forKey key: String) {
+        reporters.forEach { $0.setCustomValue(value, forKey: key) }
+    }
+
+    func setCustomValue(_ value: Int, forKey key: String) {
+        reporters.forEach { $0.setCustomValue(value, forKey: key) }
+    }
+
+    func setCustomValue(_ value: String, forKey key: String) {
+        reporters.forEach { $0.setCustomValue(value, forKey: key) }
+    }
+
+    func log(_ message: String) {
+        reporters.forEach { $0.log(message) }
+    }
+
+    func record(error: Error, context: String, code: String, additionalInfo: [String: String]?) {
+        reporters.forEach {
+            $0.record(
+                error: error,
+                context: context,
+                code: code,
+                additionalInfo: additionalInfo
+            )
+        }
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/SentryConfiguration.swift
+++ b/AscendApp/Shared/Services/Telemetry/SentryConfiguration.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct SentryConfiguration: Equatable {
+    static let live = SentryConfiguration()
+
+    static let dsnInfoKey = "AscendSentryDSN"
+    static let enabledInfoKey = "AscendSentryEnabled"
+
+    let dsn: String?
+    let isExplicitlyEnabled: Bool?
+
+    var canConfigure: Bool {
+        dsn != nil && isExplicitlyEnabled != false
+    }
+
+    init(infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:]) {
+        dsn = Self.normalizedString(infoDictionary[Self.dsnInfoKey])
+        isExplicitlyEnabled = Self.normalizedBool(infoDictionary[Self.enabledInfoKey])
+    }
+
+    private static func normalizedString(_ value: Any?) -> String? {
+        guard let rawValue = value as? String else { return nil }
+
+        let trimmedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty, !trimmedValue.hasPrefix("$(") else {
+            return nil
+        }
+
+        return trimmedValue
+    }
+
+    private static func normalizedBool(_ value: Any?) -> Bool? {
+        if let value = value as? Bool {
+            return value
+        }
+
+        guard let rawValue = value as? String else { return nil }
+
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on":
+            return true
+        case "0", "false", "no", "off":
+            return false
+        default:
+            return nil
+        }
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/SentryDiagnosticsReporter.swift
+++ b/AscendApp/Shared/Services/Telemetry/SentryDiagnosticsReporter.swift
@@ -1,0 +1,139 @@
+import Foundation
+@preconcurrency import Sentry
+
+final class SentryDiagnosticsReporter: CrashlyticsReporting, @unchecked Sendable {
+    private let configuration: SentryConfiguration
+    private let lock = NSLock()
+    private var didStart = false
+
+    init(configuration: SentryConfiguration = .live) {
+        self.configuration = configuration
+    }
+
+    func setCollectionEnabled(_ enabled: Bool) {
+        guard enabled, configuration.canConfigure, let dsn = configuration.dsn else {
+            closeIfNeeded()
+            return
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard !didStart else { return }
+
+        let options = Options()
+        options.dsn = dsn
+        options.environment = Self.appEnvironmentName
+        options.releaseName = Self.releaseName
+        options.dist = Self.buildNumber
+        options.sendDefaultPii = false
+        options.attachScreenshot = false
+        options.attachViewHierarchy = false
+        options.tracesSampleRate = 0
+        options.enableAutoPerformanceTracing = false
+        options.enableUserInteractionTracing = false
+        options.enableFileIOTracing = false
+
+        #if DEBUG
+        options.debug = true
+        #endif
+
+        SentrySDK.start(options: options)
+        SentrySDK.configureScope { scope in
+            scope.setTag(value: Self.appEnvironmentName, key: "app_environment")
+            scope.setTag(value: Self.buildConfigName, key: "build_config")
+            scope.setTag(value: Self.appVersion, key: "app_version")
+            scope.setTag(value: Self.buildNumber, key: "build_number")
+        }
+        didStart = true
+    }
+
+    func setUserID(_ userID: String?) {
+        guard didStart else { return }
+
+        if let userID {
+            SentrySDK.setUser(User(userId: userID))
+        } else {
+            SentrySDK.setUser(nil)
+        }
+    }
+
+    func setCustomValue(_ value: Bool, forKey key: String) {
+        setCustomValue(value ? "true" : "false", forKey: key)
+    }
+
+    func setCustomValue(_ value: Int, forKey key: String) {
+        setCustomValue(String(value), forKey: key)
+    }
+
+    func setCustomValue(_ value: String, forKey key: String) {
+        guard didStart else { return }
+
+        SentrySDK.configureScope { scope in
+            scope.setTag(value: value, key: key)
+        }
+    }
+
+    func log(_ message: String) {
+        guard didStart else { return }
+
+        let breadcrumb = Breadcrumb(level: .info, category: "ascend.telemetry")
+        breadcrumb.message = message
+        breadcrumb.type = "default"
+        SentrySDK.addBreadcrumb(breadcrumb)
+    }
+
+    func record(error: Error, context: String, code: String, additionalInfo: [String: String]?) {
+        guard didStart else { return }
+
+        SentrySDK.capture(error: error) { scope in
+            scope.setTag(value: context, key: "ascend_error_context")
+            scope.setTag(value: code, key: "ascend_error_code")
+
+            if let additionalInfo, !additionalInfo.isEmpty {
+                scope.setContext(value: additionalInfo, key: "ascend")
+            }
+        }
+    }
+
+    private func closeIfNeeded() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard didStart else { return }
+        SentrySDK.close()
+        didStart = false
+    }
+
+    private static var appEnvironmentName: String {
+        #if DEBUG
+        return "dev"
+        #elseif STAGING
+        return "staging"
+        #else
+        return "production"
+        #endif
+    }
+
+    private static var buildConfigName: String {
+        #if DEBUG
+        return "debug"
+        #elseif STAGING
+        return "staging"
+        #else
+        return "release"
+        #endif
+    }
+
+    private static var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    }
+
+    private static var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
+    }
+
+    private static var releaseName: String {
+        "\(Bundle.main.bundleIdentifier ?? "AscendApp")@\(appVersion)+\(buildNumber)"
+    }
+}

--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -1,0 +1,64 @@
+# Sentry Setup
+
+Ascend uses Sentry as a diagnostics companion to Firebase Crashlytics.
+
+## Role
+
+- **Sentry**: issue triage, breadcrumbs, handled errors, release/environment filtering, and agent-assisted debugging.
+- **Crashlytics**: Firebase-native crash-free metrics and release stability.
+- **Mixpanel/Firebase Analytics**: product funnels, retention, and behavior analytics.
+
+Sentry is not used for product analytics or cross-app tracking.
+
+## App Configuration
+
+The app reads Sentry config from `Info.plist`:
+
+- `ASCEND_SENTRY_DSN`: the Sentry project DSN.
+- `ASCEND_SENTRY_ENABLED`: optional kill switch. Use `false`/`0`/`no`/`off` to force-disable Sentry.
+
+Sentry is still gated by `TelemetryManager.shouldEnableCollection()`:
+
+- Debug defaults to off unless `ASC_DEBUG_TELEMETRY_ENABLED=true` or `-TelemetryEnabled` is set.
+- Staging and Release default to on when a DSN is present.
+
+Events are tagged with:
+
+- `app_environment`: `dev`, `staging`, or `production`
+- `build_config`: `debug`, `staging`, or `release`
+- `app_version`
+- `build_number`
+- `ascend_error_context` and `ascend_error_code` for handled errors
+
+## MCP Workflow
+
+Use Sentry MCP for agent triage:
+
+```sh
+codex mcp add sentry https://mcp.sentry.dev/mcp
+```
+
+Authentication should happen through Sentry OAuth or a local token flow. Do not commit Sentry tokens, auth headers, DSNs, or MCP credentials.
+
+Typical prompt:
+
+```text
+Assess unresolved production Sentry errors from the past 14 days. Prioritize them, explain likely root causes, and fix the top actionable issue.
+```
+
+Use `.agents/skills/ascend-error-triage/SKILL.md` for the triage rubric.
+
+## Debug Symbols
+
+For production-quality stack traces, the app build phase runs `scripts/upload-sentry-dsyms.sh` after the Firebase Crashlytics upload step.
+
+Required CI/build environment:
+
+- `SENTRY_AUTH_TOKEN`: secret token used by `sentry-cli`.
+- `SENTRY_ORG`: optional; defaults to `ascend-uk`.
+- `SENTRY_PROJECT`: optional; defaults to `ascend-ios`.
+- `SENTRY_CLI_PATH`: optional; use only when `sentry-cli` is not on `PATH`.
+
+GitHub Actions passes `secrets.SENTRY_AUTH_TOKEN` into the Fastlane staging and production build steps. This does not belong in the private `match` repo; `match` should stay limited to certificates and provisioning profiles.
+
+Local builds skip Sentry dSYM upload when `SENTRY_AUTH_TOKEN` is missing. Keep Sentry auth tokens out of the repo.

--- a/scripts/upload-sentry-dsyms.sh
+++ b/scripts/upload-sentry-dsyms.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -eu
+
+if [ "${ASCEND_SENTRY_ENABLED:-NO}" != "YES" ]; then
+    echo "Sentry dSYM upload skipped: ASCEND_SENTRY_ENABLED is not YES."
+    exit 0
+fi
+
+if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+    echo "Sentry dSYM upload skipped: SENTRY_AUTH_TOKEN is not set."
+    exit 0
+fi
+
+if [ -z "${DWARF_DSYM_FOLDER_PATH:-}" ] || [ ! -d "${DWARF_DSYM_FOLDER_PATH}" ]; then
+    echo "Sentry dSYM upload skipped: dSYM folder not found."
+    exit 0
+fi
+
+SENTRY_ORG="${SENTRY_ORG:-ascend-uk}"
+SENTRY_PROJECT="${SENTRY_PROJECT:-ascend-ios}"
+
+if [ -n "${SENTRY_CLI_PATH:-}" ] && [ -x "${SENTRY_CLI_PATH}" ]; then
+    SENTRY_CLI="${SENTRY_CLI_PATH}"
+elif command -v sentry-cli >/dev/null 2>&1; then
+    SENTRY_CLI="$(command -v sentry-cli)"
+else
+    echo "warning: Sentry dSYM upload skipped: sentry-cli was not found. Install sentry-cli or set SENTRY_CLI_PATH."
+    exit 0
+fi
+
+echo "Uploading dSYMs to Sentry project ${SENTRY_ORG}/${SENTRY_PROJECT}."
+"${SENTRY_CLI}" debug-files upload \
+    --org "${SENTRY_ORG}" \
+    --project "${SENTRY_PROJECT}" \
+    "${DWARF_DSYM_FOLDER_PATH}"

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -92,7 +92,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <div class="privacy-page">
     <main>
       <h1>Privacy Policy</h1>
-      <p class="last-updated">Last updated: June 10, 2026</p>
+      <p class="last-updated">Last updated: June 24, 2026</p>
 
       <h2>Introduction</h2>
       <p>Ascend ("we", "our", or "us") is a stair-stepper workout app for tracking climbs, workouts, leaderboards, achievements, and progress. This Privacy Policy explains what information we collect, how we use it, how we share it, and the choices you have.</p>
@@ -108,7 +108,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <li><strong>Purchase and subscription information:</strong> Trial, subscription, entitlement, restore-purchase, paywall interaction, and purchase-status information processed through Apple, RevenueCat, and Superwall.</li>
         <li><strong>Product usage analytics:</strong> Screen views, onboarding funnel events, feature interactions, paywall events, and other first-party product analytics collected through Firebase Analytics and Mixpanel in non-debug builds.</li>
         <li><strong>Notification data:</strong> Notification preferences, iOS notification permission state, and APNs/FCM push registration tokens used to send opted-in app notifications such as climb-drop alerts.</li>
-        <li><strong>Diagnostics:</strong> Crash reports, performance data, non-fatal error logs, app version, operating system version, device model, and related debugging context collected through Firebase Crashlytics and app telemetry.</li>
+        <li><strong>Diagnostics:</strong> Crash reports, performance data, non-fatal error logs, app version, operating system version, device model, and related debugging context collected through Firebase Crashlytics, Sentry, and app telemetry.</li>
         <li><strong>City search and map context:</strong> Searches and selected city-level location information used to help you pick profile and leaderboard context. If you choose current location during onboarding, Ascend uses it once to find your city, then saves only city, region, and country. Ascend does not collect continuous background location or gym-level location for leaderboards.</li>
       </ul>
 
@@ -140,7 +140,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </ul>
 
       <h2>Analytics, Tracking, and Advertising</h2>
-      <p>Ascend uses first-party analytics to understand whether onboarding, subscriptions, workouts, leaderboards, and core features are working. We use Firebase Analytics and Mixpanel for product analytics, Firebase Crashlytics for crash reporting, and Superwall and RevenueCat for subscription and paywall analytics.</p>
+      <p>Ascend uses first-party analytics to understand whether onboarding, subscriptions, workouts, leaderboards, and core features are working. We use Firebase Analytics and Mixpanel for product analytics, Firebase Crashlytics and Sentry for crash reporting and diagnostics, and Superwall and RevenueCat for subscription and paywall analytics.</p>
       <p>Ascend does <strong>not</strong> sell personal information, does <strong>not</strong> use advertising networks, does <strong>not</strong> use the iOS advertising identifier (IDFA), and does <strong>not</strong> track you across other companies' apps or websites for targeted advertising. Because we do not perform App Tracking Transparency-style tracking, Ascend does not show the ATT prompt.</p>
 
       <h2>Third-Party Services</h2>
@@ -152,6 +152,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <li><strong>RevenueCat:</strong> Subscription status, entitlements, purchase history, and restore-purchase support.</li>
         <li><strong>Superwall:</strong> Paywall presentation, paywall analytics, campaign logic, and subscription conversion measurement.</li>
         <li><strong>Mixpanel:</strong> First-party product analytics and onboarding funnel measurement.</li>
+        <li><strong>Sentry:</strong> Crash reporting, non-fatal error diagnostics, performance diagnostics, breadcrumbs, and release health investigation.</li>
       </ul>
 
       <h2>Data Storage and Security</h2>


### PR DESCRIPTION
What changed:\n- Added Sentry SDK integration for diagnostics alongside Crashlytics.\n- Added a build-phase dSYM upload script that runs only when SENTRY_AUTH_TOKEN is available.\n- Wired staging and production GitHub Actions Fastlane builds to pass SENTRY_AUTH_TOKEN from repo secrets.\n- Fixed the invalid onboarding lifecycle event key that Sentry surfaced.\n- Documented Sentry setup and privacy updates.\n\nVerification:\n- plutil -lint AscendApp.xcodeproj/project.pbxproj\n- xcodebuild -project AscendApp.xcodeproj -scheme AscendApp -destination generic/platform=iOS Simulator build\n\nNotes:\n- Ascend.storekit is intentionally left untracked; it is a local StoreKit configuration file not referenced by the project.