### PR TITLE
Bump firebase-tools for deploy auth

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -195,7 +195,7 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
-        run: npx -y firebase-tools@14 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
+        run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:
     name: Upload to TestFlight (Production)

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -164,7 +164,7 @@ jobs:
         run: npm --prefix web run build
 
       - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
-        run: npx -y firebase-tools@14 deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
+        run: npx -y firebase-tools@15.22.1 deploy --project ascend-staging-fa7d5 --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force
 
   upload-testflight:
     name: Upload to TestFlight (Staging)


### PR DESCRIPTION
## Summary
- Bump firebase-tools in staging and production deploy workflows to a release that works with GitHub OIDC / Workload Identity Federation
- Keep the Hosting target wiring from the previous deploy fix in place

## Validation
- Parsed both workflow files locally after the version bump
