### PR TITLE
Fix fatal TabRouter crash at end of onboarding

### DIFF
--- a/AscendApp/Features/Home/Views/HomeView.swift
+++ b/AscendApp/Features/Home/Views/HomeView.swift
@@ -10,7 +10,12 @@ import SwiftData
 
 struct HomeView: View {
     @Environment(AuthenticationViewModel.self) private var authVM
-    @Environment(TabRouter.self) private var tabRouter
+    // Passed directly rather than read from the environment: HomeView updates
+    // during the onboarding -> main-app crossfade while briefly detached from
+    // its environment, and a non-optional @Environment(TabRouter.self) read
+    // fatal-errors there (ASCEND-IOS-13). MainTabView owns the router and
+    // constructs this view, so direct injection is also the simpler shape.
+    private let tabRouter: TabRouter
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Workout.date, order: .reverse) private var workouts: [Workout]
@@ -34,8 +39,12 @@ struct HomeView: View {
         tabRouter.selectedTab == .home
     }
 
-    init(homeDashboard: HomeDashboardViewModel = HomeDashboardViewModel()) {
+    init(
+        homeDashboard: HomeDashboardViewModel = HomeDashboardViewModel(),
+        tabRouter: TabRouter
+    ) {
         self.homeDashboard = homeDashboard
+        self.tabRouter = tabRouter
     }
 
     private var hasBlockingModalPresentation: Bool {
@@ -396,9 +405,8 @@ struct HomeView: View {
 
 #Preview {
     NavigationStack {
-        HomeView()
+        HomeView(tabRouter: TabRouter())
             .environment(AuthenticationViewModel())
-            .environment(TabRouter())
     }
     .modelContainer(
         for: [

--- a/AscendApp/Shared/Views/MainTabView.swift
+++ b/AscendApp/Shared/Views/MainTabView.swift
@@ -109,7 +109,7 @@ struct MainTabView: View {
         switch tab {
         case .home:
             NavigationStack(path: $homeNavigationPath) {
-                HomeView(homeDashboard: homeDashboard)
+                HomeView(homeDashboard: homeDashboard, tabRouter: tabRouter)
                     .navigationDestination(for: HomeNavigationDestination.self) { destination in
                         homeDestination(for: destination)
                     }


### PR DESCRIPTION
Fixes the fatal crash hit during staging smoke testing ([ASCEND-IOS-13](https://ascend-uk.sentry.io/issues/ASCEND-IOS-13/)): tapping **VIEW CLIMB** at the end of onboarding crashed with `Fatal error: No Observable object of type TabRouter`.

**Root cause:** `HomeView` read `TabRouter` via non-optional `@Environment(TabRouter.self)`. During the animated onboarding → main-app route swap in RootView, SwiftUI can update the conditionally-mounted tab content while it is briefly detached from its environment, and a non-optional observable environment read fatal-errors there.

**Fix:** `MainTabView` owns the `TabRouter` and constructs `HomeView`, so the router is now passed as an init parameter (plain stored property, still observation-tracked). No environment lookup means the failure class is gone entirely — and it's the simpler dependency shape. `HomeView` was the only environment consumer of `TabRouter` in the app.

Verified: Debug build compiles clean; Home's tab-switching behavior (rank → leaderboard, training shortcut) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)