### PR TITLE
[codex] Pin Firebase CLI to v14 for deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -193,7 +193,7 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
-        run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
+        run: npx -y firebase-tools@14 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:
     name: Upload to TestFlight (Production)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -162,7 +162,7 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
-        run: npx -y firebase-tools@15.22.1 deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
+        run: npx -y firebase-tools@14 deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:
     name: Upload to TestFlight (Staging)


### PR DESCRIPTION
## Summary\n- Pin Firebase CLI deploys to v14 in staging and production workflows\n- Keep the OIDC-based GitHub Actions auth flow unchanged\n\n## Why\n- Staging deploy is failing at Firebase auth with the current v15 CLI path\n- This change avoids the broken v15 auth path while preserving the existing deploy flow\n\n## Validation\n- Previous PR CI passed\n- This follow-up changes only the deploy CLI version