### PR TITLE
feat(email): add an unsubscribe path and an in-app email preference toggle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,8 +198,48 @@ jobs:
             )"
           fi
 
+          # The runner image installs the iOS runtimes but does not always
+          # pre-create simulator devices from them, and -showdestinations only
+          # reports devices that already exist. Create one from an installed
+          # runtime rather than failing on an image that can still run tests.
           if [ -z "$simulator_id" ]; then
-            echo "::error::No available iPhone simulator destination found."
+            echo "No pre-created iPhone simulator destination. xcodebuild reported:"
+            printf '%s\n' "$destinations"
+
+            # Newest installed runtime: it is the one that still satisfies the
+            # app's deployment target.
+            runtime="$(
+              xcrun simctl list runtimes available \
+                | sed -n 's/^iOS \([0-9.]*\) .*- \(com\.apple\.CoreSimulator\.SimRuntime\.iOS-[0-9-]*\)$/\1 \2/p' \
+                | sort -V \
+                | tail -1 \
+                | cut -d' ' -f2
+            )"
+
+            for name in "${preferred_names[@]}"; do
+              device_type="$(
+                xcrun simctl list devicetypes \
+                  | sed -n "s/^${name} (\(com\.apple\.CoreSimulator\.SimDeviceType\.[^)]*\))\$/\1/p"
+              )"
+
+              if [ -z "$device_type" ] || [ -z "$runtime" ]; then
+                continue
+              fi
+
+              # Not every device type is offered by every runtime, so let
+              # simctl reject the pairing and move on to the next candidate.
+              if simulator_id="$(xcrun simctl create "ascend-ci-iphone" "$device_type" "$runtime" 2>/dev/null)"; then
+                echo "Created simulator $simulator_id ($name on $runtime)."
+                break
+              fi
+
+              simulator_id=""
+            done
+          fi
+
+          if [ -z "$simulator_id" ]; then
+            echo "::error::No iPhone simulator destination found, and no installed iOS runtime to create one from."
+            xcrun simctl list runtimes
             exit 1
           fi
 

--- a/AscendApp/Features/Account/Services/EmailPreferencesProviding.swift
+++ b/AscendApp/Features/Account/Services/EmailPreferencesProviding.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Reads and writes the account-scoped email preferences shown in settings.
+///
+/// The preference lives on the server rather than on the device because the
+/// unsubscribe link in an email can change it from outside the app.
+protocol EmailPreferencesProviding: Sendable {
+    func loadLifecycleEmailsEnabled() async throws -> Bool
+    func setLifecycleEmailsEnabled(_ isEnabled: Bool) async throws
+}

--- a/AscendApp/Features/Account/Services/EmailPreferencesService.swift
+++ b/AscendApp/Features/Account/Services/EmailPreferencesService.swift
@@ -1,0 +1,36 @@
+import Foundation
+@preconcurrency import FirebaseAuth
+@preconcurrency import FirebaseFirestore
+
+/// Server-backed email preferences for the signed-in user.
+///
+/// Reads come straight from the owner-readable preferences document; writes go
+/// through the lifecycle callable so the server stays the only writer.
+struct EmailPreferencesService: EmailPreferencesProviding {
+    func loadLifecycleEmailsEnabled() async throws -> Bool {
+        guard let uid = Auth.auth().currentUser?.uid else {
+            throw LifecycleEventRecorderError.signedOut
+        }
+
+        let snapshot = try await Firestore.firestore()
+            .collection("users")
+            .document(uid)
+            .collection("communication_preferences")
+            .document("current")
+            .getDocument()
+
+        // No stored preference means the user has never opted out.
+        guard let isEnabled = snapshot
+            .data()?["lifecycleEmailsEnabled"] as? Bool else {
+            return true
+        }
+
+        return isEnabled
+    }
+
+    func setLifecycleEmailsEnabled(_ isEnabled: Bool) async throws {
+        try await LifecycleEventRecorder.shared.recordCommunicationPreferences(
+            lifecycleEmailsEnabled: isEnabled
+        )
+    }
+}

