### PR TITLE
Live Bluetooth heart rate with effort zones during climbs

### DIFF
--- a/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
@@ -180,6 +180,11 @@ final class LiveClimbSessionViewModel {
     private(set) var stepSyncPrompt: LiveStepSyncPrompt?
     private(set) var stepSyncConfirmation: LiveStepSyncConfirmation?
 
+    let heartRateMonitor: HeartRateMonitorService = .shared
+    private(set) var heartRateZoneProfile = HeartRateZoneProfile(age: nil)
+    private var heartRateSamples: [HeartRateDataPoint] = []
+    private var lastHeartRateSampleAt: Date?
+
     private var hasSavedSession = false
     private var stepTimelineRecorder: LiveClimbStepTimelineRecorder
     private var isLeaderboardRefreshInFlight = false
@@ -430,6 +435,17 @@ final class LiveClimbSessionViewModel {
                 "resumed_from_draft": preexistingDraft == nil ? "false" : "true"
             ]
         )
+        // Strap-on-and-go: reconnect the remembered heart-rate monitor
+        // silently, and resolve the climber's zone bands from their profile
+        // age. Both are best-effort — the session never waits on them.
+        heartRateSamples.removeAll()
+        lastHeartRateSampleAt = nil
+        heartRateMonitor.autoConnectIfRemembered()
+        Task { [weak self] in
+            let profile = await HeartRateZoneProfileResolver.resolve()
+            self?.heartRateZoneProfile = profile
+        }
+
         do {
             stepTimelineRecorder.reset()
             if let splitCurve = activeDraft?.splitCurve {
@@ -698,9 +714,42 @@ final class LiveClimbSessionViewModel {
             cumulativeSteps: motionSession.stepCount,
             source: .headphoneMotion
         )
+        recordHeartRateSampleIfFresh()
         if let modelContext {
             checkpointDraft(modelContext: modelContext)
         }
+    }
+
+    // MARK: - Heart rate
+
+    /// Latest trusted heart-rate reading for live display; nil when no
+    /// monitor is connected or the last reading has gone stale.
+    var liveHeartRate: Int? {
+        heartRateMonitor.freshMeasurement?.beatsPerMinute
+    }
+
+    var liveHeartRateZone: HeartRateZone? {
+        liveHeartRate.map(heartRateZoneProfile.zone(forBeatsPerMinute:))
+    }
+
+    var isHeartRateMonitorConnected: Bool {
+        heartRateMonitor.isConnected
+    }
+
+    /// Buffers one reading per second-tick while recording so completed
+    /// workouts carry the same heart-rate series shape as imported ones —
+    /// the existing sync pipeline uploads it with zero extra plumbing.
+    private func recordHeartRateSampleIfFresh() {
+        guard let measurement = heartRateMonitor.freshMeasurement else { return }
+
+        let now = Date()
+        if let lastHeartRateSampleAt, now.timeIntervalSince(lastHeartRateSampleAt) < 0.9 {
+            return
+        }
+        lastHeartRateSampleAt = now
+        heartRateSamples.append(
+            HeartRateDataPoint(timestamp: now, heartRate: measurement.beatsPerMinute)
+        )
     }
 
     func checkpointForLifecycleChange(modelContext: ModelContext) {
@@ -980,6 +1029,11 @@ final class LiveClimbSessionViewModel {
             stepCorrections: result.stepCorrections
         )
 
+        let heartRates = heartRateSamples.map(\.heartRate)
+        let averageHeartRate = heartRates.isEmpty
+            ? nil
+            : heartRates.reduce(0, +) / heartRates.count
+
         let workout = Workout(
             name: mode.workoutName,
             date: result.startedAt,
@@ -987,6 +1041,9 @@ final class LiveClimbSessionViewModel {
             steps: result.steps,
             floors: floors,
             stepsPerFloor: Workout.defaultStepsPerFloor,
+            avgHeartRate: averageHeartRate,
+            maxHeartRate: heartRates.max(),
+            heartRateTimeSeries: heartRateSamples.isEmpty ? nil : heartRateSamples,
             source: .headphoneMotion,
             deviceModel: UIDevice.current.model,
             sourceMetadata: metadata.jsonString

--- a/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
+++ b/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
@@ -209,6 +209,10 @@ struct LiveClimbSessionView: View {
 
             Spacer(minLength: 0)
 
+            if viewModel.isHeartRateMonitorConnected {
+                heartRateChip
+            }
+
             if !(viewModel.isRecording && selectedTab == .justMe) {
                 Text(viewModel.elapsedClock)
                     .font(.montserratBold(size: 13))
@@ -226,6 +230,37 @@ struct LiveClimbSessionView: View {
         }
         .padding(.horizontal, 20)
         .padding(.top, 14)
+    }
+
+    /// Live heart rate from the connected monitor, tinted by effort zone
+    /// (blue recovery / green aerobic / amber push). Shows a dimmed "--"
+    /// when the strap is connected but the signal has gone stale.
+    private var heartRateChip: some View {
+        let zoneColor = viewModel.liveHeartRateZone?.color ?? .white.opacity(0.4)
+
+        return HStack(spacing: 5) {
+            Image(systemName: "heart.fill")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(zoneColor)
+
+            Text(viewModel.liveHeartRate.map(String.init) ?? "--")
+                .font(.montserratBold(size: 13))
+                .monospacedDigit()
+                .foregroundStyle(viewModel.liveHeartRate == nil ? .white.opacity(0.4) : .white)
+                .contentTransition(.numericText())
+        }
+        .lineLimit(1)
+        .padding(.horizontal, 12)
+        .frame(height: 38)
+        .background(
+            RoundedRectangle(cornerRadius: 13, style: .continuous)
+                .fill(zoneColor.opacity(0.16))
+        )
+        .animation(.smooth(duration: 0.3), value: zoneColor)
+        .accessibilityLabel(
+            viewModel.liveHeartRate.map { "Heart rate \($0) beats per minute" }
+                ?? "Heart rate signal lost"
+        )
     }
 
     @ViewBuilder

--- a/AscendApp/Features/Integrations/HeartRateMonitor/Views/HeartRateMonitorIntegrationCard.swift
+++ b/AscendApp/Features/Integrations/HeartRateMonitor/Views/HeartRateMonitorIntegrationCard.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+/// Overview card for Bluetooth heart-rate monitors on the Integrations list.
+/// The card stays an overview surface; pairing and device actions live in
+/// the manage sheet, matching the Apple Health card pattern.
+struct HeartRateMonitorIntegrationCard: View {
+    @Environment(\.colorScheme) private var systemColorScheme
+    @State private var themeManager = ThemeManager.shared
+    @State private var monitor = HeartRateMonitorService.shared
+    @State private var showingManageSheet = false
+
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: systemColorScheme)
+    }
+
+    var body: some View {
+        let style = IntegrationCardStyle(effectiveColorScheme: effectiveColorScheme)
+
+        IntegrationCardShell(style: style) {
+            HStack(spacing: 12) {
+                Image(systemName: "heart.fill")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(Color.ascendAccent)
+                    .frame(width: 44, height: 44)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.ascendAccent.opacity(0.14))
+                    )
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Heart Rate Monitor")
+                        .font(.montserratSemiBold(size: 17))
+                        .foregroundStyle(style.primaryText)
+
+                    Text(statusLabel)
+                        .font(.montserratMedium(size: 13))
+                        .foregroundStyle(statusColor(style: style))
+                }
+
+                Spacer()
+
+                headerAction(style: style)
+            }
+
+            IntegrationCardDescriptionSection(
+                style: style,
+                text: description
+            )
+        }
+        .sheet(isPresented: $showingManageSheet) {
+            HeartRateMonitorManageSheet(isPresented: $showingManageSheet)
+        }
+    }
+
+    @ViewBuilder
+    private func headerAction(style: IntegrationCardStyle) -> some View {
+        if monitor.rememberedDevice == nil {
+            IntegrationCardActionButton(
+                "Connect",
+                appearance: .filled(background: .accent, foreground: .black)
+            ) {
+                showingManageSheet = true
+            }
+        } else {
+            IntegrationCardActionButton(
+                "Manage",
+                appearance: .outlined(
+                    foreground: style.subtleActionText,
+                    border: style.subtleActionBorder
+                )
+            ) {
+                showingManageSheet = true
+            }
+        }
+    }
+
+    private var statusLabel: String {
+        if monitor.isConnected, let name = monitor.connectedDeviceName {
+            return "Connected · \(name)"
+        }
+        if let remembered = monitor.rememberedDevice {
+            return "Paired · \(remembered.name)"
+        }
+        return "Not connected"
+    }
+
+    private func statusColor(style: IntegrationCardStyle) -> Color {
+        monitor.isConnected ? .ascendAccent : style.secondaryText
+    }
+
+    private var description: String {
+        if monitor.rememberedDevice == nil {
+            return "Pair a Bluetooth chest strap — Polar, Garmin, Morpheus, or any standard heart rate monitor — and see live heart rate and effort zones on every climb."
+        }
+        return "Your monitor connects automatically when you start a climb. Live heart rate and effort zones show in the session, and every workout keeps its heart rate history."
+    }
+}

