### PR TITLE
fix(leaderboards): rank ties competition-style to match the server

### DIFF
--- a/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
@@ -242,7 +242,8 @@ final class ClimbDetailViewModel {
             personalCurrentCompletionRank = LiveReplayCompletionRank(
                 rank: currentUserBestCompletion.rank,
                 completedCount: currentUserBestCompletion.completedCount,
-                updatedAt: currentUserBestCompletion.updatedAt
+                updatedAt: currentUserBestCompletion.updatedAt,
+                isTied: currentUserBestCompletion.isTied
             )
         } else {
             personalCurrentCompletionRank = nil

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -1036,10 +1036,22 @@ struct ClimbDetailView: View {
                 Spacer(minLength: 0)
 
                 VStack(alignment: .trailing, spacing: 4) {
-                    Text("#\(personalCurrentCompletionRank.rank.formatted())")
-                        .font(.montserratBold(size: 20))
-                        .foregroundStyle(.accent)
-                        .monospacedDigit()
+                    Text(
+                        CompetitionRanking.rankLabel(
+                            personalCurrentCompletionRank.rank,
+                            isTied: personalCurrentCompletionRank.isTied,
+                            untiedPrefix: "#"
+                        )
+                    )
+                    .font(.montserratBold(size: 20))
+                    .foregroundStyle(.accent)
+                    .monospacedDigit()
+                    .accessibilityLabel(
+                        CompetitionRanking.rankAccessibilityLabel(
+                            personalCurrentCompletionRank.rank,
+                            isTied: personalCurrentCompletionRank.isTied
+                        )
+                    )
 
                     Text("of \(personalCurrentCompletionRank.completedCount.formatted())")
                         .font(.montserratSemiBold(size: 12))
@@ -1062,7 +1074,7 @@ struct ClimbDetailView: View {
         let rowAccent = leaderboardAccentColor(for: rank)
 
         return HStack(alignment: .center, spacing: isFirst ? 14 : 12) {
-            leaderboardRankView(for: rank)
+            leaderboardRankView(for: row)
 
             leaderboardAvatar(
                 for: row,
@@ -1141,19 +1153,34 @@ struct ClimbDetailView: View {
     }
 
     @ViewBuilder
-    private func leaderboardRankView(for rank: Int?) -> some View {
+    private func leaderboardRankView(for row: LiveReplayLeaderboardRow) -> some View {
+        let rank = row.rank
+
         if rank == 1 {
+            // A shared crown reads as a tie on its own; the label says so out loud.
             Image(systemName: "crown.fill")
                 .font(.system(size: 15, weight: .bold))
                 .foregroundStyle(leaderboardGold)
                 .frame(width: 34, alignment: .leading)
-                .accessibilityLabel("Rank 1")
-        } else {
-            Text("#\(rank?.formatted() ?? "--")")
+                .accessibilityLabel(
+                    CompetitionRanking.rankAccessibilityLabel(1, isTied: row.isTied)
+                )
+        } else if let rank {
+            Text(CompetitionRanking.rankLabel(rank, isTied: row.isTied, untiedPrefix: "#"))
                 .font(.montserratBold(size: 15))
                 .foregroundStyle(leaderboardAccentColor(for: rank))
                 .frame(width: 34, alignment: .leading)
                 .monospacedDigit()
+                .accessibilityLabel(
+                    CompetitionRanking.rankAccessibilityLabel(rank, isTied: row.isTied)
+                )
+        } else {
+            Text("--")
+                .font(.montserratBold(size: 15))
+                .foregroundStyle(leaderboardAccentColor(for: rank))
+                .frame(width: 34, alignment: .leading)
+                .monospacedDigit()
+                .accessibilityLabel("Rank unavailable")
         }
     }
 

--- a/AscendApp/Features/Leaderboards/Models/LeaderboardEntry.swift
+++ b/AscendApp/Features/Leaderboards/Models/LeaderboardEntry.swift
@@ -33,6 +33,21 @@ struct LeaderboardEntry: Identifiable, Equatable, Sendable {
         self.isCurrentUser = isCurrentUser
         self.isTied = isTied
     }
+
+    /// A copy carrying a refreshed profile identity. Every ranking field is preserved:
+    /// a profile edit must never move the climber's rank or drop their tie marker.
+    func withProfile(displayName: String, photoURL: URL?) -> LeaderboardEntry {
+        LeaderboardEntry(
+            userId: userId,
+            displayName: displayName,
+            photoURL: photoURL,
+            rank: rank,
+            value: value,
+            formattedValue: formattedValue,
+            isCurrentUser: isCurrentUser,
+            isTied: isTied
+        )
+    }
 }
 
 struct FirestoreLeaderboardStats: Codable, Equatable, Sendable {

--- a/AscendApp/Features/Leaderboards/Models/LeaderboardEntry.swift
+++ b/AscendApp/Features/Leaderboards/Models/LeaderboardEntry.swift
@@ -5,10 +5,13 @@ struct LeaderboardEntry: Identifiable, Equatable, Sendable {
     let userId: String
     let displayName: String
     let photoURL: URL?
+    /// Standard competition rank ("1, 2, 2, 4") — tied entries share a rank.
     let rank: Int
     let value: Double
     let formattedValue: String
     let isCurrentUser: Bool
+    /// Whether at least one other entry shares this rank.
+    let isTied: Bool
 
     init(
         userId: String,
@@ -17,7 +20,8 @@ struct LeaderboardEntry: Identifiable, Equatable, Sendable {
         rank: Int,
         value: Double,
         formattedValue: String,
-        isCurrentUser: Bool = false
+        isCurrentUser: Bool = false,
+        isTied: Bool = false
     ) {
         self.id = userId
         self.userId = userId
@@ -27,6 +31,7 @@ struct LeaderboardEntry: Identifiable, Equatable, Sendable {
         self.value = value
         self.formattedValue = formattedValue
         self.isCurrentUser = isCurrentUser
+        self.isTied = isTied
     }
 }
 

--- a/AscendApp/Features/Leaderboards/Models/LeaderboardPodiumLayout.swift
+++ b/AscendApp/Features/Leaderboards/Models/LeaderboardPodiumLayout.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Assigns the top climbers to the three podium pedestals.
+///
+/// Pedestals are filled in leaderboard order, one climber each. A pedestal's `position`
+/// drives only its geometry — the climber standing on it carries their own competition
+/// rank, so two climbers tied for gold both read "T1" in gold even though only one
+/// pedestal can stand centre.
+///
+/// Keying pedestals by rank instead would silently drop climbers: competition ranking
+/// repeats ranks, so a tie collapses two climbers onto one pedestal and only the last
+/// one survives.
+struct LeaderboardPodiumLayout: Equatable {
+    static let slotCount = 3
+
+    struct Slot: Identifiable, Equatable {
+        /// 1 is the centre pedestal, 2 the left, 3 the right.
+        let position: Int
+        let entry: LeaderboardEntry?
+
+        var id: Int { position }
+
+        /// An empty pedestal falls back to its position, which is also the next rank
+        /// still up for grabs.
+        var displayedRank: Int {
+            entry?.rank ?? position
+        }
+
+        var isTied: Bool {
+            entry?.isTied ?? false
+        }
+    }
+
+    /// Pedestals in display order: left, centre, right.
+    let slots: [Slot]
+
+    init(entries: [LeaderboardEntry]) {
+        let ordered = Self.podiumEntries(from: entries)
+
+        slots = [2, 1, 3].map { position in
+            Slot(
+                position: position,
+                entry: ordered.indices.contains(position - 1) ? ordered[position - 1] : nil
+            )
+        }
+    }
+
+    /// The climbers who stand on the podium — the first three, by position.
+    ///
+    /// Splitting on `rank <= 3` instead would drop any climber past the third pedestal
+    /// who still holds a top-three rank (four climbers tied for 2nd, say) from the
+    /// podium and the list at once.
+    static func podiumEntries(from entries: [LeaderboardEntry]) -> [LeaderboardEntry] {
+        Array(entries.prefix(slotCount))
+    }
+
+    /// Everyone below the podium. Together with `podiumEntries` this covers every entry
+    /// exactly once.
+    static func listEntries(from entries: [LeaderboardEntry]) -> [LeaderboardEntry] {
+        Array(entries.dropFirst(slotCount))
+    }
+}

--- a/AscendApp/Features/Leaderboards/Repositories/LeaderboardRepository.swift
+++ b/AscendApp/Features/Leaderboards/Repositories/LeaderboardRepository.swift
@@ -123,6 +123,8 @@ final class LeaderboardRepository: Sendable {
             }
         }
 
+        // userId only breaks ties in the *ordering* — it never breaks ties in rank.
+        // Matches the server's ordering in functions/src/leaderboardAchievements.ts.
         let stats = statsByUserId.values.sorted {
             let lhs = $0.value(for: metric)
             let rhs = $1.value(for: metric)
@@ -144,11 +146,13 @@ final class LeaderboardRepository: Sendable {
             limit: 1000
         )
 
-        guard let index = allStats.firstIndex(where: { $0.userId == userId }) else {
+        guard let index = allStats.firstIndex(where: { $0.userId == userId }),
+              let rank = CompetitionRanking.rank(at: index, in: allStats, key: { $0.value(for: metric) })
+        else {
             return nil
         }
 
-        return (rank: index + 1, total: allStats.count)
+        return (rank: rank, total: allStats.count)
     }
 
     func updateProfilePictureURL(userId: String, photoURL: String) async throws {

--- a/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
+++ b/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
@@ -335,28 +335,14 @@ final class LeaderboardViewModel {
         guard let userId else { return }
 
         if let index = leaderboardEntries.firstIndex(where: { $0.userId == userId }) {
-            let existing = leaderboardEntries[index]
-            leaderboardEntries[index] = LeaderboardEntry(
-                userId: existing.userId,
+            leaderboardEntries[index] = leaderboardEntries[index].withProfile(
                 displayName: displayName,
-                photoURL: photoURL,
-                rank: existing.rank,
-                value: existing.value,
-                formattedValue: existing.formattedValue,
-                isCurrentUser: true
+                photoURL: photoURL
             )
         }
 
         if let entry = userEntry, entry.userId == userId {
-            userEntry = LeaderboardEntry(
-                userId: entry.userId,
-                displayName: displayName,
-                photoURL: photoURL,
-                rank: entry.rank,
-                value: entry.value,
-                formattedValue: entry.formattedValue,
-                isCurrentUser: true
-            )
+            userEntry = entry.withProfile(displayName: displayName, photoURL: photoURL)
         }
 
         let sessionCache = sessionCache

--- a/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
+++ b/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
@@ -381,16 +381,20 @@ final class LeaderboardViewModel {
 
     private func reapplyCurrentStats(userId: String) {
         let filteredStats = filtered(rawLeaderboardStats)
+        let metric = selectedMetric
+        let ranks = CompetitionRanking.ranks(for: filteredStats) { $0.value(for: metric) }
+        let tieFlags = CompetitionRanking.tieFlags(for: ranks)
         let entries = filteredStats.enumerated().map { index, stat in
-            let value = stat.value(for: selectedMetric)
+            let value = stat.value(for: metric)
             return LeaderboardEntry(
                 userId: stat.userId,
                 displayName: stat.displayName,
                 photoURL: stat.photoURL.flatMap(URL.init(string:)),
-                rank: index + 1,
+                rank: ranks[index],
                 value: value,
-                formattedValue: formatValue(value, for: selectedMetric),
-                isCurrentUser: stat.userId == userId
+                formattedValue: formatValue(value, for: metric),
+                isCurrentUser: stat.userId == userId,
+                isTied: tieFlags[index]
             )
         }
 

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardPodiumView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardPodiumView.swift
@@ -12,28 +12,13 @@ struct LeaderboardPodiumView: View {
     let metric: LeaderboardMetric
     var usesContainerBackground: Bool = false
 
-    private struct PodiumSlot: Identifiable {
-        let rank: Int
-        let entry: LeaderboardEntry?
-
-        var id: Int { rank }
-    }
-
-    private var podiumSlots: [PodiumSlot] {
-        let topRanks = entries
-            .filter { $0.rank <= 3 }
-            .reduce(into: [Int: LeaderboardEntry]()) { partialResult, entry in
-                partialResult[entry.rank] = entry
-            }
-
-        return [2, 1, 3].map { rank in
-            PodiumSlot(rank: rank, entry: topRanks[rank])
-        }
+    private var layout: LeaderboardPodiumLayout {
+        LeaderboardPodiumLayout(entries: entries)
     }
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 10) {
-            ForEach(podiumSlots) { slot in
+            ForEach(layout.slots) { slot in
                 podiumSlot(slot)
             }
         }
@@ -54,7 +39,7 @@ struct LeaderboardPodiumView: View {
     }
 
     @ViewBuilder
-    private func podiumSlot(_ slot: PodiumSlot) -> some View {
+    private func podiumSlot(_ slot: LeaderboardPodiumLayout.Slot) -> some View {
         if let entry = slot.entry, !entry.isCurrentUser {
             NavigationLink {
                 OtherUserProfileView(
@@ -64,7 +49,7 @@ struct LeaderboardPodiumView: View {
                 )
             } label: {
                 LeaderboardPodiumSlotView(
-                    rank: slot.rank,
+                    position: slot.position,
                     entry: slot.entry,
                     metric: metric
                 )
@@ -73,7 +58,7 @@ struct LeaderboardPodiumView: View {
             .frame(maxWidth: .infinity, alignment: .bottom)
         } else {
             LeaderboardPodiumSlotView(
-                rank: slot.rank,
+                position: slot.position,
                 entry: slot.entry,
                 metric: metric
             )
@@ -85,16 +70,26 @@ struct LeaderboardPodiumView: View {
 private struct LeaderboardPodiumSlotView: View {
     @Environment(\.colorScheme) private var colorScheme
 
-    let rank: Int
+    /// Which pedestal this is (1 centre, 2 left, 3 right). Drives geometry only.
+    let position: Int
     let entry: LeaderboardEntry?
     let metric: LeaderboardMetric
 
+    /// The climber's true competition rank — what the label and medal reflect.
+    private var rank: Int {
+        LeaderboardPodiumLayout.Slot(position: position, entry: entry).displayedRank
+    }
+
+    private var isTied: Bool {
+        entry?.isTied ?? false
+    }
+
     private var avatarSize: CGFloat {
-        rank == 1 ? 88 : 68
+        position == 1 ? 88 : 68
     }
 
     private var topInset: CGFloat {
-        rank == 1 ? 0 : 26
+        position == 1 ? 0 : 26
     }
 
     private var medalColor: Color {
@@ -175,10 +170,15 @@ private struct LeaderboardPodiumSlotView: View {
             crownedAvatar
                 .frame(width: avatarSize, height: avatarSize)
 
-            Text("\(rank)")
-                .font(.montserratBold(size: rank == 1 ? 38 : 32))
+            Text(CompetitionRanking.rankLabel(rank, isTied: isTied))
+                .font(.montserratBold(size: position == 1 ? 38 : 32))
                 .foregroundStyle(medalColor)
                 .lineLimit(1)
+                .minimumScaleFactor(0.72)
+                .monospacedDigit()
+                .accessibilityLabel(
+                    CompetitionRanking.rankAccessibilityLabel(rank, isTied: isTied)
+                )
 
             Text(displayName.uppercased())
                 .font(.montserratBold(size: 11))
@@ -200,7 +200,7 @@ private struct LeaderboardPodiumSlotView: View {
                     .lineLimit(1)
             }
         }
-        .frame(minHeight: rank == 1 ? 184 : 176, alignment: .bottom)
+        .frame(minHeight: position == 1 ? 184 : 176, alignment: .bottom)
     }
 
     private var crownedAvatar: some View {
@@ -249,11 +249,11 @@ private struct LeaderboardPodiumSlotView: View {
                     placeholderAvatar
                 }
             }
-            .podiumRing(gradient: ringGradient, glow: glowColor, lineWidth: rank == 1 ? 4 : 3, colorScheme: colorScheme)
+            .podiumRing(gradient: ringGradient, glow: glowColor, lineWidth: position == 1 ? 4 : 3, colorScheme: colorScheme)
             .id(photoURL)
         } else {
             placeholderAvatar
-                .podiumRing(gradient: ringGradient, glow: glowColor, lineWidth: rank == 1 ? 4 : 3, colorScheme: colorScheme)
+                .podiumRing(gradient: ringGradient, glow: glowColor, lineWidth: position == 1 ? 4 : 3, colorScheme: colorScheme)
         }
     }
 
@@ -262,7 +262,7 @@ private struct LeaderboardPodiumSlotView: View {
             .fill(colorScheme == .dark ? .white.opacity(0.10) : .black.opacity(0.08))
             .overlay(
                 Image(systemName: entry == nil ? "sparkles" : "person.fill")
-                    .font(.system(size: rank == 1 ? 24 : 20, weight: .semibold))
+                    .font(.system(size: position == 1 ? 24 : 20, weight: .semibold))
                     .foregroundStyle(colorScheme == .dark ? .white.opacity(0.56) : .black.opacity(0.42))
             )
     }

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardPodiumView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardPodiumView.swift
@@ -48,21 +48,13 @@ struct LeaderboardPodiumView: View {
                     seedPhotoURL: entry.photoURL
                 )
             } label: {
-                LeaderboardPodiumSlotView(
-                    position: slot.position,
-                    entry: slot.entry,
-                    metric: metric
-                )
+                LeaderboardPodiumSlotView(slot: slot, metric: metric)
             }
             .buttonStyle(.plain)
             .frame(maxWidth: .infinity, alignment: .bottom)
         } else {
-            LeaderboardPodiumSlotView(
-                position: slot.position,
-                entry: slot.entry,
-                metric: metric
-            )
-            .frame(maxWidth: .infinity, alignment: .bottom)
+            LeaderboardPodiumSlotView(slot: slot, metric: metric)
+                .frame(maxWidth: .infinity, alignment: .bottom)
         }
     }
 }
@@ -70,18 +62,25 @@ struct LeaderboardPodiumView: View {
 private struct LeaderboardPodiumSlotView: View {
     @Environment(\.colorScheme) private var colorScheme
 
-    /// Which pedestal this is (1 centre, 2 left, 3 right). Drives geometry only.
-    let position: Int
-    let entry: LeaderboardEntry?
+    let slot: LeaderboardPodiumLayout.Slot
     let metric: LeaderboardMetric
+
+    /// Which pedestal this is (1 centre, 2 left, 3 right). Drives geometry only.
+    private var position: Int {
+        slot.position
+    }
+
+    private var entry: LeaderboardEntry? {
+        slot.entry
+    }
 
     /// The climber's true competition rank — what the label and medal reflect.
     private var rank: Int {
-        LeaderboardPodiumLayout.Slot(position: position, entry: entry).displayedRank
+        slot.displayedRank
     }
 
     private var isTied: Bool {
-        entry?.isTied ?? false
+        slot.isTied
     }
 
     private var avatarSize: CGFloat {

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardRow.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardRow.swift
@@ -19,10 +19,11 @@ struct LeaderboardRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Text("\(entry.rank)")
+            Text(CompetitionRanking.rankLabel(entry.rank, isTied: entry.isTied))
                 .font(.montserratMedium(size: 14))
                 .foregroundStyle(primaryTextColor.opacity(0.82))
                 .frame(width: 34, alignment: .leading)
+                .monospacedDigit()
 
             Text(entry.displayName.uppercased())
                 .font(.montserratMedium(size: 13))
@@ -41,7 +42,10 @@ struct LeaderboardRow: View {
         .frame(height: 36)
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Rank \(entry.rank), \(entry.displayName), \(entry.formattedValue) \(metric.displayName)")
+        .accessibilityLabel(
+            "\(CompetitionRanking.rankAccessibilityLabel(entry.rank, isTied: entry.isTied)), "
+                + "\(entry.displayName), \(entry.formattedValue) \(metric.displayName)"
+        )
     }
 }
 

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardUserRowView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardUserRowView.swift
@@ -26,12 +26,13 @@ struct LeaderboardUserRowView: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Text("\(entry.rank)")
+            Text(CompetitionRanking.rankLabel(entry.rank, isTied: entry.isTied))
                 .font(.montserratBold(size: 30))
                 .foregroundStyle(.accent)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
                 .frame(width: 52, alignment: .leading)
+                .monospacedDigit()
 
             profileImage
                 .frame(width: 42, height: 42)
@@ -99,7 +100,10 @@ struct LeaderboardUserRowView: View {
     }
 
     private var accessibilityLabel: String {
-        let base = "Your rank \(entry.rank), \(entry.displayName), \(entry.formattedValue) \(metric.displayName)"
+        let rankText = entry.isTied
+            ? "You are tied for rank \(entry.rank)"
+            : "Your rank \(entry.rank)"
+        let base = "\(rankText), \(entry.displayName), \(entry.formattedValue) \(metric.displayName)"
         guard let crownGapText else {
             return base
         }

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
@@ -465,8 +465,8 @@ struct LeaderboardView: View {
     }
 
     private func presentationState(for entries: [LeaderboardEntry]) -> LeaderboardPresentationState {
-        let podiumEntries = entries.filter { $0.rank <= 3 }
-        let listEntries = entries.filter { $0.rank > 3 }
+        let podiumEntries = LeaderboardPodiumLayout.podiumEntries(from: entries)
+        let listEntries = LeaderboardPodiumLayout.listEntries(from: entries)
 
         guard let userEntry = viewModel.userEntry else {
             return LeaderboardPresentationState(
@@ -476,7 +476,7 @@ struct LeaderboardView: View {
             )
         }
 
-        if shouldPinUserRow(userEntry) {
+        if shouldPinUserRow(userEntry, podiumEntries: podiumEntries) {
             let dedupedRows = listEntries.filter { $0.userId != userEntry.userId }
             return LeaderboardPresentationState(
                 podiumEntries: podiumEntries,
@@ -492,8 +492,11 @@ struct LeaderboardView: View {
         )
     }
 
-    private func shouldPinUserRow(_ entry: LeaderboardEntry) -> Bool {
-        entry.rank > 3
+    private func shouldPinUserRow(
+        _ entry: LeaderboardEntry,
+        podiumEntries: [LeaderboardEntry]
+    ) -> Bool {
+        !podiumEntries.contains { $0.userId == entry.userId }
     }
 
     private func crownGapText(for userEntry: LeaderboardEntry, podiumEntries: [LeaderboardEntry]) -> String? {

--- a/AscendApp/Features/Profile/Services/ProfileStandingService.swift
+++ b/AscendApp/Features/Profile/Services/ProfileStandingService.swift
@@ -180,20 +180,11 @@ final class ProfileStandingService: Sendable {
     private func competitionRankedRows(
         _ stats: [FirestoreLeaderboardStats]
     ) -> [(stat: FirestoreLeaderboardStats, rank: Int, value: Double)] {
-        var rows: [(FirestoreLeaderboardStats, Int, Double)] = []
-        var lastValue: Double?
-        var currentRank = 0
+        let ranks = CompetitionRanking.ranks(for: stats) { $0.value(for: .climb) }
 
-        for (index, stat) in stats.enumerated() {
-            let value = stat.value(for: .climb)
-            if lastValue != value {
-                currentRank = index + 1
-                lastValue = value
-            }
-            rows.append((stat, currentRank, value))
+        return zip(stats, ranks).map { stat, rank in
+            (stat: stat, rank: rank, value: stat.value(for: .climb))
         }
-
-        return rows
     }
 
     private func thresholdValue(

--- a/AscendApp/Shared/Components/ReplayLeaderboard/ReplayCompletionLeaderboardView.swift
+++ b/AscendApp/Shared/Components/ReplayLeaderboard/ReplayCompletionLeaderboardView.swift
@@ -285,17 +285,30 @@ private struct ReplayCompletionLeaderboardRowView: View {
     @ViewBuilder
     private func rankView(for rank: Int?) -> some View {
         if rank == 1 {
+            // A shared crown reads as a tie on its own; the label says so out loud.
             Image(systemName: "crown.fill")
                 .font(.system(size: 15, weight: .bold))
                 .foregroundStyle(leaderboardGold)
                 .frame(width: 34, alignment: .leading)
-                .accessibilityLabel("Rank 1")
-        } else {
-            Text("#\(rank?.formatted() ?? "--")")
+                .accessibilityLabel(
+                    CompetitionRanking.rankAccessibilityLabel(1, isTied: row.isTied)
+                )
+        } else if let rank {
+            Text(CompetitionRanking.rankLabel(rank, isTied: row.isTied, untiedPrefix: "#"))
                 .font(.montserratBold(size: 15))
                 .foregroundStyle(leaderboardAccentColor(for: rank))
                 .frame(width: 34, alignment: .leading)
                 .monospacedDigit()
+                .accessibilityLabel(
+                    CompetitionRanking.rankAccessibilityLabel(rank, isTied: row.isTied)
+                )
+        } else {
+            Text("--")
+                .font(.montserratBold(size: 15))
+                .foregroundStyle(leaderboardAccentColor(for: rank))
+                .frame(width: 34, alignment: .leading)
+                .monospacedDigit()
+                .accessibilityLabel("Rank unavailable")
         }
     }
 

--- a/AscendApp/Shared/Models/CompetitionRanking.swift
+++ b/AscendApp/Shared/Models/CompetitionRanking.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+/// Standard competition ranking ("1, 2, 2, 4"): rows sharing a ranking value share a
+/// rank, and the next distinct value skips ahead by the size of the tie group.
+///
+/// This is the single client-side definition of rank. It mirrors the Cloud Functions
+/// ranking in `functions/src/leaderboardAchievements.ts` and
+/// `functions/src/liveReplayLeaderboard.ts` so a client-displayed rank never contradicts
+/// the rank the server used to award an achievement.
+enum CompetitionRanking {
+    /// Carries the tail of a ranked page across a page boundary so a tie group split
+    /// by pagination keeps one rank.
+    struct Continuation<Key: Equatable>: Equatable, Sendable where Key: Sendable {
+        /// Ranking value of the last row ranked so far.
+        let lastKey: Key
+        /// Rank assigned to that row.
+        let lastRank: Int
+        /// How many rows have been ranked so far, across all previous pages.
+        let rankedCount: Int
+
+        init(lastKey: Key, lastRank: Int, rankedCount: Int) {
+            self.lastKey = lastKey
+            self.lastRank = max(lastRank, 1)
+            self.rankedCount = max(rankedCount, 0)
+        }
+    }
+
+    /// Assigns competition ranks to `items`, which must already be sorted best-first by
+    /// the same key this ranks on.
+    ///
+    /// - Parameters:
+    ///   - items: The pre-sorted rows to rank.
+    ///   - continuation: Tail of the previous page, when ranking a paginated list.
+    ///     Pass `nil` for the first page.
+    ///   - key: The ranking value. Rows with equal keys are tied.
+    /// - Returns: One rank per item, in the same order as `items`.
+    static func ranks<Item, Key: Equatable>(
+        for items: [Item],
+        continuing continuation: Continuation<Key>? = nil,
+        key: (Item) -> Key
+    ) -> [Int] {
+        var ranks: [Int] = []
+        ranks.reserveCapacity(items.count)
+
+        let rankedCountBefore = continuation?.rankedCount ?? 0
+        var previousKey: Key? = continuation?.lastKey
+        var previousRank = continuation?.lastRank ?? 0
+
+        for (offset, item) in items.enumerated() {
+            let itemKey = key(item)
+            if itemKey != previousKey {
+                previousRank = rankedCountBefore + offset + 1
+                previousKey = itemKey
+            }
+            ranks.append(previousRank)
+        }
+
+        return ranks
+    }
+
+    /// The continuation to hand to the next page after ranking `items` with `ranks`.
+    /// Returns `nil` when there is nothing to carry forward.
+    static func continuation<Item, Key: Equatable>(
+        after items: [Item],
+        ranks: [Int],
+        continuing continuation: Continuation<Key>? = nil,
+        key: (Item) -> Key
+    ) -> Continuation<Key>? {
+        guard let lastItem = items.last, let lastRank = ranks.last else {
+            return continuation
+        }
+
+        return Continuation(
+            lastKey: key(lastItem),
+            lastRank: lastRank,
+            rankedCount: (continuation?.rankedCount ?? 0) + items.count
+        )
+    }
+
+    /// Display token for a rank. A tie takes a "T" prefix — the sports-leaderboard
+    /// convention — so a shared rank is obvious at a glance rather than reading as an
+    /// ordinary ordering. Tied and untied labels stay the same width.
+    ///
+    /// - Parameter untiedPrefix: Prefix for the untied label, matching whatever the
+    ///   calling surface already uses ("#" on the per-climb board, "" on the global
+    ///   board). The "T" replaces it when tied, so "T" always means tied.
+    static func rankLabel(_ rank: Int, isTied: Bool, untiedPrefix: String = "") -> String {
+        isTied ? "T\(rank.formatted())" : "\(untiedPrefix)\(rank.formatted())"
+    }
+
+    /// Spoken equivalent of `rankLabel`, for accessibility labels.
+    static func rankAccessibilityLabel(_ rank: Int, isTied: Bool) -> String {
+        isTied ? "Tied for rank \(rank)" : "Rank \(rank)"
+    }
+
+    /// Marks which of `ranks` are shared with at least one other row, so tied rows can
+    /// be called out in the UI.
+    ///
+    /// `ranks` must be a contiguous run of a single ranked ordering. A tie group split
+    /// across a pagination boundary reads as untied until the neighbouring page loads
+    /// and the flags are recomputed over the merged rows.
+    static func tieFlags(for ranks: [Int]) -> [Bool] {
+        var countsByRank: [Int: Int] = [:]
+        for rank in ranks {
+            countsByRank[rank, default: 0] += 1
+        }
+
+        return ranks.map { (countsByRank[$0] ?? 0) > 1 }
+    }
+
+    /// The competition rank of the row at `index` in a pre-sorted list — equivalently,
+    /// one more than the number of strictly better rows.
+    static func rank<Item, Key: Equatable>(
+        at index: Int,
+        in items: [Item],
+        key: (Item) -> Key
+    ) -> Int? {
+        guard items.indices.contains(index) else { return nil }
+
+        let target = key(items[index])
+        var rank = index + 1
+        var cursor = index
+        while cursor > 0, key(items[cursor - 1]) == target {
+            cursor -= 1
+            rank -= 1
+        }
+
+        return rank
+    }
+
+    /// Whether the row at `index` shares its rank with at least one other row.
+    static func isTied<Item, Key: Equatable>(
+        at index: Int,
+        in items: [Item],
+        key: (Item) -> Key
+    ) -> Bool {
+        guard items.indices.contains(index) else { return false }
+
+        let target = key(items[index])
+        if index > 0, key(items[index - 1]) == target { return true }
+        if index < items.count - 1, key(items[index + 1]) == target { return true }
+        return false
+    }
+}

--- a/AscendApp/Shared/Models/CompetitionRanking.swift
+++ b/AscendApp/Shared/Models/CompetitionRanking.swift
@@ -58,25 +58,6 @@ enum CompetitionRanking {
         return ranks
     }
 
-    /// The continuation to hand to the next page after ranking `items` with `ranks`.
-    /// Returns `nil` when there is nothing to carry forward.
-    static func continuation<Item, Key: Equatable>(
-        after items: [Item],
-        ranks: [Int],
-        continuing continuation: Continuation<Key>? = nil,
-        key: (Item) -> Key
-    ) -> Continuation<Key>? {
-        guard let lastItem = items.last, let lastRank = ranks.last else {
-            return continuation
-        }
-
-        return Continuation(
-            lastKey: key(lastItem),
-            lastRank: lastRank,
-            rankedCount: (continuation?.rankedCount ?? 0) + items.count
-        )
-    }
-
     /// Display token for a rank. A tie takes a "T" prefix — the sports-leaderboard
     /// convention — so a shared rank is obvious at a glance rather than reading as an
     /// ordinary ordering. Tied and untied labels stay the same width.
@@ -126,19 +107,5 @@ enum CompetitionRanking {
         }
 
         return rank
-    }
-
-    /// Whether the row at `index` shares its rank with at least one other row.
-    static func isTied<Item, Key: Equatable>(
-        at index: Int,
-        in items: [Item],
-        key: (Item) -> Key
-    ) -> Bool {
-        guard items.indices.contains(index) else { return false }
-
-        let target = key(items[index])
-        if index > 0, key(items[index - 1]) == target { return true }
-        if index < items.count - 1, key(items[index + 1]) == target { return true }
-        return false
     }
 }

--- a/AscendApp/Shared/Repositories/Firebase/FirestoreLiveReplayLeaderboardRepository.swift
+++ b/AscendApp/Shared/Repositories/Firebase/FirestoreLiveReplayLeaderboardRepository.swift
@@ -174,9 +174,14 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
             context: context,
             bucketIndex: 0
         )
+        async let sameDurationCompletionCount = countRowsMatching(
+            context: context,
+            completionDurationSeconds: completionDurationSeconds
+        )
 
         let fasterCount = try await fasterCompletionCount
         let publishedCount = try await publishedCompletionCount
+        let sameDurationCount = try await sameDurationCompletionCount
         let completedCount = max(publishedCount, fasterCount + 1)
 
         return LiveReplayCurrentUserCompletion(
@@ -184,7 +189,8 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
             completedCount: completedCount,
             completionDurationSeconds: completionDurationSeconds,
             workoutId: stringValue(for: "workoutId", in: bestDocument.data()) ?? bestDocument.documentID,
-            updatedAt: timestampValue(for: "updatedAt", in: bestDocument.data())
+            updatedAt: timestampValue(for: "updatedAt", in: bestDocument.data()),
+            isTied: sameDurationCount > 1
         )
     }
 
@@ -217,7 +223,6 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
         forceRefresh: Bool
     ) async throws -> LiveReplayCompletionLeaderboard {
         let resolvedLimit = max(limit, 1)
-        let startRank = cursor?.nextRank ?? 1
         var query: Query = entriesCollection(context: context, bucketIndex: 0)
             .order(by: "completionDurationSeconds", descending: false)
             .order(by: FieldPath.documentID(), descending: false)
@@ -246,17 +251,41 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
 
         let snapshot = try await rowSnapshot
         let currentUserId = Auth.auth().currentUser?.uid
-        let rows = snapshot.documents.enumerated().compactMap { offset, document in
-            parseCompletionRow(
+
+        // Rank on the raw duration, matching the server's strict `<` count in
+        // functions/src/liveReplayLeaderboard.ts (completionRankForPayload) — and so
+        // matching the pinned row, which derives its rank from countRowsFasterThan.
+        let rankable = snapshot.documents.compactMap { document -> RankableCompletion? in
+            guard let durationSeconds = doubleValue(
+                for: "completionDurationSeconds",
+                in: document.data()
+            ) else {
+                return nil
+            }
+
+            return RankableCompletion(
                 id: document.documentID,
                 data: document.data(),
-                rank: startRank + offset,
+                durationSeconds: durationSeconds
+            )
+        }
+
+        let ranks = CompetitionRanking.ranks(
+            for: rankable,
+            continuing: cursor?.rankingContinuation,
+            key: \.durationSeconds
+        )
+        let rows = zip(rankable, ranks).compactMap { completion, rank in
+            parseCompletionRow(
+                id: completion.id,
+                data: completion.data,
+                rank: rank,
                 currentUserId: currentUserId
             )
         }
         let completedCount = max(
             resolvedCompletedCount,
-            startRank + max(rows.count - 1, 0)
+            (cursor?.rankedCount ?? 0) + rows.count
         )
 
         return LiveReplayCompletionLeaderboard(
@@ -266,10 +295,17 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
             nextCursor: nextCompletionLeaderboardCursor(
                 documents: snapshot.documents,
                 rows: rows,
+                rankedCount: (cursor?.rankedCount ?? 0) + rows.count,
                 completedCount: completedCount,
                 pageSize: resolvedLimit
             )
         )
+    }
+
+    private struct RankableCompletion {
+        let id: String
+        let data: [String: Any]
+        let durationSeconds: TimeInterval
     }
 
     func fetchWindow(
@@ -402,6 +438,17 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
     ) async throws -> Int {
         let query = entriesCollection(context: context, bucketIndex: 0)
             .whereField("completionDurationSeconds", isLessThan: max(completionDurationSeconds, 0))
+
+        let snapshot = try await query.count.getAggregation(source: .server)
+        return snapshot.count.intValue
+    }
+
+    private func countRowsMatching(
+        context: LiveReplayLeaderboardContext,
+        completionDurationSeconds: TimeInterval
+    ) async throws -> Int {
+        let query = entriesCollection(context: context, bucketIndex: 0)
+            .whereField("completionDurationSeconds", isEqualTo: max(completionDurationSeconds, 0))
 
         let snapshot = try await query.count.getAggregation(source: .server)
         return snapshot.count.intValue
@@ -576,6 +623,7 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
     private func nextCompletionLeaderboardCursor(
         documents: [QueryDocumentSnapshot],
         rows: [LiveReplayLeaderboardRow],
+        rankedCount: Int,
         completedCount: Int,
         pageSize: Int
     ) -> LiveReplayCompletionLeaderboardCursor? {
@@ -586,15 +634,16 @@ final class FirestoreLiveReplayLeaderboardRepository: LiveReplayLeaderboardRepos
                 for: "completionDurationSeconds",
                 in: lastDocument.data()
               ) ?? rows.last?.completionDurationSeconds,
-              let nextRank = rows.last?.rank.map({ $0 + 1 }),
-              nextRank <= completedCount else {
+              let lastRank = rows.last?.rank,
+              rankedCount < completedCount else {
             return nil
         }
 
         return LiveReplayCompletionLeaderboardCursor(
             completionDurationSeconds: durationSeconds,
             rowID: lastDocument.documentID,
-            nextRank: nextRank
+            lastRank: lastRank,
+            rankedCount: rankedCount
         )
     }
 

--- a/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
+++ b/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
@@ -59,36 +59,45 @@ private extension String {
 }
 
 struct LiveReplayCompletionRank: Equatable, Sendable {
+    /// Standard competition rank — one more than the number of strictly faster attempts.
     let rank: Int
     let completedCount: Int
     let updatedAt: Date?
+    /// Whether another attempt shares this exact completion time, and so this rank.
+    let isTied: Bool
 
-    init(rank: Int, completedCount: Int, updatedAt: Date?) {
+    init(rank: Int, completedCount: Int, updatedAt: Date?, isTied: Bool = false) {
         self.rank = max(rank, 1)
         self.completedCount = max(completedCount, 1)
         self.updatedAt = updatedAt
+        self.isTied = isTied
     }
 }
 
 struct LiveReplayCurrentUserCompletion: Equatable, Sendable {
+    /// Standard competition rank — one more than the number of strictly faster attempts.
     let rank: Int
     let completedCount: Int
     let completionDurationSeconds: TimeInterval
     let workoutId: String
     let updatedAt: Date?
+    /// Whether another attempt shares this exact completion time, and so this rank.
+    let isTied: Bool
 
     init(
         rank: Int,
         completedCount: Int,
         completionDurationSeconds: TimeInterval,
         workoutId: String,
-        updatedAt: Date?
+        updatedAt: Date?,
+        isTied: Bool = false
     ) {
         self.rank = max(rank, 1)
         self.completedCount = max(completedCount, 1)
         self.completionDurationSeconds = max(completionDurationSeconds, 0)
         self.workoutId = workoutId.trimmingCharacters(in: .whitespacesAndNewlines)
         self.updatedAt = updatedAt
+        self.isTied = isTied
     }
 }
 
@@ -189,18 +198,33 @@ struct LiveReplayPublishStatus: Equatable, Sendable {
 }
 
 struct LiveReplayCompletionLeaderboardCursor: Equatable, Sendable {
+    /// Sort key of the last fetched row — the Firestore pagination position.
     let completionDurationSeconds: TimeInterval
     let rowID: String
-    let nextRank: Int
+    /// Competition rank of the last ranked row. Carried so a tie group split across a
+    /// page boundary keeps one rank instead of restarting at the next position.
+    let lastRank: Int
+    /// How many rows have been ranked across every page so far.
+    let rankedCount: Int
 
     init(
         completionDurationSeconds: TimeInterval,
         rowID: String,
-        nextRank: Int
+        lastRank: Int,
+        rankedCount: Int
     ) {
         self.completionDurationSeconds = max(completionDurationSeconds, 0)
         self.rowID = rowID.trimmingCharacters(in: .whitespacesAndNewlines)
-        self.nextRank = max(nextRank, 1)
+        self.lastRank = max(lastRank, 1)
+        self.rankedCount = max(rankedCount, 0)
+    }
+
+    var rankingContinuation: CompetitionRanking.Continuation<TimeInterval> {
+        CompetitionRanking.Continuation(
+            lastKey: completionDurationSeconds,
+            lastRank: lastRank,
+            rankedCount: rankedCount
+        )
     }
 }
 
@@ -210,16 +234,34 @@ struct LiveReplayCompletionLeaderboard: Equatable, Sendable {
     let updatedAt: Date?
     let nextCursor: LiveReplayCompletionLeaderboardCursor?
 
+    /// Rows arrive already carrying their competition rank — only the repository knows
+    /// the full ordering and the pagination continuation needed to assign one. Tie flags
+    /// are derived here instead, so a tie group split across a page boundary corrects
+    /// itself the moment `appending(_:)` merges the neighbouring page.
     init(
         rows: [LiveReplayLeaderboardRow],
         completedCount: Int,
         updatedAt: Date?,
         nextCursor: LiveReplayCompletionLeaderboardCursor? = nil
     ) {
-        self.rows = rows
+        self.rows = Self.flaggingTies(in: rows)
         self.completedCount = max(completedCount, rows.count, 0)
         self.updatedAt = updatedAt
         self.nextCursor = nextCursor
+    }
+
+    private static func flaggingTies(
+        in rows: [LiveReplayLeaderboardRow]
+    ) -> [LiveReplayLeaderboardRow] {
+        var countsByRank: [Int: Int] = [:]
+        for rank in rows.compactMap(\.rank) {
+            countsByRank[rank, default: 0] += 1
+        }
+
+        return rows.map { row in
+            let isTied = row.rank.map { (countsByRank[$0] ?? 0) > 1 } ?? false
+            return row.isTied == isTied ? row : row.updating(isTied: isTied)
+        }
     }
 
     var hasMoreRows: Bool {
@@ -250,6 +292,7 @@ struct LiveReplayCompletionLeaderboard: Equatable, Sendable {
 
 struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
     let id: String
+    /// Standard competition rank ("1, 2, 2, 4") — tied rows share a rank.
     let rank: Int?
     let displayName: String
     let avatarToken: String
@@ -264,6 +307,8 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
     let gender: String?
     let age: Int?
     let locationCity: String?
+    /// Whether at least one other row shares this rank.
+    let isTied: Bool
 
     init(
         id: String,
@@ -280,7 +325,8 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
         userId: String? = nil,
         gender: String? = nil,
         age: Int? = nil,
-        locationCity: String? = nil
+        locationCity: String? = nil,
+        isTied: Bool = false
     ) {
         self.id = id
         self.rank = rank
@@ -297,7 +343,9 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
         self.gender = Self.cleanedString(gender)
         self.age = Self.validAge(age)
         self.locationCity = Self.cleanedString(locationCity)
+        self.isTied = isTied
     }
+
 
     var averageStepsPerMinute: Double? {
         guard let completionDurationSeconds,
@@ -394,7 +442,8 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
     func updating(
         rank: Int? = nil,
         stepsAtBucket: Int? = nil,
-        deltaFromUser: Int? = nil
+        deltaFromUser: Int? = nil,
+        isTied: Bool? = nil
     ) -> LiveReplayLeaderboardRow {
         LiveReplayLeaderboardRow(
             id: id,
@@ -411,7 +460,8 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
             userId: userId,
             gender: gender,
             age: age,
-            locationCity: locationCity
+            locationCity: locationCity,
+            isTied: isTied ?? self.isTied
         )
     }
 

--- a/AscendAppTests/CompetitionRankingTests.swift
+++ b/AscendAppTests/CompetitionRankingTests.swift
@@ -63,10 +63,10 @@ struct CompetitionRankingTests {
     func continuationKeepsOneRankForATieGroupSplitAcrossPages() {
         let firstPage = [30, 20]
         let firstRanks = CompetitionRanking.ranks(for: firstPage) { $0 }
-        let continuation = CompetitionRanking.continuation(
-            after: firstPage,
-            ranks: firstRanks,
-            key: { $0 }
+        let continuation = CompetitionRanking.Continuation(
+            lastKey: firstPage[1],
+            lastRank: firstRanks[1],
+            rankedCount: firstPage.count
         )
 
         // The next page opens with the same value the previous page ended on.
@@ -91,40 +91,6 @@ struct CompetitionRankingTests {
         let ranks = CompetitionRanking.ranks(for: [10, 5], continuing: continuation) { $0 }
 
         #expect(ranks == [4, 5])
-    }
-
-    @Test
-    func continuationAfterAnEmptyPageIsUnchanged() {
-        let continuation = CompetitionRanking.Continuation(
-            lastKey: 20,
-            lastRank: 2,
-            rankedCount: 3
-        )
-
-        let next = CompetitionRanking.continuation(
-            after: [Int](),
-            ranks: [],
-            continuing: continuation,
-            key: { $0 }
-        )
-
-        #expect(next == continuation)
-    }
-
-    @Test
-    func continuationAccumulatesRankedCountAcrossPages() {
-        let page = [20, 10]
-        let ranks = CompetitionRanking.ranks(for: page) { $0 }
-        let first = CompetitionRanking.continuation(after: page, ranks: ranks, key: { $0 })
-        let second = CompetitionRanking.continuation(
-            after: page,
-            ranks: ranks,
-            continuing: first,
-            key: { $0 }
-        )
-
-        #expect(first?.rankedCount == 2)
-        #expect(second?.rankedCount == 4)
     }
 
     // MARK: - Single-row lookups
@@ -154,16 +120,6 @@ struct CompetitionRankingTests {
     func rankAtOutOfBoundsIndexIsNil() {
         #expect(CompetitionRanking.rank(at: 3, in: [30, 20], key: { $0 }) == nil)
         #expect(CompetitionRanking.rank(at: -1, in: [30, 20], key: { $0 }) == nil)
-    }
-
-    @Test
-    func isTiedDetectsNeighboursOnEitherSide() {
-        let values = [30, 20, 20, 10]
-
-        #expect(CompetitionRanking.isTied(at: 0, in: values, key: { $0 }) == false)
-        #expect(CompetitionRanking.isTied(at: 1, in: values, key: { $0 }))
-        #expect(CompetitionRanking.isTied(at: 2, in: values, key: { $0 }))
-        #expect(CompetitionRanking.isTied(at: 3, in: values, key: { $0 }) == false)
     }
 
     // MARK: - Tie flags

--- a/AscendAppTests/CompetitionRankingTests.swift
+++ b/AscendAppTests/CompetitionRankingTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct CompetitionRankingTests {
+    @Test
+    func distinctValuesRankSequentially() {
+        let ranks = CompetitionRanking.ranks(for: [30, 20, 10]) { $0 }
+
+        #expect(ranks == [1, 2, 3])
+    }
+
+    @Test
+    func tiedValuesShareARankAndSkipTheNext() {
+        // The canonical "1, 2, 2, 4" from CLAUDE.md: two tied for 2nd, nobody 3rd.
+        let ranks = CompetitionRanking.ranks(for: [30, 20, 20, 10]) { $0 }
+
+        #expect(ranks == [1, 2, 2, 4])
+    }
+
+    @Test
+    func tieAtTheTopLeavesSecondPlaceUnawarded() {
+        let ranks = CompetitionRanking.ranks(for: [30, 30, 10]) { $0 }
+
+        #expect(ranks == [1, 1, 3])
+    }
+
+    @Test
+    func everyoneTiedSharesFirst() {
+        let ranks = CompetitionRanking.ranks(for: [30, 30, 30]) { $0 }
+
+        #expect(ranks == [1, 1, 1])
+    }
+
+    @Test
+    func trailingTieRunSharesTheEarliestRank() {
+        let ranks = CompetitionRanking.ranks(for: [30, 20, 20, 20]) { $0 }
+
+        #expect(ranks == [1, 2, 2, 2])
+    }
+
+    @Test
+    func emptyInputProducesNoRanks() {
+        let ranks = CompetitionRanking.ranks(for: [Int]()) { $0 }
+
+        #expect(ranks.isEmpty)
+    }
+
+    @Test
+    func rankIsIndependentOfTheOrderingTiebreak() {
+        // Sorting breaks ties by uid so the list is stable, but rank must not see it —
+        // this is exactly the bug where a tied user's displayed rank disagreed with the
+        // rank the server used to award their achievement.
+        let sorted = [("aaa", 30), ("mmm", 20), ("zzz", 20)]
+        let ranks = CompetitionRanking.ranks(for: sorted) { $0.1 }
+
+        #expect(ranks == [1, 2, 2])
+    }
+
+    // MARK: - Pagination
+
+    @Test
+    func continuationKeepsOneRankForATieGroupSplitAcrossPages() {
+        let firstPage = [30, 20]
+        let firstRanks = CompetitionRanking.ranks(for: firstPage) { $0 }
+        let continuation = CompetitionRanking.continuation(
+            after: firstPage,
+            ranks: firstRanks,
+            key: { $0 }
+        )
+
+        // The next page opens with the same value the previous page ended on.
+        let secondRanks = CompetitionRanking.ranks(
+            for: [20, 10],
+            continuing: continuation,
+            key: { $0 }
+        )
+
+        #expect(firstRanks == [1, 2])
+        #expect(secondRanks == [2, 4])
+    }
+
+    @Test
+    func continuationStartsANewValueAtItsAbsolutePosition() {
+        let continuation = CompetitionRanking.Continuation(
+            lastKey: 20,
+            lastRank: 2,
+            rankedCount: 3
+        )
+
+        let ranks = CompetitionRanking.ranks(for: [10, 5], continuing: continuation) { $0 }
+
+        #expect(ranks == [4, 5])
+    }
+
+    @Test
+    func continuationAfterAnEmptyPageIsUnchanged() {
+        let continuation = CompetitionRanking.Continuation(
+            lastKey: 20,
+            lastRank: 2,
+            rankedCount: 3
+        )
+
+        let next = CompetitionRanking.continuation(
+            after: [Int](),
+            ranks: [],
+            continuing: continuation,
+            key: { $0 }
+        )
+
+        #expect(next == continuation)
+    }
+
+    @Test
+    func continuationAccumulatesRankedCountAcrossPages() {
+        let page = [20, 10]
+        let ranks = CompetitionRanking.ranks(for: page) { $0 }
+        let first = CompetitionRanking.continuation(after: page, ranks: ranks, key: { $0 })
+        let second = CompetitionRanking.continuation(
+            after: page,
+            ranks: ranks,
+            continuing: first,
+            key: { $0 }
+        )
+
+        #expect(first?.rankedCount == 2)
+        #expect(second?.rankedCount == 4)
+    }
+
+    // MARK: - Single-row lookups
+
+    @Test
+    func rankAtIndexReportsTheSharedRankForEveryTiedRow() {
+        let values = [30, 20, 20, 10]
+
+        #expect(CompetitionRanking.rank(at: 0, in: values, key: { $0 }) == 1)
+        #expect(CompetitionRanking.rank(at: 1, in: values, key: { $0 }) == 2)
+        #expect(CompetitionRanking.rank(at: 2, in: values, key: { $0 }) == 2)
+        #expect(CompetitionRanking.rank(at: 3, in: values, key: { $0 }) == 4)
+    }
+
+    @Test
+    func rankAtIndexMatchesFullListRanking() {
+        let values = [50, 50, 50, 20, 20, 10]
+        let ranks = CompetitionRanking.ranks(for: values) { $0 }
+        let individual = values.indices.map { index in
+            CompetitionRanking.rank(at: index, in: values, key: { value in value })
+        }
+
+        #expect(individual == ranks.map(Optional.init))
+    }
+
+    @Test
+    func rankAtOutOfBoundsIndexIsNil() {
+        #expect(CompetitionRanking.rank(at: 3, in: [30, 20], key: { $0 }) == nil)
+        #expect(CompetitionRanking.rank(at: -1, in: [30, 20], key: { $0 }) == nil)
+    }
+
+    @Test
+    func isTiedDetectsNeighboursOnEitherSide() {
+        let values = [30, 20, 20, 10]
+
+        #expect(CompetitionRanking.isTied(at: 0, in: values, key: { $0 }) == false)
+        #expect(CompetitionRanking.isTied(at: 1, in: values, key: { $0 }))
+        #expect(CompetitionRanking.isTied(at: 2, in: values, key: { $0 }))
+        #expect(CompetitionRanking.isTied(at: 3, in: values, key: { $0 }) == false)
+    }
+
+    // MARK: - Tie flags
+
+    @Test
+    func tieFlagsMarkOnlySharedRanks() {
+        #expect(CompetitionRanking.tieFlags(for: [1, 2, 2, 4]) == [false, true, true, false])
+    }
+
+    @Test
+    func tieFlagsMarkEveryRowWhenAllShareARank() {
+        #expect(CompetitionRanking.tieFlags(for: [1, 1, 1]) == [true, true, true])
+    }
+
+    @Test
+    func tieFlagsAreEmptyForNoRanks() {
+        #expect(CompetitionRanking.tieFlags(for: []).isEmpty)
+    }
+
+    // MARK: - Display
+
+    @Test(arguments: [
+        (3, false, "", "3"),
+        (3, true, "", "T3"),
+        (3, false, "#", "#3"),
+        (3, true, "#", "T3"),
+        (1, true, "#", "T1"),
+        (12, true, "", "T12")
+    ])
+    func rankLabelPrefixesTiesWithT(
+        rank: Int,
+        isTied: Bool,
+        untiedPrefix: String,
+        expected: String
+    ) {
+        #expect(
+            CompetitionRanking.rankLabel(rank, isTied: isTied, untiedPrefix: untiedPrefix) == expected
+        )
+    }
+
+    @Test
+    func rankAccessibilityLabelSaysTiedOutLoud() {
+        #expect(CompetitionRanking.rankAccessibilityLabel(2, isTied: false) == "Rank 2")
+        #expect(CompetitionRanking.rankAccessibilityLabel(2, isTied: true) == "Tied for rank 2")
+    }
+}

--- a/AscendAppTests/LeaderboardPodiumLayoutTests.swift
+++ b/AscendAppTests/LeaderboardPodiumLayoutTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct LeaderboardPodiumLayoutTests {
+    @Test
+    func pedestalsAreOrderedLeftCentreRight() {
+        let layout = LeaderboardPodiumLayout(entries: makeEntries(ranks: [1, 2, 3]))
+
+        #expect(layout.slots.map(\.position) == [2, 1, 3])
+    }
+
+    @Test
+    func topClimberStandsCentre() {
+        let layout = LeaderboardPodiumLayout(entries: makeEntries(ranks: [1, 2, 3]))
+        let centre = layout.slots.first { $0.position == 1 }
+
+        #expect(centre?.entry?.rank == 1)
+    }
+
+    @Test
+    func pedestalsFillInLeaderboardOrder() {
+        let layout = LeaderboardPodiumLayout(entries: makeEntries(ranks: [1, 2, 3]))
+
+        // Left pedestal takes the runner-up, right takes third.
+        #expect(layout.slots.first { $0.position == 2 }?.entry?.rank == 2)
+        #expect(layout.slots.first { $0.position == 3 }?.entry?.rank == 3)
+    }
+
+    @Test
+    func tiedClimbersBothReachThePodium() {
+        // Keying pedestals by rank collapsed these two onto one slot and dropped a
+        // climber outright.
+        let entries = makeEntries(ranks: [1, 1, 3])
+        let layout = LeaderboardPodiumLayout(entries: entries)
+
+        let seatedIDs = layout.slots.compactMap { $0.entry?.userId }
+        #expect(seatedIDs.count == 3)
+        #expect(Set(seatedIDs) == Set(entries.map(\.userId)))
+    }
+
+    @Test
+    func tiedClimbersKeepTheirOwnRankOnWhicheverPedestalTheyStand() {
+        let layout = LeaderboardPodiumLayout(entries: makeEntries(ranks: [1, 1, 3]))
+
+        let centre = layout.slots.first { $0.position == 1 }
+        let left = layout.slots.first { $0.position == 2 }
+        let right = layout.slots.first { $0.position == 3 }
+
+        // The left pedestal seats a gold-ranked climber — position is geometry, the
+        // rank is the climber's own.
+        #expect(centre?.displayedRank == 1)
+        #expect(left?.displayedRank == 1)
+        #expect(left?.isTied == true)
+        #expect(right?.displayedRank == 3)
+        #expect(right?.isTied == false)
+    }
+
+    @Test
+    func threeWayTieForGoldSeatsEveryone() {
+        let entries = makeEntries(ranks: [1, 1, 1])
+        let layout = LeaderboardPodiumLayout(entries: entries)
+
+        #expect(layout.slots.compactMap { $0.entry?.userId }.count == 3)
+        #expect(layout.slots.allSatisfy { $0.displayedRank == 1 })
+        #expect(layout.slots.allSatisfy { $0.isTied })
+    }
+
+    @Test
+    func emptyPedestalShowsTheNextRankUpForGrabs() {
+        let layout = LeaderboardPodiumLayout(entries: makeEntries(ranks: [1]))
+
+        let left = layout.slots.first { $0.position == 2 }
+        let right = layout.slots.first { $0.position == 3 }
+
+        #expect(left?.entry == nil)
+        #expect(left?.displayedRank == 2)
+        #expect(right?.entry == nil)
+        #expect(right?.displayedRank == 3)
+    }
+
+    @Test
+    func twoClimbersTiedForGoldLeaveRankThreeOpen() {
+        // Competition ranking skips 2, so the open pedestal is honestly labelled 3.
+        let layout = LeaderboardPodiumLayout(entries: makeEntries(ranks: [1, 1]))
+
+        let right = layout.slots.first { $0.position == 3 }
+        #expect(right?.entry == nil)
+        #expect(right?.displayedRank == 3)
+    }
+
+    @Test
+    func emptyBoardRendersThreeOpenPedestals() {
+        let layout = LeaderboardPodiumLayout(entries: [])
+
+        #expect(layout.slots.count == 3)
+        #expect(layout.slots.allSatisfy { $0.entry == nil })
+        #expect(layout.slots.allSatisfy { $0.isTied == false })
+    }
+
+    // MARK: - Podium / list split
+
+    @Test
+    func podiumAndListTogetherCoverEveryClimberExactlyOnce() {
+        // Four climbers tied for 2nd all hold a top-3 rank. A rank <= 3 / rank > 3
+        // split put the fourth in neither bucket and it vanished from the screen.
+        let entries = makeEntries(ranks: [1, 2, 2, 2, 2])
+
+        let podium = LeaderboardPodiumLayout.podiumEntries(from: entries)
+        let list = LeaderboardPodiumLayout.listEntries(from: entries)
+
+        #expect(podium.count == 3)
+        #expect(list.count == 2)
+        #expect(podium.map(\.userId) + list.map(\.userId) == entries.map(\.userId))
+    }
+
+    @Test
+    func splitHandlesBoardsSmallerThanThePodium() {
+        let entries = makeEntries(ranks: [1, 2])
+
+        #expect(LeaderboardPodiumLayout.podiumEntries(from: entries).count == 2)
+        #expect(LeaderboardPodiumLayout.listEntries(from: entries).isEmpty)
+    }
+
+    @Test
+    func splitHandlesAnEmptyBoard() {
+        #expect(LeaderboardPodiumLayout.podiumEntries(from: []).isEmpty)
+        #expect(LeaderboardPodiumLayout.listEntries(from: []).isEmpty)
+    }
+
+    private func makeEntries(ranks: [Int]) -> [LeaderboardEntry] {
+        let tiedRanks = Set(ranks.filter { rank in ranks.count(where: { $0 == rank }) > 1 })
+
+        return ranks.enumerated().map { index, rank in
+            LeaderboardEntry(
+                userId: "user-\(index)",
+                displayName: "Climber \(index)",
+                rank: rank,
+                value: Double(1_000 - rank),
+                formattedValue: "\(1_000 - rank)",
+                isTied: tiedRanks.contains(rank)
+            )
+        }
+    }
+}

--- a/AscendAppTests/LeaderboardViewModelTests.swift
+++ b/AscendAppTests/LeaderboardViewModelTests.swift
@@ -43,13 +43,105 @@ struct LeaderboardViewModelTests {
         #expect(viewModel.leaderboardEntries.first?.formattedValue == "176:12:12")
     }
 
+    @Test
+    func tiedStepTotalsShareARankAndSkipTheNextOne() async {
+        let cache = LeaderboardSessionCache()
+
+        let viewModel = LeaderboardViewModel(sessionCache: cache)
+        viewModel.selectedMetric = .climb
+        viewModel.selectedTimeFrame = .weekly
+
+        // Descending by steps, then uid — the ordering the repository and the Cloud
+        // Function both produce. The uid tiebreak must not leak into the rank.
+        let stats = [
+            makeRemoteStat(userId: "aaa", displayName: "Leader", totalSteps: 9_000),
+            makeRemoteStat(userId: "mmm", displayName: "Tied A", totalSteps: 5_000),
+            makeRemoteStat(userId: "zzz", displayName: "Tied B", totalSteps: 5_000),
+            makeRemoteStat(userId: "bbb", displayName: "Trailer", totalSteps: 1_000)
+        ]
+        await cache.setDetailEntries(stats, for: .climb, timeFrame: .weekly)
+
+        await viewModel.loadLeaderboard(userId: "mmm")
+
+        #expect(viewModel.leaderboardEntries.map(\.rank) == [1, 2, 2, 4])
+        #expect(viewModel.leaderboardEntries.map(\.isTied) == [false, true, true, false])
+    }
+
+    @Test
+    func tiedCurrentUserSeesTheSameRankOnTheirPinnedRowAsInTheList() async {
+        // The reported bug: the pinned row and the list row disagreed for a tied user.
+        let cache = LeaderboardSessionCache()
+
+        let viewModel = LeaderboardViewModel(sessionCache: cache)
+        viewModel.selectedMetric = .climb
+        viewModel.selectedTimeFrame = .weekly
+
+        let stats = [
+            makeRemoteStat(userId: "aaa", displayName: "Leader", totalSteps: 9_000),
+            makeRemoteStat(userId: "mmm", displayName: "Rival", totalSteps: 5_000),
+            makeRemoteStat(userId: "zzz", displayName: "You", totalSteps: 5_000)
+        ]
+        await cache.setDetailEntries(stats, for: .climb, timeFrame: .weekly)
+
+        await viewModel.loadLeaderboard(userId: "zzz")
+
+        let listEntry = viewModel.leaderboardEntries.first { $0.userId == "zzz" }
+        #expect(listEntry?.rank == 2)
+        #expect(listEntry?.isTied == true)
+        #expect(viewModel.userEntry?.rank == listEntry?.rank)
+        #expect(viewModel.userEntry?.isTied == listEntry?.isTied)
+    }
+
+    @Test
+    func tiedTopStepTotalsBothRankFirst() async {
+        let cache = LeaderboardSessionCache()
+
+        let viewModel = LeaderboardViewModel(sessionCache: cache)
+        viewModel.selectedMetric = .climb
+        viewModel.selectedTimeFrame = .weekly
+
+        let stats = [
+            makeRemoteStat(userId: "aaa", displayName: "Tied A", totalSteps: 9_000),
+            makeRemoteStat(userId: "bbb", displayName: "Tied B", totalSteps: 9_000),
+            makeRemoteStat(userId: "ccc", displayName: "Third", totalSteps: 1_000)
+        ]
+        await cache.setDetailEntries(stats, for: .climb, timeFrame: .weekly)
+
+        await viewModel.loadLeaderboard(userId: "aaa")
+
+        #expect(viewModel.leaderboardEntries.map(\.rank) == [1, 1, 3])
+        #expect(viewModel.leaderboardEntries.map(\.isTied) == [true, true, false])
+    }
+
+    @Test
+    func untiedBoardFlagsNobodyAsTied() async {
+        let cache = LeaderboardSessionCache()
+
+        let viewModel = LeaderboardViewModel(sessionCache: cache)
+        viewModel.selectedMetric = .climb
+        viewModel.selectedTimeFrame = .weekly
+
+        let stats = [
+            makeRemoteStat(userId: "aaa", displayName: "First", totalSteps: 9_000),
+            makeRemoteStat(userId: "bbb", displayName: "Second", totalSteps: 5_000),
+            makeRemoteStat(userId: "ccc", displayName: "Third", totalSteps: 1_000)
+        ]
+        await cache.setDetailEntries(stats, for: .climb, timeFrame: .weekly)
+
+        await viewModel.loadLeaderboard(userId: "aaa")
+
+        #expect(viewModel.leaderboardEntries.map(\.rank) == [1, 2, 3])
+        #expect(viewModel.leaderboardEntries.allSatisfy { $0.isTied == false })
+    }
+
     private func makeRemoteStat(
         userId: String,
         displayName: String,
-        totalDuration: Double = 1_800
+        totalDuration: Double = 1_800,
+        totalSteps: Int = 1_200
     ) -> FirestoreLeaderboardStats {
         let period = LeaderboardTimeFrame.weekly.currentPeriod(referenceDate: utcDate(year: 2026, month: 4, day: 10))
-        let aggregate = LeaderboardAggregate(totalSteps: 1_200, totalFloors: 75, totalWorkouts: 2, totalDuration: totalDuration)
+        let aggregate = LeaderboardAggregate(totalSteps: totalSteps, totalFloors: 75, totalWorkouts: 2, totalDuration: totalDuration)
 
         return FirestoreLeaderboardStats(
             userId: userId,

--- a/AscendAppTests/LeaderboardViewModelTests.swift
+++ b/AscendAppTests/LeaderboardViewModelTests.swift
@@ -93,6 +93,40 @@ struct LeaderboardViewModelTests {
     }
 
     @Test
+    func profileSyncKeepsTheTiedCurrentUsersRankAndTieMarker() async {
+        // Renaming or re-photographing yourself must not reset your rank or drop your
+        // tie marker — that would put "2" next to a rival still reading "T2".
+        let cache = LeaderboardSessionCache()
+
+        let viewModel = LeaderboardViewModel(sessionCache: cache)
+        viewModel.selectedMetric = .climb
+        viewModel.selectedTimeFrame = .weekly
+
+        let stats = [
+            makeRemoteStat(userId: "aaa", displayName: "Leader", totalSteps: 9_000),
+            makeRemoteStat(userId: "mmm", displayName: "Rival", totalSteps: 5_000),
+            makeRemoteStat(userId: "zzz", displayName: "You", totalSteps: 5_000)
+        ]
+        await cache.setDetailEntries(stats, for: .climb, timeFrame: .weekly)
+
+        await viewModel.loadLeaderboard(userId: "zzz")
+        viewModel.updateCurrentUserProfile(
+            userId: "zzz",
+            displayName: "Renamed",
+            photoURL: URL(string: "https://example.com/avatar.jpg")
+        )
+
+        let listEntry = viewModel.leaderboardEntries.first { $0.userId == "zzz" }
+        #expect(listEntry?.displayName == "Renamed")
+        #expect(listEntry?.rank == 2)
+        #expect(listEntry?.isTied == true)
+        #expect(listEntry?.isCurrentUser == true)
+        #expect(viewModel.userEntry?.rank == listEntry?.rank)
+        #expect(viewModel.userEntry?.isTied == listEntry?.isTied)
+        #expect(viewModel.userEntry?.displayName == "Renamed")
+    }
+
+    @Test
     func tiedTopStepTotalsBothRankFirst() async {
         let cache = LeaderboardSessionCache()
 

--- a/AscendAppTests/LiveReplayCompletionLeaderboardTieTests.swift
+++ b/AscendAppTests/LiveReplayCompletionLeaderboardTieTests.swift
@@ -1,0 +1,141 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+/// The per-climb completion leaderboard ranks every completed attempt by duration.
+/// These lock the tie behaviour the Cloud Function already uses when it stamps
+/// `tiePolicy: "competition_rank_equal_durations_share_rank"` onto a completion.
+struct LiveReplayCompletionLeaderboardTieTests {
+    @Test
+    func rowsSharingARankAreFlaggedAsTied() {
+        let leaderboard = LiveReplayCompletionLeaderboard(
+            rows: [
+                makeRow(id: "a", rank: 1, durationSeconds: 600),
+                makeRow(id: "b", rank: 2, durationSeconds: 700),
+                makeRow(id: "c", rank: 2, durationSeconds: 700),
+                makeRow(id: "d", rank: 4, durationSeconds: 800)
+            ],
+            completedCount: 4,
+            updatedAt: nil
+        )
+
+        #expect(leaderboard.rows.map(\.isTied) == [false, true, true, false])
+    }
+
+    @Test
+    func untiedRowsAreNotFlagged() {
+        let leaderboard = LiveReplayCompletionLeaderboard(
+            rows: [
+                makeRow(id: "a", rank: 1, durationSeconds: 600),
+                makeRow(id: "b", rank: 2, durationSeconds: 700)
+            ],
+            completedCount: 2,
+            updatedAt: nil
+        )
+
+        #expect(leaderboard.rows.allSatisfy { $0.isTied == false })
+    }
+
+    @Test
+    func tieGroupSplitAcrossPagesCorrectsItselfOnceMerged() {
+        // The tie is invisible while only the first page is loaded — the partner row
+        // hasn't arrived yet — and must resolve as soon as the next page merges in.
+        let firstPage = LiveReplayCompletionLeaderboard(
+            rows: [
+                makeRow(id: "a", rank: 1, durationSeconds: 600),
+                makeRow(id: "b", rank: 2, durationSeconds: 700)
+            ],
+            completedCount: 3,
+            updatedAt: nil
+        )
+        #expect(firstPage.rows.map(\.isTied) == [false, false])
+
+        let secondPage = LiveReplayCompletionLeaderboard(
+            rows: [makeRow(id: "c", rank: 2, durationSeconds: 700)],
+            completedCount: 3,
+            updatedAt: nil
+        )
+
+        let merged = firstPage.appending(secondPage)
+
+        #expect(merged.rows.map(\.id) == ["a", "b", "c"])
+        #expect(merged.rows.map(\.isTied) == [false, true, true])
+    }
+
+    @Test
+    func mergingDoesNotDuplicateRowsOrDisturbTieFlags() {
+        let page = LiveReplayCompletionLeaderboard(
+            rows: [
+                makeRow(id: "a", rank: 1, durationSeconds: 700),
+                makeRow(id: "b", rank: 1, durationSeconds: 700)
+            ],
+            completedCount: 2,
+            updatedAt: nil
+        )
+
+        let merged = page.appending(page)
+
+        #expect(merged.rows.map(\.id) == ["a", "b"])
+        #expect(merged.rows.map(\.isTied) == [true, true])
+    }
+
+    @Test
+    func rowsWithoutARankAreNeverFlaggedAsTied() {
+        let leaderboard = LiveReplayCompletionLeaderboard(
+            rows: [
+                makeRow(id: "a", rank: nil, durationSeconds: 700),
+                makeRow(id: "b", rank: nil, durationSeconds: 700)
+            ],
+            completedCount: 2,
+            updatedAt: nil
+        )
+
+        #expect(leaderboard.rows.allSatisfy { $0.isTied == false })
+    }
+
+    // MARK: - Pinned row vs list row
+
+    /// The reported bug: the list numbered rows by position (a tied user read "#3")
+    /// while the pinned row counted strictly-faster attempts (the same user read "#2").
+    ///
+    /// `strictlyFasterCount + 1` is what the pinned row and the Cloud Function both
+    /// compute, expressed here independently of `CompetitionRanking`. Every list rank
+    /// must equal it, on any distribution of durations.
+    @Test(arguments: [
+        [600.0, 700.0, 800.0],
+        [600.0, 700.0, 700.0, 800.0],
+        [700.0, 700.0, 800.0],
+        [600.0, 700.0, 700.0, 700.0],
+        [700.0, 700.0, 700.0],
+        [600.0]
+    ])
+    func listRankAlwaysEqualsStrictlyFasterCountPlusOne(durations: [TimeInterval]) {
+        let listRanks = CompetitionRanking.ranks(for: durations) { $0 }
+        let pinnedRanks = durations.map { duration in
+            durations.filter { $0 < duration }.count + 1
+        }
+
+        #expect(listRanks == pinnedRanks)
+    }
+
+    private func makeRow(
+        id: String,
+        rank: Int?,
+        durationSeconds: TimeInterval
+    ) -> LiveReplayLeaderboardRow {
+        LiveReplayLeaderboardRow(
+            id: id,
+            rank: rank,
+            displayName: "Climber \(id)",
+            avatarToken: id.uppercased(),
+            photoURL: nil,
+            stepsAtBucket: 3_000,
+            finalSteps: 3_000,
+            deltaFromUser: 0,
+            isCurrentUser: false,
+            isPersonalBest: false,
+            completionDurationSeconds: durationSeconds,
+            userId: "user-\(id)"
+        )
+    }
+}

--- a/AscendAppTests/TiedRankRenderEvidenceTests.swift
+++ b/AscendAppTests/TiedRankRenderEvidenceTests.swift
@@ -1,0 +1,257 @@
+import Foundation
+import SwiftUI
+import Testing
+@testable import AscendApp
+
+/// Renders the leaderboard surfaces a climber actually sees when two of them tie, and
+/// writes the images out for review. Assertions cover the labels; the images cover the
+/// part CLAUDE.md asks a human to judge — that a shared rank is *visually obvious*.
+///
+/// Images land in `ASCEND_EVIDENCE_DIR` when it is set, and in the test host's temporary
+/// directory otherwise; either way the path is logged. Nothing here reads them back, so
+/// these are evidence rather than golden-image assertions — no snapshot to re-record when
+/// an unrelated colour or font changes.
+@MainActor
+struct TiedRankRenderEvidenceTests {
+    /// A per-climb field where two climbers finished on the same second: 10:00, 11:40,
+    /// 11:40, 13:20. Competition ranking makes that 1, 2, 2, 4.
+    private static let tiedDurations: [TimeInterval] = [600, 700, 700, 800]
+
+    // MARK: - Per-climb completion leaderboard
+
+    @Test
+    func perClimbBoardShowsOneSharedRankForTheTiedClimbers() throws {
+        let board = makeCompletionBoard(ranks: competitionRanks())
+
+        // The ranks the repository now assigns, and the tie flags the board derives.
+        #expect(board.rows.map(\.rank) == [1, 2, 2, 4])
+        #expect(board.rows.map(\.isTied) == [false, true, true, false])
+
+        try render(
+            completionBoard(board),
+            named: "per-climb-leaderboard-after",
+            height: 420
+        )
+    }
+
+    /// The same field as the old client rendered it: `startRank + offset`, no tie flag.
+    /// `rankLabel(3, isTied: false, untiedPrefix: "#")` is "#3" — byte-identical to the
+    /// `Text("#\(rank)")` this replaced — so the image reproduces the reported screen.
+    @Test
+    func perClimbBoardBeforeNumberedTiedClimbersByPosition() throws {
+        let board = makeCompletionBoard(ranks: positionalRanks())
+
+        #expect(board.rows.map(\.rank) == [1, 2, 3, 4])
+        #expect(board.rows.allSatisfy { $0.isTied == false })
+
+        try render(
+            completionBoard(board),
+            named: "per-climb-leaderboard-before",
+            height: 420
+        )
+    }
+
+    /// The contradiction the report describes, on one screen: the pinned row counted
+    /// strictly-faster completions while the list numbered by position.
+    @Test
+    func pinnedRankAndListRankNowAgreeForTheTiedClimber() {
+        let tiedIndex = 2
+        let duration = Self.tiedDurations[tiedIndex]
+
+        // What the pinned row shows — countRowsFasterThan + 1, matching the server.
+        let pinnedRank = Self.tiedDurations.count(where: { $0 < duration }) + 1
+
+        #expect(positionalRanks()[tiedIndex] == 3)
+        #expect(pinnedRank == 2)
+        #expect(competitionRanks()[tiedIndex] == pinnedRank)
+    }
+
+    // MARK: - Global leaderboard tab
+
+    @Test
+    func podiumSeatsBothClimbersTiedForGoldAndLabelsThemT1() throws {
+        // Dana and Priya finished the week on the same step total.
+        let entries = makeGlobalEntries(
+            ranks: [1, 1, 3, 4],
+            steps: [21_482, 21_482, 19_812, 17_926]
+        )
+        let layout = LeaderboardPodiumLayout(entries: entries)
+
+        // Keying pedestals by rank dropped one of the two golds outright.
+        #expect(layout.slots.compactMap { $0.entry?.userId }.count == 3)
+        #expect(layout.slots.filter { $0.displayedRank == 1 }.count == 2)
+        #expect(CompetitionRanking.rankLabel(1, isTied: true) == "T1")
+
+        try render(
+            LeaderboardPodiumView(
+                entries: LeaderboardPodiumLayout.podiumEntries(from: entries),
+                metric: .climb
+            )
+            .padding(16),
+            named: "global-podium-tied-for-gold-after",
+            height: 260
+        )
+    }
+
+    @Test
+    func globalListAndPinnedRowShowTheSameTiedRank() throws {
+        let entries = makeGlobalEntries(
+            ranks: [1, 2, 2, 4],
+            steps: [21_482, 19_812, 19_812, 17_926]
+        )
+        let you = try #require(entries.last { $0.isCurrentUser })
+
+        #expect(you.rank == 2)
+        #expect(you.isTied)
+
+        try render(
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(entries) { entry in
+                    LeaderboardRow(entry: entry, metric: .climb)
+                }
+
+                Divider().overlay(Color.white.opacity(0.2))
+
+                LeaderboardUserRowView(entry: you, metric: .climb, crownGapText: nil)
+            }
+            .padding(16),
+            named: "global-list-and-pinned-row-after",
+            height: 320
+        )
+    }
+
+    /// The old global board numbered by list position, so two climbers on identical step
+    /// totals read 2 and 3 — while the Cloud Function had already awarded both of them
+    /// rank 2 when it decided achievements.
+    @Test
+    func globalBoardBeforeSplitEqualStepTotalsAcrossTwoRanks() throws {
+        // The same week as `globalListAndPinnedRowShowTheSameTiedRank`, ranked the old way.
+        let entries = makeGlobalEntries(
+            ranks: [1, 2, 3, 4],
+            steps: [21_482, 19_812, 19_812, 17_926],
+            marksTies: false
+        )
+        let you = try #require(entries.last { $0.isCurrentUser })
+
+        #expect(you.rank == 3)
+        #expect(CompetitionRanking.ranks(for: entries, key: \.value)[2] == 2)
+
+        try render(
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(entries) { entry in
+                    LeaderboardRow(entry: entry, metric: .climb)
+                }
+
+                Divider().overlay(Color.white.opacity(0.2))
+
+                LeaderboardUserRowView(entry: you, metric: .climb, crownGapText: nil)
+            }
+            .padding(16),
+            named: "global-list-and-pinned-row-before",
+            height: 320
+        )
+    }
+
+    // MARK: - Fixtures
+
+    private func competitionRanks() -> [Int] {
+        CompetitionRanking.ranks(for: Self.tiedDurations) { $0 }
+    }
+
+    /// What the client did before: rank by list position.
+    private func positionalRanks() -> [Int] {
+        Self.tiedDurations.indices.map { $0 + 1 }
+    }
+
+    private func makeCompletionBoard(ranks: [Int]) -> LiveReplayCompletionLeaderboard {
+        let names = ["Dana R.", "Priya S.", "Marcus T.", "Owen B."]
+        let rows = zip(zip(Self.tiedDurations, ranks).map { $0 }, names.indices).map {
+            pair, index -> LiveReplayLeaderboardRow in
+            let (duration, rank) = pair
+            return LiveReplayLeaderboardRow(
+                id: "row-\(index)",
+                rank: rank,
+                displayName: names[index],
+                avatarToken: String(names[index].prefix(1)),
+                photoURL: nil,
+                stepsAtBucket: 4_000,
+                finalSteps: 4_000,
+                deltaFromUser: 0,
+                isCurrentUser: index == 2,
+                isPersonalBest: false,
+                completionDurationSeconds: duration,
+                userId: "user-\(index)"
+            )
+        }
+
+        return LiveReplayCompletionLeaderboard(
+            rows: rows,
+            completedCount: rows.count,
+            updatedAt: nil
+        )
+    }
+
+    private func completionBoard(_ board: LiveReplayCompletionLeaderboard) -> some View {
+        ReplayCompletionLeaderboardView(
+            rows: board.rows,
+            completedCount: board.completedCount,
+            isLoading: false,
+            fetchFailed: false,
+            currentUserPhotoURL: nil,
+            effectiveColorScheme: .dark,
+            emptyTitle: "No completed times yet.",
+            emptyMessage: "First Ascent open. The first finisher claims it forever."
+        )
+        .padding(16)
+    }
+
+    /// A climber is tied when another climber shares their *step total* — the ranking
+    /// value — not merely their rank number. That keeps the rendered board in a state
+    /// the app can actually reach.
+    /// - Parameter marksTies: `false` reproduces the old client, which had no tie
+    ///   concept at all.
+    private func makeGlobalEntries(
+        ranks: [Int],
+        steps: [Int],
+        marksTies: Bool = true
+    ) -> [LeaderboardEntry] {
+        let names = ["Dana R.", "Priya S.", "Marcus T.", "Owen B."]
+
+        return ranks.indices.map { index in
+            LeaderboardEntry(
+                userId: "user-\(index)",
+                displayName: names[index],
+                rank: ranks[index],
+                value: Double(steps[index]),
+                formattedValue: steps[index].formatted(),
+                isCurrentUser: index == 2,
+                isTied: marksTies && steps.count(where: { $0 == steps[index] }) > 1
+            )
+        }
+    }
+
+    // MARK: - Rendering
+
+    private func render(_ view: some View, named name: String, height: CGFloat) throws {
+        let renderer = ImageRenderer(
+            content: view
+                .frame(width: 390)
+                .frame(height: height, alignment: .top)
+                .background(Color.black)
+                .environment(\.colorScheme, .dark)
+        )
+        renderer.scale = 3
+
+        let image = try #require(renderer.uiImage, "ImageRenderer produced no image")
+        let png = try #require(image.pngData(), "UIImage produced no PNG data")
+
+        let directory = ProcessInfo.processInfo.environment["ASCEND_EVIDENCE_DIR"]
+            ?? NSTemporaryDirectory()
+        let url = URL(filePath: directory).appending(path: "\(name).png")
+        try png.write(to: url)
+
+        // Logged so the image is findable inside the simulator container when no
+        // ASCEND_EVIDENCE_DIR was provided.
+        print("Rendered tied-rank evidence: \(url.path())")
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,13 @@ Principles:
 - `CLAUDE.md` is the canonical project context file. `AGENTS.md` is a symlink to `CLAUDE.md` — editing one edits both. There is exactly one source of truth.
 - All AI providers used on this repo (Codex, Claude, Cursor, Copilot, etc.) should read from this file. Do not break the symlink by replacing `AGENTS.md` with a separate file or duplicating content between them.
 
+### Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.
+
 ---
 
 ## Tech Stack
@@ -533,6 +540,7 @@ Leaderboard UX in Ascend covers two distinct surfaces — the global tab (commun
 
 **Tie handling (applies to global and per-climb)**
 - Ties are ranked using **standard competition ranking** ("1, 2, 2, 4"). Tied users share the same rank; the next rank is skipped by the count of tied users. This matches the sports convention and honors the honest outcome.
+- `CompetitionRanking` (`AscendApp/Shared/Models/`) is the only client-side definition of rank, and it mirrors the Cloud Functions ranking. Rank every client surface through it rather than by list position - a positional rank silently disagrees with the rank the server used to award achievements. A sort tiebreak (uid, document ID) exists to make ordering stable and must never influence rank.
 - Don't break ties with secondary metrics (steps tie ≠ floors tiebreaker; time tie ≠ cadence tiebreaker). Adding a secondary criterion quietly changes what the leaderboard measures.
 - Don't break ties with submission timestamp. First-to-submit is a property of when the user happened to climb, not how well they climbed.
 - Match precision to perception. Per-climb completion times rank at second granularity; sub-second tiebreakers feel arbitrary and don't reflect anything users perceived during the attempt.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -545,7 +545,7 @@ Leaderboard UX in Ascend covers two distinct surfaces — the global tab (commun
 - Don't break ties with submission timestamp. First-to-submit is a property of when the user happened to climb, not how well they climbed.
 - Match precision to perception. Per-climb completion times rank at second granularity; sub-second tiebreakers feel arbitrary and don't reflect anything users perceived during the attempt.
 - Tied ranks must be visually obvious in the UI — same rank number on each tied row, "T" prefix or equivalent treatment. Don't render ties as if they were ordered.
-- Podium display must handle tied top ranks (e.g. three users tied for #1) — multiple users may share a podium slot. The podium is a *visual* surface; the ranking rule is the source of truth.
+- Podium display must handle tied top ranks (e.g. three users tied for #1) by giving each climber their own pedestal, filled in leaderboard order. A pedestal's position drives geometry only; the climber standing on it carries their own rank, so two climbers tied for gold both read "T1" in gold even though only one pedestal stands centre. `LeaderboardPodiumLayout` owns the slot assignment and the podium/list split - never key pedestals by rank or partition on `rank <= 3`, because repeated ranks silently drop climbers off both surfaces. The podium is a *visual* surface; the ranking rule is the source of truth.
 - First Ascent is exempt — it's keyed on submission timestamp and is unambiguous by design. Two users may tie on the leaderboard, but only one submission reached the backend first.
 
 ### Design System


### PR DESCRIPTION
## Intent

Fix a client/server ranking disagreement: the iOS client ranked leaderboards positionally (index+1) with an alphabetical uid tiebreak, while the Cloud Functions rank competition-style ('1, 2, 2, 4'). Two tied users saw contradictory ranks, and one could be awarded an achievement their displayed rank said they hadn't earned. On the per-climb board the contradiction was visible on one screen: the pinned row counted strictly-faster completions (competition rank) while the list numbered by position, so a tied user read '#2' and '#3' simultaneously. CLAUDE.md mandates standard competition ranking and that tied ranks be visually obvious.

Approach: the SERVER is the reference implementation and was already correct - the client was changed to match it, not the other way around. Added CompetitionRanking (AscendApp/Shared/Models/) as the single client-side definition of rank, mirroring functions/src/leaderboardAchievements.ts (rankedQualifiers) and functions/src/liveReplayLeaderboard.ts (completionRankForPayload). Routed the global steps board, the per-climb completion list, and both pinned rows through it.

Deliberate decisions a reviewer cannot infer from the diff:
1. Sort tiebreaks (uid, document ID) are RETAINED - they exist to make list ordering stable and deterministic, and the server sorts identically. They must never influence rank, and now they don't. Keeping them is intentional, not an oversight.
2. Tie ties are detected by RAW Double equality on completionDurationSeconds, deliberately matching the server's strict '<' comparison. CLAUDE.md says per-climb times 'rank at second granularity'; I did NOT round/floor to seconds, because the server defines what a tie is and changing tie granularity would require a Cloud Function change outside this task's scope. Client and server agreeing is the whole point of this fix; a client-side rounding would reintroduce the exact disagreement being fixed.
3. Tie display uses a 'T' prefix that REPLACES the '#' where one existed ('#3' untied -> 'T3' tied), the sports/golf convention, chosen so 'T' unambiguously means tied and label width stays stable. Rank 1 keeps its crown icon (two adjacent crowns read as a tie visually) with an accessibility label that says 'Tied for rank 1' out loud.
4. Podium: competition ranking makes ranks repeat, which broke two surfaces that had assumed ranks were unique. LeaderboardPodiumView keyed its slots by rank in a dictionary, so tied climbers collapsed onto one pedestal and all but one were SILENTLY DROPPED. The user was consulted and explicitly chose 'option B': one climber per pedestal filled in leaderboard sort order, where pedestal position drives geometry only and the climber's own rank drives their label and medal colour - so two tied for gold both read 'T1' in gold even though only one pedestal stands centre. This was a product decision made by the user, not an arbitrary choice.
5. The podium/list split in LeaderboardView partitioned on rank <= 3 / rank > 3, which put a fourth climber tied for 2nd in NEITHER bucket and dropped them off screen entirely (they were also not pinned, since pinning triggered on rank > 3). It now splits by position so the two together cover every entry exactly once.
6. Extracted the podium slot assignment and the podium/list split into LeaderboardPodiumLayout, because CLAUDE.md requires decision-driving logic be unit-testable without a SwiftUI view tree, and the drop bugs above are exactly what needs a regression guard.
7. LiveReplayCompletionLeaderboardCursor's 'nextRank' was replaced with 'lastRank' + 'rankedCount' so a tie group split across a pagination boundary keeps one rank. This is a safe reshape: nothing outside FirestoreLiveReplayLeaderboardRepository ever constructed a cursor or read nextRank (verified by sweep). Completion tie flags are derived in LiveReplayCompletionLeaderboard.init from merged rows, so a boundary-split tie reads untied until the neighbouring page loads and then self-corrects - a known, accepted tradeoff documented in the code.
8. LeaderboardRepository.getUserRank was fixed to competition ranking as the task asked, but it is DEAD CODE with zero call sites (verified by sweep). Deleting it per CLAUDE.md's 'delete before you defend' was raised to the user as a follow-up rather than done unilaterally.

Deliberate scope exclusions: LiveReplayLeaderboardPanel (the live in-session race panel) was NOT changed - its ranks come from a different steps-at-bucket computation, not completion ranking. The pre-existing inconsistency where some surfaces render '#3' and others render a bare '3', and the three duplicate NumberFormatter ordinal helpers, were left alone as unrelated cleanups.

Validation: full suite green at 281 tests / 59 suites. The new tied-rank tests were verified to FAIL against the old positional code (reproducing the exact reported symptom: listEntry rank 3 vs pinned rank 2) and pass against the fix, so they are real regression guards rather than tautologies. Also fixed a '#--' rendering quirk where '#' sat outside the optional-coalesce for a missing rank.

## What Changed

- Added `CompetitionRanking` (`AscendApp/Shared/Models/`) as the single client-side definition of rank, mirroring the Cloud Functions implementations (`rankedQualifiers`, `completionRankForPayload`), and routed the global steps board, the per-climb completion list, and both pinned rows through it. Tied climbers now share a rank ("1, 2, 2, 4") instead of being numbered by list position; the uid / document-ID sort tiebreaks stay for stable ordering but no longer influence rank. `ProfileStandingService` and `LeaderboardRepository.getUserRank` were folded onto the same helper.
- Made ties visible and stopped dropping tied climbers: rows render a `T` prefix in place of `#` (rank 1 keeps its crown with a "Tied for rank 1" accessibility label), and the new `LeaderboardPodiumLayout` seats one climber per pedestal in leaderboard order while splitting podium vs. list by position - previously the podium keyed slots by rank and the split partitioned on `rank <= 3`, so a repeated rank silently dropped climbers off both surfaces. Also fixed a `#--` render when rank is missing.
- Reshaped `LiveReplayCompletionLeaderboardCursor` from `nextRank` to `lastRank` + `rankedCount` so a tie group split across a pagination boundary keeps one rank, derived completion tie flags in `LiveReplayCompletionLeaderboard.init`, updated the CLAUDE.md podium tie rule to match the implementation, and added `CompetitionRankingTests`, `LeaderboardPodiumLayoutTests`, `LiveReplayCompletionLeaderboardTieTests`, `TiedRankRenderEvidenceTests`, plus `LeaderboardViewModelTests` coverage.

## Risk Assessment

✅ Low: All four accepted round-1 findings are fixed cleanly in 36c677c with a new regression test covering the tie-flag drop, the client now mirrors the server's already-correct competition ranking through a single tested helper, and the only remaining gaps are two items the author explicitly triaged as out of scope.

## Testing

I ran the full iOS suite twice on an iPhone 16 Pro simulator (294 tests / 62 suites, green both runs) and then produced the reviewer-visible evidence that unit tests alone can't give: a new ImageRenderer-based test that renders the real production leaderboard views with a tied field and writes PNGs. The per-climb before/after pair reproduces the reported bug exactly (two climbers at 11:40 reading #2 and #3) and shows it resolved to a shared T2 with rank 3 correctly skipped; the global pair shows the list and pinned row agreeing at T2 where they previously read 2 and 3; the podium shows both climbers tied for gold seated and labelled T1 in gold. The "before" images are rendered by feeding the current views the positional ranks the old repository produced with no tie flag — faithful because rankLabel(rank, isTied: false, untiedPrefix: "#") is byte-identical to the Text("#\(rank)") it replaced, an equivalence the author's own CompetitionRankingTests already locks. I did not render ClimbDetailView's pinned rank card directly (it is coupled to Firebase, SwiftData and singletons); its rankView code is identical to the rendered ReplayCompletionLeaderboardView row, and its pinned-vs-list agreement is covered numerically by asserting the list rank equals the strictly-faster-count + 1 formula the pinned row and the Cloud Function both use. Two process notes, neither a product problem: xcodebuild's -showdestinations advertised simulators that don't exist locally (iOS 26.0), costing several failed runs until I pinned the real iOS 18.6 device; and my render test crashed once with signal kill in an early full run but did not reproduce across two later clean full runs plus repeated isolated runs. Build cache was written to /tmp (outside the worktree) and the working tree contains only the new test file.

- Evidence: Per-climb leaderboard BEFORE — two climbers both finish 11:40 but read #2 and #3 (the reported bug) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXPT14FTQQ6CZQTDWG7WXNAD/per-climb-leaderboard-before.png</code>)
- Evidence: Per-climb leaderboard AFTER — both 11:40 rows read T2, rank 3 skipped, next climber #4 (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXPT14FTQQ6CZQTDWG7WXNAD/per-climb-leaderboard-after.png</code>)
- Evidence: Global board BEFORE — identical 19,812 step totals read 2 and 3; pinned row shows 3 (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXPT14FTQQ6CZQTDWG7WXNAD/global-list-and-pinned-row-before.png</code>)
- Evidence: Global board AFTER — both 19,812 rows read T2 and the pinned row agrees at T2 (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXPT14FTQQ6CZQTDWG7WXNAD/global-list-and-pinned-row-after.png</code>)
- Evidence: Podium with two climbers tied for gold — both seated and labelled T1 in gold (previously one was silently dropped) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXPT14FTQQ6CZQTDWG7WXNAD/global-podium-tied-for-gold-after.png</code>)
<details>
<summary>Evidence: Full suite result (run twice)</summary>

```text
$ xcodebuild test -scheme AscendApp -destination 'platform=iOS Simulator,id=6EB39107-...' -parallel-testing-enabled NO

✔ Suite CompetitionRankingTests passed after 0.007 seconds.
✔ Suite LeaderboardPodiumLayoutTests passed after 0.007 seconds.
✔ Suite LeaderboardViewModelTests passed after 0.990 seconds.
✔ Suite LiveReplayCompletionLeaderboardTieTests passed after 0.009 seconds.
✔ Suite TiedRankRenderEvidenceTests passed after 0.211 seconds.
✔ Test run with 294 tests in 62 suites passed after 2.489 seconds.
** TEST SUCCEEDED **

xcresult summary: result: Passed | passed: 294 | failed: 0 | skipped: 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 6 issues found → auto-fixed ✅</summary>

- ⚠️ `AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift:339` - updateCurrentUserProfile rebuilds LeaderboardEntry at two call sites (lines 339-347 and 351-359) without forwarding the new isTied argument, so it silently falls back to the default false. The method is reachable from .onChange(of: authVM.displayName) and .onChange(of: authVM.displayPhotoURL) in LeaderboardView.swift:127-132. Failure scenario: the user is tied at rank 2 and their row correctly reads &#39;T2&#39;; they change their display name or profile photo and return to the Leaderboard tab; their row now reads &#39;2&#39; while the climber they are tied with still reads &#39;T2&#39;. That is the same on-screen rank contradiction this change exists to remove, reintroduced through a stale call site. Fix by passing isTied: existing.isTied and isTied: entry.isTied respectively.
- ⚠️ `AscendApp/Shared/Repositories/Firebase/FirestoreLiveReplayLeaderboardRepository.swift:255` - Per-climb ties are detected by exact Double equality on completionDurationSeconds (deliberate per your intent note, to match the server&#39;s strict &#39;&lt;&#39;), but the stored value is fractional: LiveClimbSessionViewModel.swift:1040 stores max(result.duration, 1) from a wall-clock TimeInterval, and WorkoutRemoteSyncMapper.swift:69 writes it to Firestore unrounded, while DurationFormatter.format(duration:) rounds to whole seconds for display. Two consequences: (1) exact-Double ties essentially never occur in production, so the &#39;T&#39; marker and the new countRowsMatching aggregation (an extra server round trip on every climb-detail load) are effectively dead on the per-climb board; (2) two attempts at 623.41s and 623.87s both render &#39;10:23&#39; but rank 2 and 3 with no tie marker, which is the CLAUDE.md rule &#39;Match precision to perception. Per-climb completion times rank at second granularity&#39; still unmet. Your intent note flags this as deliberately out of scope pending a Cloud Function change; surfacing it so the follow-up is tracked, not to contest the decision.
- ℹ️ `AscendApp/Features/Profile/Services/ProfileStandingService.swift:180` - competitionRankedRows hand-rolls the exact algorithm CompetitionRanking.ranks now owns (same &#39;lastValue != value -&gt; currentRank = index + 1&#39; shape). This change adds a CLAUDE.md rule stating CompetitionRanking &#39;is the only client-side definition of rank&#39;, which this surviving second implementation contradicts. It is currently behaviour-identical, so the failure scenario is drift rather than a live bug: a future correction to CompetitionRanking (for example second-granularity tie bucketing) lands on the leaderboard surfaces but not on Profile Active Standings, and the two disagree again. Replacing the loop with CompetitionRanking.ranks(for:key:) is behaviour-preserving.
- ℹ️ `AscendApp/Shared/Models/CompetitionRanking.swift:63` - CompetitionRanking.continuation(after:ranks:continuing:key:) (line 63) and CompetitionRanking.isTied(at:in:key:) (line 132) have no production call sites - a sweep of AscendApp finds references only in AscendAppTests/CompetitionRankingTests.swift. The repository builds its cursor by hand in nextCompletionLeaderboardCursor rather than calling continuation, and tie flags are derived via tieFlags(for:) instead of isTied(at:in:key:). Failure scenario: they are tested API surface that nothing depends on, which per CLAUDE.md&#39;s YAGNI and &#39;delete before you defend&#39; rules is debt a future reader must reason about; a later change to the ranking contract has to keep them consistent for no benefit. (CompetitionRanking.rank(at:in:key:) has the same problem via getUserRank, which your intent already raised as a separate follow-up.)
- ℹ️ `AscendApp/Shared/Repositories/Firebase/FirestoreLiveReplayLeaderboardRepository.swift:637` - Pre-existing bug that the rewritten guard preserves rather than introduces, noted because these lines were touched. On cursor pages resolvedCompletedCount is hardcoded to 0 (line 249), so completedCount collapses to (cursor.rankedCount + rows.count) - exactly rankedCount - and the guard &#39;rankedCount &lt; completedCount&#39; is always false. Failure scenario: a climb with 30 completions and a page size of 10 loads page 1 and page 2, then nextCursor returns nil and rows 21-30 are unreachable; ClimbDetailViewModel.loadMoreCompletionLeaderboardIfNeeded reads completionLeaderboard.nextCursor and stops. The old code was equally broken (nextRank 21 &lt;= completedCount 20 was false), so this is not a regression - flagging it because the fix is to carry the total forward on cursor pages rather than recompute it from the page.
- ℹ️ `AscendApp/Features/Leaderboards/Views/LeaderboardPodiumView.swift:79` - LeaderboardPodiumSlotView.rank constructs a throwaway LeaderboardPodiumLayout.Slot(position:entry:) on every evaluation purely to read displayedRank, and isTied (line 83) re-derives entry?.isTied ?? false which Slot.isTied already exposes. The parent podiumSlot(_:) already holds the real Slot and destructures it into position + entry only to have the child reassemble it. Failure scenario: no runtime defect, but the round trip obscures that position and rank are distinct concepts - the exact distinction this change is establishing - and a future edit could easily reintroduce the position/rank conflation. Passing the Slot straight through and reading slot.displayedRank / slot.isTied removes the reconstruction.

🔧 Fix: Preserve tie flag on profile sync; dedupe ranking helpers
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`xcodebuild test -project AscendApp.xcodeproj -scheme AscendApp -destination &#39;platform=iOS Simulator,id=6EB39107-7DEC-4910-AD8B-62C1D91F2412&#39; -parallel-testing-enabled NO` — full suite, run twice back-to-back: 294 tests / 62 suites, 0 failures both times</code>
- <code>`-only-testing:AscendAppTests/CompetitionRankingTests` — competition ranking (1,2,2,4), pagination continuation, tie flags, rank labels</code>
- <code>`-only-testing:AscendAppTests/LeaderboardPodiumLayoutTests` — tied climbers all seated, podium/list split covers every entry exactly once</code>
- <code>`-only-testing:AscendAppTests/LiveReplayCompletionLeaderboardTieTests` — tie flags, page-boundary tie self-correction, list rank == strictly-faster-count + 1</code>
- <code>`-only-testing:AscendAppTests/LeaderboardViewModelTests` — tied step totals share a rank; profile sync preserves rank + tie marker</code>
- <code>`-only-testing:AscendAppTests/TiedRankRenderEvidenceTests` — NEW: renders the real ReplayCompletionLeaderboardView, LeaderboardPodiumView, LeaderboardRow and LeaderboardUserRowView to PNG with a tied field, before/after (5 images captured, all 6 tests pass)</code>
- <code>Manual cross-check of the client against its stated server reference: `functions/src/leaderboardAchievements.ts` (rankedQualifiers) and `functions/src/liveReplayLeaderboard.ts` (completionRankForPayload, strict `&lt;` on raw doubles, tiePolicy stamp)</code>
- <code>`grep -rn &#34;nextRank&#34; --include=&#34;*.swift&#34; .` and `grep -rn &#34;getUserRank&#34; --include=&#34;*.swift&#34; .` — verified the author&#39;s sweep claims (nextRank fully removed; getUserRank has zero call sites)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CLAUDE.md:546` - CLAUDE.md still states &#34;Per-climb completion times rank at second granularity; sub-second tiebreakers feel arbitrary&#34;, but neither side of the system honors that now that the client mirrors the server. The client detects ties by raw Double equality on completionDurationSeconds, and functions/src/liveReplayLeaderboard.ts passes finalDurationSeconds through to completionDurationSeconds with no rounding (verified: no Math.round/Math.floor on the value, and the strict &#39;&lt;&#39; at line 624 compares raw numbers). Two completions 0.4s apart therefore rank as distinct rather than tied. I did not rewrite the rule to match the code: the intent documents this as a deliberate scope call (the server defines what a tie is, and client-side rounding would reintroduce the exact client/server disagreement this change fixes), so editing the doc would silently delete a product decision rather than record one. Resolving it properly means either flooring durations to whole seconds in the Cloud Function and then in CompetitionRanking&#39;s key, or amending the precision rule to say ranking uses the server&#39;s raw duration. That is a product decision plus a Cloud Function change, both outside this change&#39;s scope. Suggested follow-up: decide which way the contract should go and file it.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
