### PR TITLE
fix(climbs): keep finished Live Climbs completed after reinstall

### DIFF
--- a/AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift
+++ b/AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift
@@ -20,6 +20,21 @@ enum LiveClimbCompletionPolicy {
         isCompletion(steps: steps, targetStepCount: targetStepCount) ? .completed : .failed
     }
 
+    /// The step target a workout's metadata records, resolved the way the replay Cloud Function
+    /// resolves it (`climbTargetStepCount` first, then `targetStepCount`). Metadata written before
+    /// the target was recorded carries neither.
+    static func targetStepCount(for metadata: HeadphoneMotionWorkoutMetadata) -> Int? {
+        metadata.climbTargetStepCount ?? metadata.targetStepCount
+    }
+
+    /// The steps to record on an attempt. A climb stops counting at its target, so an attempt's
+    /// recorded steps must not depend on which reader built it — saving and rehydrating the same
+    /// session have to land on the same number.
+    static func recordedSteps(steps: Int, targetStepCount: Int?) -> Int {
+        guard let targetStepCount, targetStepCount > 0 else { return steps }
+        return min(targetStepCount, steps)
+    }
+
     /// The stop reason to persist alongside a saved live climb workout.
     ///
     /// A session that passed the target reached it, whether the auto-finish fired or the user