--- a/AscendApp/Features/Integrations/HeartRateMonitor/Views/HeartRateMonitorManageSheet.swift
+++ b/AscendApp/Features/Integrations/HeartRateMonitor/Views/HeartRateMonitorManageSheet.swift
@@ -1,0 +1,236 @@
+import SwiftUI
+
+/// Pairing and device management for Bluetooth heart-rate monitors.
+/// Scanning starts when the sheet appears (first appearance triggers the
+/// system Bluetooth permission prompt) and stops when it disappears.
+struct HeartRateMonitorManageSheet: View {
+    @Binding var isPresented: Bool
+
+    @State private var monitor = HeartRateMonitorService.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 12) {
+                Image(systemName: "heart.fill")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(Color.ascendAccent)
+                    .frame(width: 38, height: 38)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color.ascendAccent.opacity(0.14))
+                    )
+
+                Text("Heart Rate Monitor")
+                    .font(.montserratBold(size: 20))
+                    .foregroundStyle(.white)
+
+                Spacer()
+            }
+
+            content
+
+            Button("Close") {
+                isPresented = false
+            }
+            .appSheetButtonStyle(tone: .subtle)
+        }
+        .padding(.top, 24)
+        .padding(.horizontal, 20)
+        .padding(.bottom, 12)
+        .appSheetBackground()
+        .appSheetStyle(.actionMenu)
+        .onAppear {
+            monitor.startPairingScan()
+        }
+        .onDisappear {
+            monitor.stopPairingScan()
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch monitor.availability {
+        case .unauthorized:
+            statusText(
+                "Bluetooth access is off for Ascend. Allow it in Settings to connect your monitor.",
+                actionTitle: "Open Settings",
+                action: openAppSettings
+            )
+        case .poweredOff:
+            statusText("Bluetooth is off. Turn it on in Control Center to connect your monitor.")
+        case .unsupported:
+            statusText("This device doesn't support Bluetooth heart rate monitors.")
+        case .unknown, .poweredOn:
+            deviceList
+        }
+    }
+
+    @ViewBuilder
+    private var deviceList: some View {
+        if monitor.isConnected, let name = monitor.connectedDeviceName {
+            connectedDeviceRow(name: name)
+        } else if let remembered = monitor.rememberedDevice {
+            rememberedDeviceRow(remembered)
+        }
+
+        if monitor.didLastConnectAttemptTimeOut {
+            statusText(
+                "Couldn't reach the monitor. If it's connected to another device — a watch or gym console — disconnect it there first. Polar straps may need two-device mode enabled in the Polar app."
+            )
+        }
+
+        scanSection
+    }
+
+    private func connectedDeviceRow(name: String) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                liveReadout
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(name)
+                        .font(.montserratSemiBold(size: 16))
+                        .foregroundStyle(.white)
+                    Text("Connected")
+                        .font(.montserratMedium(size: 12))
+                        .foregroundStyle(Color.ascendAccent)
+                }
+
+                Spacer()
+            }
+
+            HStack(spacing: 10) {
+                Button("Disconnect") {
+                    monitor.disconnect()
+                }
+                .appSheetButtonStyle(tone: .subtle)
+
+                Button("Forget Device") {
+                    monitor.forgetDevice()
+                }
+                .appSheetButtonStyle(tone: .destructive)
+            }
+        }
+        .padding(16)
+        .appSheetCardStyle(tone: .standard)
+    }
+
+    private func rememberedDeviceRow(_ device: HeartRateMonitorService.RememberedDevice) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "heart.slash")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.5))
+                .frame(width: 34, height: 34)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(.white.opacity(0.06))
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(device.name)
+                    .font(.montserratSemiBold(size: 16))
+                    .foregroundStyle(.white)
+                Text(monitor.connectionState == .connecting ? "Connecting..." : "Paired · not in range")
+                    .font(.montserratMedium(size: 12))
+                    .foregroundStyle(.white.opacity(0.55))
+            }
+
+            Spacer()
+
+            Button("Forget") {
+                monitor.forgetDevice()
+            }
+            .font(.montserratSemiBold(size: 13))
+            .foregroundStyle(.white.opacity(0.6))
+            .buttonStyle(.plain)
+        }
+        .padding(16)
+        .appSheetCardStyle(tone: .standard)
+    }
+
+    private var liveReadout: some View {
+        VStack(spacing: 1) {
+            Image(systemName: "heart.fill")
+                .font(.system(size: 12, weight: .bold))
+                .foregroundStyle(Color.ascendAccent)
+            Text(monitor.freshMeasurement.map { "\($0.beatsPerMinute)" } ?? "--")
+                .font(.montserratBold(size: 14))
+                .monospacedDigit()
+                .foregroundStyle(.white)
+        }
+        .frame(width: 44, height: 44)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.ascendAccent.opacity(0.12))
+        )
+    }
+
+    @ViewBuilder
+    private var scanSection: some View {
+        HStack(spacing: 8) {
+            Text("NEARBY MONITORS")
+                .font(.montserratBold(size: 11))
+                .foregroundStyle(.white.opacity(0.5))
+                .kerning(0.7)
+
+            ProgressView()
+                .controlSize(.mini)
+                .tint(.white.opacity(0.5))
+
+            Spacer()
+        }
+
+        let candidates = monitor.discoveredDevices.filter { $0.id != connectedCandidateID }
+        if candidates.isEmpty {
+            Text("Strap on your monitor to wake it up. Scanning...")
+                .font(.montserratMedium(size: 13))
+                .foregroundStyle(.white.opacity(0.55))
+        } else {
+            ForEach(candidates) { candidate in
+                Button {
+                    monitor.connect(to: candidate)
+                } label: {
+                    IntegrationManageActionRow(
+                        action: IntegrationManageAction(
+                            systemImage: "dot.radiowaves.left.and.right",
+                            title: candidate.name,
+                            iconTint: .accent,
+                            badgeCount: 0,
+                            isEnabled: true,
+                            action: {}
+                        )
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private var connectedCandidateID: UUID? {
+        guard monitor.isConnected else { return nil }
+        return monitor.rememberedDevice?.id
+    }
+
+    private func statusText(
+        _ text: String,
+        actionTitle: String? = nil,
+        action: (() -> Void)? = nil
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(text)
+                .font(.montserratMedium(size: 13))
+                .foregroundStyle(.white.opacity(0.65))
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .appSheetButtonStyle(tone: .subtle)
+            }
+        }
+    }
+
+    private func openAppSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}

--- a/AscendApp/Features/Integrations/Views/IntegrationsView.swift
+++ b/AscendApp/Features/Integrations/Views/IntegrationsView.swift
@@ -23,6 +23,8 @@ struct IntegrationsView: View {
 
                 AppleHealthIntegrationCard()
 
+                HeartRateMonitorIntegrationCard()
+
                 Spacer()
             }
             .padding(.horizontal, 20)

--- a/AscendApp/Info.plist
+++ b/AscendApp/Info.plist
@@ -58,6 +58,12 @@
 	<string>Ascend uses your location once to set your profile city for leaderboard context.</string>
 	<key>NSMotionUsageDescription</key>
 	<string>Ascend uses motion from compatible headphones to track steps during Live Climbs.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Ascend connects to your Bluetooth heart rate monitor to show live heart rate and effort zones while you climb.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>bluetooth-central</string>
+	</array>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 	<key>NSSupportsLiveActivitiesFrequentUpdates</key>

--- a/AscendApp/Shared/Services/HeartRate/BluetoothHeartRateClient.swift
+++ b/AscendApp/Shared/Services/HeartRate/BluetoothHeartRateClient.swift
@@ -1,0 +1,285 @@
+import CoreBluetooth
+import Foundation
+
+/// Bluetooth radio availability as seen by the client.
+enum BluetoothHeartRateAvailability: Equatable, Sendable {
+    case unknown
+    case poweredOn
+    case poweredOff
+    case unauthorized
+    case unsupported
+}
+
+/// A nearby device advertising the standard Heart Rate Service.
+struct BluetoothHeartRateDeviceCandidate: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let name: String
+    let rssi: Int
+}
+
+/// Events emitted by `BluetoothHeartRateClient`. Delivered on the client's
+/// private Bluetooth queue; the consumer is responsible for marshaling.
+enum BluetoothHeartRateClientEvent: Sendable {
+    case availabilityChanged(BluetoothHeartRateAvailability)
+    case discovered(BluetoothHeartRateDeviceCandidate)
+    case connected(id: UUID, name: String)
+    case disconnected(id: UUID, wasRequested: Bool)
+    case connectionFailed(id: UUID)
+    case measurement(HeartRateMeasurement)
+}
+
+/// CoreBluetooth central for the standard BLE Heart Rate Profile.
+///
+/// One implementation covers every compliant device — Polar/Morpheus/Garmin
+/// chest straps, WHOOP in broadcast mode, gym equipment — because they all
+/// advertise Heart Rate Service 0x180D and notify on characteristic 0x2A37.
+///
+/// All mutable state is confined to `queue`: public methods hop onto it and
+/// CoreBluetooth delivers delegate callbacks on it, so the class is safe to
+/// share despite the compiler being unable to prove it (`@unchecked Sendable`).
+final class BluetoothHeartRateClient: NSObject, @unchecked Sendable {
+    // Instance constants rather than statics: CBUUID is not Sendable, and
+    // this class's state is already confined to its Bluetooth queue.
+    private let heartRateServiceUUID = CBUUID(string: "180D")
+    private let heartRateMeasurementUUID = CBUUID(string: "2A37")
+
+    private let queue = DispatchQueue(label: "com.ascend.heart-rate-ble")
+    private let onEvent: @Sendable (BluetoothHeartRateClientEvent) -> Void
+
+    private var central: CBCentralManager?
+    private var isScanning = false
+    private var targetPeripheral: CBPeripheral?
+    private var discoveredPeripherals: [UUID: CBPeripheral] = [:]
+    /// Set when the app asked for the disconnect, so unexpected drops can
+    /// auto-reconnect while intentional ones stay disconnected.
+    private var isDisconnectRequested = false
+    /// Peripheral to reconnect to whenever it comes back in range.
+    private var reconnectIdentifier: UUID?
+
+    init(onEvent: @escaping @Sendable (BluetoothHeartRateClientEvent) -> Void) {
+        self.onEvent = onEvent
+        super.init()
+    }
+
+    // MARK: - Public API (thread-safe; hops to the Bluetooth queue)
+
+    /// Creates the central manager, which triggers the system Bluetooth
+    /// permission prompt on first use. Call from a user-initiated flow.
+    func prepare() {
+        queue.async { [self] in
+            ensureCentral()
+        }
+    }
+
+    func startScanning() {
+        queue.async { [self] in
+            isScanning = true
+            scanIfPoweredOn()
+        }
+    }
+
+    func stopScanning() {
+        queue.async { [self] in
+            isScanning = false
+            guard let central, central.state == .poweredOn else { return }
+            central.stopScan()
+        }
+    }
+
+    func connect(to identifier: UUID) {
+        queue.async { [self] in
+            isDisconnectRequested = false
+            reconnectIdentifier = identifier
+            connectOnQueue(to: identifier)
+        }
+    }
+
+    func disconnect() {
+        queue.async { [self] in
+            isDisconnectRequested = true
+            reconnectIdentifier = nil
+            guard let central, let peripheral = targetPeripheral else { return }
+            central.cancelPeripheralConnection(peripheral)
+        }
+    }
+
+    // MARK: - Queue-confined implementation
+
+    private func ensureCentral() {
+        if central == nil {
+            central = CBCentralManager(delegate: self, queue: queue)
+        }
+    }
+
+    private func scanIfPoweredOn() {
+        ensureCentral()
+        guard let central, central.state == .poweredOn, isScanning else { return }
+        central.scanForPeripherals(
+            withServices: [heartRateServiceUUID],
+            options: [CBCentralManagerScanOptionAllowDuplicatesKey: false]
+        )
+    }
+
+    private func connectOnQueue(to identifier: UUID) {
+        ensureCentral()
+        guard let central else { return }
+        guard central.state == .poweredOn else { return }
+
+        // Prefer a peripheral the SYSTEM already holds a connection to (e.g.
+        // another app on this phone is reading the same strap) — iOS shares
+        // one physical link across apps, so this connect completes instantly
+        // and consumes no extra slot on the device.
+        let systemConnected = central
+            .retrieveConnectedPeripherals(withServices: [heartRateServiceUUID])
+            .first { $0.identifier == identifier }
+
+        let peripheral: CBPeripheral?
+        if let systemConnected {
+            peripheral = systemConnected
+        } else if let discovered = discoveredPeripherals[identifier] {
+            peripheral = discovered
+        } else {
+            // A remembered device that isn't in the discovery cache. connect()
+            // on a retrieved peripheral is persistent: iOS completes it
+            // whenever the device starts advertising, which is what makes
+            // strap-on-and-go auto-connect work.
+            peripheral = central.retrievePeripherals(withIdentifiers: [identifier]).first
+        }
+
+        guard let peripheral else {
+            onEvent(.connectionFailed(id: identifier))
+            return
+        }
+
+        discoveredPeripherals[identifier] = peripheral
+        targetPeripheral = peripheral
+        central.connect(peripheral, options: nil)
+    }
+
+    private static func availability(for state: CBManagerState) -> BluetoothHeartRateAvailability {
+        switch state {
+        case .poweredOn:
+            return .poweredOn
+        case .poweredOff:
+            return .poweredOff
+        case .unauthorized:
+            return .unauthorized
+        case .unsupported:
+            return .unsupported
+        case .unknown, .resetting:
+            return .unknown
+        @unknown default:
+            return .unknown
+        }
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension BluetoothHeartRateClient: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        onEvent(.availabilityChanged(Self.availability(for: central.state)))
+
+        guard central.state == .poweredOn else {
+            // Peripheral objects are invalidated when the radio leaves
+            // poweredOn (e.g. Bluetooth toggled off) — drop them so the next
+            // connect retrieves fresh instances instead of dead references.
+            discoveredPeripherals.removeAll()
+            targetPeripheral = nil
+            return
+        }
+        scanIfPoweredOn()
+        if let reconnectIdentifier, targetPeripheral?.state != .connected {
+            connectOnQueue(to: reconnectIdentifier)
+        }
+    }
+
+    func centralManager(
+        _ central: CBCentralManager,
+        didDiscover peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi RSSI: NSNumber
+    ) {
+        discoveredPeripherals[peripheral.identifier] = peripheral
+        let name = peripheral.name
+            ?? advertisementData[CBAdvertisementDataLocalNameKey] as? String
+            ?? "Heart Rate Monitor"
+        onEvent(
+            .discovered(
+                BluetoothHeartRateDeviceCandidate(
+                    id: peripheral.identifier,
+                    name: name,
+                    rssi: RSSI.intValue
+                )
+            )
+        )
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        peripheral.delegate = self
+        peripheral.discoverServices([heartRateServiceUUID])
+        onEvent(.connected(id: peripheral.identifier, name: peripheral.name ?? "Heart Rate Monitor"))
+    }
+
+    func centralManager(
+        _ central: CBCentralManager,
+        didFailToConnect peripheral: CBPeripheral,
+        error: Error?
+    ) {
+        onEvent(.connectionFailed(id: peripheral.identifier))
+    }
+
+    func centralManager(
+        _ central: CBCentralManager,
+        didDisconnectPeripheral peripheral: CBPeripheral,
+        error: Error?
+    ) {
+        let wasRequested = isDisconnectRequested
+        onEvent(.disconnected(id: peripheral.identifier, wasRequested: wasRequested))
+
+        if wasRequested {
+            targetPeripheral = nil
+            isDisconnectRequested = false
+        } else if let reconnectIdentifier {
+            // Unexpected drop (strap out of range, battery pull): keep a
+            // persistent reconnect pending so HR resumes when it returns.
+            connectOnQueue(to: reconnectIdentifier)
+        }
+    }
+}
+
+// MARK: - CBPeripheralDelegate
+
+extension BluetoothHeartRateClient: CBPeripheralDelegate {
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        guard let service = peripheral.services?.first(where: { $0.uuid == heartRateServiceUUID }) else {
+            return
+        }
+        peripheral.discoverCharacteristics([heartRateMeasurementUUID], for: service)
+    }
+
+    func peripheral(
+        _ peripheral: CBPeripheral,
+        didDiscoverCharacteristicsFor service: CBService,
+        error: Error?
+    ) {
+        guard let characteristic = service.characteristics?.first(
+            where: { $0.uuid == heartRateMeasurementUUID }
+        ) else { return }
+        peripheral.setNotifyValue(true, for: characteristic)
+    }
+
+    func peripheral(
+        _ peripheral: CBPeripheral,
+        didUpdateValueFor characteristic: CBCharacteristic,
+        error: Error?
+    ) {
+        guard characteristic.uuid == heartRateMeasurementUUID,
+              error == nil,
+              let data = characteristic.value,
+              let measurement = HeartRateMeasurementParser.parse(data) else {
+            return
+        }
+        onEvent(.measurement(measurement))
+    }
+}