--- a/AscendApp/Features/Account/ViewModels/EmailPreferencesViewModel.swift
+++ b/AscendApp/Features/Account/ViewModels/EmailPreferencesViewModel.swift
@@ -17,6 +17,7 @@ final class EmailPreferencesViewModel {
     private(set) var errorMessage: String?
 
     private let service: EmailPreferencesProviding
+    private var isLoading = false
 
     init(service: EmailPreferencesProviding = EmailPreferencesService()) {
         self.service = service
@@ -28,15 +29,32 @@ final class EmailPreferencesViewModel {
 
     /// Reads the server value, which may have changed since the app last ran:
     /// an unsubscribe link in an email flips the same preference.
+    ///
+    /// Safe to call repeatedly. Once a value has been read, later reads are
+    /// refreshes: they never take the screen back to loading or failed, since
+    /// the value already on screen stays the best information available.
     func load() async {
-        loadState = .loading
-        errorMessage = nil
+        guard !isLoading, !isUpdating else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        let hasKnownGoodValue = loadState == .ready
+        if !hasKnownGoodValue {
+            loadState = .loading
+            errorMessage = nil
+        }
 
         do {
-            isLifecycleEmailsEnabled = try await service
-                .loadLifecycleEmailsEnabled()
+            let serverValue = try await service.loadLifecycleEmailsEnabled()
+            // A write that started mid-read owns the value; this read is stale.
+            guard !isUpdating else { return }
+
+            isLifecycleEmailsEnabled = serverValue
             loadState = .ready
+            errorMessage = nil
         } catch {
+            guard !hasKnownGoodValue else { return }
+
             loadState = .failed
             errorMessage = "Couldn't load your email settings."
         }

--- a/AscendApp/Features/Account/ViewModels/EmailPreferencesViewModel.swift
+++ b/AscendApp/Features/Account/ViewModels/EmailPreferencesViewModel.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Observation
+
+/// Drives the email preference toggle in notification settings.
+@MainActor
+@Observable
+final class EmailPreferencesViewModel {
+    enum LoadState: Equatable {
+        case loading
+        case ready
+        case failed
+    }
+
+    private(set) var loadState: LoadState = .loading
+    private(set) var isLifecycleEmailsEnabled = true
+    private(set) var isUpdating = false
+    private(set) var errorMessage: String?
+
+    private let service: EmailPreferencesProviding
+
+    init(service: EmailPreferencesProviding = EmailPreferencesService()) {
+        self.service = service
+    }
+
+    var isToggleDisabled: Bool {
+        isUpdating || loadState != .ready
+    }
+
+    /// Reads the server value, which may have changed since the app last ran:
+    /// an unsubscribe link in an email flips the same preference.
+    func load() async {
+        loadState = .loading
+        errorMessage = nil
+
+        do {
+            isLifecycleEmailsEnabled = try await service
+                .loadLifecycleEmailsEnabled()
+            loadState = .ready
+        } catch {
+            loadState = .failed
+            errorMessage = "Couldn't load your email settings."
+        }
+    }
+
+    func setLifecycleEmailsEnabled(_ isEnabled: Bool) async {
+        guard !isUpdating, isEnabled != isLifecycleEmailsEnabled else { return }
+
+        let previousValue = isLifecycleEmailsEnabled
+        isUpdating = true
+        errorMessage = nil
+        // Move the switch immediately, then put it back if the write fails, so
+        // the control never shows a state the server did not accept.
+        isLifecycleEmailsEnabled = isEnabled
+        defer { isUpdating = false }
+
+        do {
+            try await service.setLifecycleEmailsEnabled(isEnabled)
+        } catch {
+            isLifecycleEmailsEnabled = previousValue
+            errorMessage = "Couldn't save that. Check your connection."
+        }
+    }
+}

--- a/AscendApp/Features/Account/ViewModels/EmailPreferencesViewModel.swift
+++ b/AscendApp/Features/Account/ViewModels/EmailPreferencesViewModel.swift
@@ -18,6 +18,7 @@ final class EmailPreferencesViewModel {
 
     private let service: EmailPreferencesProviding
     private var isLoading = false
+    private var writeGeneration = 0
 
     init(service: EmailPreferencesProviding = EmailPreferencesService()) {
         self.service = service
@@ -44,10 +45,16 @@ final class EmailPreferencesViewModel {
             errorMessage = nil
         }
 
+        let generationAtReadStart = writeGeneration
+
         do {
             let serverValue = try await service.loadLifecycleEmailsEnabled()
-            // A write that started mid-read owns the value; this read is stale.
-            guard !isUpdating else { return }
+            // A write that started mid-read still owns the value, and so does
+            // one that both started and finished while this read was in
+            // flight: either way the write is newer than what this read saw.
+            guard !isUpdating, writeGeneration == generationAtReadStart else {
+                return
+            }
 
             isLifecycleEmailsEnabled = serverValue
             loadState = .ready
@@ -69,7 +76,12 @@ final class EmailPreferencesViewModel {
         // Move the switch immediately, then put it back if the write fails, so
         // the control never shows a state the server did not accept.
         isLifecycleEmailsEnabled = isEnabled
-        defer { isUpdating = false }
+        // A revert counts too: it settles the value just as a save does, so a
+        // read that started before it is equally out of date.
+        defer {
+            writeGeneration += 1
+            isUpdating = false
+        }
 
         do {
             try await service.setLifecycleEmailsEnabled(isEnabled)

--- a/AscendApp/Features/Account/Views/NotificationSettingsView.swift
+++ b/AscendApp/Features/Account/Views/NotificationSettingsView.swift
@@ -53,6 +53,9 @@ struct NotificationSettingsView: View {
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             Task {
                 await refreshAuthorizationStatus()
+                // The unsubscribe link changes this preference outside the app,
+                // so the server value is re-read rather than trusted from launch.
+                await emailPreferences.load()
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .climbDropNotificationPreferenceDidChange)) { _ in

--- a/AscendApp/Features/Account/Views/NotificationSettingsView.swift
+++ b/AscendApp/Features/Account/Views/NotificationSettingsView.swift
@@ -6,6 +6,7 @@ struct NotificationSettingsView: View {
     @State private var authorizationStatus: UNAuthorizationStatus = .notDetermined
     @State private var isClimbDropEnabled = ClimbDropNotificationPreferenceStore.isEnabled
     @State private var isUpdating = false
+    @State private var emailPreferences = EmailPreferencesViewModel()
 
     var body: some View {
         ScrollView {
@@ -13,6 +14,12 @@ struct NotificationSettingsView: View {
                 ProfileSection(title: "Climb Drops") {
                     ProfileCardSurface {
                         climbDropRow
+                    }
+                }
+
+                ProfileSection(title: "Emails") {
+                    ProfileCardSurface {
+                        emailRow
                     }
                 }
 
@@ -39,6 +46,9 @@ struct NotificationSettingsView: View {
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
         .task {
             await refreshAuthorizationStatus()
+        }
+        .task {
+            await emailPreferences.load()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
             Task {
@@ -88,6 +98,69 @@ struct NotificationSettingsView: View {
         .padding(.vertical, 18)
         .frame(maxWidth: .infinity, alignment: .leading)
         .opacity(isUpdating ? 0.68 : 1)
+    }
+
+    private var emailRow: some View {
+        HStack(spacing: 16) {
+            AppIcon(token: .settingsContactUs, pointSize: 22, weight: .medium)
+                .foregroundStyle(.accent)
+                .frame(width: 28, height: 28)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Climb and progress emails")
+                    .font(.montserratSemiBold(size: 16))
+                    .foregroundStyle(.white)
+
+                Text(emailSubtitle)
+                    .font(.montserratRegular(size: 13))
+                    .foregroundStyle(emailSubtitleColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            // The view model stays the single source of truth for the switch:
+            // it reverts itself when a write fails, and the unsubscribe link
+            // can change the stored value from outside the app.
+            Toggle(
+                "Climb and progress emails",
+                isOn: Binding(
+                    get: { emailPreferences.isLifecycleEmailsEnabled },
+                    set: { isEnabled in
+                        Task {
+                            await emailPreferences
+                                .setLifecycleEmailsEnabled(isEnabled)
+                        }
+                    }
+                )
+            )
+            .labelsHidden()
+            .tint(.accent)
+            .disabled(emailPreferences.isToggleDisabled)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .opacity(emailPreferences.isUpdating ? 0.68 : 1)
+    }
+
+    private var emailSubtitle: String {
+        if let errorMessage = emailPreferences.errorMessage {
+            return errorMessage
+        }
+
+        switch emailPreferences.loadState {
+        case .loading:
+            return "Checking your email settings…"
+        case .ready, .failed:
+            return "Account and security emails always come through."
+        }
+    }
+
+    private var emailSubtitleColor: Color {
+        emailPreferences.errorMessage == nil
+            ? .white.opacity(0.64)
+            : .orange
     }
 
     private var permissionStatusRow: some View {

--- a/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorder.swift
+++ b/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorder.swift
@@ -94,11 +94,13 @@ final class LifecycleEventRecorder {
         )
     }
 
+    /// Unlike the other lifecycle events, this one backs a settings control the
+    /// user is watching, so it reports failure instead of swallowing it.
     func recordCommunicationPreferences(
         lifecycleEmailsEnabled: Bool? = nil,
         productUpdatesEnabled: Bool? = nil,
         climbDropEmailsEnabled: Bool? = nil
-    ) {
+    ) async throws {
         var payload: [String: Any] = [:]
         if let lifecycleEmailsEnabled {
             payload["lifecycleEmailsEnabled"] = lifecycleEmailsEnabled
@@ -111,7 +113,10 @@ final class LifecycleEventRecorder {
         }
         guard !payload.isEmpty else { return }
 
-        record(type: "communication_preferences_updated", payload: payload)
+        try await record(
+            type: "communication_preferences_updated",
+            payload: payload
+        )
     }
 
     private func recordPaywallEvent(
@@ -126,31 +131,52 @@ final class LifecycleEventRecorder {
         record(type: type, payload: payload)
     }
 
+    /// Fire-and-forget recording for observational events, where a failed send
+    /// is not worth interrupting the user over.
     private func record(type: String, payload: sending [String: Any]) {
+        Task {
+            do {
+                try await record(type: type, payload: payload)
+            } catch {
+                guard !Self.isExpectedTransportNoise(error) else { return }
+
+                TelemetryManager.shared.recordError(
+                    error,
+                    context: .network,
+                    code: "lifecycle_event_record_failed",
+                    additionalInfo: ["type": type]
+                )
+            }
+        }
+    }
+
+    private func record(
+        type: String,
+        payload: sending [String: Any]
+    ) async throws {
         // Lifecycle events are per-user server state; the callable rejects
         // unauthenticated requests, so don't send them while signed out.
-        guard Auth.auth().currentUser != nil else { return }
+        guard Auth.auth().currentUser != nil else {
+            throw LifecycleEventRecorderError.signedOut
+        }
 
         let eventData: [String: Any] = [
             "type": type,
             "payload": payload
         ]
 
-        functions.httpsCallable("recordLifecycleEvent").call(eventData) { _, error in
-            guard let error, !Self.isExpectedTransportNoise(error) else { return }
-
-            TelemetryManager.shared.recordError(
-                error,
-                context: .network,
-                code: "lifecycle_event_record_failed",
-                additionalInfo: ["type": type]
-            )
-        }
+        _ = try await functions
+            .httpsCallable("recordLifecycleEvent")
+            .call(eventData)
     }
 
     /// Errors that are part of normal operation — a request cancelled by the
     /// system mid-flight, or auth racing sign-out — not defects worth alerting on.
     private nonisolated static func isExpectedTransportNoise(_ error: Error) -> Bool {
+        if error is LifecycleEventRecorderError {
+            return true
+        }
+
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
             return true

--- a/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorder.swift
+++ b/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorder.swift
@@ -113,7 +113,7 @@ final class LifecycleEventRecorder {
         }
         guard !payload.isEmpty else { return }
 
-        try await record(
+        try await sendLifecycleEvent(
             type: "communication_preferences_updated",
             payload: payload
         )
@@ -136,7 +136,7 @@ final class LifecycleEventRecorder {
     private func record(type: String, payload: sending [String: Any]) {
         Task {
             do {
-                try await record(type: type, payload: payload)
+                try await sendLifecycleEvent(type: type, payload: payload)
             } catch {
                 guard !Self.isExpectedTransportNoise(error) else { return }
 
@@ -150,7 +150,7 @@ final class LifecycleEventRecorder {
         }
     }
 
-    private func record(
+    private func sendLifecycleEvent(
         type: String,
         payload: sending [String: Any]
     ) async throws {

--- a/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorder.swift
+++ b/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorder.swift
@@ -173,8 +173,13 @@ final class LifecycleEventRecorder {
     /// Errors that are part of normal operation — a request cancelled by the
     /// system mid-flight, or auth racing sign-out — not defects worth alerting on.
     private nonisolated static func isExpectedTransportNoise(_ error: Error) -> Bool {
-        if error is LifecycleEventRecorderError {
-            return true
+        if let recorderError = error as? LifecycleEventRecorderError {
+            // Exhaustive on purpose: a new case must decide for itself whether
+            // it is noise rather than inheriting silence.
+            switch recorderError {
+            case .signedOut:
+                return true
+            }
         }
 
         let nsError = error as NSError

--- a/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorderError.swift
+++ b/AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorderError.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Failures raised before a lifecycle event reaches the network.
+enum LifecycleEventRecorderError: Error, Equatable {
+    /// Lifecycle events are per-user server state, and the callable rejects
+    /// unauthenticated requests, so there is nothing to send while signed out.
+    case signedOut
+}

--- a/AscendAppTests/EmailPreferencesViewModelTests.swift
+++ b/AscendAppTests/EmailPreferencesViewModelTests.swift
@@ -42,6 +42,51 @@ struct EmailPreferencesViewModelTests {
     }
 
     @Test
+    func aFailedRefreshKeepsTheLastKnownGoodValue() async {
+        // Returning to an open screen with no network must not take a working
+        // toggle away: the value already read is still the best one we have.
+        let service = StubEmailPreferencesService(storedValue: false)
+        let viewModel = EmailPreferencesViewModel(service: service)
+        await viewModel.load()
+
+        await service.setLoadError(StubError.offline)
+        await viewModel.load()
+
+        #expect(viewModel.isLifecycleEmailsEnabled == false)
+        #expect(viewModel.loadState == .ready)
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.isToggleDisabled == false)
+    }
+
+    @Test
+    func aSucceedingRefreshPicksUpAServerSideChange() async {
+        let service = StubEmailPreferencesService(storedValue: true)
+        let viewModel = EmailPreferencesViewModel(service: service)
+        await viewModel.load()
+        #expect(viewModel.isLifecycleEmailsEnabled == true)
+
+        await service.setStoredValue(false)
+        await viewModel.load()
+
+        #expect(viewModel.isLifecycleEmailsEnabled == false)
+        #expect(viewModel.loadState == .ready)
+    }
+
+    @Test
+    func concurrentLoadsReadTheServerOnce() async {
+        let service = StubEmailPreferencesService(storedValue: false)
+        let viewModel = EmailPreferencesViewModel(service: service)
+
+        async let first: Void = viewModel.load()
+        async let second: Void = viewModel.load()
+        _ = await (first, second)
+
+        #expect(await service.loadCount == 1)
+        #expect(viewModel.loadState == .ready)
+        #expect(viewModel.isLifecycleEmailsEnabled == false)
+    }
+
+    @Test
     func togglingOffWritesThePreference() async {
         let service = StubEmailPreferencesService(storedValue: true)
         let viewModel = EmailPreferencesViewModel(service: service)
@@ -125,9 +170,14 @@ private actor StubEmailPreferencesService: EmailPreferencesProviding {
     private var loadError: Error?
     private var saveError: Error?
     private(set) var savedValues: [Bool] = []
+    private(set) var loadCount = 0
 
     init(storedValue: Bool) {
         self.storedValue = storedValue
+    }
+
+    func setStoredValue(_ value: Bool) {
+        storedValue = value
     }
 
     func setLoadError(_ error: Error?) {
@@ -139,6 +189,8 @@ private actor StubEmailPreferencesService: EmailPreferencesProviding {
     }
 
     func loadLifecycleEmailsEnabled() async throws -> Bool {
+        loadCount += 1
+
         if let loadError {
             throw loadError
         }

--- a/AscendAppTests/EmailPreferencesViewModelTests.swift
+++ b/AscendAppTests/EmailPreferencesViewModelTests.swift
@@ -87,6 +87,54 @@ struct EmailPreferencesViewModelTests {
     }
 
     @Test
+    func aWriteThatLandsDuringARefreshSurvivesIt() async {
+        // The refresh read the value before the user turned the toggle off, so
+        // resolving it afterwards must not put the toggle back on while the
+        // server holds off.
+        let service = SuspendingEmailPreferencesService(storedValue: true)
+        let viewModel = EmailPreferencesViewModel(service: service)
+        await viewModel.load()
+        #expect(viewModel.isLifecycleEmailsEnabled == true)
+
+        await service.startSuspendingLoads()
+        async let refresh: Void = viewModel.load()
+        await service.waitForSuspendedLoad()
+
+        await viewModel.setLifecycleEmailsEnabled(false)
+        #expect(viewModel.isLifecycleEmailsEnabled == false)
+
+        await service.resumeSuspendedLoad(returning: true)
+        await refresh
+
+        #expect(viewModel.isLifecycleEmailsEnabled == false)
+        #expect(viewModel.loadState == .ready)
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test
+    func aFailedWriteThatRevertsDuringARefreshKeepsItsMessage() async {
+        // The revert settles the value too, so a read that started earlier must
+        // not overwrite it or clear the failure the user needs to see.
+        let service = SuspendingEmailPreferencesService(storedValue: true)
+        let viewModel = EmailPreferencesViewModel(service: service)
+        await viewModel.load()
+
+        await service.startSuspendingLoads()
+        await service.setSaveError(StubError.offline)
+        async let refresh: Void = viewModel.load()
+        await service.waitForSuspendedLoad()
+
+        await viewModel.setLifecycleEmailsEnabled(false)
+
+        await service.resumeSuspendedLoad(returning: false)
+        await refresh
+
+        #expect(viewModel.isLifecycleEmailsEnabled == true)
+        #expect(viewModel.errorMessage != nil)
+        #expect(viewModel.loadState == .ready)
+    }
+
+    @Test
     func togglingOffWritesThePreference() async {
         let service = StubEmailPreferencesService(storedValue: true)
         let viewModel = EmailPreferencesViewModel(service: service)
@@ -163,6 +211,61 @@ struct EmailPreferencesViewModelTests {
 
 private enum StubError: Error {
     case offline
+}
+
+/// Parks a read on a continuation so a test can land a write in the middle of
+/// it without depending on timing.
+private actor SuspendingEmailPreferencesService: EmailPreferencesProviding {
+    private var storedValue: Bool
+    private var saveError: Error?
+    private var isSuspendingLoads = false
+    private var suspendedLoad: CheckedContinuation<Bool, Error>?
+    private var loadObserver: CheckedContinuation<Void, Never>?
+
+    init(storedValue: Bool) {
+        self.storedValue = storedValue
+    }
+
+    func setSaveError(_ error: Error?) {
+        saveError = error
+    }
+
+    func startSuspendingLoads() {
+        isSuspendingLoads = true
+    }
+
+    func waitForSuspendedLoad() async {
+        guard suspendedLoad == nil else { return }
+
+        await withCheckedContinuation { continuation in
+            loadObserver = continuation
+        }
+    }
+
+    func resumeSuspendedLoad(returning value: Bool) {
+        let continuation = suspendedLoad
+        suspendedLoad = nil
+        continuation?.resume(returning: value)
+    }
+
+    func loadLifecycleEmailsEnabled() async throws -> Bool {
+        guard isSuspendingLoads else { return storedValue }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            suspendedLoad = continuation
+            let observer = loadObserver
+            loadObserver = nil
+            observer?.resume()
+        }
+    }
+
+    func setLifecycleEmailsEnabled(_ isEnabled: Bool) async throws {
+        if let saveError {
+            throw saveError
+        }
+
+        storedValue = isEnabled
+    }
 }
 
 private actor StubEmailPreferencesService: EmailPreferencesProviding {

--- a/AscendAppTests/EmailPreferencesViewModelTests.swift
+++ b/AscendAppTests/EmailPreferencesViewModelTests.swift
@@ -1,0 +1,157 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+@MainActor
+struct EmailPreferencesViewModelTests {
+    @Test
+    func loadReadsTheServerPreference() async {
+        let service = StubEmailPreferencesService(storedValue: false)
+        let viewModel = EmailPreferencesViewModel(service: service)
+
+        await viewModel.load()
+
+        #expect(viewModel.isLifecycleEmailsEnabled == false)
+        #expect(viewModel.loadState == .ready)
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test
+    func loadSurfacesAnUnsubscribeMadeFromAnEmailLink() async {
+        // The unsubscribe link flips the same server preference, so the toggle
+        // has to reflect it rather than trust a stale local default.
+        let service = StubEmailPreferencesService(storedValue: false)
+        let viewModel = EmailPreferencesViewModel(service: service)
+        #expect(viewModel.isLifecycleEmailsEnabled == true)
+
+        await viewModel.load()
+
+        #expect(viewModel.isLifecycleEmailsEnabled == false)
+    }
+
+    @Test
+    func failedLoadReportsTheFailure() async {
+        let service = StubEmailPreferencesService(storedValue: true)
+        await service.setLoadError(StubError.offline)
+        let viewModel = EmailPreferencesViewModel(service: service)
+
+        await viewModel.load()
+
+        #expect(viewModel.loadState == .failed)
+        #expect(viewModel.errorMessage != nil)
+    }
+
+    @Test
+    func togglingOffWritesThePreference() async {
+        let service = StubEmailPreferencesService(storedValue: true)
+        let viewModel = EmailPreferencesViewModel(service: service)
+        await viewModel.load()
+
+        await viewModel.setLifecycleEmailsEnabled(false)
+
+        #expect(await service.savedValues == [false])
+        #expect(viewModel.isLifecycleEmailsEnabled == false)
+        #expect(viewModel.errorMessage == nil)
+        #expect(viewModel.isUpdating == false)
+    }
+
+    @Test
+    func togglingBackOnWritesThePreference() async {
+        let service = StubEmailPreferencesService(storedValue: false)
+        let viewModel = EmailPreferencesViewModel(service: service)
+        await viewModel.load()
+
+        await viewModel.setLifecycleEmailsEnabled(true)
+
+        #expect(await service.savedValues == [true])
+        #expect(viewModel.isLifecycleEmailsEnabled == true)
+    }
+
+    @Test
+    func aFailedWriteRevertsTheToggle() async {
+        let service = StubEmailPreferencesService(storedValue: true)
+        let viewModel = EmailPreferencesViewModel(service: service)
+        await viewModel.load()
+        await service.setSaveError(StubError.offline)
+
+        await viewModel.setLifecycleEmailsEnabled(false)
+
+        #expect(viewModel.isLifecycleEmailsEnabled == true)
+        #expect(viewModel.errorMessage != nil)
+        #expect(viewModel.isUpdating == false)
+    }
+
+    @Test
+    func writingTheCurrentValueIsANoOp() async {
+        let service = StubEmailPreferencesService(storedValue: true)
+        let viewModel = EmailPreferencesViewModel(service: service)
+        await viewModel.load()
+
+        await viewModel.setLifecycleEmailsEnabled(true)
+
+        #expect(await service.savedValues.isEmpty)
+    }
+
+    @Test
+    func theToggleStaysDisabledUntilTheServerValueArrives() async {
+        let service = StubEmailPreferencesService(storedValue: true)
+        let viewModel = EmailPreferencesViewModel(service: service)
+
+        #expect(viewModel.isToggleDisabled == true)
+
+        await viewModel.load()
+
+        #expect(viewModel.isToggleDisabled == false)
+    }
+
+    @Test
+    func theToggleStaysDisabledWhenTheServerValueIsUnknown() async {
+        let service = StubEmailPreferencesService(storedValue: true)
+        await service.setLoadError(StubError.offline)
+        let viewModel = EmailPreferencesViewModel(service: service)
+
+        await viewModel.load()
+
+        #expect(viewModel.isToggleDisabled == true)
+    }
+}
+
+private enum StubError: Error {
+    case offline
+}
+
+private actor StubEmailPreferencesService: EmailPreferencesProviding {
+    private var storedValue: Bool
+    private var loadError: Error?
+    private var saveError: Error?
+    private(set) var savedValues: [Bool] = []
+
+    init(storedValue: Bool) {
+        self.storedValue = storedValue
+    }
+
+    func setLoadError(_ error: Error?) {
+        loadError = error
+    }
+
+    func setSaveError(_ error: Error?) {
+        saveError = error
+    }
+
+    func loadLifecycleEmailsEnabled() async throws -> Bool {
+        if let loadError {
+            throw loadError
+        }
+
+        return storedValue
+    }
+
+    func setLifecycleEmailsEnabled(_ isEnabled: Bool) async throws {
+        if let saveError {
+            throw saveError
+        }
+
+        savedValues.append(isEnabled)
+        storedValue = isEnabled
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -733,16 +733,25 @@ Website source lives in `web/` and is built to `web/dist/` before deploy.
   A missing or short key makes `getTransactionalEmailConfig()` throw, which fails every transactional send, so add the key to each environment's secret *before* deploying functions.
   It fails loudly by design: mail must never go out without a working opt-out path.
   Rotating the key invalidates unsubscribe links in already-delivered mail, so treat it as long-lived.
+- `TRANSACTIONAL_EMAIL_CONFIG.websiteUrl` is **required** and must be an https URL, and it carries the same before-deploy secret-ordering requirement as `unsubscribeSigningKey`: set it in each environment's secret *before* deploying functions or every transactional send fails.
+  It is required rather than defaulted because it is the host the unsubscribe link points at, and the token in that link is signed with the *current* environment's key.
+  A silent fallback to the production host would make staging emails carry links that verify against the production key and never work.
 - Every user-addressed email carries RFC 8058 one-click `List-Unsubscribe` headers plus a footer unsubscribe link, both derived from the job's `recipientUid`.
   Waitlist mail (Beehiiv owns its own opt-out) and admin feedback notifications have no `recipientUid` and intentionally get neither.
 - The unsubscribe endpoint (`/api/unsubscribe` hosting rewrite to `unsubscribeFromEmails`) answers GET with a confirmation page and only acts on POST.
   Keep that split: link scanners and mail-client prefetchers follow GETs, and a GET that unsubscribes would opt users out without their knowledge.
-- `users/{uid}/communication_preferences/current` has two writers: `recordLifecycleEvent` (email prefs) and `updatePushNotificationPreferences` (push prefs).
+- `users/{uid}/communication_preferences/current` has three writers: `recordLifecycleEvent` (email prefs), `updatePushNotificationPreferences` (push prefs), and `unsubscribeFromEmails` (the email unsubscribe endpoint).
   Any write to it must merge, or one feature silently clears the other's preference.
+  `recordLifecycleEvent` and `unsubscribeFromEmails` merge by passing `{merge: true}` and building the document through the shared `buildNextCommunicationPreferences` helper; `updatePushNotificationPreferences` does not pass `{merge: true}` and is safe only because it does a transactional read-modify-write that spreads `...existing`.
+  Route new writers through `buildNextCommunicationPreferences` rather than hand-rolling the document shape.
 - The Functions emulator proxies the `firebase-admin` namespace and strips its statics: inside it, `admin.firestore` is a function but `admin.firestore.Timestamp` and `.FieldValue` are `undefined`, so code using them throws only under the emulator and works in production.
   Import from the modular entry point instead (`import {Timestamp} from "firebase-admin/firestore"`) for anything that needs to run under `firebase emulators:start`.
   The Firestore emulator's REST API also enforces `firestore.rules`; seed fixtures with an `Authorization: Bearer owner` header to get the admin bypass.
 - Legacy queued transactional emails are delivered in the background by the scheduled `processEmailJobs` worker. Do not reintroduce waitlist welcome emails through `email_jobs` unless product explicitly moves off Beehiiv.
+- The lifecycle email preference is gated twice: once when the job is queued and again in `processEmailJobs` right before it sends.
+  Both gates are required. A retrying job backs off up to ~14 hours, so a queue-time-only check would still deliver mail to someone who unsubscribed in that window.
+  A job suppressed at send time gets the terminal `skipped` status, never `failed` - nothing went wrong and there is nothing to retry.
+  The gate applies only to jobs carrying a `recipientUid`; waitlist and admin feedback mail have no uid and always send.
 - In-app feedback submissions (`feedback` collection) trigger `onFeedbackCreated`, which sends an admin notification email directly via Resend (not queued). The recipient is `feedbackNotificationEmail` from the secret config (falls back to `replyTo` → `fromEmail`). Reply-to is set to the submitting user's email. Notification delivery metadata is written back onto the feedback document.
 - Email copy, templates, lifecycle automations, Beehiiv campaigns, and subject lines must follow the Ascend Email Playbook. Codex has this as the `ascend-email-playbook` skill at `~/.codex/skills/ascend-email-playbook`; other agents should apply the same rule set: app-triggered emails go through Cloud Functions/Resend with deterministic dedupe, broadcasts go through Beehiiv, copy is competitive/stair-stepper-specific, and each email has one primary CTA.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -729,6 +729,19 @@ Website source lives in `web/` and is built to `web/dist/` before deploy.
 - `joinWaitlist` rate limits public submissions using hashed requester IPs stored in `email_rate_limits`, calls Beehiiv, and mirrors normalized email hash + Beehiiv subscription metadata in the `waitlist` collection for dedupe/debugging.
 - Transactional emails for feedback and future non-Beehiiv product triggers must be sent server-side from Cloud Functions, never directly from the website or iOS client.
 - Cloud Functions email provider config lives in the `TRANSACTIONAL_EMAIL_CONFIG` Secret Manager JSON secret, with `functions/.secret.local` used only for local emulator overrides.
+- `TRANSACTIONAL_EMAIL_CONFIG.unsubscribeSigningKey` is **required** (min 32 chars) and signs unsubscribe tokens.
+  A missing or short key makes `getTransactionalEmailConfig()` throw, which fails every transactional send, so add the key to each environment's secret *before* deploying functions.
+  It fails loudly by design: mail must never go out without a working opt-out path.
+  Rotating the key invalidates unsubscribe links in already-delivered mail, so treat it as long-lived.
+- Every user-addressed email carries RFC 8058 one-click `List-Unsubscribe` headers plus a footer unsubscribe link, both derived from the job's `recipientUid`.
+  Waitlist mail (Beehiiv owns its own opt-out) and admin feedback notifications have no `recipientUid` and intentionally get neither.
+- The unsubscribe endpoint (`/api/unsubscribe` hosting rewrite to `unsubscribeFromEmails`) answers GET with a confirmation page and only acts on POST.
+  Keep that split: link scanners and mail-client prefetchers follow GETs, and a GET that unsubscribes would opt users out without their knowledge.
+- `users/{uid}/communication_preferences/current` has two writers: `recordLifecycleEvent` (email prefs) and `updatePushNotificationPreferences` (push prefs).
+  Any write to it must merge, or one feature silently clears the other's preference.
+- The Functions emulator proxies the `firebase-admin` namespace and strips its statics: inside it, `admin.firestore` is a function but `admin.firestore.Timestamp` and `.FieldValue` are `undefined`, so code using them throws only under the emulator and works in production.
+  Import from the modular entry point instead (`import {Timestamp} from "firebase-admin/firestore"`) for anything that needs to run under `firebase emulators:start`.
+  The Firestore emulator's REST API also enforces `firestore.rules`; seed fixtures with an `Authorization: Bearer owner` header to get the admin bypass.
 - Legacy queued transactional emails are delivered in the background by the scheduled `processEmailJobs` worker. Do not reintroduce waitlist welcome emails through `email_jobs` unless product explicitly moves off Beehiiv.
 - In-app feedback submissions (`feedback` collection) trigger `onFeedbackCreated`, which sends an admin notification email directly via Resend (not queued). The recipient is `feedbackNotificationEmail` from the secret config (falls back to `replyTo` → `fromEmail`). Reply-to is set to the submitting user's email. Notification delivery metadata is written back onto the feedback document.
 - Email copy, templates, lifecycle automations, Beehiiv campaigns, and subject lines must follow the Ascend Email Playbook. Codex has this as the `ascend-email-playbook` skill at `~/.codex/skills/ascend-email-playbook`; other agents should apply the same rule set: app-triggered emails go through Cloud Functions/Resend with deterministic dedupe, broadcasts go through Beehiiv, copy is competitive/stair-stepper-specific, and each email has one primary CTA.

--- a/firebase.json
+++ b/firebase.json
@@ -57,6 +57,10 @@
       {
         "source": "/api/join-waitlist",
         "function": "joinWaitlist"
+      },
+      {
+        "source": "/api/unsubscribe",
+        "function": "unsubscribeFromEmails"
       }
     ]
   }

--- a/functions/EMAIL_SETUP.md
+++ b/functions/EMAIL_SETUP.md
@@ -13,6 +13,7 @@ Ascend's Cloud Functions use the `TRANSACTIONAL_EMAIL_CONFIG` JSON secret for ba
   "fromEmail": "hello@updates.ascendstepper.com",
   "fromName": "Ascend",
   "replyTo": "support@ascendstepper.com",
+  "unsubscribeSigningKey": "a-long-random-secret-of-at-least-32-chars",
   "websiteUrl": "https://ascendstepper.com"
 }
 ```
@@ -24,14 +25,22 @@ Ascend's Cloud Functions use the `TRANSACTIONAL_EMAIL_CONFIG` JSON secret for ba
 - Keep the API key only in Secret Manager or local emulator secret overrides.
 - `betaInviteUrl` is optional. If set, waitlist emails show a primary TestFlight CTA.
 - `feedbackNotificationEmail` is optional. Admin email for feedback notifications. Falls back to `replyTo`, then `fromEmail`.
-- `websiteUrl` is optional. If omitted, waitlist emails fall back to `https://ascendstepper.com`.
+
+### Required fields
+
+`provider`, `apiKey`, `fromEmail`, and `fromName` are required, plus the two below.
+`getTransactionalEmailConfig()` throws when any is missing or invalid, which fails every transactional send, so set them in each environment's secret *before* deploying functions.
+See CLAUDE.md, Firebase Hosting, for why these two fail loudly rather than defaulting.
+
+- `unsubscribeSigningKey` is **required** and must be at least 32 characters. It signs the HMAC unsubscribe tokens in outgoing email. Rotating it invalidates the unsubscribe links in already-delivered mail, so treat it as long-lived.
+- `websiteUrl` is **required** and must be an https URL. It is the host the unsubscribe link points at, and the trailing slash and fragment are normalized away.
 
 ## Local emulator
 
 Firebase's Cloud Functions emulator can override secret values with `functions/.secret.local`.
 
 ```dotenv
-TRANSACTIONAL_EMAIL_CONFIG={"provider":"resend","apiKey":"re_xxxxxxxxx","betaInviteUrl":"https://testflight.apple.com/join/ZZ1zUmBf","fromEmail":"hello@updates.ascendstepper.com","fromName":"Ascend","replyTo":"support@ascendstepper.com","websiteUrl":"https://ascendstepper.com"}
+TRANSACTIONAL_EMAIL_CONFIG={"provider":"resend","apiKey":"re_xxxxxxxxx","betaInviteUrl":"https://testflight.apple.com/join/ZZ1zUmBf","fromEmail":"hello@updates.ascendstepper.com","fromName":"Ascend","replyTo":"support@ascendstepper.com","unsubscribeSigningKey":"a-long-random-secret-of-at-least-32-chars","websiteUrl":"https://ascendstepper.com"}
 ```
 
 ## Deploying the secret
@@ -51,9 +60,18 @@ npx firebase-tools deploy --only firestore:rules,firestore:indexes,functions
 ## Current behavior
 
 - `joinWaitlist` validates email input, rate limits by hashed requester IP, and subscribes the address to Beehiiv. Beehiiv owns broadcast/newsletter delivery and any Beehiiv-hosted welcome email.
-- The scheduled `processEmailJobs` worker sends queued transactional app emails.
+- The scheduled `processEmailJobs` worker sends queued transactional app emails. It asserts the secret config once per invocation before claiming any job, so a mis-ordered deploy fails the whole run loudly instead of per message.
 - `email_jobs` stores queue state, attempts, retry timing, and provider metadata.
 - Retryable provider failures are requeued automatically; permanent failures are marked on the job.
+
+## Unsubscribe
+
+- Every email addressed to a user carries RFC 8058 one-click `List-Unsubscribe` headers and a footer unsubscribe link, both derived from the job's `recipientUid`.
+- Waitlist mail and admin feedback notifications carry neither. They have no `recipientUid`, and Beehiiv owns the waitlist opt-out.
+- Links point at `/api/unsubscribe`, a Hosting rewrite to the `unsubscribeFromEmails` function, and carry an HMAC token signed with `unsubscribeSigningKey`. Tokens do not expire, so links outlive the message.
+- `GET` renders a confirmation page and does not act; `POST` performs the opt-out and sets `lifecycleEmailsEnabled: false`. See CLAUDE.md, Firebase Hosting, for why that split is load-bearing.
+- The write merges into `users/{uid}/communication_preferences/current`, so the push notification preference survives.
+- The in-app toggle at Settings, Notifications writes the same preference.
 
 ## Lifecycle email automation
 
@@ -63,7 +81,9 @@ npx firebase-tools deploy --only firestore:rules,firestore:indexes,functions
 - If the user answered `no`, it queues `rating_negative_feedback`.
 - The job ID is deterministic from `rating-prompt-answer-email:{uid}`, so the prompt can only enqueue one follow-up email per user.
 - The automation skips the queue when `users/{uid}/communication_preferences/current.lifecycleEmailsEnabled` is explicitly `false`.
-- The scheduled `processEmailJobs` worker sends the queued email through Resend.
+- The scheduled `processEmailJobs` worker re-reads that same preference right before it sends, and sends the queued email through Resend only if it still passes. Both gates are required: a retrying job can be hours old, so the user may have unsubscribed since it was queued.
+- A job suppressed at send time gets the terminal `skipped` status, never `failed`. Nothing went wrong and there is nothing to retry.
+- The gate applies only to jobs carrying a `recipientUid`.
 
 ## Feedback notifications
 

--- a/functions/src/email/automation.ts
+++ b/functions/src/email/automation.ts
@@ -1,6 +1,7 @@
 import * as admin from "firebase-admin";
 import {onDocumentWritten} from "firebase-functions/v2/firestore";
 import {normalizeEmail, sha256Hex} from "./crypto";
+import {isLifecycleEmailAllowed} from "./preferences";
 import {buildEmailJobId, createQueuedEmailJob} from "./queue";
 import type {EmailType} from "./types";
 
@@ -39,17 +40,6 @@ export function emailTypeForRatingPromptResponse(
  */
 export function buildRatingPromptEmailDedupeKey(uid: string): string {
   return `rating-prompt-answer-email:${uid}`;
-}
-
-/**
- * Determines whether lifecycle emails are currently allowed.
- * @param {PlainObject | null} preferences Stored communication preferences.
- * @return {boolean} True unless lifecycle emails were explicitly disabled.
- */
-export function isLifecycleEmailAllowed(
-  preferences: PlainObject | null
-): boolean {
-  return preferences?.lifecycleEmailsEnabled !== false;
 }
 
 /**

--- a/functions/src/email/automation.ts
+++ b/functions/src/email/automation.ts
@@ -178,7 +178,8 @@ async function queueRatingPromptEmail(input: {
       dedupeKey,
       {},
       now,
-      input.sourceRef
+      input.sourceRef,
+      input.uid
     );
     transaction.set(jobRef, job);
     return "queued";

--- a/functions/src/email/catalog.ts
+++ b/functions/src/email/catalog.ts
@@ -11,12 +11,16 @@ import {
 import type {
   EmailJobDocument,
   EmailJobPayload,
+  EmailRenderContext,
   EmailType,
   TransactionalEmailRenderResult,
 } from "./types";
 
 export interface EmailTypeDefinition {
-  render: (payload: EmailJobPayload) => TransactionalEmailRenderResult;
+  render: (
+    payload: EmailJobPayload,
+    context: EmailRenderContext
+  ) => TransactionalEmailRenderResult;
   retryDelaysMs: number[];
   sendPolicy: "send_now";
 }
@@ -74,10 +78,12 @@ export const emailTypeConfigs: Record<EmailType, EmailTypeDefinition> = {
 /**
  * Renders email content for a queued job using the type config map.
  * @param {EmailJobDocument} job - Queued email job
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Subject and rendered bodies
  */
 export function renderEmailContentForJob(
-  job: EmailJobDocument
+  job: EmailJobDocument,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
-  return emailTypeConfigs[job.type].render(job.payload);
+  return emailTypeConfigs[job.type].render(job.payload, context);
 }

--- a/functions/src/email/config.ts
+++ b/functions/src/email/config.ts
@@ -100,9 +100,9 @@ export function getTransactionalEmailConfig(): TransactionalEmailConfig {
 /**
  * Throws unless the transactional email secret is present and valid.
  *
- * Callers that render before sending use this to surface a deploy-config
- * problem as its own failure, rather than letting it reach a render path that
- * would misread it as an unrenderable payload.
+ * Lets a sender check the deploy config up front and fail on it directly,
+ * instead of leaving it to surface deeper in a render or send path that would
+ * misread it as a problem with the individual message.
  */
 export function assertTransactionalEmailConfig(): void {
   getTransactionalEmailConfig();

--- a/functions/src/email/config.ts
+++ b/functions/src/email/config.ts
@@ -98,6 +98,17 @@ export function getTransactionalEmailConfig(): TransactionalEmailConfig {
 }
 
 /**
+ * Throws unless the transactional email secret is present and valid.
+ *
+ * Callers that render before sending use this to surface a deploy-config
+ * problem as its own failure, rather than letting it reach a render path that
+ * would misread it as an unrenderable payload.
+ */
+export function assertTransactionalEmailConfig(): void {
+  getTransactionalEmailConfig();
+}
+
+/**
  * Returns the HMAC signing key used for one-click unsubscribe tokens.
  * @return {string} Unsubscribe signing key
  */
@@ -107,9 +118,11 @@ export function getUnsubscribeSigningKey(): string {
 
 /**
  * Returns the public marketing website used in customer-facing email copy.
- * Falls back to the primary marketing site only in test-only render paths
- * where the secret is unavailable; a configured secret must carry a valid
- * websiteUrl or getTransactionalEmailConfig throws before any send.
+ *
+ * The fallback covers only render paths that never set the secret, such as
+ * template tests. A secret that is present but invalid throws instead: it is
+ * the host the unsubscribe link points at, so guessing it wrong would emit
+ * links that verify against another environment's key and never work.
  * @return {string} Normalized website URL
  */
 export function getMarketingWebsiteUrl(): string {
@@ -117,11 +130,7 @@ export function getMarketingWebsiteUrl(): string {
     return DEFAULT_MARKETING_WEBSITE_URL;
   }
 
-  try {
-    return getTransactionalEmailConfig().websiteUrl;
-  } catch {
-    return DEFAULT_MARKETING_WEBSITE_URL;
-  }
+  return getTransactionalEmailConfig().websiteUrl;
 }
 
 /**

--- a/functions/src/email/config.ts
+++ b/functions/src/email/config.ts
@@ -6,6 +6,7 @@ export const transactionalEmailConfig =
 export const DEFAULT_MARKETING_WEBSITE_URL = "https://ascendstepper.com";
 export const DEFAULT_TRANSACTIONAL_REPLY_TO_EMAIL =
   "support@ascendstepper.com";
+export const MIN_UNSUBSCRIBE_SIGNING_KEY_LENGTH = 32;
 
 /**
  * Normalizes a public-facing HTTPS URL from config.
@@ -60,6 +61,18 @@ export function getTransactionalEmailConfig(): TransactionalEmailConfig {
     );
   }
 
+  // Required so a misconfigured secret fails loudly instead of quietly
+  // sending mail that carries no working unsubscribe path.
+  if (
+    !config.unsubscribeSigningKey ||
+    config.unsubscribeSigningKey.length < MIN_UNSUBSCRIBE_SIGNING_KEY_LENGTH
+  ) {
+    throw new Error(
+      "TRANSACTIONAL_EMAIL_CONFIG.unsubscribeSigningKey must be at least " +
+      `${MIN_UNSUBSCRIBE_SIGNING_KEY_LENGTH} characters`
+    );
+  }
+
   return {
     provider: config.provider,
     apiKey: config.apiKey,
@@ -68,8 +81,17 @@ export function getTransactionalEmailConfig(): TransactionalEmailConfig {
     fromEmail: config.fromEmail,
     fromName: config.fromName,
     replyTo: config.replyTo,
+    unsubscribeSigningKey: config.unsubscribeSigningKey,
     websiteUrl: config.websiteUrl,
   };
+}
+
+/**
+ * Returns the HMAC signing key used for one-click unsubscribe tokens.
+ * @return {string} Unsubscribe signing key
+ */
+export function getUnsubscribeSigningKey(): string {
+  return getTransactionalEmailConfig().unsubscribeSigningKey;
 }
 
 /**

--- a/functions/src/email/config.ts
+++ b/functions/src/email/config.ts
@@ -73,6 +73,17 @@ export function getTransactionalEmailConfig(): TransactionalEmailConfig {
     );
   }
 
+  // Required for the same reason as the signing key: this host is what the
+  // unsubscribe link points at, and the token is signed with this
+  // environment's key. Falling back to the production host would emit staging
+  // links that verify against the wrong key and never work.
+  const websiteUrl = normalizePublicUrl(config.websiteUrl);
+  if (!websiteUrl) {
+    throw new Error(
+      "TRANSACTIONAL_EMAIL_CONFIG.websiteUrl must be an https URL"
+    );
+  }
+
   return {
     provider: config.provider,
     apiKey: config.apiKey,
@@ -82,7 +93,7 @@ export function getTransactionalEmailConfig(): TransactionalEmailConfig {
     fromName: config.fromName,
     replyTo: config.replyTo,
     unsubscribeSigningKey: config.unsubscribeSigningKey,
-    websiteUrl: config.websiteUrl,
+    websiteUrl,
   };
 }
 
@@ -96,7 +107,9 @@ export function getUnsubscribeSigningKey(): string {
 
 /**
  * Returns the public marketing website used in customer-facing email copy.
- * Falls back to the primary marketing site when the secret is unavailable.
+ * Falls back to the primary marketing site only in test-only render paths
+ * where the secret is unavailable; a configured secret must carry a valid
+ * websiteUrl or getTransactionalEmailConfig throws before any send.
  * @return {string} Normalized website URL
  */
 export function getMarketingWebsiteUrl(): string {
@@ -105,17 +118,10 @@ export function getMarketingWebsiteUrl(): string {
   }
 
   try {
-    const configuredUrl = normalizePublicUrl(
-      getTransactionalEmailConfig().websiteUrl
-    );
-    if (configuredUrl) {
-      return configuredUrl;
-    }
+    return getTransactionalEmailConfig().websiteUrl;
   } catch {
-    // Ignore missing secret access in test-only render paths.
+    return DEFAULT_MARKETING_WEBSITE_URL;
   }
-
-  return DEFAULT_MARKETING_WEBSITE_URL;
 }
 
 /**

--- a/functions/src/email/html.ts
+++ b/functions/src/email/html.ts
@@ -1,0 +1,16 @@
+/**
+ * Escapes untrusted content before it is interpolated into HTML.
+ *
+ * Shared by every surface in the email subsystem that renders HTML, so a
+ * hardening change here cannot miss one of them.
+ * @param {string} value - Raw string value
+ * @return {string} HTML-escaped value
+ */
+export function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/functions/src/email/preferences.ts
+++ b/functions/src/email/preferences.ts
@@ -1,0 +1,61 @@
+import * as admin from "firebase-admin";
+import type {EmailJobDocument} from "./types";
+
+export type StoredCommunicationPreferences = Record<string, unknown> | null;
+export type CommunicationPreferencesReader = (
+  uid: string
+) => Promise<StoredCommunicationPreferences>;
+
+/**
+ * Determines whether lifecycle emails are currently allowed.
+ * @param {StoredCommunicationPreferences} preferences Stored preferences.
+ * @return {boolean} True unless lifecycle emails were explicitly disabled.
+ */
+export function isLifecycleEmailAllowed(
+  preferences: StoredCommunicationPreferences
+): boolean {
+  return preferences?.lifecycleEmailsEnabled !== false;
+}
+
+/**
+ * Reads a user's stored communication preferences.
+ * @param {string} uid Firebase Auth user ID.
+ * @return {Promise<StoredCommunicationPreferences>} Stored preferences.
+ */
+export async function readCommunicationPreferences(
+  uid: string
+): Promise<StoredCommunicationPreferences> {
+  const snapshot = await admin.firestore()
+    .collection("users")
+    .doc(uid)
+    .collection("communication_preferences")
+    .doc("current")
+    .get();
+
+  return snapshot.exists ?
+    snapshot.data() as Record<string, unknown> :
+    null;
+}
+
+/**
+ * Decides whether a claimed job must be suppressed instead of delivered.
+ *
+ * The queue-time gate is not enough on its own: a retrying job can sit in the
+ * queue for hours, so the preference is re-read at send time. Mail with no
+ * recipient uid (waitlist, admin notifications) has no preference to consult
+ * and always sends. A failed read throws rather than falling through, so a
+ * transient Firestore error can never deliver mail to an unsubscribed user.
+ * @param {Pick<EmailJobDocument, "recipientUid">} job Claimed email job.
+ * @param {CommunicationPreferencesReader} readPreferences Preference reader.
+ * @return {Promise<boolean>} True when the job must not be delivered.
+ */
+export async function isEmailJobSuppressed(
+  job: Pick<EmailJobDocument, "recipientUid">,
+  readPreferences: CommunicationPreferencesReader = readCommunicationPreferences
+): Promise<boolean> {
+  if (!job.recipientUid) {
+    return false;
+  }
+
+  return !isLifecycleEmailAllowed(await readPreferences(job.recipientUid));
+}

--- a/functions/src/email/preferences.ts
+++ b/functions/src/email/preferences.ts
@@ -1,10 +1,35 @@
 import * as admin from "firebase-admin";
 import type {EmailJobDocument} from "./types";
 
-export type StoredCommunicationPreferences = Record<string, unknown> | null;
+export type CommunicationPreferences = Record<string, unknown>;
+export type StoredCommunicationPreferences = CommunicationPreferences | null;
 export type CommunicationPreferencesReader = (
   uid: string
 ) => Promise<StoredCommunicationPreferences>;
+
+/**
+ * Builds the next communication preferences document from the stored one.
+ *
+ * The document is shared by every writer of communication_preferences, so only
+ * the keys in the payload change and unrelated stored keys are carried forward.
+ * @param {CommunicationPreferences} existing Stored preferences document.
+ * @param {CommunicationPreferences} payload Validated preference payload.
+ * @param {admin.firestore.Timestamp} now Server timestamp for this write.
+ * @return {CommunicationPreferences} Preferences document to write.
+ */
+export function buildNextCommunicationPreferences(
+  existing: CommunicationPreferences,
+  payload: CommunicationPreferences,
+  now: admin.firestore.Timestamp
+): CommunicationPreferences {
+  return {
+    ...existing,
+    ...payload,
+    createdAt: existing.createdAt ?? now,
+    schemaVersion: 1,
+    updatedAt: now,
+  };
+}
 
 /**
  * Determines whether lifecycle emails are currently allowed.

--- a/functions/src/email/processor.ts
+++ b/functions/src/email/processor.ts
@@ -6,6 +6,7 @@ import {
   transactionalEmailConfig,
 } from "./config";
 import {renderEmailContentForJob} from "./catalog";
+import {isEmailJobSuppressed} from "./preferences";
 import {sendTransactionalEmail, EmailDeliveryError} from "./provider";
 import {getNextRetryDelayMs} from "./retry";
 import {
@@ -16,6 +17,8 @@ import type {EmailJobDocument} from "./types";
 
 const JOB_BATCH_SIZE = 25;
 const STALE_PROCESSING_MS = 15 * 60 * 1000;
+
+type JobOutcome = "sent" | "retried" | "failed" | "skipped";
 
 /**
  * Creates a Firestore timestamp from a Date instance.
@@ -182,6 +185,26 @@ async function markJobFailed(
 }
 
 /**
+ * Marks an email job as intentionally not delivered.
+ *
+ * Distinct from "failed": nothing went wrong and there is nothing to retry,
+ * so attemptCount and the last error stay untouched.
+ * @param {DocumentReference} jobRef - Email job document reference
+ * @param {Timestamp} nowTimestamp - Current timestamp
+ * @return {Promise<void>}
+ */
+async function markJobSkipped(
+  jobRef: admin.firestore.DocumentReference,
+  nowTimestamp: admin.firestore.Timestamp
+): Promise<void> {
+  await jobRef.update({
+    processingStartedAt: null,
+    status: "skipped",
+    updatedAt: nowTimestamp,
+  });
+}
+
+/**
  * Requeues an email job after a retryable failure.
  * @param {DocumentReference} jobRef - Email job document reference
  * @param {Timestamp} nowTimestamp - Current timestamp
@@ -221,13 +244,25 @@ async function requeueEmailJob(
  * @param {DocumentReference} jobRef - Email job document reference
  * @param {EmailJobDocument} job - Claimed email job
  * @param {Timestamp} nowTimestamp - Current timestamp
- * @return {Promise<"sent" | "retried" | "failed">} Processing outcome
+ * @return {Promise<JobOutcome>} Processing outcome
  */
 async function processClaimedJob(
   jobRef: admin.firestore.DocumentReference,
   job: EmailJobDocument,
   nowTimestamp: admin.firestore.Timestamp
-): Promise<"sent" | "retried" | "failed"> {
+): Promise<JobOutcome> {
+  // Re-read the preference the job was queued under: a retrying job can be
+  // hours old, and the user may have unsubscribed in the meantime. A read
+  // failure throws rather than falling through to a send, leaving the job
+  // claimed for reclaim and a later retry.
+  if (await isEmailJobSuppressed(job)) {
+    await markJobSkipped(jobRef, nowTimestamp);
+    console.log("processEmailJobs skipped by preferences", {
+      jobId: jobRef.id,
+    });
+    return "skipped";
+  }
+
   const nextAttemptCount = job.attemptCount + 1;
   // A signing-key failure is a deploy-config problem, not a bad payload, so
   // let it throw: the job stays claimed and is reclaimed for a later retry
@@ -344,6 +379,7 @@ export const processEmailJobs = onSchedule(
     let sentCount = 0;
     let retriedCount = 0;
     let failedCount = 0;
+    let skippedCount = 0;
 
     for (const document of dueJobsSnapshot.docs) {
       const claimedJob = await claimEmailJob(document.ref, startedAtTimestamp);
@@ -360,6 +396,8 @@ export const processEmailJobs = onSchedule(
         sentCount += 1;
       } else if (outcome === "retried") {
         retriedCount += 1;
+      } else if (outcome === "skipped") {
+        skippedCount += 1;
       } else {
         failedCount += 1;
       }
@@ -371,6 +409,7 @@ export const processEmailJobs = onSchedule(
       reclaimedCount,
       retriedCount,
       sentCount,
+      skippedCount,
     });
   }
 );

--- a/functions/src/email/processor.ts
+++ b/functions/src/email/processor.ts
@@ -1,9 +1,17 @@
 import * as admin from "firebase-admin";
 import {onSchedule} from "firebase-functions/v2/scheduler";
-import {transactionalEmailConfig} from "./config";
+import {
+  getMarketingWebsiteUrl,
+  getUnsubscribeSigningKey,
+  transactionalEmailConfig,
+} from "./config";
 import {renderEmailContentForJob} from "./catalog";
 import {sendTransactionalEmail, EmailDeliveryError} from "./provider";
 import {getNextRetryDelayMs} from "./retry";
+import {
+  buildUnsubscribeToken,
+  buildUnsubscribeUrl,
+} from "./unsubscribeToken";
 import type {EmailJobDocument} from "./types";
 
 const JOB_BATCH_SIZE = 25;
@@ -29,6 +37,26 @@ function serializeErrorMessage(error: unknown): string {
   }
 
   return "unknown_error";
+}
+
+/**
+ * Builds the signed unsubscribe URL for a job's recipient.
+ *
+ * Only user-addressed mail gets a link: waitlist and admin notifications have
+ * no uid whose preference an unsubscribe could flip.
+ * @param {EmailJobDocument} job - Claimed email job
+ * @return {string | null} Signed unsubscribe URL, or null when not applicable
+ */
+function unsubscribeUrlForJob(job: EmailJobDocument): string | null {
+  if (!job.recipientUid) {
+    return null;
+  }
+
+  const token = buildUnsubscribeToken(
+    job.recipientUid,
+    getUnsubscribeSigningKey()
+  );
+  return buildUnsubscribeUrl(getMarketingWebsiteUrl(), token);
 }
 
 /**
@@ -201,10 +229,14 @@ async function processClaimedJob(
   nowTimestamp: admin.firestore.Timestamp
 ): Promise<"sent" | "retried" | "failed"> {
   const nextAttemptCount = job.attemptCount + 1;
+  // A signing-key failure is a deploy-config problem, not a bad payload, so
+  // let it throw: the job stays claimed and is reclaimed for a later retry
+  // instead of being dead-lettered as unrenderable.
+  const unsubscribeUrl = unsubscribeUrlForJob(job);
   let renderedEmail;
 
   try {
-    renderedEmail = renderEmailContentForJob(job);
+    renderedEmail = renderEmailContentForJob(job, {unsubscribeUrl});
   } catch (error) {
     await markJobFailed(
       jobRef,
@@ -228,6 +260,7 @@ async function processClaimedJob(
       subject: renderedEmail.subject,
       text: renderedEmail.text,
       to: [job.recipientEmail],
+      unsubscribeUrl,
     });
 
     await jobRef.update({

--- a/functions/src/email/processor.ts
+++ b/functions/src/email/processor.ts
@@ -264,12 +264,6 @@ async function processClaimedJob(
     return "skipped";
   }
 
-  // Every job, uid or not, resolves the config here rather than lazily inside
-  // the render below: a deploy-config problem is not a bad payload, and the
-  // render path dead-letters what it cannot render. Throwing leaves the job
-  // claimed for reclaim and a later retry.
-  assertTransactionalEmailConfig();
-
   const nextAttemptCount = job.attemptCount + 1;
   const unsubscribeUrl = unsubscribeUrlForJob(job);
   let renderedEmail;
@@ -370,6 +364,12 @@ export const processEmailJobs = onSchedule(
     timeZone: "Etc/UTC",
   },
   async () => {
+    // A batch-level precondition, checked before anything is claimed: without
+    // a valid secret no job in this run can be delivered, and mail must never
+    // go out without a working opt-out path. Throwing here fails the
+    // invocation, which is the signal a mis-ordered deploy needs to raise.
+    assertTransactionalEmailConfig();
+
     const startedAt = new Date();
     const startedAtTimestamp = toTimestamp(startedAt);
     const reclaimedCount = await reclaimStaleJobs(startedAtTimestamp);
@@ -400,8 +400,9 @@ export const processEmailJobs = onSchedule(
           startedAtTimestamp
         );
       } catch (error) {
-        // One job's config or Firestore failure must not end the run and stall
-        // the rest of the batch. The job stays claimed and unsent, so the
+        // Scoped to faults affecting this job alone, such as its own
+        // preference read failing: they must not end the run and stall the
+        // rest of the batch. The job stays claimed and unsent, so the
         // stale-processing reclaim requeues it rather than dead-lettering it.
         erroredCount += 1;
         console.error("processEmailJobs job error", {

--- a/functions/src/email/processor.ts
+++ b/functions/src/email/processor.ts
@@ -1,6 +1,7 @@
 import * as admin from "firebase-admin";
 import {onSchedule} from "firebase-functions/v2/scheduler";
 import {
+  assertTransactionalEmailConfig,
   getMarketingWebsiteUrl,
   getUnsubscribeSigningKey,
   transactionalEmailConfig,
@@ -263,10 +264,13 @@ async function processClaimedJob(
     return "skipped";
   }
 
+  // Every job, uid or not, resolves the config here rather than lazily inside
+  // the render below: a deploy-config problem is not a bad payload, and the
+  // render path dead-letters what it cannot render. Throwing leaves the job
+  // claimed for reclaim and a later retry.
+  assertTransactionalEmailConfig();
+
   const nextAttemptCount = job.attemptCount + 1;
-  // A signing-key failure is a deploy-config problem, not a bad payload, so
-  // let it throw: the job stays claimed and is reclaimed for a later retry
-  // instead of being dead-lettered as unrenderable.
   const unsubscribeUrl = unsubscribeUrlForJob(job);
   let renderedEmail;
 
@@ -380,6 +384,7 @@ export const processEmailJobs = onSchedule(
     let retriedCount = 0;
     let failedCount = 0;
     let skippedCount = 0;
+    let erroredCount = 0;
 
     for (const document of dueJobsSnapshot.docs) {
       const claimedJob = await claimEmailJob(document.ref, startedAtTimestamp);
@@ -387,11 +392,26 @@ export const processEmailJobs = onSchedule(
         continue;
       }
 
-      const outcome = await processClaimedJob(
-        document.ref,
-        claimedJob,
-        startedAtTimestamp
-      );
+      let outcome: JobOutcome;
+      try {
+        outcome = await processClaimedJob(
+          document.ref,
+          claimedJob,
+          startedAtTimestamp
+        );
+      } catch (error) {
+        // One job's config or Firestore failure must not end the run and stall
+        // the rest of the batch. The job stays claimed and unsent, so the
+        // stale-processing reclaim requeues it rather than dead-lettering it.
+        erroredCount += 1;
+        console.error("processEmailJobs job error", {
+          errorCode: "job_processing_error",
+          errorMessage: serializeErrorMessage(error),
+          jobId: document.ref.id,
+        });
+        continue;
+      }
+
       if (outcome === "sent") {
         sentCount += 1;
       } else if (outcome === "retried") {
@@ -404,6 +424,7 @@ export const processEmailJobs = onSchedule(
     }
 
     console.log("processEmailJobs summary", {
+      erroredCount,
       failedCount,
       queuedCount: dueJobsSnapshot.size,
       reclaimedCount,

--- a/functions/src/email/provider.ts
+++ b/functions/src/email/provider.ts
@@ -83,6 +83,28 @@ export function classifyResendStatus(
 }
 
 /**
+ * Builds the RFC 8058 one-click unsubscribe headers for a message.
+ *
+ * Both headers must travel together: mailbox providers only treat the list
+ * URL as one-click when List-Unsubscribe-Post is present, and without it a
+ * POST from Gmail would be indistinguishable from a link prefetch.
+ * @param {string | null | undefined} unsubscribeUrl - Signed unsubscribe URL
+ * @return {Record<string, string>} Headers to attach to the outgoing message
+ */
+export function buildUnsubscribeHeaders(
+  unsubscribeUrl: string | null | undefined
+): Record<string, string> {
+  if (!unsubscribeUrl) {
+    return {};
+  }
+
+  return {
+    "List-Unsubscribe": `<${unsubscribeUrl}>`,
+    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+  };
+}
+
+/**
  * Safely parses a JSON HTTP response body.
  * @param {Response} response - Fetch response
  * @return {Promise<ResendEmailResponse | null>} Parsed JSON or null
@@ -117,6 +139,7 @@ export async function sendTransactionalEmail(
       },
       body: JSON.stringify({
         from: formatSender(config.fromName, config.fromEmail),
+        headers: buildUnsubscribeHeaders(message.unsubscribeUrl),
         html: message.html,
         reply_to: message.replyTo ?? config.replyTo,
         subject: message.subject,

--- a/functions/src/email/queue.ts
+++ b/functions/src/email/queue.ts
@@ -33,6 +33,7 @@ export function buildEmailJobId(dedupeKey: string): string {
  * @param {EmailJobPayload} payload - Template payload
  * @param {Timestamp} scheduledFor - Scheduled send time
  * @param {string | null} sourceRef - Source Firestore reference string
+ * @param {string | null} recipientUid - Recipient uid when user-addressed
  * @return {EmailJobDocument} Firestore-ready queued job
  */
 export function createQueuedEmailJob(
@@ -42,7 +43,8 @@ export function createQueuedEmailJob(
   dedupeKey: string,
   payload: EmailJobPayload,
   scheduledFor: admin.firestore.Timestamp,
-  sourceRef: string | null
+  sourceRef: string | null,
+  recipientUid: string | null = null
 ): EmailJobDocument {
   return {
     attemptCount: 0,
@@ -57,6 +59,7 @@ export function createQueuedEmailJob(
     readyAt: scheduledFor,
     recipientEmail,
     recipientHash,
+    recipientUid,
     scheduledFor,
     sentAt: null,
     sourceRef,

--- a/functions/src/email/templates.ts
+++ b/functions/src/email/templates.ts
@@ -3,6 +3,7 @@ import {
   getMarketingWebsiteUrl,
   getTransactionalReplyToEmail,
 } from "./config";
+import {escapeHtml} from "./html";
 import type {
   EmailJobPayload,
   EmailRenderContext,
@@ -27,20 +28,6 @@ interface BrandedEmailContent {
   subject: string;
   unsubscribeUrl?: string | null;
   whyReceived: string;
-}
-
-/**
- * Escapes untrusted HTML content for safe email rendering.
- * @param {string} value - Raw user-provided content
- * @return {string} Escaped HTML string
- */
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 /**

--- a/functions/src/email/templates.ts
+++ b/functions/src/email/templates.ts
@@ -5,6 +5,7 @@ import {
 } from "./config";
 import type {
   EmailJobPayload,
+  EmailRenderContext,
   EmptyEmailPayload,
   FeedbackAdminNotifyPayload,
   FirstAscentClaimedPayload,
@@ -24,6 +25,7 @@ interface BrandedEmailContent {
   headline: string;
   preheader: string;
   subject: string;
+  unsubscribeUrl?: string | null;
   whyReceived: string;
 }
 
@@ -169,6 +171,7 @@ function renderBrandedEmail(
   const escapedPrivacyPolicyUrl = escapeHtml(privacyPolicyUrl);
   const ctaUrl = content.ctaUrl ?? replyCtaUrl(content.subject);
   const escapedCtaUrl = escapeHtml(ctaUrl);
+  const unsubscribeUrl = content.unsubscribeUrl ?? null;
   const escapedBody = content.bodyParagraphs.map((paragraph) =>
     escapeHtml(paragraph)
   );
@@ -183,6 +186,7 @@ function renderBrandedEmail(
     "",
     content.whyReceived,
     `Privacy Policy: ${privacyPolicyUrl}`,
+    ...(unsubscribeUrl ? [`Unsubscribe: ${unsubscribeUrl}`] : []),
   ].join("\n");
 
   const bodyHtml = escapedBody.map((paragraph) => [
@@ -191,6 +195,18 @@ function renderBrandedEmail(
     paragraph,
     "</p>",
   ].join("")).join("");
+
+  const footerLinksHtml = [
+    "<a href=\"",
+    escapedPrivacyPolicyUrl,
+    "\" style=\"color:#6b7280;text-decoration:underline;\">Privacy Policy</a>",
+    ...(unsubscribeUrl ? [
+      "<span style=\"color:#9ca3af;\"> &middot; </span><a href=\"",
+      escapeHtml(unsubscribeUrl),
+      // eslint-disable-next-line max-len
+      "\" style=\"color:#6b7280;text-decoration:underline;\">Unsubscribe</a>",
+    ] : []),
+  ].join("");
 
   const ctaHtml = [
     "<a href=\"",
@@ -243,10 +259,9 @@ function renderBrandedEmail(
       "<tr><td style=\"padding:0 30px 34px;\"><div style=\"border-top:1px solid rgba(17,17,17,0.08);padding-top:22px;text-align:center;\"><p style=\"margin:0 0 10px;font-size:13px;line-height:1.6;color:#9ca3af;\">",
       escapeHtml(content.whyReceived),
       // eslint-disable-next-line max-len
-      "</p><p style=\"margin:0 0 10px;font-size:13px;line-height:1.6;color:#9ca3af;\">Need help? Reply to this email.</p><p style=\"margin:0;font-size:13px;line-height:1.6;\"><a href=\"",
-      escapedPrivacyPolicyUrl,
-      // eslint-disable-next-line max-len
-      "\" style=\"color:#6b7280;text-decoration:underline;\">Privacy Policy</a></p></div></td></tr>",
+      "</p><p style=\"margin:0 0 10px;font-size:13px;line-height:1.6;color:#9ca3af;\">Need help? Reply to this email.</p><p style=\"margin:0;font-size:13px;line-height:1.6;\">",
+      footerLinksHtml,
+      "</p></div></td></tr>",
       "</table></td></tr></table></body></html>",
     ].join(""),
   };
@@ -404,14 +419,17 @@ export function renderWaitlistWelcomeEmailFromPayload(
 /**
  * Renders the positive rating follow-up email.
  * @param {EmptyEmailPayload} payload - Optional template payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderRatingPositiveFollowupEmail(
-  payload: EmptyEmailPayload = {}
+  payload: EmptyEmailPayload = {},
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   void payload;
 
   return renderBrandedEmail({
+    unsubscribeUrl: context.unsubscribeUrl,
     subject: "Thanks for climbing with Ascend",
     preheader: "Your feedback helps shape what we build next.",
     eyebrow: "Founder Note",
@@ -435,25 +453,33 @@ export function renderRatingPositiveFollowupEmail(
 /**
  * Validates and renders the positive rating follow-up email.
  * @param {EmailJobPayload} payload - Stored job payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderRatingPositiveFollowupEmailFromPayload(
-  payload: EmailJobPayload
+  payload: EmailJobPayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
-  return renderRatingPositiveFollowupEmail(parseEmptyEmailPayload(payload));
+  return renderRatingPositiveFollowupEmail(
+    parseEmptyEmailPayload(payload),
+    context
+  );
 }
 
 /**
  * Renders the negative rating feedback email.
  * @param {EmptyEmailPayload} payload - Optional template payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderRatingNegativeFeedbackEmail(
-  payload: EmptyEmailPayload = {}
+  payload: EmptyEmailPayload = {},
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   void payload;
 
   return renderBrandedEmail({
+    unsubscribeUrl: context.unsubscribeUrl,
     subject: "Tell me what missed",
     preheader: "One reply helps make Ascend better.",
     eyebrow: "Founder Note",
@@ -477,25 +503,33 @@ export function renderRatingNegativeFeedbackEmail(
 /**
  * Validates and renders the negative rating feedback email.
  * @param {EmailJobPayload} payload - Stored job payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderRatingNegativeFeedbackEmailFromPayload(
-  payload: EmailJobPayload
+  payload: EmailJobPayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
-  return renderRatingNegativeFeedbackEmail(parseEmptyEmailPayload(payload));
+  return renderRatingNegativeFeedbackEmail(
+    parseEmptyEmailPayload(payload),
+    context
+  );
 }
 
 /**
  * Renders the onboarding abandonment email before paywall.
  * @param {EmptyEmailPayload} payload - Optional template payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderOnboardingAbandonedBeforePaywallEmail(
-  payload: EmptyEmailPayload = {}
+  payload: EmptyEmailPayload = {},
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   const appUrl = appUrlFromPayload(payload);
 
   return renderBrandedEmail({
+    unsubscribeUrl: context.unsubscribeUrl,
     subject: "Your first climb is waiting",
     preheader: "Pick a landmark. Put your steps on the board.",
     eyebrow: "First Climb",
@@ -516,27 +550,33 @@ export function renderOnboardingAbandonedBeforePaywallEmail(
 /**
  * Validates and renders the onboarding abandonment email before paywall.
  * @param {EmailJobPayload} payload - Stored job payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderOnboardingAbandonedBeforePaywallEmailFromPayload(
-  payload: EmailJobPayload
+  payload: EmailJobPayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   return renderOnboardingAbandonedBeforePaywallEmail(
-    parseEmptyEmailPayload(payload)
+    parseEmptyEmailPayload(payload),
+    context
   );
 }
 
 /**
  * Renders the onboarding abandonment email after paywall.
  * @param {EmptyEmailPayload} payload - Optional template payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderOnboardingAbandonedAfterPaywallEmail(
-  payload: EmptyEmailPayload = {}
+  payload: EmptyEmailPayload = {},
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   const appUrl = appUrlFromPayload(payload);
 
   return renderBrandedEmail({
+    unsubscribeUrl: context.unsubscribeUrl,
     subject: "Race real climbs",
     preheader: [
       "Leaderboards, First Ascents, and stair-stepper records",
@@ -563,13 +603,16 @@ export function renderOnboardingAbandonedAfterPaywallEmail(
 /**
  * Validates and renders the onboarding abandonment email after paywall.
  * @param {EmailJobPayload} payload - Stored job payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderOnboardingAbandonedAfterPaywallEmailFromPayload(
-  payload: EmailJobPayload
+  payload: EmailJobPayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   return renderOnboardingAbandonedAfterPaywallEmail(
-    parseEmptyEmailPayload(payload)
+    parseEmptyEmailPayload(payload),
+    context
   );
 }
 
@@ -602,16 +645,19 @@ function parseFirstClimbCompletedPayload(
 /**
  * Renders the first climb completed email.
  * @param {FirstClimbCompletedPayload} payload - Template payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderFirstClimbCompletedEmail(
-  payload: FirstClimbCompletedPayload
+  payload: FirstClimbCompletedPayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   const resultLine = payload.climbName ?
     `Your first Ascend climb, ${payload.climbName}, is logged.` :
     "Your first Ascend climb is logged.";
 
   return renderBrandedEmail({
+    unsubscribeUrl: context.unsubscribeUrl,
     subject: "First climb logged",
     preheader: "Your stair-stepper work is on the board.",
     eyebrow: "First Result",
@@ -632,13 +678,16 @@ export function renderFirstClimbCompletedEmail(
 /**
  * Validates and renders the first climb completed email.
  * @param {EmailJobPayload} payload - Stored job payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderFirstClimbCompletedEmailFromPayload(
-  payload: EmailJobPayload
+  payload: EmailJobPayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   return renderFirstClimbCompletedEmail(
-    parseFirstClimbCompletedPayload(payload)
+    parseFirstClimbCompletedPayload(payload),
+    context
   );
 }
 
@@ -671,12 +720,15 @@ function parseFirstAscentClaimedPayload(
 /**
  * Renders the First Ascent claimed email.
  * @param {FirstAscentClaimedPayload} payload - Template payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderFirstAscentClaimedEmail(
-  payload: FirstAscentClaimedPayload
+  payload: FirstAscentClaimedPayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   return renderBrandedEmail({
+    unsubscribeUrl: context.unsubscribeUrl,
     subject: "You claimed it first",
     preheader: "That First Ascent is yours.",
     eyebrow: "First Ascent",
@@ -700,13 +752,16 @@ export function renderFirstAscentClaimedEmail(
 /**
  * Validates and renders the First Ascent claimed email.
  * @param {EmailJobPayload} payload - Stored job payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderFirstAscentClaimedEmailFromPayload(
-  payload: EmailJobPayload
+  payload: EmailJobPayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   return renderFirstAscentClaimedEmail(
-    parseFirstAscentClaimedPayload(payload)
+    parseFirstAscentClaimedPayload(payload),
+    context
   );
 }
 
@@ -739,12 +794,15 @@ function parseLeaderboardFirstPlacePayload(
 /**
  * Renders the leaderboard first place email.
  * @param {LeaderboardFirstPlacePayload} payload - Template payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderLeaderboardFirstPlaceEmail(
-  payload: LeaderboardFirstPlacePayload
+  payload: LeaderboardFirstPlacePayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   return renderBrandedEmail({
+    unsubscribeUrl: context.unsubscribeUrl,
     subject: "You own the board",
     preheader: "You moved into #1.",
     eyebrow: "Leaderboard",
@@ -765,13 +823,16 @@ export function renderLeaderboardFirstPlaceEmail(
 /**
  * Validates and renders the leaderboard first place email.
  * @param {EmailJobPayload} payload - Stored job payload
+ * @param {EmailRenderContext} context - Per-recipient render context
  * @return {TransactionalEmailRenderResult} Rendered email
  */
 export function renderLeaderboardFirstPlaceEmailFromPayload(
-  payload: EmailJobPayload
+  payload: EmailJobPayload,
+  context: EmailRenderContext = {}
 ): TransactionalEmailRenderResult {
   return renderLeaderboardFirstPlaceEmail(
-    parseLeaderboardFirstPlacePayload(payload)
+    parseLeaderboardFirstPlacePayload(payload),
+    context
   );
 }
 

--- a/functions/src/email/types.ts
+++ b/functions/src/email/types.ts
@@ -10,7 +10,14 @@ export type EmailType =
   | "first_climb_completed"
   | "first_ascent_claimed"
   | "leaderboard_first_place";
-export type EmailJobStatus = "queued" | "processing" | "sent" | "failed";
+export type EmailJobStatus =
+  | "queued"
+  | "processing"
+  | "sent"
+  | "failed"
+  // Deliberately not delivered, e.g. the recipient unsubscribed after the job
+  // was queued. A terminal outcome with nothing to retry and no error.
+  | "skipped";
 
 export interface TransactionalEmailConfig {
   provider: TransactionalEmailProvider;
@@ -21,7 +28,7 @@ export interface TransactionalEmailConfig {
   fromName: string;
   replyTo?: string;
   unsubscribeSigningKey: string;
-  websiteUrl?: string;
+  websiteUrl: string;
 }
 
 export interface TransactionalEmailMessage {

--- a/functions/src/email/types.ts
+++ b/functions/src/email/types.ts
@@ -20,6 +20,7 @@ export interface TransactionalEmailConfig {
   fromEmail: string;
   fromName: string;
   replyTo?: string;
+  unsubscribeSigningKey: string;
   websiteUrl?: string;
 }
 
@@ -30,6 +31,15 @@ export interface TransactionalEmailMessage {
   subject: string;
   text: string;
   to: string[];
+  unsubscribeUrl?: string | null;
+}
+
+/**
+ * Per-recipient context threaded into templates at render time. Values are
+ * resolved from the job, never stored on the template payload.
+ */
+export interface EmailRenderContext {
+  unsubscribeUrl?: string | null;
 }
 
 export interface TransactionalEmailDelivery {
@@ -86,6 +96,9 @@ export interface EmailJobDocument {
   readyAt: admin.firestore.Timestamp;
   recipientEmail: string;
   recipientHash: string;
+  // Present only for emails addressed to a signed-in user. Drives the
+  // per-recipient unsubscribe link; null for waitlist and admin mail.
+  recipientUid: string | null;
   scheduledFor: admin.firestore.Timestamp;
   sentAt: admin.firestore.Timestamp | null;
   sourceRef: string | null;

--- a/functions/src/email/unsubscribe.ts
+++ b/functions/src/email/unsubscribe.ts
@@ -5,9 +5,9 @@ import * as admin from "firebase-admin";
 // endpoint untestable locally.
 import {Timestamp} from "firebase-admin/firestore";
 import {onRequest} from "firebase-functions/v2/https";
-import {buildNextCommunicationPreferences} from "../lifecycle";
 import {getUnsubscribeSigningKey, transactionalEmailConfig} from "./config";
 import {escapeHtml} from "./html";
+import {buildNextCommunicationPreferences} from "./preferences";
 import {verifyUnsubscribeToken} from "./unsubscribeToken";
 
 const BRAND_ACCENT_COLOR = "#86D30A";

--- a/functions/src/email/unsubscribe.ts
+++ b/functions/src/email/unsubscribe.ts
@@ -1,0 +1,196 @@
+import * as admin from "firebase-admin";
+// Imported from the modular entry point rather than reached through
+// admin.firestore.Timestamp: the Functions emulator proxies the admin
+// namespace and strips those static properties, which would make this
+// endpoint untestable locally.
+import {Timestamp} from "firebase-admin/firestore";
+import {onRequest} from "firebase-functions/v2/https";
+import {getUnsubscribeSigningKey, transactionalEmailConfig} from "./config";
+import {verifyUnsubscribeToken} from "./unsubscribeToken";
+
+const BRAND_ACCENT_COLOR = "#86D30A";
+
+export type UnsubscribeOutcome =
+  | "already_unsubscribed"
+  | "unsubscribed";
+
+/**
+ * Escapes untrusted content before it is interpolated into the page.
+ * @param {string} value - Raw string value
+ * @return {string} HTML-escaped value
+ */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Renders a standalone confirmation or error page.
+ *
+ * The page is intentionally self-contained: it is served straight from the
+ * function, so it cannot rely on any hosted stylesheet or asset.
+ * @param {string} heading - Page headline
+ * @param {string} body - Supporting copy
+ * @param {string | null} confirmToken - Token to POST back, when confirming
+ * @return {string} Complete HTML document
+ */
+export function renderUnsubscribePage(
+  heading: string,
+  body: string,
+  confirmToken: string | null = null
+): string {
+  const formHtml = confirmToken ?
+    [
+      "<form method=\"post\" action=\"/api/unsubscribe?token=",
+      encodeURIComponent(confirmToken),
+      "\" style=\"margin:28px 0 0;\">",
+      "<button type=\"submit\" style=\"display:inline-block;padding:16px 24px;",
+      "border:0;border-radius:16px;cursor:pointer;background:",
+      BRAND_ACCENT_COLOR,
+      ";color:#111111;font-size:16px;font-weight:800;",
+      "text-transform:uppercase;letter-spacing:0.04em;\">",
+      "Unsubscribe",
+      "</button></form>",
+    ].join("") :
+    "";
+
+  return [
+    "<!doctype html>",
+    "<html lang=\"en\"><head><meta charset=\"utf-8\" />",
+    // eslint-disable-next-line max-len
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />",
+    "<meta name=\"robots\" content=\"noindex\" />",
+    "<title>Ascend Emails</title></head>",
+    // eslint-disable-next-line max-len
+    "<body style=\"margin:0;padding:48px 20px;background:#f4f2eb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;color:#111111;\">",
+    // eslint-disable-next-line max-len
+    "<main style=\"max-width:520px;margin:0 auto;background:#ffffff;border:1px solid rgba(17,17,17,0.08);border-radius:28px;padding:40px 32px;text-align:center;\">",
+    // eslint-disable-next-line max-len
+    "<h1 style=\"margin:0 0 16px;font-size:32px;line-height:1.05;font-weight:900;letter-spacing:-0.03em;\">",
+    escapeHtml(heading),
+    "</h1>",
+    // eslint-disable-next-line max-len
+    "<p style=\"margin:0;font-size:17px;line-height:1.6;color:#4b5563;\">",
+    escapeHtml(body),
+    "</p>",
+    formHtml,
+    "</main></body></html>",
+  ].join("");
+}
+
+/**
+ * Disables lifecycle emails for a verified uid.
+ *
+ * Merges rather than overwrites so the shared preferences document keeps the
+ * push notification preference, and skips the write when the user is already
+ * unsubscribed so repeated clicks cannot amplify writes.
+ * @param {string} uid - Verified Firebase Auth user ID
+ * @return {Promise<UnsubscribeOutcome>} What the request actually changed
+ */
+export async function disableLifecycleEmails(
+  uid: string
+): Promise<UnsubscribeOutcome> {
+  const firestore = admin.firestore();
+  const preferencesRef = firestore
+    .collection("users")
+    .doc(uid)
+    .collection("communication_preferences")
+    .doc("current");
+
+  return firestore.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(preferencesRef);
+    const existing = snapshot.exists ? snapshot.data() ?? {} : {};
+    if (existing.lifecycleEmailsEnabled === false) {
+      return "already_unsubscribed";
+    }
+
+    const now = Timestamp.now();
+    transaction.set(preferencesRef, {
+      createdAt: existing.createdAt ?? now,
+      lifecycleEmailsEnabled: false,
+      schemaVersion: 1,
+      unsubscribedAt: now,
+      unsubscribedVia: "email_link",
+      updatedAt: now,
+    }, {merge: true});
+
+    return "unsubscribed";
+  });
+}
+
+/**
+ * Handles one-click and link-based unsubscribe requests from email.
+ *
+ * GET renders a confirmation page rather than acting, so link scanners and
+ * mail-client prefetchers cannot unsubscribe a user by following the footer
+ * link. POST performs the opt-out, which is what RFC 8058 one-click sends.
+ */
+export const unsubscribeFromEmails = onRequest(
+  {secrets: [transactionalEmailConfig]},
+  async (request, response) => {
+    response.set("Cache-Control", "no-store");
+
+    if (request.method !== "GET" && request.method !== "POST") {
+      response.set("Allow", "GET, POST");
+      response.status(405).send(renderUnsubscribePage(
+        "Method not supported.",
+        "Open the unsubscribe link from your email to manage Ascend emails."
+      ));
+      return;
+    }
+
+    const uid = verifyUnsubscribeToken(
+      request.query.token,
+      getUnsubscribeSigningKey()
+    );
+    if (!uid) {
+      response.status(400).send(renderUnsubscribePage(
+        "This link is not valid.",
+        [
+          "The unsubscribe link is incomplete or has been changed.",
+          "Manage email preferences in Ascend under Settings, Notifications.",
+        ].join(" ")
+      ));
+      return;
+    }
+
+    if (request.method === "GET") {
+      response.status(200).send(renderUnsubscribePage(
+        "Unsubscribe from Ascend emails?",
+        [
+          "You will stop receiving climb and progress emails.",
+          "Account and security emails still reach you.",
+        ].join(" "),
+        typeof request.query.token === "string" ? request.query.token : null
+      ));
+      return;
+    }
+
+    try {
+      const outcome = await disableLifecycleEmails(uid);
+      console.log("unsubscribeFromEmails processed", {outcome, uid});
+    } catch (error) {
+      console.error("unsubscribeFromEmails failed", {
+        message: error instanceof Error ? error.message : "unknown_error",
+        uid,
+      });
+      response.status(500).send(renderUnsubscribePage(
+        "Something went wrong.",
+        "Try the link again, or turn emails off in Ascend under Settings."
+      ));
+      return;
+    }
+
+    response.status(200).send(renderUnsubscribePage(
+      "You're unsubscribed.",
+      [
+        "Ascend will stop sending climb and progress emails.",
+        "Turn them back on anytime in Settings, Notifications.",
+      ].join(" ")
+    ));
+  }
+);

--- a/functions/src/email/unsubscribe.ts
+++ b/functions/src/email/unsubscribe.ts
@@ -5,7 +5,9 @@ import * as admin from "firebase-admin";
 // endpoint untestable locally.
 import {Timestamp} from "firebase-admin/firestore";
 import {onRequest} from "firebase-functions/v2/https";
+import {buildNextCommunicationPreferences} from "../lifecycle";
 import {getUnsubscribeSigningKey, transactionalEmailConfig} from "./config";
+import {escapeHtml} from "./html";
 import {verifyUnsubscribeToken} from "./unsubscribeToken";
 
 const BRAND_ACCENT_COLOR = "#86D30A";
@@ -13,20 +15,6 @@ const BRAND_ACCENT_COLOR = "#86D30A";
 export type UnsubscribeOutcome =
   | "already_unsubscribed"
   | "unsubscribed";
-
-/**
- * Escapes untrusted content before it is interpolated into the page.
- * @param {string} value - Raw string value
- * @return {string} HTML-escaped value
- */
-function escapeHtml(value: string): string {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
-}
 
 /**
  * Renders a standalone confirmation or error page.
@@ -109,14 +97,19 @@ export async function disableLifecycleEmails(
     }
 
     const now = Timestamp.now();
-    transaction.set(preferencesRef, {
-      createdAt: existing.createdAt ?? now,
-      lifecycleEmailsEnabled: false,
-      schemaVersion: 1,
-      unsubscribedAt: now,
-      unsubscribedVia: "email_link",
-      updatedAt: now,
-    }, {merge: true});
+    transaction.set(
+      preferencesRef,
+      buildNextCommunicationPreferences(
+        existing,
+        {
+          lifecycleEmailsEnabled: false,
+          unsubscribedAt: now,
+          unsubscribedVia: "email_link",
+        },
+        now
+      ),
+      {merge: true}
+    );
 
     return "unsubscribed";
   });

--- a/functions/src/email/unsubscribeToken.ts
+++ b/functions/src/email/unsubscribeToken.ts
@@ -1,0 +1,121 @@
+import {createHmac, timingSafeEqual} from "crypto";
+
+const TOKEN_VERSION = "v1";
+
+/**
+ * Encodes a UTF-8 string as base64url without padding.
+ * @param {string} value - Raw string value
+ * @return {string} base64url-encoded value
+ */
+function encodeBase64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+/**
+ * Decodes a base64url segment back into a UTF-8 string.
+ * @param {string} value - base64url-encoded value
+ * @return {string | null} Decoded string, or null when malformed
+ */
+function decodeBase64Url(value: string): string | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) {
+    return null;
+  }
+
+  const decoded = Buffer.from(value, "base64url").toString("utf8");
+  return decoded.length > 0 ? decoded : null;
+}
+
+/**
+ * Signs the token body with the unsubscribe signing key.
+ * @param {string} body - Versioned token body
+ * @param {string} signingKey - Server-held HMAC signing key
+ * @return {string} base64url-encoded HMAC-SHA256 signature
+ */
+function signTokenBody(body: string, signingKey: string): string {
+  return createHmac("sha256", signingKey).update(body).digest("base64url");
+}
+
+/**
+ * Compares two signatures without leaking timing information.
+ * @param {string} expected - Signature computed from the signing key
+ * @param {string} provided - Signature supplied by the request
+ * @return {boolean} True when the signatures match
+ */
+function signaturesMatch(expected: string, provided: string): boolean {
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  const providedBuffer = Buffer.from(provided, "utf8");
+  if (expectedBuffer.length !== providedBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(expectedBuffer, providedBuffer);
+}
+
+/**
+ * Builds a signed, non-expiring unsubscribe token for a user.
+ *
+ * Unsubscribe links must keep working for the life of the message, so the
+ * token intentionally carries no expiry. It only ever authorizes disabling
+ * lifecycle emails for the encoded uid.
+ * @param {string} uid - Firebase Auth user ID
+ * @param {string} signingKey - Server-held HMAC signing key
+ * @return {string} Signed unsubscribe token
+ */
+export function buildUnsubscribeToken(
+  uid: string,
+  signingKey: string
+): string {
+  if (!uid || !signingKey) {
+    throw new Error("unsubscribe_token_requires_uid_and_key");
+  }
+
+  const body = `${TOKEN_VERSION}.${encodeBase64Url(uid)}`;
+  return `${body}.${signTokenBody(body, signingKey)}`;
+}
+
+/**
+ * Verifies a signed unsubscribe token and recovers its uid.
+ * @param {unknown} token - Untrusted token from the request
+ * @param {string} signingKey - Server-held HMAC signing key
+ * @return {string | null} Verified uid, or null when the token is invalid
+ */
+export function verifyUnsubscribeToken(
+  token: unknown,
+  signingKey: string
+): string | null {
+  if (typeof token !== "string" || !signingKey) {
+    return null;
+  }
+
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    return null;
+  }
+
+  const [version, encodedUid, signature] = segments;
+  if (version !== TOKEN_VERSION) {
+    return null;
+  }
+
+  const body = `${version}.${encodedUid}`;
+  if (!signaturesMatch(signTokenBody(body, signingKey), signature)) {
+    return null;
+  }
+
+  return decodeBase64Url(encodedUid);
+}
+
+/**
+ * Builds the public one-click unsubscribe URL for a signed token.
+ * @param {string} websiteUrl - Normalized public website origin
+ * @param {string} token - Signed unsubscribe token
+ * @return {string} Absolute unsubscribe URL
+ */
+export function buildUnsubscribeUrl(
+  websiteUrl: string,
+  token: string
+): string {
+  const url = new URL("/api/unsubscribe", websiteUrl);
+  url.searchParams.set("token", token);
+  return url.toString();
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,6 +12,7 @@ admin.initializeApp();
 export {cleanupDeletedUserData} from "./accountCleanup";
 export {processEmailJobs} from "./email/processor";
 export {onLifecycleEventEmailAutomation} from "./email/automation";
+export {unsubscribeFromEmails} from "./email/unsubscribe";
 export {onFeedbackCreated} from "./feedback";
 export {recordLifecycleEvent} from "./lifecycle";
 export {finalizeLeaderboardAchievements} from "./leaderboardAchievements";

--- a/functions/src/lifecycle.ts
+++ b/functions/src/lifecycle.ts
@@ -302,9 +302,10 @@ function statePatchForEvent(
     };
 
   case "communication_preferences_updated":
-    return {
-      communicationPreferences: event.payload,
-    };
+    // No mirror here: communication_preferences/current is the only source of
+    // truth, and unsubscribeFromEmails writes it without touching this state
+    // document, so a copy here would go stale.
+    return {};
   }
 }
 

--- a/functions/src/lifecycle.ts
+++ b/functions/src/lifecycle.ts
@@ -1,5 +1,6 @@
 import {onCall, HttpsError} from "firebase-functions/v2/https";
 import * as admin from "firebase-admin";
+import {buildNextCommunicationPreferences} from "./email/preferences";
 
 type LifecycleEventType =
   | "rating_prompt_answered"
@@ -155,30 +156,6 @@ export const recordLifecycleEvent = onCall(async (request) => {
     ok: true,
   };
 });
-
-/**
- * Builds the next communication preferences document from the stored one.
- *
- * The document is shared with updatePushNotificationPreferences, so only the
- * keys in the payload change and unrelated stored keys are carried forward.
- * @param {PlainObject} existing Stored preferences document.
- * @param {PlainObject} payload Validated preference payload.
- * @param {admin.firestore.Timestamp} now Server timestamp for this write.
- * @return {PlainObject} Preferences document to write.
- */
-export function buildNextCommunicationPreferences(
-  existing: PlainObject,
-  payload: PlainObject,
-  now: admin.firestore.Timestamp
-): PlainObject {
-  return {
-    ...existing,
-    ...payload,
-    createdAt: existing.createdAt ?? now,
-    schemaVersion: 1,
-    updatedAt: now,
-  };
-}
 
 /**
  * Normalizes untrusted callable input into a server-owned event document.

--- a/functions/src/lifecycle.ts
+++ b/functions/src/lifecycle.ts
@@ -86,11 +86,17 @@ export const recordLifecycleEvent = onCall(async (request) => {
     .collection("communication_preferences")
     .doc("current");
 
+  const updatesPreferences = event.type === "communication_preferences_updated";
+
   await firestore.runTransaction(async (transaction) => {
-    const [stateSnapshot, eventSnapshot] = await Promise.all([
-      transaction.get(stateRef),
-      transaction.get(eventRef),
-    ]);
+    // Firestore requires every read before the first write. The preferences
+    // document is only read for the event that rewrites it.
+    const [stateSnapshot, eventSnapshot, preferencesSnapshot] =
+      await Promise.all([
+        transaction.get(stateRef),
+        transaction.get(eventRef),
+        updatesPreferences ? transaction.get(preferencesRef) : null,
+      ]);
 
     const currentState = stateSnapshot.exists ?
       stateSnapshot.data() as PlainObject :
@@ -125,20 +131,22 @@ export const recordLifecycleEvent = onCall(async (request) => {
       updatedAt: now,
     });
 
-    if (event.type == "communication_preferences_updated") {
-      const currentPreferences = currentState.communicationPreferences;
-      const preferences = mergePlainObjects(
-        isPlainObject(currentPreferences) ? currentPreferences : {},
-        {
-          ...event.payload,
-          schemaVersion: 1,
-          updatedAt: now,
-        }
+    if (updatesPreferences) {
+      const existingPreferences = preferencesSnapshot?.exists ?
+        preferencesSnapshot.data() as PlainObject :
+        {};
+      transaction.set(
+        preferencesRef,
+        buildNextCommunicationPreferences(
+          existingPreferences ?? {},
+          event.payload,
+          now
+        ),
+        // Merge so preferences owned by other writers, notably the push
+        // preference from updatePushNotificationPreferences, survive an
+        // email preference change.
+        {merge: true}
       );
-      if (!preferences.createdAt) {
-        preferences.createdAt = now;
-      }
-      transaction.set(preferencesRef, preferences);
     }
   });
 
@@ -147,6 +155,30 @@ export const recordLifecycleEvent = onCall(async (request) => {
     ok: true,
   };
 });
+
+/**
+ * Builds the next communication preferences document from the stored one.
+ *
+ * The document is shared with updatePushNotificationPreferences, so only the
+ * keys in the payload change and unrelated stored keys are carried forward.
+ * @param {PlainObject} existing Stored preferences document.
+ * @param {PlainObject} payload Validated preference payload.
+ * @param {admin.firestore.Timestamp} now Server timestamp for this write.
+ * @return {PlainObject} Preferences document to write.
+ */
+export function buildNextCommunicationPreferences(
+  existing: PlainObject,
+  payload: PlainObject,
+  now: admin.firestore.Timestamp
+): PlainObject {
+  return {
+    ...existing,
+    ...payload,
+    createdAt: existing.createdAt ?? now,
+    schemaVersion: 1,
+    updatedAt: now,
+  };
+}
 
 /**
  * Normalizes untrusted callable input into a server-owned event document.

--- a/functions/test/email-system.test.ts
+++ b/functions/test/email-system.test.ts
@@ -3,8 +3,8 @@ import assert from "node:assert/strict";
 import {
   buildRatingPromptEmailDedupeKey,
   emailTypeForRatingPromptResponse,
-  isLifecycleEmailAllowed,
 } from "../src/email/automation";
+import {isLifecycleEmailAllowed} from "../src/email/preferences";
 import {
   buildEmailJobId,
   buildWaitlistWelcomeDedupeKey,

--- a/functions/test/email-system.test.ts
+++ b/functions/test/email-system.test.ts
@@ -170,6 +170,7 @@ test("waitlist template includes beta invite CTA when configured", () => {
     fromEmail: "hello@updates.ascendstepper.com",
     fromName: "Ascend",
     replyTo: "support@ascendstepper.com",
+    unsubscribeSigningKey: "test-unsubscribe-signing-key-0123456789",
     websiteUrl: "https://ascendstepper.com",
     betaInviteUrl: "https://testflight.apple.com/join/ZZ1zUmBf",
   });

--- a/functions/test/unsubscribe.test.ts
+++ b/functions/test/unsubscribe.test.ts
@@ -1,0 +1,303 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {Timestamp} from "firebase-admin/firestore";
+import {
+  buildUnsubscribeToken,
+  buildUnsubscribeUrl,
+  verifyUnsubscribeToken,
+} from "../src/email/unsubscribeToken";
+import {buildUnsubscribeHeaders} from "../src/email/provider";
+import {renderUnsubscribePage} from "../src/email/unsubscribe";
+import {buildNextCommunicationPreferences} from "../src/lifecycle";
+import {isLifecycleEmailAllowed} from "../src/email/automation";
+import {
+  renderRatingPositiveFollowupEmail,
+  renderFirstAscentClaimedEmail,
+} from "../src/email/templates";
+
+const SIGNING_KEY = "test-unsubscribe-signing-key-0123456789";
+const OTHER_SIGNING_KEY = "another-unsubscribe-signing-key-987654321";
+
+// =============================================================================
+// Unsubscribe Tokens
+// =============================================================================
+
+test("unsubscribe tokens round-trip the signed uid", () => {
+  const token = buildUnsubscribeToken("user_123", SIGNING_KEY);
+
+  assert.equal(verifyUnsubscribeToken(token, SIGNING_KEY), "user_123");
+});
+
+test("unsubscribe tokens are deterministic for the same uid and key", () => {
+  assert.equal(
+    buildUnsubscribeToken("user_123", SIGNING_KEY),
+    buildUnsubscribeToken("user_123", SIGNING_KEY)
+  );
+});
+
+test("unsubscribe tokens differ per uid", () => {
+  assert.notEqual(
+    buildUnsubscribeToken("user_123", SIGNING_KEY),
+    buildUnsubscribeToken("user_456", SIGNING_KEY)
+  );
+});
+
+test("unsubscribe tokens never expose the raw uid", () => {
+  const token = buildUnsubscribeToken("user_123", SIGNING_KEY);
+
+  assert.doesNotMatch(token, /user_123/);
+});
+
+test("unsubscribe tokens require a uid and a signing key", () => {
+  assert.throws(() => buildUnsubscribeToken("", SIGNING_KEY));
+  assert.throws(() => buildUnsubscribeToken("user_123", ""));
+});
+
+test("unsubscribe token verification rejects a forged signature", () => {
+  const token = buildUnsubscribeToken("user_123", SIGNING_KEY);
+  const [version, encodedUid] = token.split(".");
+  const forged = `${version}.${encodedUid}.not-a-real-signature`;
+
+  assert.equal(verifyUnsubscribeToken(forged, SIGNING_KEY), null);
+});
+
+test("unsubscribe token verification rejects a swapped uid", () => {
+  // The attack this blocks: re-encoding someone else's uid onto a signature
+  // that was issued for your own token.
+  const own = buildUnsubscribeToken("attacker", SIGNING_KEY);
+  const signature = own.split(".")[2];
+  const victimUid = Buffer.from("victim", "utf8").toString("base64url");
+  const tampered = `v1.${victimUid}.${signature}`;
+
+  assert.equal(verifyUnsubscribeToken(tampered, SIGNING_KEY), null);
+});
+
+test("unsubscribe token verification rejects another key's token", () => {
+  const token = buildUnsubscribeToken("user_123", OTHER_SIGNING_KEY);
+
+  assert.equal(verifyUnsubscribeToken(token, SIGNING_KEY), null);
+});
+
+test("unsubscribe token verification rejects malformed input", () => {
+  for (const candidate of [
+    undefined,
+    null,
+    42,
+    "",
+    "v1",
+    "v1.abc",
+    "v1.abc.def.ghi",
+    "v2.abc.def",
+  ]) {
+    assert.equal(
+      verifyUnsubscribeToken(candidate, SIGNING_KEY),
+      null,
+      `expected ${JSON.stringify(candidate)} to be rejected`
+    );
+  }
+});
+
+test("unsubscribe token verification rejects an empty signing key", () => {
+  const token = buildUnsubscribeToken("user_123", SIGNING_KEY);
+
+  assert.equal(verifyUnsubscribeToken(token, ""), null);
+});
+
+test("unsubscribe urls carry the token on the public api route", () => {
+  const token = buildUnsubscribeToken("user_123", SIGNING_KEY);
+  const url = new URL(
+    buildUnsubscribeUrl("https://ascendstepper.com", token)
+  );
+
+  assert.equal(url.origin, "https://ascendstepper.com");
+  assert.equal(url.pathname, "/api/unsubscribe");
+  assert.equal(url.searchParams.get("token"), token);
+});
+
+// =============================================================================
+// List-Unsubscribe Headers
+// =============================================================================
+
+test("one-click unsubscribe headers travel together", () => {
+  const headers = buildUnsubscribeHeaders(
+    "https://ascendstepper.com/api/unsubscribe?token=abc"
+  );
+
+  assert.equal(
+    headers["List-Unsubscribe"],
+    "<https://ascendstepper.com/api/unsubscribe?token=abc>"
+  );
+  assert.equal(headers["List-Unsubscribe-Post"], "List-Unsubscribe=One-Click");
+});
+
+test("unsubscribe headers are omitted without an unsubscribe url", () => {
+  for (const candidate of [null, undefined, ""]) {
+    assert.deepEqual(buildUnsubscribeHeaders(candidate), {});
+  }
+});
+
+// =============================================================================
+// Footer Rendering
+// =============================================================================
+
+test("lifecycle emails render an unsubscribe link in the footer", () => {
+  const unsubscribeUrl =
+    "https://ascendstepper.com/api/unsubscribe?token=abc123";
+  const rendered = renderRatingPositiveFollowupEmail({}, {unsubscribeUrl});
+
+  assert.match(rendered.html, /<a href="[^"]*token=abc123"[^>]*>Unsubscribe/);
+  assert.match(rendered.html, /Privacy Policy/);
+  assert.ok(rendered.text.includes(`Unsubscribe: ${unsubscribeUrl}`));
+});
+
+test("lifecycle emails omit the unsubscribe link without a url", () => {
+  const rendered = renderRatingPositiveFollowupEmail();
+
+  assert.doesNotMatch(rendered.html, /Unsubscribe/);
+  assert.doesNotMatch(rendered.text, /Unsubscribe/);
+  assert.match(rendered.html, /Privacy Policy/);
+});
+
+test("unsubscribe urls are escaped into the footer markup", () => {
+  const rendered = renderFirstAscentClaimedEmail(
+    {climbName: "Everest", climbUrl: "https://ascendstepper.com/climbs/everest"},
+    {unsubscribeUrl: "https://ascendstepper.com/api/unsubscribe?a=1&b=\"x\""}
+  );
+
+  assert.doesNotMatch(rendered.html, /token[^"]*"x"/);
+  assert.match(rendered.html, /a=1&amp;b=&quot;x&quot;/);
+});
+
+// =============================================================================
+// Unsubscribe Page
+// =============================================================================
+
+test("unsubscribe confirmation page posts the token back", () => {
+  const page = renderUnsubscribePage("Unsubscribe?", "Body copy.", "v1.a.b");
+
+  assert.match(page, /<form method="post" action="\/api\/unsubscribe\?token=/);
+  assert.match(page, /v1\.a\.b/);
+  assert.match(page, /<button type="submit"/);
+});
+
+test("unsubscribe result page has no confirmation form", () => {
+  const page = renderUnsubscribePage("You're unsubscribed.", "Body copy.");
+
+  assert.doesNotMatch(page, /<form/);
+  assert.match(page, /You&#39;re unsubscribed\./);
+});
+
+test("unsubscribe page escapes injected content", () => {
+  const page = renderUnsubscribePage(
+    "<script>alert('x')</script>",
+    "<img onerror=alert(1)>"
+  );
+
+  assert.doesNotMatch(page, /<script>/);
+  assert.doesNotMatch(page, /<img/);
+});
+
+test("unsubscribe page keeps crawlers out", () => {
+  assert.match(
+    renderUnsubscribePage("Heading", "Body."),
+    /<meta name="robots" content="noindex"/
+  );
+});
+
+// =============================================================================
+// Preference Gate
+// =============================================================================
+
+test("unsubscribing blocks further lifecycle email sends", () => {
+  const preferences = buildNextCommunicationPreferences(
+    {},
+    {lifecycleEmailsEnabled: false},
+    stubTimestamp(1000)
+  );
+
+  assert.equal(isLifecycleEmailAllowed(preferences), false);
+});
+
+test("resubscribing re-opens lifecycle email sends", () => {
+  const unsubscribed = buildNextCommunicationPreferences(
+    {},
+    {lifecycleEmailsEnabled: false},
+    stubTimestamp(1000)
+  );
+  const resubscribed = buildNextCommunicationPreferences(
+    unsubscribed,
+    {lifecycleEmailsEnabled: true},
+    stubTimestamp(2000)
+  );
+
+  assert.equal(isLifecycleEmailAllowed(resubscribed), true);
+});
+
+// =============================================================================
+// Communication Preference Merge (E6)
+// =============================================================================
+
+test("changing an email preference preserves the push preference", () => {
+  // Regression: the preferences document is shared with
+  // updatePushNotificationPreferences, so a non-merging write here would
+  // silently opt the user out of climb-drop push notifications.
+  const existing = {
+    createdAt: stubTimestamp(500),
+    pushClimbDropsEnabled: true,
+    schemaVersion: 1,
+  };
+
+  const next = buildNextCommunicationPreferences(
+    existing,
+    {lifecycleEmailsEnabled: false},
+    stubTimestamp(1000)
+  );
+
+  assert.equal(next.pushClimbDropsEnabled, true);
+  assert.equal(next.lifecycleEmailsEnabled, false);
+});
+
+test("communication preferences keep the original createdAt", () => {
+  const createdAt = stubTimestamp(500);
+  const now = stubTimestamp(1000);
+  const next = buildNextCommunicationPreferences(
+    {createdAt, pushClimbDropsEnabled: false},
+    {lifecycleEmailsEnabled: false},
+    now
+  );
+
+  assert.equal(next.createdAt, createdAt);
+  assert.equal(next.updatedAt, now);
+});
+
+test("communication preferences stamp createdAt on first write", () => {
+  const now = stubTimestamp(1000);
+  const next = buildNextCommunicationPreferences(
+    {},
+    {lifecycleEmailsEnabled: false},
+    now
+  );
+
+  assert.equal(next.createdAt, now);
+  assert.equal(next.schemaVersion, 1);
+});
+
+test("communication preferences only change the supplied keys", () => {
+  const next = buildNextCommunicationPreferences(
+    {climbDropEmailsEnabled: true, lifecycleEmailsEnabled: true},
+    {lifecycleEmailsEnabled: false},
+    stubTimestamp(1000)
+  );
+
+  assert.equal(next.climbDropEmailsEnabled, true);
+  assert.equal(next.lifecycleEmailsEnabled, false);
+});
+
+/**
+ * Builds a fixed Timestamp for pure preference merging.
+ * @param {number} millis - Millisecond value
+ * @return {Timestamp} Firestore timestamp
+ */
+function stubTimestamp(millis: number): Timestamp {
+  return Timestamp.fromMillis(millis);
+}

--- a/functions/test/unsubscribe.test.ts
+++ b/functions/test/unsubscribe.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../src/email/unsubscribeToken";
 import {buildUnsubscribeHeaders} from "../src/email/provider";
 import {
+  assertTransactionalEmailConfig,
   DEFAULT_MARKETING_WEBSITE_URL,
   getMarketingWebsiteUrl,
 } from "../src/email/config";
@@ -282,6 +283,35 @@ test("render paths with no secret fall back to the marketing host", () => {
   withTransactionalEmailConfig(undefined, () => {
     assert.equal(getMarketingWebsiteUrl(), DEFAULT_MARKETING_WEBSITE_URL);
   });
+});
+
+// =============================================================================
+// Send Precondition
+// =============================================================================
+
+test("a valid secret passes the send precondition", () => {
+  withTransactionalEmailConfig(VALID_CONFIG, () => {
+    assert.doesNotThrow(() => assertTransactionalEmailConfig());
+  });
+});
+
+test("a mis-ordered deploy trips the send precondition", () => {
+  // The tripwire the required fields exist for: a sender checks this before
+  // claiming work, so a bad secret fails the run instead of quietly
+  // delivering nothing.
+  for (const broken of [
+    {...VALID_CONFIG, unsubscribeSigningKey: undefined},
+    {...VALID_CONFIG, unsubscribeSigningKey: "too-short"},
+    {...VALID_CONFIG, websiteUrl: undefined},
+    {...VALID_CONFIG, apiKey: undefined},
+  ]) {
+    withTransactionalEmailConfig(broken, () => {
+      assert.throws(
+        () => assertTransactionalEmailConfig(),
+        /TRANSACTIONAL_EMAIL_CONFIG/
+      );
+    });
+  }
 });
 
 // =============================================================================

--- a/functions/test/unsubscribe.test.ts
+++ b/functions/test/unsubscribe.test.ts
@@ -9,7 +9,10 @@ import {
 import {buildUnsubscribeHeaders} from "../src/email/provider";
 import {renderUnsubscribePage} from "../src/email/unsubscribe";
 import {buildNextCommunicationPreferences} from "../src/lifecycle";
-import {isLifecycleEmailAllowed} from "../src/email/automation";
+import {
+  isEmailJobSuppressed,
+  isLifecycleEmailAllowed,
+} from "../src/email/preferences";
 import {
   renderRatingPositiveFollowupEmail,
   renderFirstAscentClaimedEmail,
@@ -231,6 +234,69 @@ test("resubscribing re-opens lifecycle email sends", () => {
   );
 
   assert.equal(isLifecycleEmailAllowed(resubscribed), true);
+});
+
+// =============================================================================
+// Send-Time Preference Gate
+// =============================================================================
+
+test("a job unsubscribed after queueing is suppressed", async () => {
+  // The queue-time gate cannot cover this: a retrying job backs off for hours,
+  // and the unsubscribe click lands in that window.
+  const suppressed = await isEmailJobSuppressed(
+    {recipientUid: "user_123"},
+    async () => ({lifecycleEmailsEnabled: false})
+  );
+
+  assert.equal(suppressed, true);
+});
+
+test("a job for a still-subscribed user sends", async () => {
+  const suppressed = await isEmailJobSuppressed(
+    {recipientUid: "user_123"},
+    async () => ({lifecycleEmailsEnabled: true})
+  );
+
+  assert.equal(suppressed, false);
+});
+
+test("a job for a user with no stored preferences sends", async () => {
+  const suppressed = await isEmailJobSuppressed(
+    {recipientUid: "user_123"},
+    async () => null
+  );
+
+  assert.equal(suppressed, false);
+});
+
+test("mail with no recipient uid sends unconditionally", async () => {
+  // Waitlist and admin feedback mail: Beehiiv owns the waitlist opt-out, and
+  // admin notifications are not user mail, so neither has a uid to gate on.
+  let readCount = 0;
+  const suppressed = await isEmailJobSuppressed(
+    {recipientUid: null},
+    async () => {
+      readCount += 1;
+      return {lifecycleEmailsEnabled: false};
+    }
+  );
+
+  assert.equal(suppressed, false);
+  assert.equal(readCount, 0);
+});
+
+test("a failed preference read never falls through to a send", async () => {
+  // The job must stay claimed for reclaim and retry rather than being
+  // delivered on a transient Firestore error.
+  await assert.rejects(
+    () => isEmailJobSuppressed(
+      {recipientUid: "user_123"},
+      async () => {
+        throw new Error("firestore_unavailable");
+      }
+    ),
+    /firestore_unavailable/
+  );
 });
 
 // =============================================================================

--- a/functions/test/unsubscribe.test.ts
+++ b/functions/test/unsubscribe.test.ts
@@ -7,9 +7,13 @@ import {
   verifyUnsubscribeToken,
 } from "../src/email/unsubscribeToken";
 import {buildUnsubscribeHeaders} from "../src/email/provider";
-import {renderUnsubscribePage} from "../src/email/unsubscribe";
-import {buildNextCommunicationPreferences} from "../src/lifecycle";
 import {
+  DEFAULT_MARKETING_WEBSITE_URL,
+  getMarketingWebsiteUrl,
+} from "../src/email/config";
+import {renderUnsubscribePage} from "../src/email/unsubscribe";
+import {
+  buildNextCommunicationPreferences,
   isEmailJobSuppressed,
   isLifecycleEmailAllowed,
 } from "../src/email/preferences";
@@ -237,6 +241,50 @@ test("resubscribing re-opens lifecycle email sends", () => {
 });
 
 // =============================================================================
+// Website Host Config
+// =============================================================================
+
+const VALID_CONFIG = {
+  provider: "resend",
+  apiKey: "re_test",
+  fromEmail: "hello@updates.ascendstepper.com",
+  fromName: "Ascend",
+  unsubscribeSigningKey: SIGNING_KEY,
+  websiteUrl: "https://staging.ascendstepper.com",
+};
+
+test("the configured host drives customer-facing email links", () => {
+  withTransactionalEmailConfig(VALID_CONFIG, () => {
+    assert.equal(
+      getMarketingWebsiteUrl(),
+      "https://staging.ascendstepper.com"
+    );
+  });
+});
+
+test("a secret missing websiteUrl fails loudly", () => {
+  // Guessing the production host would point a staging link, signed with the
+  // staging key, at the production endpoint that cannot verify it.
+  withTransactionalEmailConfig(
+    {...VALID_CONFIG, websiteUrl: undefined},
+    () => assert.throws(() => getMarketingWebsiteUrl(), /websiteUrl/)
+  );
+});
+
+test("a non-https websiteUrl fails loudly", () => {
+  withTransactionalEmailConfig(
+    {...VALID_CONFIG, websiteUrl: "http://ascendstepper.com"},
+    () => assert.throws(() => getMarketingWebsiteUrl(), /websiteUrl/)
+  );
+});
+
+test("render paths with no secret fall back to the marketing host", () => {
+  withTransactionalEmailConfig(undefined, () => {
+    assert.equal(getMarketingWebsiteUrl(), DEFAULT_MARKETING_WEBSITE_URL);
+  });
+});
+
+// =============================================================================
 // Send-Time Preference Gate
 // =============================================================================
 
@@ -366,4 +414,31 @@ test("communication preferences only change the supplied keys", () => {
  */
 function stubTimestamp(millis: number): Timestamp {
   return Timestamp.fromMillis(millis);
+}
+
+/**
+ * Runs a body with a specific transactional email secret in place.
+ * @param {unknown} config - Secret payload, or undefined to leave it unset
+ * @param {Function} body - Test body
+ */
+function withTransactionalEmailConfig(
+  config: unknown,
+  body: () => void
+): void {
+  const original = process.env.TRANSACTIONAL_EMAIL_CONFIG;
+  if (config === undefined) {
+    delete process.env.TRANSACTIONAL_EMAIL_CONFIG;
+  } else {
+    process.env.TRANSACTIONAL_EMAIL_CONFIG = JSON.stringify(config);
+  }
+
+  try {
+    body();
+  } finally {
+    if (original === undefined) {
+      delete process.env.TRANSACTIONAL_EMAIL_CONFIG;
+    } else {
+      process.env.TRANSACTIONAL_EMAIL_CONFIG = original;
+    }
+  }
 }

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -92,7 +92,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <div class="privacy-page">
     <main>
       <h1>Privacy Policy</h1>
-      <p class="last-updated">Last updated: June 24, 2026</p>
+      <p class="last-updated">Last updated: July 17, 2026</p>
 
       <h2>Introduction</h2>
       <p>Ascend ("we", "our", or "us") is a stair-stepper workout app for tracking climbs, workouts, leaderboards, achievements, and progress. This Privacy Policy explains what information we collect, how we use it, how we share it, and the choices you have.</p>
@@ -167,6 +167,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <li><strong>Account deletion:</strong> You can delete your account in the app. You may also contact us if you need help.</li>
         <li><strong>HealthKit:</strong> You can grant or revoke HealthKit permissions in iOS Settings or the Health app.</li>
         <li><strong>Notifications:</strong> You can enable or disable notification categories in Ascend where supported, and you can turn all notifications off in iOS Settings.</li>
+        <li><strong>Emails:</strong> Climb and progress emails include an unsubscribe link, and you can change the same preference in Ascend's Settings under Notifications. Opting out stops climb and progress emails, including any already queued to send. Account, security, and other transactional messages still come through. If you joined the Ascend waitlist or newsletter, that is a separate subscription with its own unsubscribe link.</li>
         <li><strong>Photos:</strong> You can control Photos access in iOS Settings.</li>
         <li><strong>Subscriptions:</strong> You can manage App Store subscriptions through your Apple account subscription settings.</li>
         <li><strong>Support requests:</strong> You can contact us to request access, correction, deletion, or export of personal information, subject to identity verification and applicable law.</li>

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -153,6 +153,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <li><strong>Superwall:</strong> Paywall presentation, paywall analytics, campaign logic, and subscription conversion measurement.</li>
         <li><strong>Mixpanel:</strong> First-party product analytics and onboarding funnel measurement.</li>
         <li><strong>Sentry:</strong> Crash reporting, non-fatal error diagnostics, performance diagnostics, breadcrumbs, and release health investigation.</li>
+        <li><strong>Resend:</strong> Email delivery. Resend receives the recipient email address and the contents of the message we send. When you send feedback or a support message, your email address is also used as the reply-to address on the notification sent to us.</li>
+        <li><strong>Beehiiv:</strong> Waitlist and newsletter subscription management. Beehiiv receives the email address you submit on the Ascend website, along with the signup source and campaign information for that submission.</li>
       </ul>
 
       <h2>Data Storage and Security</h2>


### PR DESCRIPTION
## Intent

Add an email unsubscribe path to Ascend, and fix a related merge bug. Six parts: (1) List-Unsubscribe headers on outgoing email; (2) unsubscribe link in the email footer; (3) a Cloud Function endpoint setting lifecycleEmailsEnabled:false; (4) wire the existing but never-called LifecycleEventRecorder.recordCommunicationPreferences to a settings toggle; (5) fix the 'E6' merge bug where set() without {merge:true} wiped the push preference; (6) tests for the unsubscribe flow. Users previously had no way to opt out, and Gmail/Yahoo bulk-sender rules expect one-click List-Unsubscribe.

Deliberate decisions: unsubscribeSigningKey and websiteUrl are REQUIRED in TRANSACTIONAL_EMAIL_CONFIG so a misconfigured secret fails loudly rather than silently sending mail with no opt-out or cross-environment links; documented before-deploy secret-ordering tradeoff. The endpoint answers GET with a confirmation page and only acts on POST (RFC 8058 one-click sends POST; scanners and prefetchers follow GETs). Tokens are HMAC-signed, verified with timingSafeEqual, and intentionally never expire so links outlive the message. Waitlist and admin feedback mail deliberately get no unsubscribe header or link (no recipientUid; Beehiiv owns the waitlist opt-out). The app toggle reads from Firestore rather than mirroring in UserDefaults like the adjacent push toggle, because the unsubscribe link mutates the same account-scoped value from outside the app. recordCommunicationPreferences went from fire-and-forget to async throws so the toggle can surface failure and revert; it had zero callers. unsubscribe.ts imports Timestamp from firebase-admin/firestore because the Functions emulator strips admin.firestore statics. No firestore.rules change is needed: email_jobs and communication_preferences are server-only with no field validation.

ALREADY-SETTLED gate decisions - do NOT re-litigate. Commits e2635ef, 9c50043, 2cf8365 on this branch are prior gate fixes. send-time-preference-gate: FIXED (prefs re-read at send time for jobs with a recipientUid). marketing-url-fallback-cross-env: FIXED (websiteUrl required and https-validated). stale-unsubscribed-markers: deliberately APPROVED AS-IS by the user - unsubscribedAt/unsubscribedVia intentionally persist after re-subscribe as an audit trail, nothing reads them, so do NOT re-flag or fix it. Earlier rounds also separated first-load from refresh so a failed foreground refresh keeps the last known-good value, and made the transactional-config check a batch-level precondition at the top of processEmailJobs so a bad secret fails the invocation loudly while one job's read failure only skips that job.

ONE KNOWN OPEN ISSUE this run should fix (previous run surfaced it, then its fix agent crashed before applying anything): load-write-race-overwrites-fresh-value in EmailPreferencesViewModel. load() only discards its result when a write is still in flight (guard !isUpdating), so a write that both starts AND completes during a slow read goes undetected and the stale pre-write value overwrites the fresh one - user toggles off, write succeeds, the hung read then resolves with stale true and puts the toggle back to true while the server holds false. Fix with a write-generation counter bumped on every completed write (including the failed-write revert path); load() captures it before awaiting and discards the read if it changed, since a write that landed during a read is strictly newer information. Keep the !isUpdating guard as the in-flight short-circuit. The discard path must leave loadState .ready with the post-write value and must not set errorMessage or flip to .failed. Add a deterministic (continuation/signal-based, not sleep-based) view-model test reproducing that exact interleaving.

Prior-run status for context: review previously reached 0 findings after three fix rounds; the test step drove the full flow against the Firebase emulator (14/14), clicked the footer link in a real browser through the /api/unsubscribe rewrite, reproduced the E6 bug on base 6341ad6 and proved it fixed on target, and ran 260 Swift tests green. Locally on this HEAD: functions build+lint clean, 81/81 node tests pass. Both prior runs failed only because the pipeline agent process exited status 1 at a long step (usage limits), not because of any code defect.

Known environment limitation, not a defect to chase: the iOS Settings -> Notifications toggle cannot be screenshotted here because it needs an authenticated Firebase session and the internal QA credentials are user-local env vars (ASC_INTERNAL_QA_EMAIL / ASC_INTERNAL_QA_PASSWORD per CLAUDE.md) not present in this environment. Its logic is covered by passing view-model tests and the callable payload is exercised end-to-end. Do not burn the test step trying to authenticate a simulator; note the gap instead.

## What Changed

- Added a server-side unsubscribe path: outgoing lifecycle mail now carries RFC 8058 `List-Unsubscribe` / `List-Unsubscribe-Post` headers plus a footer link, backed by a new `unsubscribeFromEmails` Cloud Function behind the `/api/unsubscribe` hosting rewrite. Links carry HMAC-signed, non-expiring tokens verified with `timingSafeEqual`; GET renders a confirmation page and only POST flips `lifecycleEmailsEnabled` to false. Waitlist and admin feedback mail have no `recipientUid` and deliberately get neither header nor link. `unsubscribeSigningKey` and `websiteUrl` are now required in `TRANSACTIONAL_EMAIL_CONFIG`, so a misconfigured secret fails the run loudly instead of sending mail with a broken or cross-environment opt-out.
- Wired the previously uncalled `LifecycleEventRecorder.recordCommunicationPreferences` to a new email toggle in Settings -> Notifications, via `EmailPreferencesService` / `EmailPreferencesViewModel`. The recorder went from fire-and-forget to `async throws` so the toggle can surface a failure and revert. The toggle reads from Firestore rather than mirroring in UserDefaults, because the unsubscribe link mutates the same account-scoped value from outside the app. A write-generation counter makes `load()` discard a read that a completed write superseded, and `processEmailJobs` re-reads preferences at send time so a job that backs off for hours can't deliver to someone who unsubscribed in the window.
- Fixed the E6 merge bug where writing `users/{uid}/communication_preferences/current` without `{merge: true}` wiped the push preference; all writers now route through a shared `buildNextCommunicationPreferences` helper, and the write-only `communicationPreferences` mirror on `lifecycle/state` was dropped. Also added 37 unsubscribe tests, deterministic view-model race tests, an "Emails" bullet to the privacy policy's Your Choices section, and Resend + Beehiiv to its third-party subprocessor list.

The pipeline's functions suite passes 109/109 and the iOS suite 344/344. The Settings toggle has no screenshot: rendering it needs an authenticated Firebase session and the internal QA credentials are user-local env vars absent from this environment, so its behavior is covered by the view-model tests and by an end-to-end check of the exact callable payload it sends against the emulator.

## Risk Assessment

✅ Low: The final commit is a tightly scoped, verified fix of all three accepted findings - a write-generation counter with deterministic continuation-based tests, a rename that removes a load-bearing overload, and a dead mirror deletion confirmed orphan-free by grep - leaving the branch fully conformant with the stated intent and free of substantiable defects.

## Testing

Ran the functions suite (109/109) and the Swift suite (344/344), then demonstrated the whole unsubscribe path end-to-end against the Firebase emulator rather than relying on unit tests: a real lifecycle email was sent through the actual processEmailJobs with only the Resend HTTP call replaced by a local mail sink, carrying both RFC 8058 List-Unsubscribe headers plus a footer link in HTML and text, while waitlist mail correctly got neither. I opened that email in Chrome, clicked the footer link through the real /api/unsubscribe hosting rewrite, confirmed the GET left Firestore untouched (scanner-safe), pressed Unsubscribe, and saw lifecycleEmailsEnabled flip to false while the push preference survived; a subsequently queued email was then suppressed at send time as skipped, and a second click was an idempotent no-op. The E6 merge bug was reproduced on base e841ecc and proven fixed on target a1d025f by running the real recordLifecycleEvent callable (the exact function the iOS toggle invokes) on both commits, and the new load/write race test was proven non-vacuous by temporarily reverting the fix and observing the precise reported failure before restoring the file. Two notes: the CI-style Staging build cannot run locally because the build script's plist symlink is blocked by Xcode's user script sandbox (the Staging plist secret is not in this worktree), so I ran the Debug configuration which uses the Dev plist already present - a local environment limitation, not a product issue, since CI decodes real plists into place; and the iOS Settings email toggle itself has no screenshot because it requires an authenticated Firebase session whose QA credentials are user-local env vars confirmed absent here, a gap the author's intent explicitly designated as known, with its logic covered by passing view-model tests and its callable payload exercised end-to-end. All emulator state, harnesses, the local secret file and the hosting stub were removed; git status is clean.

<details>
<summary>Evidence: Evidence index: full end-to-end walkthrough with headers, state dumps and verdicts</summary>

```text
# Email unsubscribe path - end-to-end evidence

Branch `fm/add-unsubscribe-path-c9`, base `e841ecc` -> target `a1d025f`.

Everything below ran against the **Firebase emulator suite** (Firestore + Functions + Hosting,
`firebase emulators:start --only functions,firestore,hosting`).
The only stub is `globalThis.fetch` to `api.resend.com`, replaced by a local mail sink so the
outgoing message can be inspected instead of actually mailed.
Template rendering, HMAC token signing, the preference gate, the job state machine, the
`recordLifecycleEvent` / `updatePushNotificationPreferences` callables, and the
`unsubscribeFromEmails` endpoint behind the real `/api/unsubscribe` hosting rewrite are all
production code.

## What a climber actually experiences

| # | Step | Evidence |
|---|------|----------|
| 1 | A lifecycle email is sent, carrying RFC 8058 headers and a footer Unsubscribe link | `01-send-email.log`, `resend-payload-headers.json`, `02-email-with-unsubscribe-footer.png` |
| 2 | Clicking the footer link (GET) shows a confirmation page and **changes nothing** | `03-unsubscribe-confirm-page-GET.png` |
| 3 | Pressing Unsubscribe (POST) opts them out | `04-unsubscribed-confirmation-POST.png` |
| 4 | Further lifecycle mail is suppressed at send time as `skipped` | `05-send-gate.log`, `05-send-gate-summary.json` |
| 5 | A tampered/forged link is refused | `07-endpoint-http-behavior.log`, `09-invalid-token-page.png` |

## Headers on the wire (step 1)

`` `json
{
  "List-Unsubscribe": "<https://ascendstepper.com/api/unsubscribe?token=v1.cWEtY2xpbWJlci11aWQtMDAx.g8-RwYnYlCW_9UtDra4jZE-Sa2rVl-SZT2LAleCkZiw>",
  "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"
}
`` `

The same URL appears in the HTML footer and the plaintext part.
The email renders at `https://ascendstepper.com`; for the browser click-through the host was
swapped to the local hosting emulator (`127.0.0.1:5002`) - identical path and token.

Waitlist mail (no `recipientUid`) got `headers: {}` and no footer link, as intended - Beehiiv owns
that opt-out.

## GET is safe, POST acts

Firestore immediately after the GET - still subscribed:

`` `
{ "lifecycleEmailsEnabled": true, "pushClimbDropsEnabled": true }
`` `

After the POST:

`` `
{ "lifecycleEmailsEnabled": false, "unsubscribedVia": "email_link", "pushClimbDropsEnabled": true }
`` `

Request-level behavior through the rewrite (`07-endpoint-http-behavior.log`):

`` `
GET  valid token      -> 200 (confirmation page, no write)
POST valid token      -> 200 (opt-out performed)
POST tampered sig     -> 400
POST forged uid token -> 400
POST no token         -> 400
DELETE valid token    -> 405
cache-control: no-store
`` `

## The E6 merge bug: reproduced on base, fixed on target

`06-e6-merge-ab.log` runs the **real `recordLifecycleEvent` callable** - the exact function the iOS
email toggle invokes - on both commits. The push preference is seeded through the real
`updatePushNotificationPreferences` callable, which stores `pushClimbDropsEnabled` on the same
shared document.

`` `
BASE  e841ecc  (set() without {merge:true})
  before -> {"pushClimbDropsEnabled":true}
  after  -> {"lifecycleEmailsEnabled":false}          <-- push preference silently WIPED

TARGET a1d025f (buildNextCommunicationPreferences + {merge:true})
  before -> {"pushClimbDropsEnabled":true}
  after  -> {"lifecycleEmailsEnabled":false,"pushClimbDropsEnabled":true}
`` `

`08-three-writers-merge.log` then drives all three writers of that document in sequence
(push toggle -> in-app email toggle -> unsubscribe link -> in-app re-subscribe); every writer's
value survives the others.

## The load/write race test is not vacuous

`11-race-test-non-vacuity.log`. With the write-generation fix temporarily reverted (back to
`guard !isUpdating` alone), the new tests fail with exactly the reported symptom:

`` `
✘ aWriteThatLandsDuringARefreshSurvivesIt()
    Expectation failed: (viewModel.isLifecycleEmailsEnabled → true) == false
✘ aFailedWriteThatRevertsDuringARefreshKeepsItsMessage()
    Expectation failed: (viewModel.isLifecycleEmailsEnabled → false) == true
    Expectation failed: (viewModel.errorMessage → nil) != nil
`` `

The stale read resolves with `true` and overwrites the fresh `false` - the toggle flips back on
while the server holds off. With the fix in place the full suite passes (344 tests).
The view model was restored to the committed version afterwards.

## Not covered

The iOS Settings -> Notifications email toggle was not screenshotted: it needs an authenticated
Firebase session, and the internal QA credentials are user-local env vars
(`ASC_INTERNAL_QA_EMAIL` / `ASC_INTERNAL_QA_PASSWORD`) that are not set in this environment
(verified). Its logic is covered by the `EmailPreferencesViewModel` tests, and the callable payload
it sends is exercised end-to-end in `06-e6-merge-ab.log`.
```
</details>
- Evidence: Rendered lifecycle email showing the Unsubscribe link in the footer (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXQR2VRM0PVAT9CEA1YDKRD6/02-email-with-unsubscribe-footer.png</code>)
- Evidence: Confirmation page after clicking the footer link (GET performs no write) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXQR2VRM0PVAT9CEA1YDKRD6/03-unsubscribe-confirm-page-GET.png</code>)
- Evidence: &#34;You&#39;re unsubscribed.&#34; result page after pressing Unsubscribe (POST) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXQR2VRM0PVAT9CEA1YDKRD6/04-unsubscribed-confirmation-POST.png</code>)
- Evidence: Invalid/tampered link page (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXQR2VRM0PVAT9CEA1YDKRD6/09-invalid-token-page.png</code>)
<details>
<summary>Evidence: RFC 8058 headers actually handed to the mail provider</summary>

<code>{&#10;&#34;to&#34;: [&#34;climber@example.com&#34;],&#10;&#34;subject&#34;: &#34;First climb logged&#34;,&#10;&#34;headers&#34;: {&#10;&#34;List-Unsubscribe&#34;: &#34;&lt;https://ascendstepper.com/api/unsubscribe?token=v1.cWEtY2xpbWJlci11aWQtMDAx.g8-RwYnYlCW_9UtDra4jZE-Sa2rVl-SZT2LAleCkZiw&gt;&#34;,&#10;&#34;List-Unsubscribe-Post&#34;: &#34;List-Unsubscribe=One-Click&#34;&#10;}&#10;}</code>

```text
{
  "to": [
    "climber@example.com"
  ],
  "subject": "First climb logged",
  "headers": {
    "List-Unsubscribe": "<https://ascendstepper.com/api/unsubscribe?token=v1.cWEtY2xpbWJlci11aWQtMDAx.g8-RwYnYlCW_9UtDra4jZE-Sa2rVl-SZT2LAleCkZiw>",
    "List-Unsubscribe-Post": "List-Unsubscribe=One-Click"
  }
}
```
</details>
<details>
<summary>Evidence: E6 merge bug: reproduced on base, fixed on target, via the real recordLifecycleEvent callable</summary>

<code>BASE e841ecc (set() without {merge:true})&#10;before -&gt; {&#34;pushClimbDropsEnabled&#34;:true}&#10;user turns the EMAIL toggle off -&gt;&#10;after -&gt; {&#34;lifecycleEmailsEnabled&#34;:false}&#10;email preference saved : true&#10;push preference survived : false &lt;-- E6: push preference silently WIPED&#10;&#10;TARGET a1d025f (buildNextCommunicationPreferences + {merge:true})&#10;before -&gt; {&#34;pushClimbDropsEnabled&#34;:true}&#10;user turns the EMAIL toggle off -&gt;&#10;after -&gt; {&#34;lifecycleEmailsEnabled&#34;:false,&#34;pushClimbDropsEnabled&#34;:true}&#10;email preference saved : true&#10;push preference survived : true&#10;&#10;bug reproduces on base and is fixed on target: true</code>

```text
====================================================================
E6 REGRESSION A/B - real recordLifecycleEvent callable
====================================================================

--------------------------------------------------------------------
BASE  e841ecc  (set() without {merge:true})
--------------------------------------------------------------------
before  -> {"pushClimbDropsEnabled":true}
user turns the EMAIL toggle off ->
after   -> {"lifecycleEmailsEnabled":false}

  email preference saved      : true
  push preference survived    : false   <-- E6: push preference silently WIPED

--------------------------------------------------------------------
TARGET a1d025f (buildNextCommunicationPreferences + {merge:true})
--------------------------------------------------------------------
before  -> {"pushClimbDropsEnabled":true}
user turns the EMAIL toggle off ->
after   -> {"lifecycleEmailsEnabled":false,"pushClimbDropsEnabled":true}

  email preference saved      : true
  push preference survived    : true

====================================================================
VERDICT
====================================================================
base   : email saved=true  push kept=false
target : email saved=true  push kept=true

bug reproduces on base and is fixed on target: true
```
</details>
<details>
<summary>Evidence: Send-time gate: mail to an unsubscribed climber is skipped, not sent</summary>

<code>processEmailJobs skipped by preferences { jobId: &#39;first-ascent-qa-002&#39; }&#10;processEmailJobs summary { sentCount: 0, skippedCount: 1, failedCount: 0 }&#10;&#10;job status : skipped&#10;attemptCount : 0 (untouched: nothing failed)&#10;lastErrorCode : null&#10;messages sent : 0&#10;&#10;suppressed at send time, terminal &#39;skipped&#39; not &#39;failed&#39;: true&#10;&#10;STEP 5 second unsubscribe click outcome: already_unsubscribed</code>

```text
========================================================================
STEP 4  Climber is now unsubscribed. Queue ANOTHER lifecycle email.
========================================================================
queued email_jobs/first-ascent-qa-002 (status=queued)
processEmailJobs skipped by preferences { jobId: 'first-ascent-qa-002' }
processEmailJobs summary {
  erroredCount: 0,
  failedCount: 0,
  queuedCount: 1,
  reclaimedCount: 0,
  retriedCount: 0,
  sentCount: 0,
  skippedCount: 1
}

job status      : skipped
attemptCount    : 0  (untouched: nothing failed)
lastErrorCode   : null
messages sent   : 0

suppressed at send time, terminal 'skipped' not 'failed': true

========================================================================
STEP 5  A second unsubscribe click must be an idempotent no-op
========================================================================
second click outcome: already_unsubscribed
```
</details>
<details>
<summary>Evidence: Unsubscribe endpoint HTTP behavior through the /api/unsubscribe hosting rewrite</summary>

<code>GET valid token (confirmation page, no write) -&gt; HTTP 200&#10;POST valid token (performs opt-out) -&gt; HTTP 200&#10;POST tampered signature -&gt; HTTP 400&#10;POST token for another uid, resigned by attacker -&gt; HTTP 400&#10;POST no token -&gt; HTTP 400&#10;DELETE valid token (unsupported method) -&gt; HTTP 405&#10;&#10;cache-control: no-store</code>

```text
=== Unsubscribe endpoint: request-level behavior (via hosting rewrite) ===
GET  valid token (confirmation page, no write)             -> HTTP 200
POST valid token (performs opt-out)                        -> HTTP 200
POST tampered signature                                    -> HTTP 400
POST token for another uid, resigned by attacker           -> HTTP 400
POST no token                                              -> HTTP 400
DELETE valid token (unsupported method)                    -> HTTP 405

=== Cache-Control on the confirmation page ===
cache-control: no-store
```
</details>
<details>
<summary>Evidence: All three writers of the shared preferences document coexist</summary>

<code>WRITER 1 updatePushNotificationPreferences -&gt; {&#34;pushClimbDropsEnabled&#34;:true}&#10;WRITER 2 recordLifecycleEvent (in-app toggle) -&gt; {&#34;lifecycleEmailsEnabled&#34;:true,&#34;pushClimbDropsEnabled&#34;:true}&#10;WRITER 3 unsubscribeFromEmails (footer link) -&gt; {&#34;lifecycleEmailsEnabled&#34;:false,&#34;pushClimbDropsEnabled&#34;:true}&#10;WRITER 2 again (re-subscribe) -&gt; {&#34;lifecycleEmailsEnabled&#34;:true,&#34;pushClimbDropsEnabled&#34;:true}&#10;&#10;push preference survived the email toggle : true&#10;push preference survived the unsubscribe : true&#10;unsubscribe actually disabled email : true&#10;re-subscribe restored email, push intact : true</code>

```text
==============================================================================
Three writers on users/{uid}/communication_preferences/current
==============================================================================

WRITER 1  updatePushNotificationPreferences (push toggle)
  after push toggle ON:                        {"pushClimbDropsEnabled":true}

WRITER 2  recordLifecycleEvent (in-app email toggle -> OFF)
  after email toggle ON:                       {"lifecycleEmailsEnabled":true,"pushClimbDropsEnabled":true}

WRITER 3  unsubscribeFromEmails (footer link / one-click)
  after unsubscribe link:                      {"lifecycleEmailsEnabled":false,"pushClimbDropsEnabled":true}

WRITER 2 again  (user re-subscribes from in-app settings)
  after in-app re-subscribe:                   {"lifecycleEmailsEnabled":true,"pushClimbDropsEnabled":true}

==============================================================================
RESULTS
==============================================================================
push preference survived the email toggle   : true
push preference survived the unsubscribe    : true
unsubscribe actually disabled email         : true
re-subscribe restored email, push intact    : true
```
</details>
<details>
<summary>Evidence: Race test non-vacuity: reverting the fix reproduces the exact reported bug</summary>

<code>With the write-generation fix temporarily reverted (guard !isUpdating only):&#10;&#10;✘ aWriteThatLandsDuringARefreshSurvivesIt()&#10;Expectation failed: (viewModel.isLifecycleEmailsEnabled → true) == false&#10;✘ aFailedWriteThatRevertsDuringARefreshKeepsItsMessage()&#10;Expectation failed: (viewModel.isLifecycleEmailsEnabled → false) == true&#10;Expectation failed: (viewModel.errorMessage → nil) != nil&#10;✘ Test run with 14 tests in 1 suite failed with 3 issues.&#10;&#10;With the fix in place (target a1d025f):&#10;✔ aWriteThatLandsDuringARefreshSurvivesIt() passed&#10;✔ aFailedWriteThatRevertsDuringARefreshKeepsItsMessage() passed&#10;✔ Test run with 344 tests in 66 suites passed</code>

```text
Non-vacuity check: the write-generation fix was temporarily reverted in
EmailPreferencesViewModel (guard !isUpdating only, no generation counter),
then AscendAppTests/EmailPreferencesViewModelTests was run.

Result: the two race tests fail exactly as the reported bug describes -
the stale read resolves with true and overwrites the fresh false.

✘ Test aWriteThatLandsDuringARefreshSurvivesIt() recorded an issue at EmailPreferencesViewModelTests.swift:109:9: Expectation failed: (viewModel.isLifecycleEmailsEnabled → true) == false
✘ Test aFailedWriteThatRevertsDuringARefreshKeepsItsMessage() recorded an issue at EmailPreferencesViewModelTests.swift:132:9: Expectation failed: (viewModel.isLifecycleEmailsEnabled → false) == true
✘ Test aWriteThatLandsDuringARefreshSurvivesIt() failed after 0.004 seconds with 1 issue.
✘ Test aFailedWriteThatRevertsDuringARefreshKeepsItsMessage() recorded an issue at EmailPreferencesViewModelTests.swift:133:9: Expectation failed: (viewModel.errorMessage → nil) != nil
✘ Test aFailedWriteThatRevertsDuringARefreshKeepsItsMessage() failed after 0.014 seconds with 2 issues.
✘ Suite EmailPreferencesViewModelTests failed after 0.016 seconds with 3 issues.
✘ Test run with 14 tests in 1 suite failed after 0.016 seconds with 3 issues.

With the fix in place (target a1d025f), the same suite passes:
✔ Test aWriteThatLandsDuringARefreshSurvivesIt() passed after 0.757 seconds.
✔ Test aFailedWriteThatRevertsDuringARefreshKeepsItsMessage() passed after 0.757 seconds.
✔ Test run with 344 tests in 66 suites passed after 0.951 seconds.
```
</details>
<details>
<summary>Evidence: Emulator log confirming real hosting rewrite routing to the function</summary>

<code>[hosting] Rewriting /api/unsubscribe?token=v1.cWEtY2xpbWJlci11aWQtMDAx... to http://127.0.0.1:5001/ascend-f2e4f/us-central1/unsubscribeFromEmails for local Function us-central1/unsubscribeFromEmails&#10;i functions: Beginning execution of &#34;us-central1-unsubscribeFromEmails&#34;&#10;&gt; unsubscribeFromEmails processed { outcome: &#39;unsubscribed&#39;, uid: &#39;qa-climber-uid-001&#39; }</code>

```text
[hosting] Rewriting /api/unsubscribe?token=v1.cWEtY2xpbWJlci11aWQtMDAx.g8-RwYnYlCW_9UtDra4jZE-Sa2rVl-SZT2LAleCkZiw to http://127.0.0.1:5001/ascend-f2e4f/us-central1/unsubscribeFromEmails for local Function us-central1/unsubscribeFromEmails
i  functions: Beginning execution of "us-central1-unsubscribeFromEmails"
[hosting] Rewriting /api/unsubscribe?token=v1.cWEtY2xpbWJlci11aWQtMDAx.g8-RwYnYlCW_9UtDra4jZE-Sa2rVl-SZT2LAleCkZiw to http://127.0.0.1:5001/ascend-f2e4f/us-central1/unsubscribeFromEmails for local Function us-central1/unsubscribeFromEmails
i  functions: Beginning execution of "us-central1-unsubscribeFromEmails"
[hosting] Rewriting /api/unsubscribe?token=v1.cWEtY2xpbWJlci11aWQtMDAx.g8-RwYnYlCW_9UtDra4jZE-Sa2rVl-SZT2LAleCkZiw to http://127.0.0.1:5001/ascend-f2e4f/us-central1/unsubscribeFromEmails for local Function us-central1/unsubscribeFromEmails
i  functions: Beginning execution of "us-central1-unsubscribeFromEmails"
>  unsubscribeFromEmails processed { outcome: 'unsubscribed', uid: 'qa-climber-uid-001' }
[hosting] Rewriting /api/unsubscribe?token=v1.cWEtY2xpbWJlci11aWQtMDAx.g8-RwYnYlCW_9UtDra4jZE-Sa2rVl-SZT2LAleCkZiw to http://127.0.0.1:5001/ascend-f2e4f/us-central1/unsubscribeFromEmails for local Function us-central1/unsubscribeFromEmails
```
</details>
<details>
<summary>Evidence: Raw HTML of the actual sent lifecycle email (footer link included)</summary>

```text
<!doctype html><html lang="en" xmlns="http://www.w3.org/1999/xhtml"><body style="margin:0;padding:0;background:#f4f2eb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Arial,sans-serif;color:#111111;"><div style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;">Your stair-stepper work is on the board.</div><table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#f4f2eb;padding:24px 12px;"><tr><td align="center"><table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:620px;background:#ffffff;border:1px solid rgba(17,17,17,0.08);border-radius:28px;overflow:hidden;"><tr><td style="background:#111111;padding:24px 30px;"><table role="presentation" cellspacing="0" cellpadding="0" border="0"><tr><td valign="middle" style="padding-right:12px;"><img src="https://ascendstepper.com/images/ascend-a-icon.png" width="38" height="38" alt="Ascend icon" style="display:block;width:38px;height:38px;border:0;border-radius:9px;" /></td><td valign="middle" style="font-size:15px;line-height:1;color:#ffffff;font-weight:800;letter-spacing:0.08em;text-transform:uppercase;">Ascend</td></tr></table></td></tr><tr><td style="padding:36px 30px 26px;"><p style="margin:0 0 16px;font-size:12px;line-height:1.3;color:#86D30A;font-weight:700;letter-spacing:0.22em;text-transform:uppercase;">First Result</p><h1 style="margin:0 0 20px;font-size:42px;line-height:1.02;font-weight:900;letter-spacing:-0.03em;color:#111111;">FIRST CLIMB LOGGED.</h1><p style="margin:0 0 18px;font-size:17px;line-height:1.65;color:#4b5563;max-width:500px;">Your first Ascend climb, Empire State Building, is logged.</p><p style="margin:0 0 18px;font-size:17px;line-height:1.65;color:#4b5563;max-width:500px;">Now you have a rank to beat, a history to build, and a board to climb.</p><div style="padding-top:10px;text-align:center;"><a href="https://ascendstepper.com/climbs/empire-state-building" style="display:inline-block;padding:18px 24px;border-radius:16px;background:#86D30A;color:#111111;font-size:16px;line-height:1;font-weight:800;text-decoration:none;text-transform:uppercase;letter-spacing:0.04em;">View your result</a></div></td></tr><tr><td style="padding:0 30px 34px;"><div style="border-top:1px solid rgba(17,17,17,0.08);padding-top:22px;text-align:center;"><p style="margin:0 0 10px;font-size:13px;line-height:1.6;color:#9ca3af;">You received this because your first eligible Ascend Live Climb was completed.</p><p style="margin:0 0 10px;font-size:13px;line-height:1.6;color:#9ca3af;">Need help? Reply to this email.</p><p style="margin:0;font-size:13px;line-height:1.6;"><a href="https://ascendstepper.com/privacy" style="color:#6b7280;text-decoration:underline;">Privacy Policy</a><span style="color:#9ca3af;"> &middot; </span><a href="https://ascendstepper.com/api/unsubscribe?token=v1.cWEtY2xpbWJlci11aWQtMDAx.g8-RwYnYlCW_9UtDra4jZE-Sa2rVl-SZT2LAleCkZiw" style="color:#6b7280;text-decoration:underline;">Unsubscribe</a></p></div></td></tr></table></td></tr></table></body></html>
```
</details>
- Outcome: ⚠️ 1 info across 1 run (18m19s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- 🚨 `AscendApp/Features/Account/ViewModels/EmailPreferencesViewModel.swift:50` - load() only discards its result when a write is still in flight (`guard !isUpdating`), so a write that both starts AND completes during a slow read goes undetected and the stale pre-write value overwrites the fresh one. Interleaving: user toggles off -&gt; setLifecycleEmailsEnabled sets isUpdating = true, optimistically sets isLifecycleEmailsEnabled = false, awaits the write, the write succeeds, and its `defer { isUpdating = false }` fires; the hung read then resolves, passes `guard !isUpdating` at line 50, and line 52 puts the toggle back to `true` while the server holds `false`. Line 54&#39;s `errorMessage = nil` compounds it by clearing a failed-write message on the same path. Fix with a write-generation counter bumped on every completed write (including the failed-write revert path in the catch at line 77); load() captures it before awaiting service.loadLifecycleEmailsEnabled() and discards the read if it changed, since a write that landed during a read is strictly newer information. Keep the `!isUpdating` guard as the in-flight short-circuit. The discard path must leave loadState .ready with the post-write value and must not set errorMessage or flip to .failed. Add a deterministic (continuation/signal-based, not sleep-based) view-model test reproducing that exact interleaving - AscendAppTests/EmailPreferencesViewModelTests.swift currently has no test for it, and the existing StubEmailPreferencesService actor cannot suspend a load at a controlled point.
- ℹ️ `AscendApp/Shared/Services/Lifecycle/LifecycleEventRecorder.swift:139` - `record(type:payload:)` now exists twice with identical parameter labels and types, differing only in `async throws` (line 136 sync fire-and-forget, line 153 async). The sync one calls `try await record(type:payload:)` inside a Task and depends entirely on Swift preferring the async overload in an async context. It does resolve correctly, but the failure mode if it ever didn&#39;t is silent and severe: the sync version would spawn a Task that calls itself and spawns another Task, unbounded, with the only compiler signal being an &#39;await has no async operations&#39; warning. Give the async variant a distinct name (e.g. `sendLifecycleEvent(type:payload:)`) so the call at line 139 names its target explicitly instead of leaning on overload-resolution subtlety.
- ℹ️ `functions/src/lifecycle.ts:306` - statePatchForEvent still writes `communicationPreferences: event.payload` into `users/{uid}/lifecycle/state`. Before this change that mirror was the merge base the callable read back (`currentState.communicationPreferences`); now the callable reads the real `communication_preferences/current` document via buildNextCommunicationPreferences, and a grep across functions/src, functions/test, and AscendApp shows nothing reads the mirror at all - it is write-only. `unsubscribeFromEmails` writes only the real document, so the mirror will report `lifecycleEmailsEnabled: true` for any user who unsubscribed via an email link. Harmless today because no gate consults it, but it is a stale-data trap for the next reader who assumes lifecycle/state reflects preferences. Consider dropping the mirror (this changes what is persisted in a server-owned document, so it is your call) or documenting it as non-authoritative.

🔧 Fix: Fix email preference read/write race; drop stale lifecycle mirror
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `AscendApp/Features/Account/Views/NotificationSettingsView.swift` - The iOS Settings -&gt; Notifications email toggle is the one UI surface in this change without a screenshot. Rendering it needs an authenticated Firebase session, and the internal QA credentials are user-local env vars (ASC_INTERNAL_QA_EMAIL / ASC_INTERNAL_QA_PASSWORD) that are confirmed absent in this environment. The user&#39;s intent pre-designated this a known environment limitation rather than a defect, so no decision is pending. Its logic is covered by the passing EmailPreferencesViewModel tests (including the reverted-fix non-vacuity check), and the exact callable payload the toggle sends is exercised end-to-end against the emulator in 06-e6-merge-ab.log. All other UI surfaces (rendered email, confirmation page, result page, invalid-link page) were captured visually.
- <code>`npm test` in functions/ (109/109 pass, includes 37 unsubscribe tests)</code>
- <code>`xcrun xcodebuild test -scheme AscendApp -configuration Debug -destination &#39;platform=iOS Simulator,id=DC178358...&#39; ENABLE_TESTABILITY=YES -only-testing:AscendAppTests` (344/344 pass, includes `aWriteThatLandsDuringARefreshSurvivesIt` and `aFailedWriteThatRevertsDuringARefreshKeepsItsMessage`)</code>
- <code>`firebase emulators:start --only functions,firestore,hosting --project ascend-f2e4f` - full emulator suite for all end-to-end checks below</code>
- <code>Drove the real `processEmailJobs` against the Firestore emulator with a local mail sink replacing api.resend.com; captured the outgoing Resend payload and asserted `List-Unsubscribe` + `List-Unsubscribe-Post` headers and the footer link in both HTML and plaintext parts</code>
- <code>Verified waitlist mail (no recipientUid) is sent with `headers: {}` and no footer unsubscribe link</code>
- <code>Opened the rendered lifecycle email in Chrome and clicked the footer Unsubscribe link through the real `/api/unsubscribe` hosting rewrite (chrome-devtools-axi)</code>
- <code>Confirmed the GET confirmation page performs no write: Firestore still read `lifecycleEmailsEnabled: true` after the GET</code>
- <code>Clicked the UNSUBSCRIBE button (POST) and confirmed Firestore flipped to `lifecycleEmailsEnabled: false` with `unsubscribedVia: email_link` while `pushClimbDropsEnabled: true` survived</code>
- <code>Queued a further lifecycle email for the now-unsubscribed user and confirmed `processEmailJobs` gave it terminal status `skipped` (not `failed`), attemptCount untouched, zero messages sent</code>
- <code>Confirmed a second unsubscribe click returns the idempotent `already_unsubscribed` outcome</code>
- <code>HTTP probes through the rewrite: GET valid 200, POST valid 200, POST tampered signature 400, POST forged-uid token 400, POST no token 400, DELETE 405, `cache-control: no-store`</code>
- <code>E6 A/B on the real `recordLifecycleEvent` callable (the function the iOS toggle calls) on base e841ecc vs target a1d025f, with the push preference seeded through the real `updatePushNotificationPreferences` callable: base wipes `pushClimbDropsEnabled`, target preserves it</code>
- <code>Exercised all three writers of `users/{uid}/communication_preferences/current` in sequence (push toggle -&gt; in-app email toggle -&gt; unsubscribe link -&gt; in-app re-subscribe); every writer&#39;s value survives the others</code>
- <code>Non-vacuity check: temporarily reverted the write-generation fix in EmailPreferencesViewModel and re-ran `-only-testing:AscendAppTests/EmailPreferencesViewModelTests`; both race tests failed with the exact reported symptom, then restored the file (git status clean)</code>

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (2) ✅</summary>

- ℹ️ `web/src/pages/privacy.astro:164` - The privacy policy&#39;s &#39;Your Choices&#39; section enumerates user-facing controls (account deletion, HealthKit, Notifications, Photos, Subscriptions) but does not mention the email opt-out this change added. I left it alone rather than editing it, for two reasons worth your judgment. First, it is user-facing legal copy, and CLAUDE.md requires the privacy policy, PrivacyInfo.xcprivacy, the App Store questionnaire, and Info.plist to describe the same practices, so a change here should be a deliberate four-way decision rather than a housekeeping edit. Second, it is not strictly false today: the existing &#39;Notifications&#39; bullet says you can enable or disable notification categories in Ascend where supported, and the new email toggle does live in Settings, Notifications, so it is loosely covered. The change also collects no new Apple data type (unsubscribedAt/unsubscribedVia are preference metadata on an existing document), so no privacy-manifest update appears due. Decide whether you want an explicit &#39;Email&#39; bullet naming the in-app toggle and the unsubscribe link.
- ℹ️ `CLAUDE.md:732` - Out-of-scope consolidation worth a follow-up, not something to fix in this change. The Firebase Hosting section of CLAUDE.md now carries roughly 22 lines of email detail that is conditional deep-reference material rather than knowledge useful to almost every session: the secret-field contracts, the unsubscribe GET/POST split, the communication_preferences writer list, and the Functions-emulator admin-statics quirk. Per the placement policy, deep reference docs should own conditional material and always-loaded guidance should link to them; functions/EMAIL_SETUP.md is the natural owner and I have extended it accordingly. The emulator-quirk bullet is already duplicated as a code comment at functions/src/email/unsubscribe.ts:2-5, though the CLAUDE.md copy adds the &#39;Authorization: Bearer owner&#39; seed-fixture detail that the comment lacks. I did not move any of it because the change added these lines deliberately and moving them would be a documentation architecture migration this pass should not perform. PR #214 (&#39;docs: decompose CLAUDE.md into a lean core plus conditional skills&#39;) is already doing exactly this decomposition and is the right place to land it.

🔧 Fix: Document email opt-out in privacy policy Your Choices
1 info still open:
- ℹ️ `web/src/pages/privacy.astro:148` - Pre-existing gap, out of scope for this pass, worth a follow-up decision. The &#39;Third-Party Services&#39; list enumerates subprocessors that receive personal information (Apple, Google Firebase, Google Sign-In, RevenueCat, Superwall, Mixpanel, Sentry) but omits the two providers that receive user email addresses: Resend (sends every transactional/lifecycle email via functions/src/email/provider.ts) and Beehiiv (receives waitlist signups server-side per the joinWaitlist function). Both predate this change, so I did not add them: scope discipline limits this pass to what the change made stale, and adding named subprocessors to legal copy is a deliberate decision rather than housekeeping. I am surfacing it now for two reasons. First, the Emails bullet I just added references the separate waitlist/newsletter subscription, which makes the absence of its provider more noticeable to a reader. Second, this list is the section where a reader would look to learn who handles their email address, and both providers do. If you want them added, the natural entries mirror the existing style: &#39;Resend: Transactional email delivery&#39; and &#39;Beehiiv: Waitlist and newsletter subscription management&#39;. Note this is a data-sharing disclosure question, not a manifest question - it does not trigger CLAUDE.md&#39;s four-way consistency rule, since no new Apple data category or required-reason API is involved.

🔧 Fix: Disclose Resend and Beehiiv as email subprocessors
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