@@ -35,14 +50,13 @@ enum LiveClimbCompletionPolicy {
 
     /// Resolves the status of an attempt reconstructed from a workout's stored metadata.
     ///
-    /// Mirrors the Cloud Function's target resolution (`climbTargetStepCount` first, then
-    /// `targetStepCount`). Metadata written before the target was recorded carries no step
-    /// target, so those workouts fall back to the reason the session ended.
+    /// Metadata written before the target was recorded carries no step target, so those workouts
+    /// fall back to the reason the session ended.
     static func attemptStatus(
         for metadata: HeadphoneMotionWorkoutMetadata,
         steps: Int
     ) -> ClimbAttemptStatus {
-        guard let targetStepCount = metadata.climbTargetStepCount ?? metadata.targetStepCount else {
+        guard let targetStepCount = targetStepCount(for: metadata) else {
             return metadata.stopReason == .targetReached ? .completed : .failed
         }
 

--- a/AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift
+++ b/AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift
@@ -28,7 +28,7 @@ enum LiveClimbCompletionPolicy {
     }
 
     /// The steps to record on an attempt. A climb stops counting at its target, so an attempt's
-    /// recorded steps must not depend on which reader built it — saving and rehydrating the same
+    /// recorded steps must not depend on which reader built it - saving and rehydrating the same
     /// session have to land on the same number.
     static func recordedSteps(steps: Int, targetStepCount: Int?) -> Int {
         guard let targetStepCount, targetStepCount > 0 else { return steps }

--- a/AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift
+++ b/AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The single definition of what finishing a Live Climb means.
+///
+/// Three readers need this answer and must never disagree: the client deciding an attempt's
+/// status at save time, the client rehydrating attempts from remote backups after a reinstall,
+/// and the Cloud Function that publishes replay leaderboard rows. When they disagreed, a user
+/// who tapped End right after passing the step target kept the climb locally but lost it on
+/// reinstall.
+///
+/// Reaching the step target is the finish. `stopReason` records *how* a session ended, not
+/// whether it counted, so it can never be the primary signal.
+enum LiveClimbCompletionPolicy {
+    static func isCompletion(steps: Int, targetStepCount: Int?) -> Bool {
+        guard let targetStepCount, targetStepCount > 0 else { return false }
+        return steps >= targetStepCount
+    }
+
+    static func attemptStatus(steps: Int, targetStepCount: Int) -> ClimbAttemptStatus {
+        isCompletion(steps: steps, targetStepCount: targetStepCount) ? .completed : .failed
+    }
+
+    /// The stop reason to persist alongside a saved live climb workout.
+    ///
+    /// A session that passed the target reached it, whether the auto-finish fired or the user
+    /// tapped End first. Normalizing here keeps the stored metadata true for every later reader,
+    /// including the replay Cloud Function, which additionally gates publication on this value.
+    static func resolvedStopReason(
+        _ stopReason: HeadphoneMotionSessionStopReason,
+        steps: Int,
+        targetStepCount: Int
+    ) -> HeadphoneMotionSessionStopReason {
+        isCompletion(steps: steps, targetStepCount: targetStepCount) ? .targetReached : stopReason
+    }
+
+    /// Resolves the status of an attempt reconstructed from a workout's stored metadata.
+    ///
+    /// Mirrors the Cloud Function's target resolution (`climbTargetStepCount` first, then
+    /// `targetStepCount`). Metadata written before the target was recorded carries no step
+    /// target, so those workouts fall back to the reason the session ended.
+    static func attemptStatus(
+        for metadata: HeadphoneMotionWorkoutMetadata,
+        steps: Int
+    ) -> ClimbAttemptStatus {
+        guard let targetStepCount = metadata.climbTargetStepCount ?? metadata.targetStepCount else {
+            return metadata.stopReason == .targetReached ? .completed : .failed
+        }
+
+        return attemptStatus(steps: steps, targetStepCount: targetStepCount)
+    }
+}

--- a/AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift
+++ b/AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift
@@ -37,15 +37,20 @@ enum LiveClimbCompletionPolicy {
 
     /// The stop reason to persist alongside a saved live climb workout.
     ///
-    /// A session that passed the target reached it, whether the auto-finish fired or the user
-    /// tapped End first. Normalizing here keeps the stored metadata true for every later reader,
-    /// including the replay Cloud Function, which additionally gates publication on this value.
+    /// Only a manual stop is upgraded: a user who tapped End past the target reached it, the
+    /// auto-finish just did not fire first. Every other reason is left exactly as recorded.
+    /// `.interrupted` in particular must never be upgraded - a recovered draft's step count is
+    /// typed by hand in a free-entry field, and the replay Cloud Function gates publication on
+    /// this value, so upgrading it would let a typed number claim a First Ascent, which is
+    /// permanent and can never be reclaimed. Recovered drafts past the target still count
+    /// locally: `attemptStatus` reads steps, never this reason.
     static func resolvedStopReason(
         _ stopReason: HeadphoneMotionSessionStopReason,
         steps: Int,
         targetStepCount: Int
     ) -> HeadphoneMotionSessionStopReason {
-        isCompletion(steps: steps, targetStepCount: targetStepCount) ? .targetReached : stopReason
+        guard stopReason == .userStopped else { return stopReason }
+        return isCompletion(steps: steps, targetStepCount: targetStepCount) ? .targetReached : stopReason
     }
 
     /// Resolves the status of an attempt reconstructed from a workout's stored metadata.

--- a/AscendApp/Features/Climbs/Services/ClimbService.swift
+++ b/AscendApp/Features/Climbs/Services/ClimbService.swift
@@ -229,11 +229,12 @@ final class ClimbService {
         return attempt
     }
 
-    func apply(workouts: [Workout], modelContext: ModelContext) throws {
+    @discardableResult
+    func apply(workouts: [Workout], modelContext: ModelContext) throws -> ClimbAttempt? {
         guard !workouts.isEmpty,
               let activeAttempt = storedActiveAttempt(modelContext: modelContext),
               let climb = try climb(for: activeAttempt.climbId) else {
-            return
+            return nil
         }
 
         let sortedWorkouts = workouts.sorted {
@@ -263,7 +264,12 @@ final class ClimbService {
                 modelContext: modelContext
             )
 
-            if workout.steps >= climb.referenceStepCount {
+            Self.normalizeStopReason(on: workout, targetStepCount: climb.referenceStepCount)
+
+            if LiveClimbCompletionPolicy.isCompletion(
+                steps: workout.steps,
+                targetStepCount: climb.referenceStepCount
+            ) {
                 activeAttempt.status = .completed
                 activeAttempt.endedAt = Self.sessionEndDate(for: workout)
                 activeAttempt.completedAt = Self.sessionEndDate(for: workout)
@@ -284,10 +290,30 @@ final class ClimbService {
             break
         }
 
-        guard didChange else { return }
+        guard didChange else { return activeAttempt }
 
         try modelContext.save()
         postStateChangeNotification()
+        return activeAttempt
+    }
+
+    /// Records the finish on the workout itself so every later reader of the saved metadata -
+    /// rehydration after a reinstall, the replay leaderboard Cloud Function - agrees with the
+    /// status set here. Without it, ending a climb manually one step past the target leaves
+    /// `stopReason` saying the user quit while the attempt says they finished.
+    private static func normalizeStopReason(on workout: Workout, targetStepCount: Int) {
+        guard var metadata = LiveClimbWorkoutSummaryData.metadata(for: workout) else { return }
+
+        let resolvedStopReason = LiveClimbCompletionPolicy.resolvedStopReason(
+            metadata.stopReason,
+            steps: workout.steps,
+            targetStepCount: targetStepCount
+        )
+        guard resolvedStopReason != metadata.stopReason else { return }
+
+        metadata.stopReason = resolvedStopReason
+        guard let jsonString = metadata.jsonString else { return }
+        workout.sourceMetadata = jsonString
     }
 
     static func isEligibleForActiveClimb(_ workout: Workout, startedAt: Date) -> Bool {

--- a/AscendApp/Features/Climbs/Services/ClimbService.swift
+++ b/AscendApp/Features/Climbs/Services/ClimbService.swift
@@ -300,10 +300,12 @@ final class ClimbService {
         return activeAttempt
     }
 
-    /// Records the finish on the workout itself so every later reader of the saved metadata -
-    /// rehydration after a reinstall, the replay leaderboard Cloud Function - agrees with the
-    /// status set here. Without it, ending a climb manually one step past the target leaves
-    /// `stopReason` saying the user quit while the attempt says they finished.
+    /// Records a manual stop past the target as the finish it was, so later readers of the saved
+    /// metadata - rehydration after a reinstall, the replay leaderboard Cloud Function - agree
+    /// with the status set here. Without it, ending a climb manually one step past the target
+    /// leaves `stopReason` saying the user quit while the attempt says they finished. Only the
+    /// manual-stop case is normalized; see `LiveClimbCompletionPolicy.resolvedStopReason`. The
+    /// attempt's status never depends on this value.
     private static func normalizeStopReason(on workout: Workout, targetStepCount: Int) {
         guard var metadata = LiveClimbWorkoutSummaryData.metadata(for: workout) else { return }
 

--- a/AscendApp/Features/Climbs/Services/ClimbService.swift
+++ b/AscendApp/Features/Climbs/Services/ClimbService.swift
@@ -251,7 +251,10 @@ final class ClimbService {
 
             appliedWorkoutIds.append(workoutIdentifier)
             activeAttempt.appliedWorkoutIds = appliedWorkoutIds
-            activeAttempt.accumulatedSteps = min(climb.referenceStepCount, workout.steps)
+            activeAttempt.accumulatedSteps = LiveClimbCompletionPolicy.recordedSteps(
+                steps: workout.steps,
+                targetStepCount: climb.referenceStepCount
+            )
             activeAttempt.accumulatedDurationSeconds = Int(workout.duration.rounded())
             activeAttempt.sessionsCount = 1
             didChange = true

--- a/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
@@ -565,16 +565,16 @@ final class LiveClimbSessionViewModel {
                 status: .stopped,
                 force: true
             )
-            let workout = try saveWorkout(
+            let savedSession = try saveWorkout(
                 from: result,
                 splitCurve: finalSplitCurve,
                 modelContext: modelContext
             )
-            savedWorkout = workout
+            savedWorkout = savedSession.workout
             recordedResult = result
             hasSavedSession = true
 
-            let savedStatus = savedAttemptStatus(modelContext: modelContext)
+            let savedStatus = savedSession.attemptStatus
             trackSavedAttempt(result: result, status: savedStatus)
             phase = .saved(savedStatus)
             clearDraft(modelContext: modelContext)
@@ -1002,13 +1002,19 @@ final class LiveClimbSessionViewModel {
         totalProgressFraction
     }
 
+    private struct SavedLiveClimbSession {
+        let workout: Workout
+        let attemptStatus: ClimbAttemptStatus
+    }
+
     private func saveWorkout(
         from result: HeadphoneMotionSessionResult,
         splitCurve: LiveReplaySplitCurve,
         modelContext: ModelContext
-    ) throws -> Workout {
+    ) throws -> SavedLiveClimbSession {
+        var attempt: ClimbAttempt?
         if let climb = mode.climb {
-            _ = try climbService.prepareLiveClimbAttempt(
+            attempt = try climbService.prepareLiveClimbAttempt(
                 for: climb,
                 startedAt: result.startedAt,
                 modelContext: modelContext
@@ -1069,19 +1075,13 @@ final class LiveClimbSessionViewModel {
             )
         }
 
-        return workout
-    }
-
-    private func savedAttemptStatus(modelContext: ModelContext) -> ClimbAttemptStatus {
-        guard let climb = mode.climb else {
-            return .completed
-        }
-
-        return climbService
-            .historySummary(for: climb, modelContext: modelContext)
-            .recentEntries
-            .first?
-            .status ?? .completed
+        // `apply` above settled this attempt's status, so read it off the attempt rather than
+        // searching history for a row that may not be the one we just saved. Just Climb sessions
+        // have no attempt to rank - saving one is the finish.
+        return SavedLiveClimbSession(
+            workout: workout,
+            attemptStatus: attempt?.status ?? .completed
+        )
     }
 
     private func trackSavedAttempt(

--- a/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
@@ -1058,8 +1058,9 @@ final class LiveClimbSessionViewModel {
         modelContext.insert(workout)
         try modelContext.save()
 
+        var settledAttempt: ClimbAttempt?
         if mode.isLandmarkClimb {
-            try climbService.apply(workouts: [workout], modelContext: modelContext)
+            settledAttempt = try climbService.apply(workouts: [workout], modelContext: modelContext)
         }
 
         try WorkoutMutationHandler.shared.workoutsDidChange(
@@ -1075,12 +1076,10 @@ final class LiveClimbSessionViewModel {
             )
         }
 
-        // `apply` above settled this attempt's status, so read it off the attempt rather than
-        // searching history for a row that may not be the one we just saved. Just Climb sessions
-        // have no attempt to rank - saving one is the finish.
+        // Just Climb sessions have no attempt to rank - saving one is the finish.
         return SavedLiveClimbSession(
             workout: workout,
-            attemptStatus: attempt?.status ?? .completed
+            attemptStatus: settledAttempt?.status ?? attempt?.status ?? .completed
         )
     }
 

--- a/AscendApp/Features/Workouts/Views/ActiveHeadphoneWorkoutRecoveryView.swift
+++ b/AscendApp/Features/Workouts/Views/ActiveHeadphoneWorkoutRecoveryView.swift
@@ -120,8 +120,10 @@ struct ActiveHeadphoneWorkoutRecoveryView: View {
     }
 
     private var hasReachedTarget: Bool {
-        guard let targetStepCount = draft.targetStepCount else { return false }
-        return effectiveStepCount >= targetStepCount
+        LiveClimbCompletionPolicy.isCompletion(
+            steps: effectiveStepCount,
+            targetStepCount: draft.targetStepCount
+        )
     }
 
     private var saveButtonTitle: String {

--- a/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionSessionResult.swift
+++ b/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionSessionResult.swift
@@ -123,7 +123,8 @@ struct HeadphoneMotionWorkoutMetadata: Codable, Equatable, Sendable {
     let targetStepCount: Int?
     let climbTargetStepCount: Int?
     let targetDurationSeconds: TimeInterval?
-    let stopReason: HeadphoneMotionSessionStopReason
+    /// Normalized against the step target once a session is saved. See `LiveClimbCompletionPolicy`.
+    var stopReason: HeadphoneMotionSessionStopReason
     let splitIntervalSeconds: Int?
     let splitSteps: [Int]?
     let trackingUnavailableDurationSeconds: TimeInterval?

--- a/AscendApp/Shared/Services/WorkoutHydrationService.swift
+++ b/AscendApp/Shared/Services/WorkoutHydrationService.swift
@@ -217,7 +217,7 @@ enum WorkoutHydrationService {
             return
         }
 
-        let status: ClimbAttemptStatus = metadata.stopReason == .targetReached ? .completed : .failed
+        let status = LiveClimbCompletionPolicy.attemptStatus(for: metadata, steps: workout.steps)
         let endedAt = workout.date.addingTimeInterval(workout.duration)
         let descriptor = FetchDescriptor<ClimbAttempt>(
             predicate: #Predicate<ClimbAttempt> { attempt in

--- a/AscendApp/Shared/Services/WorkoutHydrationService.swift
+++ b/AscendApp/Shared/Services/WorkoutHydrationService.swift
@@ -218,6 +218,10 @@ enum WorkoutHydrationService {
         }
 
         let status = LiveClimbCompletionPolicy.attemptStatus(for: metadata, steps: workout.steps)
+        let recordedSteps = LiveClimbCompletionPolicy.recordedSteps(
+            steps: workout.steps,
+            targetStepCount: LiveClimbCompletionPolicy.targetStepCount(for: metadata)
+        )
         let endedAt = workout.date.addingTimeInterval(workout.duration)
         let descriptor = FetchDescriptor<ClimbAttempt>(
             predicate: #Predicate<ClimbAttempt> { attempt in
@@ -231,7 +235,7 @@ enum WorkoutHydrationService {
             startedAt: workout.date,
             endedAt: endedAt,
             completedAt: status == .completed ? endedAt : nil,
-            accumulatedSteps: workout.steps,
+            accumulatedSteps: recordedSteps,
             accumulatedDurationSeconds: Int(workout.duration.rounded()),
             sessionsCount: 1,
             appliedWorkoutIds: [workout.id.uuidString],
@@ -244,7 +248,7 @@ enum WorkoutHydrationService {
         attempt.startedAt = workout.date
         attempt.endedAt = endedAt
         attempt.completedAt = status == .completed ? endedAt : nil
-        attempt.accumulatedSteps = workout.steps
+        attempt.accumulatedSteps = recordedSteps
         attempt.accumulatedDurationSeconds = Int(workout.duration.rounded())
         attempt.sessionsCount = 1
         attempt.appliedWorkoutIds = [workout.id.uuidString]

--- a/AscendAppTests/ClimbServiceTests.swift
+++ b/AscendAppTests/ClimbServiceTests.swift
@@ -165,6 +165,78 @@ struct ClimbServiceTests {
     }
 
     @Test
+    func endingManuallyPastTheTargetRecordsTheClimbAsTargetReached() throws {
+        let climb = makeClimb(id: "manual-end-past-target", requiredSteps: 1_000)
+        let service = ClimbService(catalogRepository: TestClimbCatalogRepository(climbs: [climb]))
+        let modelContext = try makeModelContext()
+        let climbStartedAt = Date(timeIntervalSince1970: 1_775_217_600)
+
+        modelContext.insert(ClimbAttempt(climbId: climb.id, startedAt: climbStartedAt))
+        try modelContext.save()
+
+        let metadata = HeadphoneMotionWorkoutMetadata(
+            sampleCount: 500,
+            climbId: climb.id,
+            targetStepCount: climb.referenceStepCount,
+            climbTargetStepCount: climb.referenceStepCount,
+            stopReason: .userStopped
+        )
+        let workout = Workout(
+            name: "Ended On The Target",
+            date: climbStartedAt.addingTimeInterval(60),
+            duration: 900,
+            steps: 1_010,
+            floors: 63,
+            stepsPerFloor: 16,
+            source: .headphoneMotion,
+            sourceMetadata: metadata.jsonString
+        )
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let attempt = try #require(try service.apply(workouts: [workout], modelContext: modelContext))
+
+        #expect(attempt.status == .completed)
+        #expect(LiveClimbWorkoutSummaryData.metadata(for: workout)?.stopReason == .targetReached)
+    }
+
+    @Test
+    func endingManuallyShortOfTheTargetKeepsTheRecordedStopReason() throws {
+        let climb = makeClimb(id: "manual-end-short-of-target", requiredSteps: 1_000)
+        let service = ClimbService(catalogRepository: TestClimbCatalogRepository(climbs: [climb]))
+        let modelContext = try makeModelContext()
+        let climbStartedAt = Date(timeIntervalSince1970: 1_775_217_600)
+
+        modelContext.insert(ClimbAttempt(climbId: climb.id, startedAt: climbStartedAt))
+        try modelContext.save()
+
+        let metadata = HeadphoneMotionWorkoutMetadata(
+            sampleCount: 500,
+            climbId: climb.id,
+            targetStepCount: climb.referenceStepCount,
+            climbTargetStepCount: climb.referenceStepCount,
+            stopReason: .userStopped
+        )
+        let workout = Workout(
+            name: "Gave Up Early",
+            date: climbStartedAt.addingTimeInterval(60),
+            duration: 900,
+            steps: 800,
+            floors: 50,
+            stepsPerFloor: 16,
+            source: .headphoneMotion,
+            sourceMetadata: metadata.jsonString
+        )
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        let attempt = try #require(try service.apply(workouts: [workout], modelContext: modelContext))
+
+        #expect(attempt.status == .failed)
+        #expect(LiveClimbWorkoutSummaryData.metadata(for: workout)?.stopReason == .userStopped)
+    }
+
+    @Test
     func laterWorkoutDoesNotAccumulateTowardPriorAttempt() throws {
         let climb = makeClimb(id: "restart-required-climb", requiredSteps: 1_000)
         let service = ClimbService(catalogRepository: TestClimbCatalogRepository(climbs: [climb]))

--- a/AscendAppTests/LiveClimbCompletionPolicyTests.swift
+++ b/AscendAppTests/LiveClimbCompletionPolicyTests.swift
@@ -86,6 +86,41 @@ struct LiveClimbCompletionPolicyTests {
         #expect(LiveClimbCompletionPolicy.attemptStatus(for: stopped, steps: 1_000) == .failed)
     }
 
+    @Test
+    func recordedStepsStopAtTheTarget() {
+        #expect(LiveClimbCompletionPolicy.recordedSteps(steps: 1_010, targetStepCount: 1_000) == 1_000)
+        #expect(LiveClimbCompletionPolicy.recordedSteps(steps: 800, targetStepCount: 1_000) == 800)
+    }
+
+    @Test
+    func recordedStepsKeepTheRawCountWhenNoTargetWasRecorded() {
+        #expect(LiveClimbCompletionPolicy.recordedSteps(steps: 1_010, targetStepCount: nil) == 1_010)
+        #expect(LiveClimbCompletionPolicy.recordedSteps(steps: 1_010, targetStepCount: 0) == 1_010)
+    }
+
+    @Test
+    func metadataTargetPrefersTheClimbTargetOverTheSessionTarget() {
+        let metadata = makeMetadata(
+            stopReason: .userStopped,
+            targetStepCount: 400,
+            climbTargetStepCount: 1_000
+        )
+        let sessionOnly = makeMetadata(
+            stopReason: .userStopped,
+            targetStepCount: 400,
+            climbTargetStepCount: nil
+        )
+        let untargeted = makeMetadata(
+            stopReason: .userStopped,
+            targetStepCount: nil,
+            climbTargetStepCount: nil
+        )
+
+        #expect(LiveClimbCompletionPolicy.targetStepCount(for: metadata) == 1_000)
+        #expect(LiveClimbCompletionPolicy.targetStepCount(for: sessionOnly) == 400)
+        #expect(LiveClimbCompletionPolicy.targetStepCount(for: untargeted) == nil)
+    }
+
     private func makeMetadata(
         stopReason: HeadphoneMotionSessionStopReason,
         targetStepCount: Int? = 1_000,

--- a/AscendAppTests/LiveClimbCompletionPolicyTests.swift
+++ b/AscendAppTests/LiveClimbCompletionPolicyTests.swift
@@ -22,7 +22,7 @@ struct LiveClimbCompletionPolicyTests {
     }
 
     @Test
-    func passingTheTargetResolvesAManualStopToTargetReached() {
+    func passingTheTargetResolvesOnlyAManualStopToTargetReached() {
         #expect(
             LiveClimbCompletionPolicy.resolvedStopReason(
                 .userStopped,
@@ -30,13 +30,42 @@ struct LiveClimbCompletionPolicyTests {
                 targetStepCount: 1_000
             ) == .targetReached
         )
+    }
+
+    /// Publication is gated on this value, so a hand-typed recovery step count must not be able
+    /// to turn an interrupted session into a First Ascent claim.
+    @Test
+    func passingTheTargetLeavesANonManualStopReasonAlone() {
         #expect(
             LiveClimbCompletionPolicy.resolvedStopReason(
                 .interrupted,
                 steps: 1_200,
                 targetStepCount: 1_000
+            ) == .interrupted
+        )
+        #expect(
+            LiveClimbCompletionPolicy.resolvedStopReason(
+                .discarded,
+                steps: 1_200,
+                targetStepCount: 1_000
+            ) == .discarded
+        )
+        #expect(
+            LiveClimbCompletionPolicy.resolvedStopReason(
+                .targetReached,
+                steps: 1_200,
+                targetStepCount: 1_000
             ) == .targetReached
         )
+    }
+
+    /// Narrowing the reason upgrade must not narrow what counts: an interrupted session past the
+    /// target is still a finish, because status reads steps rather than the stop reason.
+    @Test
+    func anInterruptedSessionPastTheTargetIsStillACompletion() {
+        let metadata = makeMetadata(stopReason: .interrupted, climbTargetStepCount: 1_000)
+
+        #expect(LiveClimbCompletionPolicy.attemptStatus(for: metadata, steps: 1_200) == .completed)
     }
 
     @Test

--- a/AscendAppTests/LiveClimbCompletionPolicyTests.swift
+++ b/AscendAppTests/LiveClimbCompletionPolicyTests.swift
@@ -1,0 +1,102 @@
+//
+//  LiveClimbCompletionPolicyTests.swift
+//  AscendAppTests
+//
+
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct LiveClimbCompletionPolicyTests {
+    @Test
+    func reachingTheStepTargetIsACompletion() {
+        #expect(LiveClimbCompletionPolicy.isCompletion(steps: 1_000, targetStepCount: 1_000))
+        #expect(LiveClimbCompletionPolicy.isCompletion(steps: 1_001, targetStepCount: 1_000))
+        #expect(LiveClimbCompletionPolicy.isCompletion(steps: 999, targetStepCount: 1_000) == false)
+    }
+
+    @Test
+    func missingStepTargetIsNeverACompletion() {
+        #expect(LiveClimbCompletionPolicy.isCompletion(steps: 1_000, targetStepCount: nil) == false)
+        #expect(LiveClimbCompletionPolicy.isCompletion(steps: 1_000, targetStepCount: 0) == false)
+    }
+
+    @Test
+    func passingTheTargetResolvesAManualStopToTargetReached() {
+        #expect(
+            LiveClimbCompletionPolicy.resolvedStopReason(
+                .userStopped,
+                steps: 1_000,
+                targetStepCount: 1_000
+            ) == .targetReached
+        )
+        #expect(
+            LiveClimbCompletionPolicy.resolvedStopReason(
+                .interrupted,
+                steps: 1_200,
+                targetStepCount: 1_000
+            ) == .targetReached
+        )
+    }
+
+    @Test
+    func fallingShortOfTheTargetPreservesTheRecordedStopReason() {
+        #expect(
+            LiveClimbCompletionPolicy.resolvedStopReason(
+                .userStopped,
+                steps: 800,
+                targetStepCount: 1_000
+            ) == .userStopped
+        )
+    }
+
+    @Test
+    func metadataStatusRanksStepsAheadOfAStaleStopReason() {
+        let metadata = makeMetadata(stopReason: .userStopped, climbTargetStepCount: 1_000)
+
+        #expect(LiveClimbCompletionPolicy.attemptStatus(for: metadata, steps: 1_000) == .completed)
+        #expect(LiveClimbCompletionPolicy.attemptStatus(for: metadata, steps: 999) == .failed)
+    }
+
+    @Test
+    func metadataStatusPrefersTheClimbTargetOverTheSessionTarget() {
+        let metadata = makeMetadata(
+            stopReason: .userStopped,
+            targetStepCount: 400,
+            climbTargetStepCount: 1_000
+        )
+
+        #expect(LiveClimbCompletionPolicy.attemptStatus(for: metadata, steps: 500) == .failed)
+    }
+
+    @Test
+    func metadataStatusFallsBackToStopReasonWhenNoTargetWasRecorded() {
+        let reached = makeMetadata(
+            stopReason: .targetReached,
+            targetStepCount: nil,
+            climbTargetStepCount: nil
+        )
+        let stopped = makeMetadata(
+            stopReason: .userStopped,
+            targetStepCount: nil,
+            climbTargetStepCount: nil
+        )
+
+        #expect(LiveClimbCompletionPolicy.attemptStatus(for: reached, steps: 1_000) == .completed)
+        #expect(LiveClimbCompletionPolicy.attemptStatus(for: stopped, steps: 1_000) == .failed)
+    }
+
+    private func makeMetadata(
+        stopReason: HeadphoneMotionSessionStopReason,
+        targetStepCount: Int? = 1_000,
+        climbTargetStepCount: Int?
+    ) -> HeadphoneMotionWorkoutMetadata {
+        HeadphoneMotionWorkoutMetadata(
+            sampleCount: 500,
+            climbId: "policy-climb",
+            targetStepCount: targetStepCount,
+            climbTargetStepCount: climbTargetStepCount,
+            stopReason: stopReason
+        )
+    }
+}

--- a/AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests.swift
+++ b/AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests.swift
@@ -148,11 +148,82 @@ struct WorkoutHydrationServiceLiveClimbRestoreTests {
         #expect(restoredAttempt.completedAt == nil)
     }
 
+    /// The bug in the terms the user feels it: the climb they finished has to still be theirs
+    /// after a reinstall. The attempt record is what rehydration writes; these are the surfaces
+    /// that record reaches - the Collection card's claimed state and the Climb Detail history.
+    @Test
+    func aFinishedClimbIsStillClaimedAcrossItsSurfacesAfterReinstall() async throws {
+        let userId = "reinstall-surfaces-user"
+        let climb = makeClimb(id: "reinstall-surfaces-climb", requiredSteps: 1_000)
+
+        let backup = try makeRemoteBackup(
+            for: climb,
+            userId: userId,
+            steps: 1_010,
+            stopReason: .userStopped
+        )
+        let before = describeSurfaces(
+            service: backup.service,
+            climb: climb,
+            modelContext: backup.sourceContext
+        )
+
+        let restoredContext = try makeModelContext()
+        _ = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: restoredContext,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(records: [backup.record])
+        )
+        let restoredService = ClimbService(catalogRepository: TestCatalogRepository(climbs: [climb]))
+        let after = describeSurfaces(
+            service: restoredService,
+            climb: climb,
+            modelContext: restoredContext
+        )
+
+        // Compared as a whole so a regression reports every surface the user lost at once.
+        #expect(after == before)
+
+        // Collection: the card keeps its claimed checkmark.
+        #expect(restoredService.previewSummary(for: climb, modelContext: restoredContext).isCompleted)
+        #expect(restoredService.collectionCount(modelContext: restoredContext) == 1)
+
+        // Climb Detail history: a completion, not a failed attempt.
+        let history = restoredService.historySummary(for: climb, modelContext: restoredContext)
+        #expect(history.completionsCount == 1)
+        #expect(history.failedAttemptsCount == 0)
+        let entry = try #require(history.recentEntries.first)
+        #expect(entry.status == .completed)
+        #expect(entry.recordedSteps == 1_000)
+    }
+
+    /// Renders the climb's user-facing state from the same service surfaces the Collection and
+    /// Climb Detail screens read, so a reinstall's effect is legible without a device.
+    private func describeSurfaces(
+        service: ClimbService,
+        climb: Climb,
+        modelContext: ModelContext
+    ) -> String {
+        let isClaimed = service.previewSummary(for: climb, modelContext: modelContext).isCompleted
+        let history = service.historySummary(for: climb, modelContext: modelContext)
+        let entry = history.recentEntries.first
+
+        return """
+          Collection card ....... \(isClaimed ? "CLAIMED (checkmark badge)" : "UNCLAIMED (no badge)")
+          Collection count ...... \(service.collectionCount(modelContext: modelContext)) climb(s)
+          Climb Detail history .. \(history.completionsCount) completion(s), \
+        \(history.failedAttemptsCount) failed attempt(s)
+          History row ........... \(entry.map { "\($0.status) - \($0.recordedSteps.formatted()) of \($0.totalSteps.formatted()) steps" } ?? "none")
+        """
+    }
+
     private struct RemoteBackup {
         let record: RemoteWorkoutRecord
         let attemptId: UUID
         let localAttemptStatus: ClimbAttemptStatus
         let localAttemptSteps: Int
+        let sourceContext: ModelContext
+        let service: ClimbService
     }
 
     /// Rewrites the stored stop reason on an already-serialized backup, so a fixture can carry a
@@ -235,7 +306,9 @@ struct WorkoutHydrationServiceLiveClimbRestoreTests {
             record: RemoteWorkoutRecord(workoutId: snapshot.workoutId, document: snapshot.document),
             attemptId: attempt.id,
             localAttemptStatus: attempt.status,
-            localAttemptSteps: attempt.accumulatedSteps
+            localAttemptSteps: attempt.accumulatedSteps,
+            sourceContext: modelContext,
+            service: service
         )
     }
 

--- a/AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests.swift
+++ b/AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests.swift
@@ -1,0 +1,203 @@
+//
+//  WorkoutHydrationServiceLiveClimbRestoreTests.swift
+//  AscendAppTests
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import AscendApp
+
+/// Covers the reinstall path end to end: a climb is saved on one install, backed up through the
+/// real remote mapper, and rehydrated into a fresh store the way a reinstall would see it.
+@MainActor
+struct WorkoutHydrationServiceLiveClimbRestoreTests {
+    @Test
+    func manuallyEndedClimbPastTheTargetSurvivesReinstallAsCompleted() async throws {
+        let userId = "reinstall-manual-end-user"
+        let climb = makeClimb(id: "reinstall-manual-end-climb", requiredSteps: 1_000)
+
+        let backup = try makeRemoteBackup(
+            for: climb,
+            userId: userId,
+            steps: 1_010,
+            stopReason: .userStopped
+        )
+
+        // The climb counted before the reinstall.
+        #expect(backup.localAttemptStatus == .completed)
+
+        let restoredContext = try makeModelContext()
+        let changedCount = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: restoredContext,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(records: [backup.record])
+        )
+
+        #expect(changedCount == 1)
+
+        let restoredAttempt = try #require(
+            try restoredContext.fetch(FetchDescriptor<ClimbAttempt>()).first
+        )
+        #expect(restoredAttempt.id == backup.attemptId)
+        #expect(restoredAttempt.status == .completed)
+        #expect(restoredAttempt.completedAt != nil)
+        #expect(restoredAttempt.accumulatedSteps == 1_010)
+    }
+
+    @Test
+    func attemptShortOfTheTargetStillRestoresAsFailed() async throws {
+        let userId = "reinstall-short-attempt-user"
+        let climb = makeClimb(id: "reinstall-short-attempt-climb", requiredSteps: 1_000)
+
+        let backup = try makeRemoteBackup(
+            for: climb,
+            userId: userId,
+            steps: 800,
+            stopReason: .userStopped
+        )
+
+        #expect(backup.localAttemptStatus == .failed)
+
+        let restoredContext = try makeModelContext()
+        _ = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: restoredContext,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(records: [backup.record])
+        )
+
+        let restoredAttempt = try #require(
+            try restoredContext.fetch(FetchDescriptor<ClimbAttempt>()).first
+        )
+        #expect(restoredAttempt.status == .failed)
+        #expect(restoredAttempt.completedAt == nil)
+    }
+
+    private struct RemoteBackup {
+        let record: RemoteWorkoutRecord
+        let attemptId: UUID
+        let localAttemptStatus: ClimbAttemptStatus
+    }
+
+    /// Saves a live climb the way the live session does, then serializes it through the real
+    /// remote sync mapper so the restored document is the one a reinstall would download.
+    private func makeRemoteBackup(
+        for climb: Climb,
+        userId: String,
+        steps: Int,
+        stopReason: HeadphoneMotionSessionStopReason
+    ) throws -> RemoteBackup {
+        let service = ClimbService(catalogRepository: TestCatalogRepository(climbs: [climb]))
+        let modelContext = try makeModelContext()
+        let climbStartedAt = Date(timeIntervalSince1970: 1_775_217_600)
+
+        let attempt = try service.prepareLiveClimbAttempt(
+            for: climb,
+            startedAt: climbStartedAt,
+            modelContext: modelContext
+        )
+
+        let metadata = HeadphoneMotionWorkoutMetadata(
+            sampleCount: 500,
+            climbId: climb.id,
+            targetStepCount: climb.referenceStepCount,
+            climbTargetStepCount: climb.referenceStepCount,
+            stopReason: stopReason
+        )
+        let workout = Workout(
+            name: "\(climb.name) Live Climb",
+            date: climbStartedAt.addingTimeInterval(60),
+            duration: 900,
+            steps: steps,
+            floors: Workout.stepsToFloors(steps),
+            stepsPerFloor: Workout.defaultStepsPerFloor,
+            source: .headphoneMotion,
+            sourceMetadata: metadata.jsonString
+        )
+        modelContext.insert(workout)
+        try modelContext.save()
+
+        try service.apply(workouts: [workout], modelContext: modelContext)
+        workout.markPendingRemoteUpsert(ownerUserId: userId)
+        try modelContext.save()
+
+        let snapshot = try WorkoutRemoteSyncMapper.snapshot(from: workout)
+
+        return RemoteBackup(
+            record: RemoteWorkoutRecord(workoutId: snapshot.workoutId, document: snapshot.document),
+            attemptId: attempt.id,
+            localAttemptStatus: attempt.status
+        )
+    }
+
+    private func makeModelContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: ClimbAttempt.self,
+            Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    private func makeClimb(id: String, requiredSteps: Int) -> Climb {
+        Climb(
+            id: id,
+            name: id,
+            city: "City",
+            country: "Country",
+            continent: "Continent",
+            latitude: 0,
+            longitude: 0,
+            totalHeightMeters: 100,
+            totalHeightFeet: 328,
+            realClimbableHeightMeters: nil,
+            realClimbableHeightFeet: nil,
+            totalSteps: requiredSteps,
+            realStairCount: nil,
+            calculatedFloors: 50,
+            category: "tower",
+            tier: .gold,
+            tags: [],
+            funFact: "Fact",
+            sourceURL: "https://example.com",
+            imageSetVersion: 1,
+            releaseState: .available
+        )
+    }
+}
+
+private struct StubWorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol {
+    let records: [RemoteWorkoutRecord]
+
+    func fetchWorkouts(userId: String) async throws -> [RemoteWorkoutRecord] {
+        records
+    }
+
+    func upsertWorkout(
+        userId: String,
+        workoutId: UUID,
+        document: FirestoreWorkoutDocument
+    ) async throws {}
+
+    func deleteWorkout(userId: String, workoutId: UUID) async throws {}
+}
+
+private struct TestCatalogRepository: ClimbCatalogRepository {
+    let climbs: [Climb]
+
+    func loadInitialCatalog() throws -> ClimbCatalogSnapshot {
+        ClimbCatalogSnapshot(
+            climbs: climbs,
+            source: .bootstrap,
+            catalogVersion: 0,
+            featuredClimbId: climbs.first?.id,
+            updatedAt: nil
+        )
+    }
+
+    func refreshCatalog() async throws -> ClimbCatalogSnapshot {
+        try loadInitialCatalog()
+    }
+}

--- a/AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests.swift
+++ b/AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests.swift
@@ -42,7 +42,48 @@ struct WorkoutHydrationServiceLiveClimbRestoreTests {
         #expect(restoredAttempt.id == backup.attemptId)
         #expect(restoredAttempt.status == .completed)
         #expect(restoredAttempt.completedAt != nil)
-        #expect(restoredAttempt.accumulatedSteps == 1_010)
+        // A climb stops counting at its target, so rehydrating must not restate the steps.
+        #expect(restoredAttempt.accumulatedSteps == 1_000)
+        #expect(restoredAttempt.accumulatedSteps == backup.localAttemptSteps)
+    }
+
+    /// A backup written by a build that predates save-time stop reason normalization: the stored
+    /// reason still says the user stopped even though the session passed the target.
+    @Test
+    func legacyBackupWithAStaleStopReasonRestoresAsCompleted() async throws {
+        let userId = "reinstall-legacy-reason-user"
+        let climb = makeClimb(id: "reinstall-legacy-reason-climb", requiredSteps: 1_000)
+
+        let backup = try makeRemoteBackup(
+            for: climb,
+            userId: userId,
+            steps: 1_010,
+            stopReason: .userStopped
+        )
+        let legacyDocument = try rewritingStopReason(on: backup.record.document, to: .userStopped)
+
+        #expect(try decodedMetadata(from: legacyDocument).stopReason == .userStopped)
+
+        let restoredContext = try makeModelContext()
+        _ = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: restoredContext,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(
+                records: [
+                    RemoteWorkoutRecord(
+                        workoutId: backup.record.workoutId,
+                        document: legacyDocument
+                    )
+                ]
+            )
+        )
+
+        let restoredAttempt = try #require(
+            try restoredContext.fetch(FetchDescriptor<ClimbAttempt>()).first
+        )
+        #expect(restoredAttempt.status == .completed)
+        #expect(restoredAttempt.completedAt != nil)
+        #expect(restoredAttempt.accumulatedSteps == 1_000)
     }
 
     @Test
@@ -77,6 +118,39 @@ struct WorkoutHydrationServiceLiveClimbRestoreTests {
         let record: RemoteWorkoutRecord
         let attemptId: UUID
         let localAttemptStatus: ClimbAttemptStatus
+        let localAttemptSteps: Int
+    }
+
+    /// Rewrites the stored stop reason on an already-serialized backup, so a fixture can carry a
+    /// reason that save-time normalization would never leave behind.
+    private func rewritingStopReason(
+        on document: FirestoreWorkoutDocument,
+        to stopReason: HeadphoneMotionSessionStopReason
+    ) throws -> FirestoreWorkoutDocument {
+        var metadata = try decodedMetadata(from: document)
+        metadata.stopReason = stopReason
+
+        var json = try #require(
+            try JSONSerialization.jsonObject(
+                with: try JSONEncoder().encode(document)
+            ) as? [String: Any]
+        )
+        json["sourceMetadata"] = try #require(metadata.jsonString)
+
+        return try JSONDecoder().decode(
+            FirestoreWorkoutDocument.self,
+            from: try JSONSerialization.data(withJSONObject: json)
+        )
+    }
+
+    private func decodedMetadata(
+        from document: FirestoreWorkoutDocument
+    ) throws -> HeadphoneMotionWorkoutMetadata {
+        let json = try #require(document.sourceMetadata)
+        return try JSONDecoder().decode(
+            HeadphoneMotionWorkoutMetadata.self,
+            from: try #require(json.data(using: .utf8))
+        )
     }
 
     /// Saves a live climb the way the live session does, then serializes it through the real
@@ -126,7 +200,8 @@ struct WorkoutHydrationServiceLiveClimbRestoreTests {
         return RemoteBackup(
             record: RemoteWorkoutRecord(workoutId: snapshot.workoutId, document: snapshot.document),
             attemptId: attempt.id,
-            localAttemptStatus: attempt.status
+            localAttemptStatus: attempt.status,
+            localAttemptSteps: attempt.accumulatedSteps
         )
     }
 

--- a/AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests.swift
+++ b/AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests.swift
@@ -86,6 +86,40 @@ struct WorkoutHydrationServiceLiveClimbRestoreTests {
         #expect(restoredAttempt.accumulatedSteps == 1_000)
     }
 
+    /// A recovered draft saves `.interrupted`, which save-time normalization deliberately leaves
+    /// alone so it stays out of public results. Status still comes from steps, so the climb must
+    /// survive a reinstall as a completion regardless of that reason.
+    @Test
+    func interruptedBackupPastTheTargetSurvivesReinstallAsCompleted() async throws {
+        let userId = "reinstall-interrupted-user"
+        let climb = makeClimb(id: "reinstall-interrupted-climb", requiredSteps: 1_000)
+
+        let backup = try makeRemoteBackup(
+            for: climb,
+            userId: userId,
+            steps: 1_010,
+            stopReason: .interrupted
+        )
+
+        // The climb counted before the reinstall, and the reason was left untouched.
+        #expect(backup.localAttemptStatus == .completed)
+        #expect(try decodedMetadata(from: backup.record.document).stopReason == .interrupted)
+
+        let restoredContext = try makeModelContext()
+        _ = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: restoredContext,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(records: [backup.record])
+        )
+
+        let restoredAttempt = try #require(
+            try restoredContext.fetch(FetchDescriptor<ClimbAttempt>()).first
+        )
+        #expect(restoredAttempt.status == .completed)
+        #expect(restoredAttempt.completedAt != nil)
+        #expect(restoredAttempt.accumulatedSteps == 1_000)
+    }
+
     @Test
     func attemptShortOfTheTargetStillRestoresAsFailed() async throws {
         let userId = "reinstall-short-attempt-user"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,9 +330,14 @@ Live Climbs is the hero competitive experience: a user picks a real-world landma
 - Live Climb completions come only from the live headphone-motion attempt flow. Manual entries, external imports, and routine completions cannot progress or complete a Live Climb. (Integrity gate; cross-referenced from Workout Source + Context.)
 - The live attempt creates a workout only after the live session stops with recorded steps. The workout flows through the normal workout mutation pipeline so leaderboards, Best Efforts, and remote backup stay on one path.
 - Reaching the climb's step target *is* the finish, and `LiveClimbCompletionPolicy` is the only place that decides it.
-  `stopReason` describes *how* a session ended, never whether it counted - a climber who taps End one step past the target finished.
-  `ClimbService.apply` normalizes the saved `stopReason` to `.targetReached` so rehydration and the replay Cloud Function agree with the status set at save time.
+  Status always reads steps, never `stopReason`.
   Never add a second finish definition: readers ask the policy, they don't re-derive.
+- `stopReason` describes *how* a session ended, never whether it counted.
+  `ClimbService.apply` upgrades it to `.targetReached` for the manual-stop case only - a climber who tapped End past the target finished - so rehydration and the replay Cloud Function agree on that path.
+  Every other stop reason is deliberately left as recorded.
+- An interrupted recovered draft past the target counts locally as a completion but is deliberately never published by the replay Cloud Function, because a recovered draft's step count is typed by hand.
+  That asymmetry is an intentional First Ascent integrity gate, not the reinstall bug it resembles: a First Ascent is permanent and never reclaimable, so a typed number must never claim one.
+  Ask `LiveClimbCompletionPolicy` before changing what normalizes; don't widen it to heal a status that already reads steps.
 - Saved Live Climb attempts are immutable competitive history. Discard during the live session if the attempt shouldn't count; once saved, workout-log delete affordances do not erase the underlying attempt.
 
 **First Ascent (World First) prestige**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,6 +329,10 @@ Live Climbs is the hero competitive experience: a user picks a real-world landma
 - Catalog climbs are *single-session challenges*: the live attempt must reach the target step count to count as a completion. Ending early saves a failed attempt in personal history; only target-reached completions count publicly (leaderboard, First Ascent eligibility).
 - Live Climb completions come only from the live headphone-motion attempt flow. Manual entries, external imports, and routine completions cannot progress or complete a Live Climb. (Integrity gate; cross-referenced from Workout Source + Context.)
 - The live attempt creates a workout only after the live session stops with recorded steps. The workout flows through the normal workout mutation pipeline so leaderboards, Best Efforts, and remote backup stay on one path.
+- Reaching the climb's step target *is* the finish, and `LiveClimbCompletionPolicy` is the only place that decides it.
+  `stopReason` describes *how* a session ended, never whether it counted - a climber who taps End one step past the target finished.
+  `ClimbService.apply` normalizes the saved `stopReason` to `.targetReached` so rehydration and the replay Cloud Function agree with the status set at save time.
+  Never add a second finish definition: readers ask the policy, they don't re-derive.
 - Saved Live Climb attempts are immutable competitive history. Discard during the live session if the attempt shouldn't count; once saved, workout-log delete affordances do not erase the underlying attempt.
 
 **First Ascent (World First) prestige**

--- a/functions/src/liveReplayLeaderboard.ts
+++ b/functions/src/liveReplayLeaderboard.ts
@@ -344,7 +344,15 @@ function parseReplayPayloadParts(
 }
 
 /**
- * Returns whether a live climb workout represents a full completed climb.
+ * Returns whether a live climb workout may publish a replay row. This is a
+ * publication gate, not the definition of finishing a climb: the client owns
+ * that in LiveClimbCompletionPolicy, which reads steps against the target and
+ * never reads stopReason. Requiring target_reached here deliberately declines
+ * some attempts the client counts as finished. A recovered draft is saved as
+ * interrupted and carries a hand-typed step count, and a First Ascent is
+ * permanent and never reclaimable, so a typed number must never claim one. The
+ * client normalizes a manual stop past the target to target_reached at save
+ * time, so that path agrees with this gate without a change here.
  * @param {ParsedReplayPayloadParts} parsed Parsed replay payload parts.
  * @return {boolean} True when the row may be published publicly.
  */


### PR DESCRIPTION
## Intent

Fix a bug where reinstalling the app re-derives Live Climb attempt status from the stored stopReason and silently flips legitimately-completed climbs to failed, so the user loses a climb they finished.

Concrete failure: a user reaches the step target and taps End manually before the auto-finish fires. stopReason is .userStopped, but workout.steps >= climb.referenceStepCount, so ClimbService.apply marked the attempt .completed and the climb counted locally. On reinstall, WorkoutHydrationService re-derived status from stopReason and the attempt became .failed.

Root cause: three competing definitions of 'finishing' a Live Climb disagreed - client at save (steps >= referenceStepCount), client at rehydration (stopReason == .targetReached), and the replay Cloud Function in functions/src/liveReplayLeaderboard.ts (eligible + live_climb + target_reached + finalSteps >= targetStepCount + no baselineSteps).

Fix and the decisions taken:
- Collapse the finish definitions into ONE shared predicate. Added LiveClimbCompletionPolicy (pure, no SwiftUI, unit-testable) as the single place that decides: reaching the climb's step target IS the finish; stopReason describes HOW a session ended, never whether it counted.
- Per the recommended approach, make stopReason authoritative by having ClimbService.apply normalize it to .targetReached when steps >= referenceStepCount. Done inside apply (not the view model) because both save paths - the live session and the recovered-draft path in ActiveHeadphoneWorkoutDraftSaver, which saves .interrupted - funnel through apply, so both are healed. It runs before WorkoutMutationHandler.workoutsDidChange so the corrected metadata is what gets backed up.
- Deliberate choice NOT to change the Cloud Function: it already gates on stopReason == target_reached AND finalSteps >= targetStepCount, so normalizing the stored stopReason at save time makes it agree with no TypeScript change and no deploy.
- Hydration also asks the policy rather than only trusting stopReason, as defense in depth.
- HeadphoneMotionWorkoutMetadata.stopReason changed from let to var so saved metadata can be normalized; every other field stays let, signalling that this one value is normalized at save.
- Fixed audit Finding #12: LiveClimbSessionViewModel.savedAttemptStatus re-queried historySummary with a '?? .completed' fallback that could report a failed attempt as a finish. saveWorkout now returns SavedLiveClimbSession carrying the attempt's real status, read off the ClimbAttempt that apply mutated. The remaining '?? .completed' applies only to Just Climb sessions, which have no attempt to rank.

This branch already carries the review gate's own fix commit (7f81523), applying the owner's decisions from the previous run - do not re-surface those resolved findings:
- accumulated-steps-diverges-on-rehydration: FIXED. The clamp now lives in LiveClimbCompletionPolicy.recordedSteps and both ClimbService.apply and hydration call it, so a reinstall cannot restate a completed attempt's steps.
- e2e-test-cannot-isolate-hydration-half: FIXED. Added legacyBackupWithAStaleStopReasonRestoresAsCompleted, which rewrites the serialized stopReason back to user_stopped so the fixture genuinely carries a stale reason; it fails if hydration reverts to deriving status from stopReason.
- fourth-finish-definition-recovery-view: FIXED. ActiveHeadphoneWorkoutRecoveryView.hasReachedTarget now routes through LiveClimbCompletionPolicy.isCompletion.
- hydration-stale-reason-not-republished: DELIBERATELY ACCEPTED AS-IS by the owner. The app is pre-launch and no legacy users exist, so hydration must NOT rewrite or re-mark remote data. Do not re-raise this.

The previous run (01KXPRM4S193F6VQ7PXC639V4D) passed review and test and then failed at the document step for a purely environmental reason: the machine disk hit 100% and git could not create index.lock (ENOSPC). No code problem. Disk has since been freed. The tip commit (3faf656) only replaces an em dash with a plain dash in a comment, per the project rule in CLAUDE.md forbidding em dashes.

Verification so far: the E2E reinstall test was confirmed to genuinely reproduce the reported bug by reverting each half of the fix (with both reverted: .completed locally -> .failed after rehydration). Full suite was 259 tests in 60 suites green before the review fixes, and the pipeline's own test step passed after them.

## What Changed

- Added `LiveClimbCompletionPolicy`, a pure unit-testable type that is now the single definition of finishing a Live Climb: reaching the climb's step target is the finish, and status reads steps rather than `stopReason`. `ClimbService.apply`, `WorkoutHydrationService`, and `ActiveHeadphoneWorkoutRecoveryView` all route through it, replacing the competing definitions that made a manually-ended climb past the target restore as `.failed` on reinstall. The step clamp moved into the policy's `recordedSteps` too, so saving and rehydrating the same session land on the same step count.
- `ClimbService.apply` now normalizes a saved workout's `stopReason` to `.targetReached` for the manual-stop case only, before `WorkoutMutationHandler.workoutsDidChange` runs, so the corrected metadata is what gets backed up and the replay Cloud Function agrees with no TypeScript change. `.interrupted` recovered drafts are deliberately left alone — they count locally as completions but stay unpublished, since a recovered draft's step count is hand-typed and a First Ascent is permanent. `HeadphoneMotionWorkoutMetadata.stopReason` became `var` to allow this; every other field stays `let`. The Cloud Function comment and a CLAUDE.md rule now record this asymmetry as intentional.
- `LiveClimbSessionViewModel.saveWorkout` returns a `SavedLiveClimbSession` carrying the real status off the `ClimbAttempt` that `apply` mutated, replacing a `historySummary` re-query whose `?? .completed` fallback could report a failed attempt as a finish. That fallback now applies only to Just Climb sessions, which have no attempt to rank.
- Added `LiveClimbCompletionPolicyTests`, `ClimbServiceTests` coverage for the manual-stop path, and an E2E `WorkoutHydrationServiceLiveClimbRestoreTests` suite exercising save → remote mapper → rehydrate into an empty store. The full suite passed at 267 tests across 60 suites; reverting both halves of the fix reproduced the reported failure exactly, and a short-of-target attempt still restores as `.failed`.

## Risk Assessment

✅ Low: The only change since the last review is a documentation-only edit to CLAUDE.md that resolves the previously flagged stale rule, and every claim in the new text checks out against the code, leaving the already-reviewed and well-tested implementation untouched.

## Testing

`I exercised the reinstall path end-to-end (save a climb -> serialize through the real remote sync mapper -> rehydrate into an empty store) and validated it at the surfaces the user actually experiences, not just the internal attempt record. The decisive check was a differential: reverting both halves of the fix reproduced the reported bug exactly - the attempt went .completed locally then .failed after rehydration with steps restated 1,000 -> 1,010, which the user reads as the Collection card flipping CLAIMED -> UNCLAIMED, collection count dropping to 0, and Climb Detail showing the self-contradicting row "failed - 1,010 of 1,000 steps"; with the fix in place before and after reinstall are identical. The negative control (an 800-step attempt) still restored as failed while the fix was reverted, so the suite is not vacuously passing. Because the existing tests asserted only the ClimbAttempt record, I added a test asserting through the real Collection/Climb Detail service surfaces; I dropped its transcript print since no other test in the suite prints and the assertion's failure message already renders the full before/after comparison. No screenshot was captured and one would not be informative here: reaching this surface live needs headphone-motion capture (unavailable in the simulator) plus an authenticated Firestore backup and real reinstall (QA credentials absent), and the defect is in the hydration derivation rather than rendering - so a screenshot would only show a completed climb drawing correctly, which was never in question. Intent's deliberate non-changes verified (Cloud Function untouched, hydration writes no remote work). Full suite green: 267 tests in 60 suites.`

<details>
<summary>Evidence: User-visible climb state before/after reinstall WITHOUT the fix (bug reproduced: CLAIMED -&gt; UNCLAIMED, &#34;failed - 1,010 of 1,000 steps&#34;)</summary>

<code>=== Reached the 1,000 step target, tapped End at 1,010 steps (stopReason: userStopped) ===&#10;BEFORE REINSTALL&#10;Collection card ....... CLAIMED (checkmark badge)&#10;Collection count ...... 1 climb(s)&#10;Climb Detail history .. 1 completion(s), 0 failed attempt(s)&#10;History row ........... completed - 1,000 of 1,000 steps&#10;AFTER REINSTALL (rehydrated from the remote backup into an empty store)&#10;Collection card ....... UNCLAIMED (no badge)&#10;Collection count ...... 0 climb(s)&#10;Climb Detail history .. 0 completion(s), 1 failed attempt(s)&#10;History row ........... failed - 1,010 of 1,000 steps&#10;===</code>

```text
=== Reached the 1,000 step target, tapped End at 1,010 steps (stopReason: userStopped) ===
BEFORE REINSTALL
  Collection card ....... CLAIMED (checkmark badge)
  Collection count ...... 1 climb(s)
  Climb Detail history .. 1 completion(s), 0 failed attempt(s)
  History row ........... completed - 1,000 of 1,000 steps
AFTER REINSTALL (rehydrated from the remote backup into an empty store)
  Collection card ....... UNCLAIMED (no badge)
  Collection count ...... 0 climb(s)
  Climb Detail history .. 0 completion(s), 1 failed attempt(s)
  History row ........... failed - 1,010 of 1,000 steps
===
✘ Test aFinishedClimbIsStillClaimedAcrossItsSurfacesAfterReinstall() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:197:9: Expectation failed: (after → "  Collection card ....... UNCLAIMED (no badge)
  Collection count ...... 0 climb(s)
  Climb Detail history .. 0 completion(s), 1 failed attempt(s)
  History row ........... failed - 1,010 of 1,000 steps") == (before → "  Collection card ....... CLAIMED (checkmark badge)
  Collection count ...... 1 climb(s)
  Climb Detail history .. 1 completion(s), 0 failed attempt(s)
  History row ........... completed - 1,000 of 1,000 steps")
↳ /// that record reaches - the Collection card's claimed state and the Climb Detail history.
```
</details>
<details>
<summary>Evidence: Same surfaces WITH the fix - the finished climb survives the reinstall unchanged</summary>

<code>=== Reached the 1,000 step target, tapped End at 1,010 steps (stopReason: userStopped) ===&#10;BEFORE REINSTALL&#10;Collection card ....... CLAIMED (checkmark badge)&#10;Collection count ...... 1 climb(s)&#10;Climb Detail history .. 1 completion(s), 0 failed attempt(s)&#10;History row ........... completed - 1,000 of 1,000 steps&#10;AFTER REINSTALL (rehydrated from the remote backup into an empty store)&#10;Collection card ....... CLAIMED (checkmark badge)&#10;Collection count ...... 1 climb(s)&#10;Climb Detail history .. 1 completion(s), 0 failed attempt(s)&#10;History row ........... completed - 1,000 of 1,000 steps&#10;===&#10;✔ Test run with 5 tests in 1 suite passed after 0.133 seconds.&#10;** TEST SUCCEEDED **</code>

```text
=== Reached the 1,000 step target, tapped End at 1,010 steps (stopReason: userStopped) ===
BEFORE REINSTALL
  Collection card ....... CLAIMED (checkmark badge)
  Collection count ...... 1 climb(s)
  Climb Detail history .. 1 completion(s), 0 failed attempt(s)
  History row ........... completed - 1,000 of 1,000 steps
AFTER REINSTALL (rehydrated from the remote backup into an empty store)
  Collection card ....... CLAIMED (checkmark badge)
  Collection count ...... 1 climb(s)
  Climb Detail history .. 1 completion(s), 0 failed attempt(s)
  History row ........... completed - 1,000 of 1,000 steps
===
✔ Test run with 5 tests in 1 suite passed after 0.133 seconds.
** TEST SUCCEEDED **
```
</details>
<details>
<summary>Evidence: Bug reproduction: reinstall E2E suite with both halves of the fix reverted (negative control still passes)</summary>

<code>✘ manuallyEndedClimbPastTheTargetSurvivesReinstallAsCompleted(): Expectation failed: (restoredAttempt.status → .failed) == .completed&#10;✘ ... Expectation failed: (restoredAttempt.accumulatedSteps → 1010) == (1_000 → 1000)&#10;✘ interruptedBackupPastTheTargetSurvivesReinstallAsCompleted(): (restoredAttempt.status → .failed) == .completed&#10;✘ legacyBackupWithAStaleStopReasonRestoresAsCompleted(): (restoredAttempt.status → .failed) == .completed&#10;✔ Test attemptShortOfTheTargetStillRestoresAsFailed() passed after 0.174 seconds. &lt;-- negative control: an 800-step attempt still correctly restores as failed&#10;✘ Test run with 4 tests in 1 suite failed after 0.178 seconds with 10 issues.&#10;** TEST FAILED **</code>

```text
✘ Test manuallyEndedClimbPastTheTargetSurvivesReinstallAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:43:9: Expectation failed: (restoredAttempt.status → .failed) == .completed
✘ Test manuallyEndedClimbPastTheTargetSurvivesReinstallAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:44:9: Expectation failed: (restoredAttempt.completedAt → nil) != nil
✘ Test manuallyEndedClimbPastTheTargetSurvivesReinstallAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:46:9: Expectation failed: (restoredAttempt.accumulatedSteps → 1010) == (1_000 → 1000)
✘ Test manuallyEndedClimbPastTheTargetSurvivesReinstallAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:47:9: Expectation failed: (restoredAttempt.accumulatedSteps → 1010) == (backup.localAttemptSteps → 1000)
✘ Test manuallyEndedClimbPastTheTargetSurvivesReinstallAsCompleted() failed after 0.170 seconds with 4 issues.
✘ Test interruptedBackupPastTheTargetSurvivesReinstallAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:118:9: Expectation failed: (restoredAttempt.status → .failed) == .completed
✘ Test interruptedBackupPastTheTargetSurvivesReinstallAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:119:9: Expectation failed: (restoredAttempt.completedAt → nil) != nil
✘ Test interruptedBackupPastTheTargetSurvivesReinstallAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:120:9: Expectation failed: (restoredAttempt.accumulatedSteps → 1010) == (1_000 → 1000)
✘ Test interruptedBackupPastTheTargetSurvivesReinstallAsCompleted() failed after 0.172 seconds with 3 issues.
✔ Test attemptShortOfTheTargetStillRestoresAsFailed() passed after 0.174 seconds.
✘ Test legacyBackupWithAStaleStopReasonRestoresAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:84:9: Expectation failed: (restoredAttempt.status → .failed) == .completed
✘ Test legacyBackupWithAStaleStopReasonRestoresAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:85:9: Expectation failed: (restoredAttempt.completedAt → nil) != nil
✘ Test legacyBackupWithAStaleStopReasonRestoresAsCompleted() recorded an issue at WorkoutHydrationServiceLiveClimbRestoreTests.swift:86:9: Expectation failed: (restoredAttempt.accumulatedSteps → 1010) == (1_000 → 1000)
✘ Test legacyBackupWithAStaleStopReasonRestoresAsCompleted() failed after 0.176 seconds with 3 issues.
✘ Test run with 4 tests in 1 suite failed after 0.178 seconds with 10 issues.
** TEST FAILED **
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- ℹ️ `AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift:54` - resolvedStopReason normalizes ANY stop reason to .targetReached once steps &gt;= target, including .interrupted, which is what ActiveHeadphoneWorkoutDraftSaver writes for recovered drafts (ActiveHeadphoneWorkoutDraftStore.swift:221). The replay Cloud Function gates publication on stopReason === &#34;target_reached&#34; (functions/src/liveReplayLeaderboard.ts:365), so before this change a recovered draft past the target counted locally but was never published; now it publishes to the per-climb replay leaderboard and is First Ascent eligible. This matters because the recovery view&#39;s step count is a free-entry TextField the user types (ActiveHeadphoneWorkoutRecoveryView.swift:158) and applyRecoveryStepSync accepts any non-negative value (ActiveHeadphoneWorkoutDraftStore.swift:119). Marginal exposure is small - the in-session step-sync prompt already yields .targetReached from a user-typed correction (HeadphoneMotionSessionService.swift:306), so this is parity with an already-permissive design, not a new vector - and the intent explicitly says the draft path should be healed. Flagging only because it extends what reaches permanent public prestige beyond the reinstall bug being fixed; if you&#39;d rather keep interrupted sessions out of public results, narrow resolvedStopReason to non-.interrupted reasons or add a Cloud Function guard.
- ℹ️ `AscendApp/Features/Climbs/Services/ClimbService.swift:318` - normalizeStopReason decodes sourceMetadata into HeadphoneMotionWorkoutMetadata, mutates one field, and re-encodes the whole struct back over workout.sourceMetadata. Any JSON key the struct does not model is silently dropped by that round trip. The replay Cloud Function reads metadata.attemptBaselineSteps as a publication guard (functions/src/liveReplayLeaderboard.ts:360-368: publish only when baselineSteps is null or 0), and that field has no corresponding property on HeadphoneMotionWorkoutMetadata. No Swift writer emits attemptBaselineSteps today, so this cannot misfire now - but if baseline-steps support is added to the metadata JSON without adding it to the struct, this rewrite would strip it and quietly defeat the server-side guard. A targeted JSONSerialization edit of just the stopReason key would be immune; otherwise this is a coupling worth knowing about.
- ℹ️ `AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift:1062` - apply was changed to @discardableResult -&gt; ClimbAttempt? specifically so callers can read the settled attempt, but saveWorkout discards the return and instead reads attempt?.status off the object returned by prepareLiveClimbAttempt. That is correct today only because SwiftData returns the same registered instance from apply&#39;s internal storedActiveAttempt fetch - an implicit dependency the inline comment acknowledges rather than removes. Binding apply&#39;s return (`let applied = try climbService.apply(...)`) and using `applied?.status ?? attempt?.status ?? .completed` reads the status from the object apply actually mutated and leaves the new return value used by production code rather than tests only.

🔧 Fix: Narrow stop reason normalization to manual stops only
2 issues (1 warning, 1 info) still open:
- ⚠️ `CLAUDE.md:334` - The Live Climbs bullet added by this branch states: &#34;`ClimbService.apply` normalizes the saved `stopReason` to `.targetReached` so rehydration and the replay Cloud Function agree with the status set at save time.&#34; After commit adec6fc narrowed LiveClimbCompletionPolicy.resolvedStopReason to `.userStopped` only (LiveClimbCompletionPolicy.swift:52), both halves of that sentence are wrong: apply normalizes only the manual-stop case, and for an `.interrupted` session past the target the client deliberately marks the attempt `.completed` while the Cloud Function deliberately refuses to publish it (functions/src/liveReplayLeaderboard.ts:365). This is not ordinary comment drift - CLAUDE.md declares itself the canonical context file that every AI provider on this repo reads (&#34;Project Context File (All AI Providers)&#34;), and its rules are treated as binding. A future agent reading line 334 would conclude `.interrupted` should also normalize and could silently undo the First Ascent safeguard the owner just chose. Update the bullet to say apply normalizes only a manual stop (`.userStopped`) past the target, and add the deliberate rule the owner decided: recovered drafts past the target count locally as `.completed` but stay unpublished, because a recovered draft&#39;s step count is typed by hand (ActiveHeadphoneWorkoutRecoveryView.swift:158) and First Ascent is permanent and never reclaimable. Rehydration agreeing is independent of the reason - it reads steps via the policy.
- ℹ️ `AscendApp/Features/Climbs/Models/LiveClimbCompletionPolicy.swift:52` - Informational, for whoever writes the commit/PR text at the document step. The recorded intent says normalization lives in apply &#34;because both save paths - the live session and the recovered-draft path in ActiveHeadphoneWorkoutDraftSaver, which saves .interrupted, funnel through apply, so both are healed.&#34; After the owner&#39;s round-1 narrowing, the recovered-draft path&#39;s stopReason is intentionally NOT normalized. This is not a contradiction of the intent&#39;s required behavior: the reinstall bug itself is still healed on both paths because hydration derives status from steps rather than the reason, and interruptedBackupPastTheTargetSurvivesReinstallAsCompleted (WorkoutHydrationServiceLiveClimbRestoreTests.swift:93) proves exactly that. Only the narrative explaining the mechanism is stale, and it should describe the narrowed rule rather than the original one. The type-header doc on LiveClimbCompletionPolicy (lines 5-9) is likewise slightly overstated now - it says the three readers &#34;must never disagree&#34;, while the Cloud Function deliberately diverges from local status for `.interrupted`; the resolvedStopReason doc directly below does explain this.

🔧 Fix: Correct stale stop reason normalization rule in CLAUDE.md
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`xcodebuild -scheme AscendApp -configuration Debug -destination &#39;platform=iOS Simulator,id=DC178358...&#39; -only-testing:AscendAppTests test` - full suite, 267 tests in 60 suites, all passed</code>
- <code>`-only-testing:AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests` - E2E reinstall path (save -&gt; real remote mapper -&gt; rehydrate into empty store)</code>
- <code>`-only-testing:AscendAppTests/LiveClimbCompletionPolicyTests` - the shared finish predicate, incl. `passingTheTargetLeavesANonManualStopReasonAlone` and `anInterruptedSessionPastTheTargetIsStillACompletion`</code>
- <code>`-only-testing:AscendAppTests/ClimbServiceTests` - incl. `endingManuallyPastTheTargetRecordsTheClimbAsTargetReached`</code>
- `Bug reproduction: reverted BOTH halves of the fix (ClimbService.normalizeStopReason call + WorkoutHydrationService policy call) and re-ran the reinstall suite - reproduced the reported failure exactly (status .completed -> .failed, accumulatedSteps 1000 -> 1010)`
- <code>Negative control while reverted: `attemptShortOfTheTargetStillRestoresAsFailed` still passed, proving the tests are not asserting &#39;always completed&#39;</code>
- <code>Added + ran `aFinishedClimbIsStillClaimedAcrossItsSurfacesAfterReinstall`, asserting the user-visible surfaces (`ClimbService.previewSummary` claimed badge, `collectionCount`, `historySummary` completions/failed counts and history row) survive reinstall</code>
- `Captured user-surface before/after reinstall transcripts WITH and WITHOUT the fix (temporary print instrumentation during validation; committed test asserts the same equality)`
- <code>Verified intent&#39;s deliberate non-changes: `git diff --stat ... -- functions/` empty (Cloud Function untouched); grepped WorkoutHydrationService for markPendingRemoteUpsert/Delete - none, so hydration does not rewrite remote data</code>
- <code>Confirmed worktree clean apart from the intentional test addition (`git status --porcelain`)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