--- a/AscendApp/Shared/Services/HeartRate/HeartRateMeasurement.swift
+++ b/AscendApp/Shared/Services/HeartRate/HeartRateMeasurement.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// A single heart-rate reading from a connected monitor.
+struct HeartRateMeasurement: Equatable, Sendable {
+    enum SensorContact: Equatable, Sendable {
+        /// The device does not report sensor-contact state.
+        case unsupported
+        /// The device reports the sensor is not against skin (reading may be junk).
+        case notDetected
+        case detected
+    }
+
+    let beatsPerMinute: Int
+    let sensorContact: SensorContact
+    let receivedAt: Date
+}
+
+/// Parses the standard BLE Heart Rate Measurement characteristic (GATT 0x2A37).
+///
+/// Byte layout per the Bluetooth Heart Rate Service specification:
+/// - Byte 0 is a flags field:
+///   - bit 0: heart-rate value format (0 = UInt8, 1 = UInt16 little-endian)
+///   - bits 1-2: sensor contact (bit 2 = feature supported, bit 1 = contact detected)
+///   - bit 3: energy-expended field present (UInt16, skipped)
+///   - bit 4: RR-interval values present (trailing UInt16s, unused)
+/// - Heart-rate value follows the flags byte in the declared format.
+enum HeartRateMeasurementParser {
+    static func parse(_ data: Data, receivedAt: Date = Date()) -> HeartRateMeasurement? {
+        guard data.count >= 2 else { return nil }
+
+        let bytes = [UInt8](data)
+        let flags = bytes[0]
+        let isSixteenBit = flags & 0b0000_0001 != 0
+
+        let beatsPerMinute: Int
+        if isSixteenBit {
+            guard bytes.count >= 3 else { return nil }
+            beatsPerMinute = Int(bytes[1]) | (Int(bytes[2]) << 8)
+        } else {
+            beatsPerMinute = Int(bytes[1])
+        }
+
+        guard beatsPerMinute > 0 else { return nil }
+
+        let sensorContact: HeartRateMeasurement.SensorContact
+        if flags & 0b0000_0100 != 0 {
+            sensorContact = flags & 0b0000_0010 != 0 ? .detected : .notDetected
+        } else {
+            sensorContact = .unsupported
+        }
+
+        return HeartRateMeasurement(
+            beatsPerMinute: beatsPerMinute,
+            sensorContact: sensorContact,
+            receivedAt: receivedAt
+        )
+    }
+}

