### PR TITLE
Fix Sentry error noise, push reliability, and production launch readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,3 +161,32 @@ jobs:
             -destination "platform=iOS Simulator,id=${{ steps.simulator.outputs.id }}" \
             ENABLE_TESTABILITY=YES \
             test
+
+  ios-verify-release:
+    name: iOS Verify (Release)
+    runs-on: macos-15
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      # The production deploy pipeline is the first place the Release
+      # configuration would otherwise compile. Building it unsigned here means
+      # Release-only build errors surface on the PR, not on launch day. Uses
+      # the committed GoogleService-Info-Production.plist; no secrets needed.
+      - name: Build app (Release, unsigned)
+        run: |
+          xcodebuild \
+            -project AscendApp.xcodeproj \
+            -scheme "AscendApp" \
+            -configuration Release \
+            -sdk iphoneos \
+            -destination "generic/platform=iOS" \
+            CODE_SIGNING_ALLOWED=NO \
+            clean build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,10 +176,23 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Decode production Firebase plist
+        env:
+          GOOGLE_SERVICE_INFO_PRODUCTION_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_PRODUCTION_BASE64 }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$GOOGLE_SERVICE_INFO_PRODUCTION_BASE64" ]; then
+            echo "::error::Required secret GOOGLE_SERVICE_INFO_PRODUCTION_BASE64 is missing or empty."
+            exit 1
+          fi
+          mkdir -p AscendApp/App/Firebase
+          printf "%s" "$GOOGLE_SERVICE_INFO_PRODUCTION_BASE64" | base64 --decode > AscendApp/App/Firebase/GoogleService-Info-Production.plist
+          plutil -lint AscendApp/App/Firebase/GoogleService-Info-Production.plist
+
       # The production deploy pipeline is the first place the Release
       # configuration would otherwise compile. Building it unsigned here means
-      # Release-only build errors surface on the PR, not on launch day. Uses
-      # the committed GoogleService-Info-Production.plist; no secrets needed.
+      # Release-only build errors surface on the PR, not on launch day.
       - name: Build app (Release, unsigned)
         run: |
           xcodebuild \

--- a/AscendApp.xcodeproj/xcshareddata/xcschemes/AscendApp.xcscheme
+++ b/AscendApp.xcodeproj/xcshareddata/xcschemes/AscendApp.xcscheme
@@ -112,7 +112,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/AscendApp/Shared/Managers/TelemetryManager.swift
+++ b/AscendApp/Shared/Managers/TelemetryManager.swift
@@ -80,6 +80,14 @@ final class TelemetryManager: @unchecked Sendable {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         userDefaults: UserDefaults = .standard
     ) -> Bool {
+        // The unit-test host must never ship telemetry: test-injected failures
+        // would surface in Crashlytics/Sentry as real issues. This overrides
+        // every other enablement path, including persisted debug toggles.
+        if environment["XCTestConfigurationFilePath"] != nil ||
+            environment["XCTestSessionIdentifier"] != nil {
+            return false
+        }
+
         if arguments.contains("-TelemetryDisabled") {
             #if DEBUG
             userDefaults.set(false, forKey: debugCollectionEnabledDefaultsKey)

--- a/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorder.swift
+++ b/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorder.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import FirebaseAuth
 @preconcurrency import FirebaseFunctions
 import UserNotifications
 
@@ -126,21 +127,39 @@ final class LifecycleEventRecorder {
     }
 
     private func record(type: String, payload: sending [String: Any]) {
+        // Lifecycle events are per-user server state; the callable rejects
+        // unauthenticated requests, so don't send them while signed out.
+        guard Auth.auth().currentUser != nil else { return }
+
         let eventData: [String: Any] = [
             "type": type,
             "payload": payload
         ]
 
         functions.httpsCallable("recordLifecycleEvent").call(eventData) { _, error in
-            if let error {
-                TelemetryManager.shared.recordError(
-                    error,
-                    context: .network,
-                    code: "lifecycle_event_record_failed",
-                    additionalInfo: ["type": type]
-                )
-            }
+            guard let error, !Self.isExpectedTransportNoise(error) else { return }
+
+            TelemetryManager.shared.recordError(
+                error,
+                context: .network,
+                code: "lifecycle_event_record_failed",
+                additionalInfo: ["type": type]
+            )
         }
+    }
+
+    /// Errors that are part of normal operation — a request cancelled by the
+    /// system mid-flight, or auth racing sign-out — not defects worth alerting on.
+    private nonisolated static func isExpectedTransportNoise(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+            return true
+        }
+        if nsError.domain == FunctionsErrorDomain,
+           nsError.code == FunctionsErrorCode.unauthenticated.rawValue {
+            return true
+        }
+        return false
     }
 }
 

