### PR TITLE
[codex] Use Firebase access token for deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -171,10 +171,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud (OIDC)
+        id: auth
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER_PRODUCTION }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL_PRODUCTION }}
+          token_format: access_token
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
@@ -193,6 +195,8 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
+        env:
+          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: npx -y firebase-tools@14 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -140,10 +140,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Authenticate to Google Cloud (OIDC)
+        id: auth
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          token_format: access_token
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
@@ -162,6 +164,8 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
+        env:
+          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: npx -y firebase-tools@14 deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:


### PR DESCRIPTION
## Summary
- Switch staging and production Firebase deploys to explicit access-token auth
- Keep OIDC for Google Cloud, but pass the token directly to firebase-tools

## Why
- Firebase deploys were failing with `Failed to authenticate, have you run firebase login?` even after OIDC auth
- This makes the deploy step independent of Firebase CLI ADC handling

## Validation
- CI on the previous deploy workflow change passed
- Staging deploy run 28390984486 failed at Firebase deploy with auth failure before this fix