--- a/AscendApp/Shared/Services/HeartRate/HeartRateMonitorService.swift
+++ b/AscendApp/Shared/Services/HeartRate/HeartRateMonitorService.swift
@@ -1,0 +1,217 @@
+import CoreBluetooth
+import Foundation
+import Observation
+
+/// App-facing facade for live heart-rate monitors.
+///
+/// Owns the Bluetooth client, remembers the paired device across launches,
+/// auto-reconnects at session start, and exposes observable connection +
+/// measurement state for SwiftUI. This is the seam future heart-rate sources
+/// (Apple Watch companion via HealthKit mirroring) plug into: consumers read
+/// `currentMeasurement`/`connectionState` and never talk to a transport.
+@MainActor
+@Observable
+final class HeartRateMonitorService {
+    static let shared = HeartRateMonitorService()
+
+    enum ConnectionState: Equatable {
+        case disconnected
+        case scanning
+        case connecting
+        case connected
+    }
+
+    struct RememberedDevice: Equatable {
+        let id: UUID
+        let name: String
+    }
+
+    /// A reading older than this is treated as stale: chest straps notify at
+    /// ~1 Hz, and BLE has no "signal lost" push — silence is the only signal.
+    static let sampleFreshnessWindow: TimeInterval = 5
+    /// connect() never times out natively; without this a strap whose slots
+    /// are held by another device (Polar H10 ships single-slot) hangs forever.
+    private static let connectTimeout: TimeInterval = 15
+
+    private static let rememberedIDDefaultsKey = "heartRateMonitor.rememberedDeviceID"
+    private static let rememberedNameDefaultsKey = "heartRateMonitor.rememberedDeviceName"
+
+    private(set) var availability: BluetoothHeartRateAvailability = .unknown
+    private(set) var connectionState: ConnectionState = .disconnected
+    private(set) var discoveredDevices: [BluetoothHeartRateDeviceCandidate] = []
+    private(set) var currentMeasurement: HeartRateMeasurement?
+    private(set) var connectedDeviceName: String?
+    private(set) var didLastConnectAttemptTimeOut = false
+    private(set) var rememberedDevice: RememberedDevice?
+
+    @ObservationIgnored private var client: BluetoothHeartRateClient?
+    @ObservationIgnored private var connectTimeoutTask: Task<Void, Never>?
+    @ObservationIgnored private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        if let idString = userDefaults.string(forKey: Self.rememberedIDDefaultsKey),
+           let id = UUID(uuidString: idString) {
+            let name = userDefaults.string(forKey: Self.rememberedNameDefaultsKey) ?? "Heart Rate Monitor"
+            rememberedDevice = RememberedDevice(id: id, name: name)
+        }
+    }
+
+    /// Bluetooth permission state, readable without triggering the prompt.
+    var authorization: CBManagerAuthorization {
+        CBCentralManager.authorization
+    }
+
+    var isConnected: Bool {
+        connectionState == .connected
+    }
+
+    /// The latest reading if it arrived recently enough to trust for display.
+    var freshMeasurement: HeartRateMeasurement? {
+        guard let currentMeasurement,
+              Date().timeIntervalSince(currentMeasurement.receivedAt) <= Self.sampleFreshnessWindow else {
+            return nil
+        }
+        return currentMeasurement
+    }
+
+    // MARK: - Pairing flow (manage sheet)
+
+    /// Starts discovery. First call creates the Bluetooth central, which
+    /// triggers the system permission prompt — only call from a
+    /// user-initiated pairing flow.
+    func startPairingScan() {
+        didLastConnectAttemptTimeOut = false
+        discoveredDevices = []
+        if connectionState != .connected {
+            connectionState = .scanning
+        }
+        ensureClient().startScanning()
+    }
+
+    func stopPairingScan() {
+        client?.stopScanning()
+        if connectionState == .scanning {
+            connectionState = .disconnected
+        }
+    }
+
+    func connect(to candidate: BluetoothHeartRateDeviceCandidate) {
+        remember(id: candidate.id, name: candidate.name)
+        beginConnection(to: candidate.id)
+    }
+
+    func disconnect() {
+        connectTimeoutTask?.cancel()
+        client?.disconnect()
+        connectionState = .disconnected
+        connectedDeviceName = nil
+        currentMeasurement = nil
+    }
+
+    /// Disconnects and stops auto-connecting to the remembered device.
+    func forgetDevice() {
+        disconnect()
+        rememberedDevice = nil
+        userDefaults.removeObject(forKey: Self.rememberedIDDefaultsKey)
+        userDefaults.removeObject(forKey: Self.rememberedNameDefaultsKey)
+    }
+
+    // MARK: - Session integration
+
+    /// Silently connects to the remembered device if one exists. Called at
+    /// live-session start so a worn strap "just works" with no UI. No-op when
+    /// nothing was ever paired or Bluetooth permission was never granted, so
+    /// it can never trigger a permission prompt mid-session.
+    func autoConnectIfRemembered() {
+        guard let rememberedDevice,
+              authorization == .allowedAlways,
+              connectionState == .disconnected else {
+            return
+        }
+        beginConnection(to: rememberedDevice.id, timesOut: false)
+    }
+
+    // MARK: - Internals
+
+    private func beginConnection(to id: UUID, timesOut: Bool = true) {
+        didLastConnectAttemptTimeOut = false
+        connectionState = .connecting
+        let client = ensureClient()
+        client.stopScanning()
+        client.connect(to: id)
+
+        connectTimeoutTask?.cancel()
+        guard timesOut else { return }
+        connectTimeoutTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(Self.connectTimeout))
+            guard !Task.isCancelled, let self, self.connectionState == .connecting else { return }
+            self.client?.disconnect()
+            self.connectionState = .disconnected
+            self.didLastConnectAttemptTimeOut = true
+        }
+    }
+
+    private func remember(id: UUID, name: String) {
+        rememberedDevice = RememberedDevice(id: id, name: name)
+        userDefaults.set(id.uuidString, forKey: Self.rememberedIDDefaultsKey)
+        userDefaults.set(name, forKey: Self.rememberedNameDefaultsKey)
+    }
+
+    private func ensureClient() -> BluetoothHeartRateClient {
+        if let client {
+            return client
+        }
+        let newClient = BluetoothHeartRateClient { [weak self] event in
+            Task { @MainActor in
+                self?.handle(event)
+            }
+        }
+        client = newClient
+        return newClient
+    }
+
+    private func handle(_ event: BluetoothHeartRateClientEvent) {
+        switch event {
+        case .availabilityChanged(let availability):
+            self.availability = availability
+            if availability != .poweredOn, connectionState == .connected {
+                connectionState = .disconnected
+                connectedDeviceName = nil
+            }
+
+        case .discovered(let candidate):
+            if let index = discoveredDevices.firstIndex(where: { $0.id == candidate.id }) {
+                discoveredDevices[index] = candidate
+            } else {
+                discoveredDevices.append(candidate)
+            }
+            discoveredDevices.sort { $0.rssi > $1.rssi }
+
+        case .connected(let id, let name):
+            connectTimeoutTask?.cancel()
+            connectionState = .connected
+            connectedDeviceName = name
+            didLastConnectAttemptTimeOut = false
+            if rememberedDevice?.id == id {
+                remember(id: id, name: name)
+            }
+
+        case .disconnected(let id, let wasRequested):
+            currentMeasurement = nil
+            guard !wasRequested else { return }
+            connectedDeviceName = nil
+            // The client keeps a persistent reconnect pending for unexpected
+            // drops; reflect that so the UI can show "reconnecting".
+            connectionState = rememberedDevice?.id == id ? .connecting : .disconnected
+
+        case .connectionFailed:
+            connectTimeoutTask?.cancel()
+            connectionState = .disconnected
+            connectedDeviceName = nil
+
+        case .measurement(let measurement):
+            currentMeasurement = measurement
+        }
+    }
+}