--- a/AscendApp/Shared/Services/Notifications/PushNotificationService.swift
+++ b/AscendApp/Shared/Services/Notifications/PushNotificationService.swift
@@ -12,6 +12,7 @@ final class PushNotificationService: NSObject, MessagingDelegate {
     private let functions = Functions.functions(region: "us-central1")
     private var isConfigured = false
     private var lastRegisteredToken: String?
+    private var inFlightSyncTask: Task<Void, Never>?
 
     private override init() {
         super.init()
@@ -73,13 +74,29 @@ final class PushNotificationService: NSObject, MessagingDelegate {
     }
 
     func synchronizeAuthenticatedDeviceIfNeeded() async {
-        let status = await authorizationStatus()
+        guard Auth.auth().currentUser != nil else { return }
 
-        if status == .denied, ClimbDropNotificationPreferenceStore.isEnabled {
-            ClimbDropNotificationPreferenceStore.isEnabled = false
+        // Launch fires this from several hooks at once (root task, APNS
+        // callback, FCM token refresh). Concurrent registerPushDevice calls
+        // contend on the same Firestore documents server-side, so overlapping
+        // requests join the in-flight sync instead of starting another.
+        if let inFlightSyncTask {
+            await inFlightSyncTask.value
+            return
         }
 
-        await synchronizePreferenceAndDevice(authorizationStatus: status)
+        let syncTask = Task {
+            let status = await authorizationStatus()
+
+            if status == .denied, ClimbDropNotificationPreferenceStore.isEnabled {
+                ClimbDropNotificationPreferenceStore.isEnabled = false
+            }
+
+            await synchronizePreferenceAndDevice(authorizationStatus: status)
+        }
+        inFlightSyncTask = syncTask
+        await syncTask.value
+        inFlightSyncTask = nil
     }
 
     func unregisterCurrentDevice() async {
@@ -183,7 +200,7 @@ final class PushNotificationService: NSObject, MessagingDelegate {
     private func fetchFCMToken() async -> String? {
         await withCheckedContinuation { continuation in
             Messaging.messaging().token { token, error in
-                if let error {
+                if let error, !Self.isMissingAPNSTokenError(error) {
                     Task { @MainActor in
                         TelemetryManager.shared.recordError(
                             error,
@@ -196,6 +213,16 @@ final class PushNotificationService: NSObject, MessagingDelegate {
                 continuation.resume(returning: token)
             }
         }
+    }
+
+    /// FCM error 505: token requested before APNS delivered a device token
+    /// (always the case on Simulator, and briefly after
+    /// `registerForRemoteNotifications()`). The APNS callback and the FCM
+    /// token-refresh delegate both re-run the sync, so this is an expected
+    /// transient state, not an error worth reporting.
+    private nonisolated static func isMissingAPNSTokenError(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == "com.google.fcm" && nsError.code == 505
     }
 
     private func callFunction(_ name: String, data: sending [String: Any]) async throws {

--- a/AscendAppTests/TelemetryManagerTests.swift
+++ b/AscendAppTests/TelemetryManagerTests.swift
@@ -124,6 +124,35 @@ struct TelemetryManagerTests {
     }
 
     @Test
+    func xcTestEnvironmentDisablesCollectionOverridingAllOtherPaths() throws {
+        let (defaults, suiteName) = try makeDefaults()
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let enabledArgumentUnderTests = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp", "-TelemetryEnabled"],
+            environment: ["XCTestConfigurationFilePath": "/tmp/tests.xctestconfiguration"],
+            userDefaults: defaults
+        )
+        let enabledEnvironmentUnderTests = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp"],
+            environment: [
+                "ASC_DEBUG_TELEMETRY_ENABLED": "1",
+                "XCTestSessionIdentifier": UUID().uuidString
+            ],
+            userDefaults: defaults
+        )
+        let persistedAfterTestRuns = TelemetryManager.shouldEnableCollection(
+            arguments: ["AscendApp"],
+            environment: [:],
+            userDefaults: defaults
+        )
+
+        #expect(!enabledArgumentUnderTests)
+        #expect(!enabledEnvironmentUnderTests)
+        #expect(!persistedAfterTestRuns)
+    }
+
+    @Test
     func debugCollectionDefaultsOffWithoutOverride() throws {
         let (defaults, suiteName) = try makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,7 @@ Multiple analytics destinations are sanctioned — each is best at a different j
 - **Firebase Analytics** — broad funnel, cohort, retention analysis. Most product events go here.
 - **SuperWall** — onboarding-flow step-level conversion + paywall presentation analytics (its specialty).
 - **Crashlytics** — crashes, fatal errors, stability metrics.
+- **Sentry** — error/crash diagnostics mirror alongside Crashlytics (non-fatal errors, app hangs, symbolicated traces). When reading, triaging, or updating Sentry issues/events, use the repo-local skill at `skills/sentry/SKILL.md`. Like the climb-content skill, it is harness-neutral so Codex, Claude, Cursor, or any other AI provider can follow the same workflow.
 
 When evaluating new providers, justify them by what they uniquely measure that the existing set doesn't.
 
@@ -494,6 +495,7 @@ Both have their own browse, detail, live, and leaderboard surfaces. Don't fold o
 - Use `scripts/dev-db.mjs` as the central dev/staging database tool for repeatable fixture workflows. It can seed, clear, or reset `profiles`, `leaderboard`, `live-replay`, or `all`, and it must keep refusing production (`ascend-prod-9c8f2`) and unknown Firebase projects.
 - Dev database cleanup should be target-scoped and metadata-driven. Do not hide an unrestricted project wipe behind a friendly `clear all` command; full destructive wipes need an explicit, separately guarded command and a reviewed collection list.
 - Profile fixture data must include the full public profile contract: display name, age, gender, `weight_kg`, `location_country`, optional `location_region`, `joined_at`, public profile mirror, profile stats, achievements, and public workout summaries.
+- To create one dev/staging QA Auth account, use `scripts/dev-db.mjs create-auth-user`. It must stay dev/staging-only, can generate a password, and can optionally run `--hydrate-profile` or `--seed-demo-data` after the Auth account exists.
 - To patch one dev/staging account, use `scripts/dev-db.mjs hydrate-user` so private `users/{uid}` and public `users/{uid}/public_profile/current` stay in sync.
 - Live replay leaderboard seed data must be Admin SDK/server-written into the read-only `live_replay_leaderboards` index, never client-written during a live session.
 - `scripts/seed-live-replay-leaderboards.mjs` may write only to dev (`ascend-f2e4f`) or staging (`ascend-staging-fa7d5`) and must hard-refuse production or any unknown project; use environment-specific seed packs for repeatable active/warm Live Climb replay fixtures.

--- a/functions/src/pushNotifications.ts
+++ b/functions/src/pushNotifications.ts
@@ -42,7 +42,7 @@ export const registerPushDevice = onCall(async (request) => {
     .collection("communication_preferences")
     .doc("current");
 
-  await firestore.runTransaction(async (transaction) => {
+  await runContendedTransaction(firestore, async (transaction) => {
     const [deviceSnapshot, preferencesSnapshot] = await Promise.all([
       transaction.get(deviceRef),
       transaction.get(preferencesRef),
@@ -137,7 +137,7 @@ export const updatePushNotificationPreferences = onCall(async (request) => {
     .collection("communication_preferences")
     .doc("current");
 
-  await firestore.runTransaction(async (transaction) => {
+  await runContendedTransaction(firestore, async (transaction) => {
     const snapshot = await transaction.get(preferencesRef);
     const existing = snapshot.exists ? snapshot.data() ?? {} : {};
     transaction.set(preferencesRef, {
@@ -505,6 +505,71 @@ async function deactivateInvalidTokens(tokenHashes: string[]) {
     }
     await deactivateToken(uid, tokenHash, now);
   }));
+}
+
+const grpcAbortedCode = 10;
+const contentionRetryAttempts = 3;
+
+/**
+ * Runs a Firestore transaction, retrying cross-transaction contention.
+ *
+ * Concurrent callable invocations for the same user (the client can fire
+ * launch, APNS, and token-refresh syncs close together) contend on the same
+ * documents. The SDK does not always classify that ABORTED as transient, so
+ * it escapes runTransaction as an unhandled error and reaches the client as
+ * INTERNAL. Retry it here, and fail with a typed callable error when the
+ * retries are exhausted.
+ * @param {admin.firestore.Firestore} firestore Firestore instance.
+ * @param {Function} updateFunction Transaction body.
+ * @return {Promise<*>} Transaction result.
+ */
+async function runContendedTransaction<T>(
+  firestore: admin.firestore.Firestore,
+  updateFunction: (
+    transaction: admin.firestore.Transaction
+  ) => Promise<T>
+): Promise<T> {
+  for (let attempt = 1; attempt <= contentionRetryAttempts; attempt++) {
+    try {
+      return await firestore.runTransaction(updateFunction);
+    } catch (error) {
+      if (
+        !isTransactionContentionError(error) ||
+        attempt === contentionRetryAttempts
+      ) {
+        if (isTransactionContentionError(error)) {
+          throw new HttpsError(
+            "aborted",
+            "Another update is in progress. Retry shortly."
+          );
+        }
+        throw error;
+      }
+      await delay(50 * 2 ** (attempt - 1) + Math.floor(Math.random() * 50));
+    }
+  }
+  throw new HttpsError("internal", "Transaction retry loop exited early.");
+}
+
+/**
+ * Detects the gRPC ABORTED contention error surfaced by the Firestore SDK.
+ * @param {unknown} error Candidate error.
+ * @return {boolean} True when the error is transaction contention.
+ */
+function isTransactionContentionError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  return (error as {code?: unknown}).code === grpcAbortedCode;
+}
+
+/**
+ * Waits for a duration.
+ * @param {number} milliseconds Delay duration.
+ * @return {Promise<void>} Resolves after the delay.
+ */
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 /**

--- a/scripts/dev-db.mjs
+++ b/scripts/dev-db.mjs
@@ -13,14 +13,17 @@
  *   node scripts/dev-db.mjs clear --target profiles,leaderboard --project dev
  *   node scripts/dev-db.mjs reset --target all --project dev
  *   node scripts/dev-db.mjs wipe --project dev --confirm-dev-wipe
+ *   node scripts/dev-db.mjs create-auth-user --project staging --email qa@example.com --display-name "QA Tester"
  *   node scripts/dev-db.mjs hydrate-user --project dev --user <uid> --display-name "Tyler P." --age 27 --gender man --height-in 70 --weight-lb 178 --country US --region IL
  *   node scripts/dev-db.mjs seed-demo-user --project staging --email person@example.com
  */
 
 import {spawnSync} from "node:child_process";
+import {randomBytes} from "node:crypto";
 import {dirname, resolve} from "node:path";
 import {fileURLToPath} from "node:url";
 import {applicationDefault, initializeApp} from "firebase-admin/app";
+import {getAuth} from "firebase-admin/auth";
 import {FieldValue, getFirestore, Timestamp} from "firebase-admin/firestore";
 import {
   DEV_PROJECT_ID,
@@ -68,6 +71,7 @@ const TARGETS = {
 };
 
 const SERVER_TIMESTAMP_PREVIEW = "<serverTimestamp>";
+let initializedProjectId = null;
 const LIVE_REPLAY_SEED_FLAGS = new Set([
   "--source-user",
   "--avatar-dir",
@@ -109,6 +113,13 @@ function parseArgs(argv) {
     confirmDevWipe: false,
     passthrough: [],
     userId: null,
+    password: null,
+    passwordEnv: null,
+    generatePassword: false,
+    useExistingAuthUser: false,
+    emailVerified: true,
+    hydrateProfile: false,
+    seedDemoData: false,
     displayName: null,
     firstName: null,
     lastName: null,
@@ -156,6 +167,31 @@ function parseArgs(argv) {
       case "--user":
       case "--uid":
         args.userId = requireValue(argv, ++index, value);
+        break;
+      case "--password":
+        args.password = requireValue(argv, ++index, value);
+        break;
+      case "--password-env":
+        args.passwordEnv = requireValue(argv, ++index, value);
+        break;
+      case "--generate-password":
+      case "--random-password":
+        args.generatePassword = true;
+        break;
+      case "--use-existing":
+        args.useExistingAuthUser = true;
+        break;
+      case "--unverified":
+        args.emailVerified = false;
+        break;
+      case "--email-verified":
+        args.emailVerified = true;
+        break;
+      case "--hydrate-profile":
+        args.hydrateProfile = true;
+        break;
+      case "--seed-demo-data":
+        args.seedDemoData = true;
         break;
       case "--display-name":
         args.displayName = requireValue(argv, ++index, value);
@@ -253,6 +289,7 @@ Usage:
   node scripts/dev-db.mjs clear --target profiles,leaderboard --project dev
   node scripts/dev-db.mjs reset --target all --project dev
   node scripts/dev-db.mjs wipe --project dev --confirm-dev-wipe
+  node scripts/dev-db.mjs create-auth-user --project staging --email qa@example.com --display-name "QA Tester"
   node scripts/dev-db.mjs hydrate-user --project dev --user <uid> --display-name "Tyler P." --age 27 --gender man --height-in 70 --weight-lb 178 --country US --region IL
   node scripts/dev-db.mjs seed-demo-user --project staging --email person@example.com
 
@@ -263,6 +300,7 @@ Commands:
   clear         Clear one or more targets.
   reset         Clear then seed one or more targets.
   wipe          Delete all reviewed top-level Firestore collections in dev only.
+  create-auth-user Create one Firebase Auth email/password user in dev/staging.
   hydrate-user  Merge complete profile identity/demographic fields into one dev/staging user.
   seed-demo-user Seed one real dev/staging Auth user with product-demo data.
 
@@ -287,6 +325,12 @@ Options:
   --scenario <name>                  Demo user scenario. Defaults to full-showcase.
   --first-ascent-climb <climbId>     Demo First Ascent climb. Defaults in seed script.
   --no-first-ascent                  Demo user seed will not claim a First Ascent.
+
+create-auth-user fields:
+  --email <email> [--display-name <name>] [--uid <uid>] [--photo-url <url>]
+  [--password <password> | --password-env <ENV_NAME> | --generate-password]
+  [--use-existing] [--unverified] [--hydrate-profile | --seed-demo-data]
+  If no password flag is provided, a random password is generated and printed once.
 
 hydrate-user fields:
   --user <uid> --display-name <name> --age <13-120> --gender <woman|man|non_binary|prefer_not_to_say>
@@ -323,6 +367,11 @@ async function main() {
     return;
   }
 
+  if (args.command === "create-auth-user") {
+    await createAuthUser(projectId, args);
+    return;
+  }
+
   if (args.command === "hydrate-user") {
     await hydrateUser(projectId, args);
     return;
@@ -334,7 +383,7 @@ async function main() {
   }
 
   if (!["seed", "clear", "reset"].includes(args.command)) {
-    throw new Error("Command must be plan, seed, audit, clear, reset, wipe, hydrate-user, seed-demo-user, or help");
+    throw new Error("Command must be plan, seed, audit, clear, reset, wipe, create-auth-user, hydrate-user, seed-demo-user, or help");
   }
 
   const targets = resolveTargets(args.targets);
@@ -365,6 +414,7 @@ function printPlan() {
   console.log("  node scripts/dev-db.mjs seed --target profiles,live-replay --project dev --dry-run");
   console.log("  node scripts/dev-db.mjs seed --target routine-templates --project dev");
   console.log("  node scripts/dev-db.mjs clear --target leaderboard --project dev");
+  console.log("  node scripts/dev-db.mjs create-auth-user --project staging --email qa@example.com --display-name \"QA Tester\"");
   console.log("  node scripts/dev-db.mjs hydrate-user --project dev --user <uid> --display-name \"Tyler P.\" --age 27 --gender man --height-in 70 --weight-lb 178 --country US --region IL");
   console.log("  node scripts/dev-db.mjs seed-demo-user --project staging --email person@example.com");
 }
@@ -375,6 +425,18 @@ function resolveProjectId(projectOrAlias) {
 
 function assertAllowedProject(projectId) {
   assertSeedableProject(projectId);
+}
+
+function initializeFirebaseAdmin(projectId) {
+  if (initializedProjectId) {
+    if (initializedProjectId !== projectId) {
+      throw new Error(`Firebase Admin already initialized for ${initializedProjectId}; refusing to reuse it for ${projectId}.`);
+    }
+    return;
+  }
+
+  initializeApp({credential: applicationDefault(), projectId});
+  initializedProjectId = projectId;
 }
 
 function resolveTargets(rawTargets) {
@@ -546,6 +608,169 @@ function appendFilteredPassthroughArgs(scriptArgs, passthroughArgs, allowedFlags
   }
 }
 
+async function createAuthUser(projectId, args) {
+  validateCreateAuthUserArgs(args);
+  const password = resolveCreateAuthPassword(args);
+
+  printCreateAuthUserPlan(projectId, args, password);
+  if (args.dryRun) {
+    console.log("Dry run only. No Firebase Auth user or Firestore documents were written.");
+    return;
+  }
+
+  initializeFirebaseAdmin(projectId);
+  const auth = getAuth();
+  const createRequest = {
+    email: args.email,
+    password: password.value,
+    emailVerified: args.emailVerified,
+    disabled: false,
+  };
+  if (args.userId) {
+    createRequest.uid = args.userId;
+  }
+  if (args.displayName) {
+    createRequest.displayName = args.displayName;
+  }
+  if (args.photoURL) {
+    createRequest.photoURL = args.photoURL;
+  }
+
+  let userRecord;
+  let created = false;
+  try {
+    userRecord = await auth.createUser(createRequest);
+    created = true;
+  } catch (error) {
+    if (!args.useExistingAuthUser || !isExistingAuthUserError(error)) {
+      throw new Error(`Failed to create Firebase Auth user: ${firebaseAuthErrorMessage(error)}`);
+    }
+
+    userRecord = await resolveExistingAuthUserForCreate(auth, args, error);
+  }
+
+  const action = created ? "Created" : "Using existing";
+  console.log(`${action} Firebase Auth user ${userRecord.uid} (${userRecord.email ?? args.email}) in ${projectId}.`);
+  if (created && password.generated) {
+    console.log(`Generated password: ${password.value}`);
+  }
+
+  const childArgs = {
+    ...args,
+    userId: userRecord.uid,
+    email: userRecord.email ?? args.email,
+    displayName: args.displayName ?? userRecord.displayName ?? null,
+    photoURL: args.photoURL ?? userRecord.photoURL ?? null,
+  };
+
+  if (args.hydrateProfile) {
+    await hydrateUser(projectId, childArgs);
+  }
+
+  if (args.seedDemoData) {
+    runDemoUserScript(projectId, childArgs);
+  }
+}
+
+function validateCreateAuthUserArgs(args) {
+  args.email = trimmed(args.email);
+  args.displayName = trimmed(args.displayName);
+  args.photoURL = trimmed(args.photoURL);
+  args.password = trimmed(args.password);
+  args.passwordEnv = trimmed(args.passwordEnv);
+
+  if (!args.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(args.email)) {
+    throw new Error("create-auth-user requires --email <email>");
+  }
+
+  const passwordSources = [args.password != null, args.passwordEnv != null, args.generatePassword]
+    .filter(Boolean).length;
+  if (passwordSources > 1) {
+    throw new Error("Use only one password source: --password, --password-env, or --generate-password");
+  }
+
+  if (args.password && args.password.length < 6) {
+    throw new Error("--password must be at least 6 characters for Firebase Auth");
+  }
+
+  if (args.hydrateProfile && args.seedDemoData) {
+    throw new Error("Use either --hydrate-profile or --seed-demo-data. Demo seeding already writes profile data.");
+  }
+
+  if (args.hydrateProfile) {
+    validateHydrateUserArgs({...args, userId: args.userId ?? "new-auth-user"});
+  }
+}
+
+function resolveCreateAuthPassword(args) {
+  if (args.password) {
+    return {value: args.password, generated: false, source: "provided via --password"};
+  }
+
+  if (args.passwordEnv) {
+    const value = trimmed(process.env[args.passwordEnv]);
+    if (!value) {
+      throw new Error(`--password-env ${args.passwordEnv} is not set or is empty`);
+    }
+    if (value.length < 6) {
+      throw new Error(`--password-env ${args.passwordEnv} must contain at least 6 characters`);
+    }
+    return {value, generated: false, source: `provided via ${args.passwordEnv}`};
+  }
+
+  return {value: randomAuthPassword(), generated: true, source: "generated random password"};
+}
+
+function randomAuthPassword() {
+  return `${randomBytes(18).toString("base64url")}Aa1!`;
+}
+
+function printCreateAuthUserPlan(projectId, args, password) {
+  console.log(`Project: ${projectId}`);
+  console.log(`Command: create-auth-user${args.dryRun ? " (dry run)" : ""}`);
+  console.log(`Email: ${args.email}`);
+  console.log(`UID: ${args.userId ?? "(Firebase generated)"}`);
+  console.log(`Display name: ${args.displayName ?? "(none)"}`);
+  console.log(`Email verified: ${args.emailVerified ? "yes" : "no"}`);
+  console.log(`Password: ${password.source}${password.generated ? " (printed only if a new user is created)" : " (not printed)"}`);
+  console.log(`Existing user behavior: ${args.useExistingAuthUser ? "reuse matching existing user" : "fail if the email or uid already exists"}`);
+  if (args.hydrateProfile) {
+    console.log("After create: hydrate profile documents");
+  }
+  if (args.seedDemoData) {
+    console.log("After create: seed product-demo account data");
+  }
+}
+
+function isExistingAuthUserError(error) {
+  return error?.code === "auth/email-already-exists" || error?.code === "auth/uid-already-exists";
+}
+
+async function resolveExistingAuthUserForCreate(auth, args, createError) {
+  if (createError?.code === "auth/email-already-exists") {
+    const existing = await auth.getUserByEmail(args.email);
+    if (args.userId && existing.uid !== args.userId) {
+      throw new Error(`Firebase Auth email ${args.email} already belongs to uid ${existing.uid}, not requested uid ${args.userId}.`);
+    }
+    return existing;
+  }
+
+  if (createError?.code === "auth/uid-already-exists") {
+    const existing = await auth.getUser(args.userId);
+    if (existing.email !== args.email) {
+      throw new Error(`Firebase Auth uid ${args.userId} already belongs to ${existing.email ?? "(no email)"}, not ${args.email}.`);
+    }
+    return existing;
+  }
+
+  throw createError;
+}
+
+function firebaseAuthErrorMessage(error) {
+  const code = error?.code ? `${error.code}: ` : "";
+  return `${code}${error?.message ?? String(error)}`;
+}
+
 async function wipeDevFirestore(projectId, args) {
   if (projectId !== DEV_PROJECT_ID) {
     throw new Error(`wipe is dev-only. Refusing to wipe ${projectId}.`);
@@ -554,7 +779,7 @@ async function wipeDevFirestore(projectId, args) {
     throw new Error("wipe requires --confirm-dev-wipe unless --dry-run is set");
   }
 
-  initializeApp({credential: applicationDefault(), projectId});
+  initializeFirebaseAdmin(projectId);
   const db = getFirestore();
   const existingCollections = await db.listCollections();
   const existingIds = existingCollections.map((collection) => collection.id).sort();
@@ -589,7 +814,7 @@ async function wipeDevFirestore(projectId, args) {
 
 async function hydrateUser(projectId, args) {
   validateHydrateUserArgs(args);
-  initializeApp({credential: applicationDefault(), projectId});
+  initializeFirebaseAdmin(projectId);
   const db = getFirestore();
   const userRef = db.collection("users").doc(args.userId);
   const existingSnapshot = await userRef.get();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -13,6 +13,8 @@
     "db:reset": "node dev-db.mjs reset --project dev",
     "db:reset:staging": "node dev-db.mjs reset --project staging",
     "db:wipe": "node dev-db.mjs wipe --project dev --confirm-dev-wipe",
+    "db:create-auth-user": "node dev-db.mjs create-auth-user --project dev",
+    "db:create-auth-user:staging": "node dev-db.mjs create-auth-user --project staging",
     "db:hydrate-user": "node dev-db.mjs hydrate-user --project dev",
     "db:hydrate-user:staging": "node dev-db.mjs hydrate-user --project staging",
     "db:seed-demo-user": "node dev-db.mjs seed-demo-user --project dev",
@@ -42,7 +44,13 @@
     "seed:profiles": "node seed-test-users.mjs seed --project dev",
     "seed:profiles:staging": "node seed-test-users.mjs seed --project staging",
     "clear:profiles": "node seed-test-users.mjs clear --project dev",
-    "clear:profiles:staging": "node seed-test-users.mjs clear --project staging"
+    "clear:profiles:staging": "node seed-test-users.mjs clear --project staging",
+    "images:audit": "node sync-climb-images.mjs audit --project dev",
+    "images:audit:staging": "node sync-climb-images.mjs audit --project staging",
+    "images:audit:production": "node sync-climb-images.mjs audit --project production",
+    "images:diff:staging-to-production": "node sync-climb-images.mjs diff --from staging --to production",
+    "images:sync:staging-to-dev": "node sync-climb-images.mjs sync --from staging --to dev",
+    "images:sync:staging-to-production": "node sync-climb-images.mjs sync --from staging --to production --confirm-production"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/sync-climb-images.mjs
+++ b/scripts/sync-climb-images.mjs
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+
+/**
+ * Ascend Climb Image Sync Tool
+ *
+ * Audits, diffs, uploads, and syncs climb artwork (climb-images/) across the
+ * dev, staging, and production Firebase Storage buckets. Climb images are
+ * remote-only content — the app ships no artwork — so every environment's
+ * bucket must carry the images its hosted catalog references.
+ *
+ * Unlike the fixture seeders, production is a legitimate TARGET here (this is
+ * content publishing, not test data). Any write to production requires the
+ * explicit --confirm-production flag.
+ *
+ * Usage:
+ *   node scripts/sync-climb-images.mjs audit --project dev
+ *   node scripts/sync-climb-images.mjs diff --from staging --to production
+ *   node scripts/sync-climb-images.mjs sync --from staging --to production --dry-run
+ *   node scripts/sync-climb-images.mjs sync --from staging --to production --confirm-production
+ *   node scripts/sync-climb-images.mjs sync --from staging --to dev --climb burj-khalifa
+ *   node scripts/sync-climb-images.mjs upload --project staging --climb burj-khalifa --dir ~/art/burj --image-set-version 2
+ */
+
+import {existsSync, readFileSync} from "node:fs";
+import {resolve, dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {applicationDefault, initializeApp} from "firebase-admin/app";
+import {getStorage} from "firebase-admin/storage";
+import {
+  PRODUCTION_PROJECT_ID,
+  resolveProjectId,
+  seedEnvironmentName,
+} from "./seed/lib/environments.mjs";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const CATALOG_PATH = resolve(REPO_ROOT, "web/public/climbs/catalog-v1.json");
+
+const IMAGE_PREFIX = "climb-images/";
+const IMAGE_SIZES = ["hero", "card", "thumb"];
+const IMAGE_CONTENT_TYPE = "image/heic";
+// Versioned paths are immutable — a new image set bumps imageSetVersion and
+// gets a new path — so clients and CDNs may cache aggressively.
+const IMAGE_CACHE_CONTROL = "public, max-age=604800, immutable";
+
+const apps = new Map();
+
+function appFor(projectId) {
+  if (!apps.has(projectId)) {
+    apps.set(
+      projectId,
+      initializeApp(
+        {
+          credential: applicationDefault(),
+          projectId,
+          storageBucket: `${projectId}.firebasestorage.app`,
+        },
+        projectId
+      )
+    );
+  }
+  return apps.get(projectId);
+}
+
+function bucketFor(projectId) {
+  return getStorage(appFor(projectId)).bucket();
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  const flags = {};
+  for (let index = 0; index < rest.length; index++) {
+    const arg = rest[index];
+    if (!arg.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${arg}`);
+    }
+    const key = arg.slice(2);
+    const next = rest[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      flags[key] = true;
+    } else {
+      flags[key] = next;
+      index++;
+    }
+  }
+  return {command, flags};
+}
+
+function requireProject(flags, name) {
+  const value = flags[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`--${name} <dev|staging|production> is required.`);
+  }
+  return resolveProjectId(value, REPO_ROOT);
+}
+
+function assertWritableTarget(projectId, flags) {
+  if (projectId === PRODUCTION_PROJECT_ID && flags["confirm-production"] !== true) {
+    throw new Error(
+      `Refusing to write to production (${projectId}) without --confirm-production.`
+    );
+  }
+}
+
+function loadCatalog() {
+  return JSON.parse(readFileSync(CATALOG_PATH, "utf-8"));
+}
+
+function expectedObjectPaths(catalog) {
+  const paths = new Map();
+  for (const climb of catalog.climbs ?? catalog) {
+    const version = climb.imageSetVersion ?? 1;
+    for (const size of IMAGE_SIZES) {
+      paths.set(
+        `${IMAGE_PREFIX}${climb.id}/v${version}/${size}.heic`,
+        {climbId: climb.id, releaseState: climb.releaseState, size}
+      );
+    }
+  }
+  return paths;
+}
+
+async function listImageObjects(projectId) {
+  const [files] = await bucketFor(projectId).getFiles({prefix: IMAGE_PREFIX});
+  const objects = new Map();
+  for (const file of files) {
+    objects.set(file.name, {
+      md5: file.metadata.md5Hash ?? null,
+      size: Number(file.metadata.size ?? 0),
+    });
+  }
+  return objects;
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+async function commandAudit(flags) {
+  const projectId = requireProject(flags, "project");
+  const catalog = loadCatalog();
+  const expected = expectedObjectPaths(catalog);
+  const actual = await listImageObjects(projectId);
+
+  const missing = [];
+  for (const [path, info] of expected) {
+    if (!actual.has(path)) {
+      missing.push({path, ...info});
+    }
+  }
+  const orphans = [...actual.keys()].filter((path) => !expected.has(path));
+
+  console.log(`Climb image audit — ${seedEnvironmentName(projectId)} (${projectId})`);
+  console.log(`  catalog climbs: ${expected.size / IMAGE_SIZES.length}`);
+  console.log(`  objects in bucket under ${IMAGE_PREFIX}: ${actual.size}`);
+  console.log(`  missing expected objects: ${missing.length}`);
+  for (const item of missing) {
+    console.log(`    MISSING [${item.releaseState}] ${item.path}`);
+  }
+  console.log(`  objects not referenced by current catalog: ${orphans.length}`);
+  for (const path of orphans) {
+    console.log(`    EXTRA ${path}`);
+  }
+
+  const missingAvailable = missing.filter((item) => item.releaseState === "available");
+  if (missingAvailable.length > 0) {
+    process.exitCode = 1;
+    console.log(
+      `\n${missingAvailable.length} image(s) missing for AVAILABLE climbs — these render as placeholders in the app.`
+    );
+  }
+}
+
+function computeCopyPlan(sourceObjects, targetObjects, climbFilter) {
+  const plan = [];
+  for (const [path, sourceInfo] of sourceObjects) {
+    if (climbFilter && !path.startsWith(`${IMAGE_PREFIX}${climbFilter}/`)) {
+      continue;
+    }
+    const targetInfo = targetObjects.get(path);
+    if (!targetInfo) {
+      plan.push({path, reason: "missing", bytes: sourceInfo.size});
+    } else if (targetInfo.md5 !== sourceInfo.md5) {
+      plan.push({path, reason: "changed", bytes: sourceInfo.size});
+    }
+  }
+  return plan;
+}
+
+async function commandDiff(flags) {
+  const fromProject = requireProject(flags, "from");
+  const toProject = requireProject(flags, "to");
+  const [sourceObjects, targetObjects] = await Promise.all([
+    listImageObjects(fromProject),
+    listImageObjects(toProject),
+  ]);
+  const plan = computeCopyPlan(sourceObjects, targetObjects, flags.climb);
+  const onlyInTarget = [...targetObjects.keys()].filter((path) => !sourceObjects.has(path));
+
+  console.log(
+    `Diff ${seedEnvironmentName(fromProject)} → ${seedEnvironmentName(toProject)}: ` +
+      `${plan.length} object(s) would copy, ${onlyInTarget.length} exist only in target`
+  );
+  for (const item of plan) {
+    console.log(`  ${item.reason.toUpperCase()} ${item.path} (${formatBytes(item.bytes)})`);
+  }
+  for (const path of onlyInTarget) {
+    console.log(`  TARGET-ONLY ${path}`);
+  }
+}
+
+async function commandSync(flags) {
+  const fromProject = requireProject(flags, "from");
+  const toProject = requireProject(flags, "to");
+  if (fromProject === toProject) {
+    throw new Error("--from and --to must be different environments.");
+  }
+  const dryRun = flags["dry-run"] === true;
+  if (!dryRun) {
+    assertWritableTarget(toProject, flags);
+  }
+
+  const [sourceObjects, targetObjects] = await Promise.all([
+    listImageObjects(fromProject),
+    listImageObjects(toProject),
+  ]);
+  const plan = computeCopyPlan(sourceObjects, targetObjects, flags.climb);
+  const totalBytes = plan.reduce((sum, item) => sum + item.bytes, 0);
+
+  console.log(
+    `Sync ${seedEnvironmentName(fromProject)} → ${seedEnvironmentName(toProject)}: ` +
+      `${plan.length} object(s), ${formatBytes(totalBytes)}${dryRun ? " (dry run)" : ""}`
+  );
+
+  if (plan.length === 0) {
+    console.log("Nothing to copy — target is up to date.");
+    return;
+  }
+
+  const sourceBucket = bucketFor(fromProject);
+  const targetBucket = bucketFor(toProject);
+  for (const item of plan) {
+    console.log(`  ${dryRun ? "would copy" : "copying"} ${item.path}`);
+    if (dryRun) continue;
+    await sourceBucket.file(item.path).copy(targetBucket.file(item.path));
+    await targetBucket.file(item.path).setMetadata({
+      cacheControl: IMAGE_CACHE_CONTROL,
+    });
+  }
+
+  if (!dryRun) {
+    console.log(`Copied ${plan.length} object(s). Run audit --project ${flags.to} to verify.`);
+  }
+}
+
+async function commandUpload(flags) {
+  const projectId = requireProject(flags, "project");
+  assertWritableTarget(projectId, flags);
+
+  const climbId = flags.climb;
+  if (typeof climbId !== "string" || climbId.length === 0) {
+    throw new Error("--climb <climb-id> is required.");
+  }
+  const directory = flags.dir;
+  if (typeof directory !== "string" || !existsSync(directory)) {
+    throw new Error("--dir <folder containing hero.heic, card.heic, thumb.heic> is required.");
+  }
+  const version = Number(flags["image-set-version"] ?? 1);
+  if (!Number.isInteger(version) || version < 1) {
+    throw new Error("--image-set-version must be a positive integer.");
+  }
+
+  const localFiles = IMAGE_SIZES.map((size) => ({
+    size,
+    localPath: join(directory, `${size}.heic`),
+    remotePath: `${IMAGE_PREFIX}${climbId}/v${version}/${size}.heic`,
+  }));
+  const missingLocal = localFiles.filter((file) => !existsSync(file.localPath));
+  if (missingLocal.length > 0) {
+    throw new Error(
+      `Missing local files: ${missingLocal.map((file) => file.localPath).join(", ")}`
+    );
+  }
+
+  const bucket = bucketFor(projectId);
+  for (const file of localFiles) {
+    console.log(`  uploading ${file.remotePath}`);
+    await bucket.upload(file.localPath, {
+      destination: file.remotePath,
+      metadata: {
+        cacheControl: IMAGE_CACHE_CONTROL,
+        contentType: IMAGE_CONTENT_TYPE,
+      },
+    });
+  }
+  console.log(
+    `Uploaded ${localFiles.length} image(s) for ${climbId} v${version} to ` +
+      `${seedEnvironmentName(projectId)}. Ensure the catalog's imageSetVersion matches.`
+  );
+}
+
+function printUsage() {
+  console.log(`Commands:
+  audit  --project <env>                       Check bucket contents against the catalog
+  diff   --from <env> --to <env> [--climb id]  Show what sync would copy
+  sync   --from <env> --to <env> [--climb id] [--dry-run] [--confirm-production]
+  upload --project <env> --climb <id> --dir <folder> [--image-set-version n] [--confirm-production]
+
+Environments: dev, staging, production. Writes to production require --confirm-production.`);
+}
+
+async function main() {
+  const {command, flags} = parseArgs(process.argv.slice(2));
+  switch (command) {
+  case "audit":
+    await commandAudit(flags);
+    break;
+  case "diff":
+    await commandDiff(flags);
+    break;
+  case "sync":
+    await commandSync(flags);
+    break;
+  case "upload":
+    await commandUpload(flags);
+    break;
+  default:
+    printUsage();
+    process.exitCode = command ? 1 : 0;
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message ?? error);
+  process.exit(1);
+});

--- a/skills/live-climb-content/SKILL.md
+++ b/skills/live-climb-content/SKILL.md
@@ -103,6 +103,24 @@ climb-images/{climbId}/thumb.heic
 
 If replacing images for an existing climb, increment `imageSetVersion` in both catalog files so clients fetch the new cached path.
 
+### Image tooling (`scripts/sync-climb-images.mjs`)
+
+Images are per-environment Storage content — publishing a catalog does NOT move images. Use this tool to keep buckets in sync with the catalog:
+
+```bash
+# Check a bucket against the catalog (exits 1 if an available climb lacks images)
+node scripts/sync-climb-images.mjs audit --project staging
+
+# Upload new artwork (folder must contain hero.heic, card.heic, thumb.heic)
+node scripts/sync-climb-images.mjs upload --project dev --climb <id> --dir <folder> --image-set-version 1
+
+# Propagate images between environments (dry-run first)
+node scripts/sync-climb-images.mjs sync --from staging --to production --dry-run
+node scripts/sync-climb-images.mjs sync --from staging --to production --confirm-production
+```
+
+Writes to production require `--confirm-production`. Sync copies only missing/changed objects (md5 compare) and never deletes. When adding a climb: upload images to dev/staging first, validate in-app, then sync to production alongside (or before) the catalog deploy that references them.
+
 ## Workflow
 
 1. Read the existing catalog entries to match style, order, tags, and category naming.

--- a/skills/sentry/SKILL.md
+++ b/skills/sentry/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: sentry
+description: Use when reading, triaging, searching, or updating Sentry issues and events for the Ascend iOS app — error investigation, issue detail, stack traces, tag breakdowns, resolving/archiving issues, and weekly error-report follow-up.
+---
+
+# Sentry Access
+
+Use this skill for any request to look at Sentry errors, investigate an issue, pull event details, or change issue state (resolve, archive, assign).
+
+This is harness-neutral. If the current AI tool does not support skills, paste or reference this file and follow it as the source-of-truth workflow.
+
+## Project Constants
+
+- Org slug: `ascend-uk`
+- Project slug: `ascend-ios`
+- Project ID: `4511621439815680`
+- API base: `https://sentry.io/api/0`
+- Web UI: `https://ascend-uk.sentry.io`
+- Issue short IDs look like `ASCEND-IOS-B`; numeric issue IDs look like `7582495782`. Both appear in alert emails.
+- Sentry environments match the app's build configs: `dev`, `staging`, `production` (set in `AscendApp/Shared/Services/Telemetry/SentryDiagnosticsReporter.swift`).
+- Useful custom tags set by the app: `ascend_error_code`, `ascend_error_context`, `build_config`, `app_environment`, `has_app_access`, `last_diagnostic_event`, `release` (format `com.TylerPavay.AscendApp.staging@1.0+<build>`).
+
+## Authentication
+
+All API calls need a **user auth token** in the `Authorization: Bearer` header.
+
+Token resolution order:
+
+1. `SENTRY_AUTH_TOKEN` environment variable.
+2. `token` under `[auth]` in `~/.sentryclirc`.
+
+```bash
+SENTRY_TOKEN="${SENTRY_AUTH_TOKEN:-$(awk -F= '/^token/{gsub(/ /,"",$2); print $2}' ~/.sentryclirc 2>/dev/null)}"
+```
+
+If no token is found, stop and ask the user to create one:
+
+1. Open `https://ascend-uk.sentry.io/settings/account/api/auth-tokens/` (User Auth Tokens — NOT an Organization Auth Token; org tokens are CI-scoped for releases/dSYMs).
+2. Create a token with scopes: `event:read`, `event:write`, `org:read`, `project:read`. Add `event:admin` only if issue deletion is needed.
+3. Store it user-locally, e.g. `export SENTRY_AUTH_TOKEN=...` in `~/.zshrc`, or in `~/.sentryclirc`.
+
+Rules:
+
+- Never commit a token, write it into any repo file, or echo it into output/logs.
+- The `SENTRY_AUTH_TOKEN` GitHub Actions secret is a separate CI token for dSYM upload (fastlane). Do not reuse or print it.
+
+Verify access:
+
+```bash
+curl -sf -H "Authorization: Bearer $SENTRY_TOKEN" \
+  "https://sentry.io/api/0/organizations/ascend-uk/" >/dev/null \
+  && echo "sentry auth ok" || echo "sentry auth FAILED"
+```
+
+## Read Operations (safe, do freely)
+
+List unresolved issues (default triage view; sorted by last seen):
+
+```bash
+curl -s -H "Authorization: Bearer $SENTRY_TOKEN" \
+  "https://sentry.io/api/0/projects/ascend-uk/ascend-ios/issues/?query=is:unresolved&statsPeriod=14d" \
+  | jq -r '.[] | [.shortId, .count, .userCount, .substatus, .title] | @tsv'
+```
+
+Common query variations (URL-encode the `query` value):
+
+- Filter environment: append `&environment=staging` (or `dev` / `production`).
+- Sort by event count: `&sort=freq`. New issues first: `&sort=new`.
+- By custom tag: `query=is:unresolved ascend_error_code:lifecycle_event_record_failed`
+- By release: `query=release:com.TylerPavay.AscendApp.staging@1.0+120`
+- Escalating only: `query=is:unresolved is:escalating`
+
+Look up an issue by short ID (from an alert email):
+
+```bash
+curl -s -H "Authorization: Bearer $SENTRY_TOKEN" \
+  "https://sentry.io/api/0/organizations/ascend-uk/issues/?query=issue:ASCEND-IOS-B&project=4511621439815680" | jq '.[0]'
+```
+
+Issue detail (counts, first/last seen, status):
+
+```bash
+curl -s -H "Authorization: Bearer $SENTRY_TOKEN" \
+  "https://sentry.io/api/0/organizations/ascend-uk/issues/{issue_id}/" | jq .
+```
+
+Latest event for an issue (full stack trace, breadcrumbs, tags, contexts — the main debugging payload; it is large, so filter with `jq`):
+
+```bash
+curl -s -H "Authorization: Bearer $SENTRY_TOKEN" \
+  "https://sentry.io/api/0/organizations/ascend-uk/issues/{issue_id}/events/latest/" \
+  | jq '{title, dateCreated, tags, "exception": [.entries[] | select(.type=="exception")], "breadcrumbs": [.entries[] | select(.type=="breadcrumbs")]}'
+```
+
+Tag breakdown for an issue (e.g. which releases/devices are affected):
+
+```bash
+curl -s -H "Authorization: Bearer $SENTRY_TOKEN" \
+  "https://sentry.io/api/0/organizations/ascend-uk/issues/{issue_id}/tags/release/values/" | jq .
+```
+
+Recent events across an issue:
+
+```bash
+curl -s -H "Authorization: Bearer $SENTRY_TOKEN" \
+  "https://sentry.io/api/0/organizations/ascend-uk/issues/{issue_id}/events/?statsPeriod=14d" \
+  | jq -r '.[] | [.dateCreated, .eventID, .title] | @tsv'
+```
+
+Pagination: responses use a `Link` header with `cursor`. Fetch the next page by appending `&cursor=<value>` from the `Link` header where `results="true"`.
+
+## Write Operations (mutations — only when the user explicitly asks)
+
+Never resolve, archive, assign, or delete issues as a side effect of investigation. Confirm intent first, and name the short IDs being mutated.
+
+Resolve an issue:
+
+```bash
+curl -s -X PUT -H "Authorization: Bearer $SENTRY_TOKEN" -H "Content-Type: application/json" \
+  "https://sentry.io/api/0/organizations/ascend-uk/issues/{issue_id}/" \
+  -d '{"status": "resolved"}' | jq '{shortId, status}'
+```
+
+Resolve in next release: `{"status": "resolvedInNextRelease"}`.
+
+Archive (ignore) an issue: `{"status": "ignored"}`. Archive until it escalates: `{"status": "ignored", "substatus": "archived_until_escalating"}`.
+
+Bulk update by ID list:
+
+```bash
+curl -s -X PUT -H "Authorization: Bearer $SENTRY_TOKEN" -H "Content-Type: application/json" \
+  "https://sentry.io/api/0/projects/ascend-uk/ascend-ios/issues/?id={id1}&id={id2}" \
+  -d '{"status": "resolved"}'
+```
+
+Add a triage note to an issue:
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SENTRY_TOKEN" -H "Content-Type: application/json" \
+  "https://sentry.io/api/0/organizations/ascend-uk/issues/{issue_id}/comments/" \
+  -d '{"text": "Root cause: ..."}'
+```
+
+## Triage Conventions
+
+- Staging (`environment:staging`) is TestFlight + CI traffic; dev (`environment:dev`) is simulator/local. Neither represents production users — weigh severity accordingly, but treat escalating staging issues as launch blockers to fix before production.
+- Issues titled `AscendAppTests.*` are unit-test errors leaking into Sentry from a test host with telemetry enabled — telemetry noise to suppress at the source, never real app bugs. Safe to archive after the leak is fixed.
+- `App Hang` issues are Sentry ANR detection. Unsymbolicated frames (`?` frames) mean dSYMs were missing for that build; check whether the release predates CI dSYM upload before investigating.
+- When reporting findings, cite issue short IDs and web links (`https://ascend-uk.sentry.io/issues/{issue_id}/`) so the user can click through.
+
+## Output Checklist
+
+When done, report:
+
+- Which issues were inspected (short IDs + links).
+- Root-cause hypothesis per issue, with the app code path where relevant.
+- Any mutations performed (resolve/archive/note), each explicitly requested by the user.
+- Whether any follow-up code fix is needed, and where.


### PR DESCRIPTION
## What this does

Three groups of changes, all verified locally (unit tests pass, functions lint/build clean, unsigned Release build compiles):

### Sentry error noise + push reliability
- **Lifecycle events skip when signed out** — `recordLifecycleEvent` was called on every launch/foreground while unauthenticated, producing the escalating `ASCEND-IOS-B` issue (200+ events/week). Expected transport noise (unauthenticated, request-cancelled, FCM 505 missing-APNS-token) is no longer reported to Sentry.
- **Telemetry hard-disabled under XCTest** — test-injected failures (`TestSyncFailure`) were creating new Sentry issues on every test run because the test host inherited the debug telemetry toggle. New unit test proves the guard overrides every enablement path.
- **Push device sync fixed on both sides** — overlapping `synchronizeAuthenticatedDeviceIfNeeded()` calls now coalesce client-side, and `registerPushDevice`/`updatePushNotificationPreferences` retry Firestore transaction contention with backoff instead of leaking unhandled `ABORTED` as `INTERNAL` (Sentry `ASCEND-IOS-5`/`-6`, reproduced in dev function logs).

### Production launch readiness
- Xcode Archive action on the `AscendApp` scheme now builds **Release** (was Debug — a manual archive produced a dev-Firebase build).
- CI gains an `ios-verify-release` job: unsigned Release compile on PRs, so Release-only build errors surface here instead of on the production pipeline's first run. Decodes the production plist from the new `GOOGLE_SERVICE_INFO_PRODUCTION_BASE64` secret.
- Production Firebase plist (delivered via secret) now has Analytics enabled.

### Tooling + skills
- `scripts/sync-climb-images.mjs` — audit/diff/sync/upload climb artwork across env Storage buckets (climb images are remote-only content). Production writes require `--confirm-production`. Already used to populate the prod bucket (264 objects, audit passes). Documented in the `live-climb-content` skill.
- New harness-neutral `skills/sentry` for API-based Sentry triage; registered in CLAUDE.md.
- Includes pre-existing local `dev-db create-auth-user` command as its own commit.

## Verification
- `AscendAppTests` TelemetryManager + WorkoutSyncCoordinator suites: 21/21 pass (iPhone 17 sim)
- `npm --prefix functions run lint && npm --prefix functions run build`: clean
- Unsigned Release build compiles locally
- Test push delivered end-to-end on device after APNs key setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)