### PR TITLE
Fix Firebase deploy auth and Hosting target

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -4,5 +4,28 @@
     "dev": "ascend-f2e4f",
     "staging": "ascend-staging-fa7d5",
     "production": "ascend-prod-9c8f2"
+  },
+  "targets": {
+    "ascend-f2e4f": {
+      "hosting": {
+        "web": [
+          "ascend-f2e4f"
+        ]
+      }
+    },
+    "ascend-staging-fa7d5": {
+      "hosting": {
+        "web": [
+          "ascend-staging-fa7d5"
+        ]
+      }
+    },
+    "ascend-prod-9c8f2": {
+      "hosting": {
+        "web": [
+          "ascend-prod-9c8f2"
+        ]
+      }
+    }
   }
 }

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -195,8 +195,6 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
-        env:
-          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: npx -y firebase-tools@14 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -164,8 +164,6 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
-        env:
-          FIREBASE_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: npx -y firebase-tools@14 deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:

--- a/firebase.json
+++ b/firebase.json
@@ -25,6 +25,7 @@
     }
   ],
   "hosting": {
+    "target": "web",
     "public": "web/dist",
     "cleanUrls": true,
     "ignore": [


### PR DESCRIPTION
## Summary
- Remove the incorrect use of the Firebase legacy token env var from deploy jobs so firebase-tools can use OIDC credentials
- Add a Firebase Hosting target mapping for the web deploy so Hosting can resolve a site in staging and production

## Validation
- Parsed `firebase.json`, `.firebaserc`, and both deploy workflow YAML files locally