--- a/AscendApp/Shared/Services/HeartRate/HeartRateZone+UI.swift
+++ b/AscendApp/Shared/Services/HeartRate/HeartRateZone+UI.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+extension HeartRateZone {
+    /// Zone colors shown during live sessions: blue → green → amber as
+    /// effort rises. Green is the brand accent so the "working" zone reads
+    /// as the app's home state.
+    var color: Color {
+        switch self {
+        case .recovery:
+            return Color(red: 0.29, green: 0.62, blue: 1.0)
+        case .aerobic:
+            return .ascendAccent
+        case .push:
+            return Color(red: 1.0, green: 0.69, blue: 0.13)
+        }
+    }
+}

--- a/AscendApp/Shared/Services/HeartRate/HeartRateZone.swift
+++ b/AscendApp/Shared/Services/HeartRate/HeartRateZone.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// The three live effort zones shown while climbing.
+///
+/// Product-defined absolute bands over percent of estimated max heart rate —
+/// deliberately NOT a per-user calibrated effort model (see CLAUDE.md →
+/// Workout Measurement). Blue is conversational effort, green is aerobic work,
+/// amber is pushing hard.
+enum HeartRateZone: String, CaseIterable, Sendable {
+    case recovery
+    case aerobic
+    case push
+
+    var displayName: String {
+        switch self {
+        case .recovery:
+            return "Recovery"
+        case .aerobic:
+            return "Aerobic"
+        case .push:
+            return "Push"
+        }
+    }
+}
+
+/// Resolves a heart-rate reading into a zone for a given climber.
+struct HeartRateZoneProfile: Equatable, Sendable {
+    /// Upper bound of the recovery (blue) zone as a fraction of max HR.
+    static let recoveryUpperFraction = 0.70
+    /// Upper bound of the aerobic (green) zone as a fraction of max HR.
+    static let aerobicUpperFraction = 0.85
+
+    /// Used when the profile has no age (age is optional pre-onboarding).
+    static let fallbackAge = 35
+
+    let maxHeartRate: Int
+
+    /// Estimated max HR from age using the Tanaka formula (208 − 0.7 × age),
+    /// which tracks measured max HR better than 220 − age across age groups.
+    init(age: Int?) {
+        let boundedAge = min(max(age ?? Self.fallbackAge, 13), 120)
+        maxHeartRate = Int((208.0 - 0.7 * Double(boundedAge)).rounded())
+    }
+
+    func zone(forBeatsPerMinute beatsPerMinute: Int) -> HeartRateZone {
+        let fraction = Double(beatsPerMinute) / Double(maxHeartRate)
+        if fraction < Self.recoveryUpperFraction {
+            return .recovery
+        }
+        if fraction < Self.aerobicUpperFraction {
+            return .aerobic
+        }
+        return .push
+    }
+}

