### PR TITLE
[codex] Force firebase-tools deploy CLI version

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -186,7 +186,6 @@ jobs:
 
       - name: Install dependencies for deploy
         run: |
-          npm install --global firebase-tools@15.22.1
           npm --prefix functions ci
           npm --prefix web ci
 
@@ -194,7 +193,7 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
-        run: firebase deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
+        run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:
     name: Upload to TestFlight (Production)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -155,7 +155,6 @@ jobs:
 
       - name: Install dependencies for deploy
         run: |
-          npm install --global firebase-tools@15.22.1
           npm --prefix functions ci
           npm --prefix web ci
 
@@ -163,7 +162,7 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
-        run: firebase deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
+        run: npx -y firebase-tools@15.22.1 deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:
     name: Upload to TestFlight (Staging)


### PR DESCRIPTION
## Summary\n- Invoke Firebase deploy through  with an exact  version\n- Remove PATH ambiguity from the staging/production Firebase deploy jobs\n\n## Why\n- The staging deploy is failing at  with an auth error even after pinning the CLI globally.\n- Using  guarantees the workflow runs the intended Firebase CLI version.