--- a/AscendApp/Shared/Services/HeartRate/HeartRateZoneProfileResolver.swift
+++ b/AscendApp/Shared/Services/HeartRate/HeartRateZoneProfileResolver.swift
@@ -1,0 +1,17 @@
+@preconcurrency import FirebaseAuth
+import Foundation
+
+/// Resolves the signed-in climber's zone profile from their declared age.
+/// Falls back to the age-agnostic default when signed out, the profile has
+/// no age yet, or the fetch fails — zones are display-only, so a fallback
+/// band is always acceptable.
+enum HeartRateZoneProfileResolver {
+    static func resolve() async -> HeartRateZoneProfile {
+        guard let userId = Auth.auth().currentUser?.uid else {
+            return HeartRateZoneProfile(age: nil)
+        }
+
+        let userData = try? await UserDataRepository.shared.getUserFromFirestore(userId: userId)
+        return HeartRateZoneProfile(age: userData?.age)
+    }
+}

--- a/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
+++ b/AscendApp/Shared/Services/WorkoutImportCoordinator.swift
@@ -1119,19 +1119,27 @@ final class WorkoutImportCoordinator {
     ) -> Bool {
         var didChange = false
 
-        if let avgHeartRate = metrics.avgHeartRate, workout.avgHeartRate != avgHeartRate {
-            workout.avgHeartRate = avgHeartRate
-            didChange = true
-        }
-        if let maxHeartRate = metrics.maxHeartRate, workout.maxHeartRate != maxHeartRate {
-            workout.maxHeartRate = maxHeartRate
-            didChange = true
-        }
-        if !metrics.heartRateTimeSeries.isEmpty {
-            let encodedHeartRateData = metrics.heartRateTimeSeries.encoded
-            if workout.heartRateData != encodedHeartRateData {
-                workout.heartRateData = encodedHeartRateData
+        // A workout that already carries a live-captured heart-rate series
+        // (Bluetooth chest strap during the session) keeps it: strap data is
+        // first-party and more accurate than wrist-derived Apple Health HR.
+        // Enrichment still fills calories/METs below.
+        let hasLiveCapturedHeartRate = !workout.heartRateTimeSeries.isEmpty
+
+        if !hasLiveCapturedHeartRate {
+            if let avgHeartRate = metrics.avgHeartRate, workout.avgHeartRate != avgHeartRate {
+                workout.avgHeartRate = avgHeartRate
                 didChange = true
+            }
+            if let maxHeartRate = metrics.maxHeartRate, workout.maxHeartRate != maxHeartRate {
+                workout.maxHeartRate = maxHeartRate
+                didChange = true
+            }
+            if !metrics.heartRateTimeSeries.isEmpty {
+                let encodedHeartRateData = metrics.heartRateTimeSeries.encoded
+                if workout.heartRateData != encodedHeartRateData {
+                    workout.heartRateData = encodedHeartRateData
+                    didChange = true
+                }
             }
         }
         if let caloriesBurned = metrics.caloriesBurned, workout.caloriesBurned != caloriesBurned {

--- a/AscendAppTests/HeartRateMonitorTests.swift
+++ b/AscendAppTests/HeartRateMonitorTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct HeartRateMeasurementParserTests {
+    @Test
+    func parsesEightBitHeartRate() throws {
+        let measurement = try #require(HeartRateMeasurementParser.parse(Data([0b0000_0000, 72])))
+        #expect(measurement.beatsPerMinute == 72)
+        #expect(measurement.sensorContact == .unsupported)
+    }
+
+    @Test
+    func parsesSixteenBitHeartRateLittleEndian() throws {
+        // 0x0110 = 272 bpm — implausible but exercises the wide format.
+        let measurement = try #require(HeartRateMeasurementParser.parse(Data([0b0000_0001, 0x10, 0x01])))
+        #expect(measurement.beatsPerMinute == 272)
+    }
+
+    @Test
+    func parsesSensorContactStates() throws {
+        let detected = try #require(HeartRateMeasurementParser.parse(Data([0b0000_0110, 140])))
+        #expect(detected.sensorContact == .detected)
+
+        let notDetected = try #require(HeartRateMeasurementParser.parse(Data([0b0000_0100, 140])))
+        #expect(notDetected.sensorContact == .notDetected)
+    }
+
+    @Test
+    func parsesValueWithEnergyExpendedAndRRIntervals() throws {
+        // Flags: 8-bit HR + contact supported/detected + energy expended + RR present.
+        let data = Data([0b0001_1110, 155, 0x34, 0x12, 0x00, 0x04, 0x10, 0x04])
+        let measurement = try #require(HeartRateMeasurementParser.parse(data))
+        #expect(measurement.beatsPerMinute == 155)
+        #expect(measurement.sensorContact == .detected)
+    }
+
+    @Test
+    func rejectsMalformedPackets() {
+        #expect(HeartRateMeasurementParser.parse(Data()) == nil)
+        #expect(HeartRateMeasurementParser.parse(Data([0b0000_0000])) == nil)
+        // 16-bit flag but only one value byte present.
+        #expect(HeartRateMeasurementParser.parse(Data([0b0000_0001, 72])) == nil)
+        // Zero bpm is not a usable reading.
+        #expect(HeartRateMeasurementParser.parse(Data([0b0000_0000, 0])) == nil)
+    }
+}
+
+struct HeartRateZoneTests {
+    @Test
+    func tanakaMaxHeartRateFromAge() {
+        // 208 − 0.7 × 30 = 187
+        #expect(HeartRateZoneProfile(age: 30).maxHeartRate == 187)
+        // 208 − 0.7 × 50 = 173
+        #expect(HeartRateZoneProfile(age: 50).maxHeartRate == 173)
+    }
+
+    @Test
+    func missingAgeUsesFallback() {
+        #expect(HeartRateZoneProfile(age: nil) == HeartRateZoneProfile(age: HeartRateZoneProfile.fallbackAge))
+    }
+
+    @Test
+    func implausibleAgesAreBounded() {
+        #expect(HeartRateZoneProfile(age: 5).maxHeartRate == HeartRateZoneProfile(age: 13).maxHeartRate)
+        #expect(HeartRateZoneProfile(age: 500).maxHeartRate == HeartRateZoneProfile(age: 120).maxHeartRate)
+    }
+
+    @Test
+    func zoneBoundariesSplitAtSeventyAndEightyFivePercent() {
+        let profile = HeartRateZoneProfile(age: 30) // max 187
+        let recoveryCeiling = Int(Double(profile.maxHeartRate) * HeartRateZoneProfile.recoveryUpperFraction)
+        let aerobicCeiling = Int(Double(profile.maxHeartRate) * HeartRateZoneProfile.aerobicUpperFraction)
+
+        #expect(profile.zone(forBeatsPerMinute: 60) == .recovery)
+        #expect(profile.zone(forBeatsPerMinute: recoveryCeiling - 1) == .recovery)
+        #expect(profile.zone(forBeatsPerMinute: recoveryCeiling + 1) == .aerobic)
+        #expect(profile.zone(forBeatsPerMinute: aerobicCeiling - 1) == .aerobic)
+        #expect(profile.zone(forBeatsPerMinute: aerobicCeiling + 1) == .push)
+        #expect(profile.zone(forBeatsPerMinute: profile.maxHeartRate + 20) == .push)
+    }
+}


### PR DESCRIPTION
Implements live heart-rate display for climbs from Bluetooth heart-rate monitors, per the parked plan in `docs/heart-rate-zones-plan.md` (Tier A: standard BLE straps first; the architecture leaves a clean seam for the Apple Watch companion later).

## What it does
- **Pair once**: Integrations → new Heart Rate Monitor card → scan + tap to connect (Polar H10, Morpheus, Garmin straps, WHOOP in broadcast mode — anything speaking the standard BLE Heart Rate Profile).
- **Then it just works**: every live session (landmark climbs and Just Climb) silently auto-connects the remembered strap and shows a live BPM chip in the session chrome, tinted by effort zone — **blue** <70%, **green** 70–85%, **amber** >85% of max HR (Tanaka estimate from profile age, fallback when absent). Chip dims to `--` on signal loss and recovers on reconnect.
- **Workouts keep the data**: 1 Hz samples buffer during the session; avg/max HR + the full series are set at save and ride the existing heart-rate sidecar sync pipeline (workout detail charts + cloud backup work unchanged).

## Architecture
- `HeartRateMonitorService` (@MainActor @Observable) is the single device-agnostic facade; consumers never see a transport.
- `BluetoothHeartRateClient` is queue-confined CoreBluetooth against 0x180D/0x2A37 with research-validated edge handling: parse flags per notification (8/16-bit, sensor contact), persistent reconnect on unexpected drops, system-connection piggyback (`retrieveConnectedPeripherals`), peripheral-cache invalidation on radio power-off, 15s connect timeout with Polar two-device-mode help copy.
- Pure, tested core: `HeartRateMeasurementParser` (GATT byte layout incl. energy-expended/RR flags, malformed-packet rejection) and `HeartRateZoneProfile` (Tanaka max HR, bounded ages, 70/85% bands) — 9 new unit tests.
- Fix in passing: Apple Health enrichment no longer overwrites live-captured chest-strap HR with wrist-derived data (still fills calories/METs).

## Compliance (same-PR rule)
- `NSBluetoothAlwaysUsageDescription` added with a specific purpose string.
- `UIBackgroundModes: bluetooth-central` so HR keeps streaming when the phone locks mid-climb (sessions already survive backgrounding).
- Privacy manifest: no change needed — Bluetooth is not a required-reason API, and heart-rate collection is already declared under Health & Fitness. ASC nutrition labels already cover HR via HealthKit.

## Verification
- Full app builds clean (Swift 6 strict concurrency), 9/9 new tests pass.
- On-device pairing test with a real Polar H10 recommended on the next TestFlight build: Integrations → connect → start a climb → chip appears → lock phone → HR persists → finish → workout detail shows the HR chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)