### PR TITLE
chore(scripts): keep seeded First Ascent slots on a reachable state

### DIFF
--- a/.claude/skills/ascend-dev-fixtures/SKILL.md
+++ b/.claude/skills/ascend-dev-fixtures/SKILL.md
@@ -33,6 +33,9 @@ paths:
 - `scripts/seed-live-replay-leaderboards.mjs` may write only to dev (`ascend-f2e4f`) or staging (`ascend-staging-fa7d5`) and must hard-refuse production or any unknown project; use environment-specific seed packs for repeatable active/warm Live Climb replay fixtures.
 - Live replay seed entries must carry `isSynthetic`, `source`, and `seedPackId` so synthetic replay data can be filtered, cleared, or phased out later. Do not claim seeded replay rows are users climbing right now.
 - Live replay seed data must not reuse the same synthetic profile name or photo within a climb. Duplicate profiles make the replay look like one person appears multiple times.
+- Seeded replay summaries must stay on a First Ascent state the app can actually reach: completions imply a holder, and an open slot implies zero completions.
+  Seeding completions without `firstAscent*` fields permanently kills the slot, because the server only claims it when there are no completions and no holder.
+  `scripts/seed/lib/live-replay-first-ascent.mjs` owns this contract and fails the seed plan when it is violated; keep its field list in sync with `firstAscentWrite` in `functions/src/liveReplayLeaderboard.ts`.
 - Seeded replay curves should be calibrated from historical workout pace distributions when available. Apple Health-derived step counts should be conservatively reduced before shaping synthetic attempts because imported stair-stepper data can overestimate steps.
 
 ## Script Dependency Policy

--- a/.claude/skills/live-climb-content/SKILL.md
+++ b/.claude/skills/live-climb-content/SKILL.md
@@ -131,6 +131,7 @@ Writes to production require `--confirm-production`. Sync copies only missing/ch
 6. Update `updatedAt` in `web/public/climbs/manifest.json` to a UTC ISO timestamp.
 7. Update `featuredClimbId` only if the user asked to feature the new climb.
 8. If dev replay fixtures should include the climb, add it to `ACTIVE_CLIMBS` or `WARM_CLIMBS` in `scripts/seed-live-replay-leaderboards.mjs`.
+   To seed the climb with an open First Ascent slot instead of synthetic traffic, use `FIRST_ASCENT_OPEN_CLIMBS` in the same file and follow the constraints documented on that list.
 9. Validate JSON and schema by decoding both catalog files.
 10. Build web before deploying hosted catalog content.
 

--- a/scripts/audit-seed-data.mjs
+++ b/scripts/audit-seed-data.mjs
@@ -315,6 +315,10 @@ async function auditLiveReplay(db, projectId, failures) {
     const bucketZero = await doc.ref.collection("splitBuckets").doc("0").collection("entries").get();
     bucketZeroEntries += bucketZero.size;
 
+    // Read off the counts and the holder, never off activityTier: the seed
+    // script is the only writer of that tier and the Cloud Function's summary
+    // merge never resets it, so it stays "open" on a climb a real climber has
+    // legitimately claimed. It records what the seed intended, not the state.
     const firstAscentState = {
       climbId: path,
       completedCount: numberValue(data.completedCount),

--- a/scripts/audit-seed-data.mjs
+++ b/scripts/audit-seed-data.mjs
@@ -19,7 +19,8 @@ import {
   resolveProjectId,
 } from "./seed/lib/environments.mjs";
 import {
-  FIRST_ASCENT_OPEN_ACTIVITY_TIER,
+  firstAscentInvariantFailure,
+  isOpenFirstAscentSummary,
   summaryHasFirstAscent,
 } from "./seed/lib/live-replay-first-ascent.mjs";
 import {
@@ -54,6 +55,7 @@ const TARGET_ALIASES = new Map([
 ]);
 
 const LIVE_REPLAY_COLLECTION = "live_replay_leaderboards";
+const LIVE_CLIMB_CONTEXT_TYPE = "live_climb";
 const LEGACY_LEADERBOARD_USER_IDS = Array.from({length: 40}, (_, index) => `test_user_${index + 1}`);
 const LEGACY_TIME_FRAMES = ["daily", "weekly", "monthly", "yearly", "all_time"];
 
@@ -313,14 +315,28 @@ async function auditLiveReplay(db, projectId, failures) {
     const bucketZero = await doc.ref.collection("splitBuckets").doc("0").collection("entries").get();
     bucketZeroEntries += bucketZero.size;
 
-    if (data.activityTier === FIRST_ASCENT_OPEN_ACTIVITY_TIER) {
-      auditOpenFirstAscentSummary(data, path, bucketZero, failures);
-      continue;
+    const firstAscentState = {
+      climbId: path,
+      completedCount: numberValue(data.completedCount),
+      hasFirstAscent: summaryHasFirstAscent(data),
+    };
+
+    // The global Just Climb context is exempt: First Ascent is per-landmark
+    // prestige and nothing renders one there, so it keeps completions with no
+    // holder on purpose.
+    if (data.contextType === LIVE_CLIMB_CONTEXT_TYPE) {
+      const invariantFailure = firstAscentInvariantFailure(firstAscentState);
+      if (invariantFailure) failures.push(invariantFailure);
+
+      if (isOpenFirstAscentSummary(firstAscentState)) {
+        auditOpenFirstAscentSummary(data, path, bucketZero, failures);
+        continue;
+      }
     }
 
     if (!positiveNumber(data.completedCount)) failures.push(`${path} completedCount must be positive`);
     if (!positiveNumber(data.totalClimbers)) failures.push(`${path} totalClimbers must be positive`);
-    if (!positiveNumber(data.replayEntryCount)) failures.push(`${path} replayEntryCount must be positive`);
+    auditSeededReplayRowCount(data, path, bucketZero, seedPackId, failures);
 
     if (bucketZero.empty) {
       failures.push(`${path}/splitBuckets/0 has no entries`);
@@ -343,32 +359,54 @@ async function auditLiveReplay(db, projectId, failures) {
 }
 
 /**
- * Audits a summary seeded with an open First Ascent slot.
+ * Audits a summary whose First Ascent slot is still open.
  *
- * An open slot is only claimable while the climb has zero completions and no
- * holder, so these summaries carry deliberate zeros rather than the seeded
- * traffic every other climb has. They stay strictly audited: a count or a holder
- * that leaked in - from a stale seed, or another script merging a completion
- * into the same summary - puts the climb back in the dead state where the UI
- * reads "open" but the server refuses the claim.
+ * An open slot is only claimable while the climb has zero completions, so these
+ * summaries carry deliberate zeros rather than the seeded traffic every other
+ * climb has. The rest of the summary has to agree with that: a climber count or
+ * a replay row without a matching completion means the seed half-wrote the
+ * fixture, and the climb no longer reads as the clean opportunity it promises.
  * @param {Record<string, unknown>} data Summary fields.
  * @param {string} path Summary document path, for failure messages.
  * @param {object} bucketZero Bucket-zero entries snapshot.
  * @param {string[]} failures Accumulated audit failures.
  */
 function auditOpenFirstAscentSummary(data, path, bucketZero, failures) {
-  for (const field of ["completedCount", "totalClimbers", "replayEntryCount"]) {
-    if (Number(data[field]) !== 0) {
-      failures.push(`${path} has an open First Ascent but ${field} is ${data[field]}; the slot could never be claimed`);
+  for (const field of ["totalClimbers", "replayEntryCount"]) {
+    if (numberValue(data[field]) !== 0) {
+      failures.push(`${path} has an open First Ascent but ${field} is ${data[field]}`);
     }
   }
 
-  if (summaryHasFirstAscent(data)) {
-    failures.push(`${path} has an open First Ascent but already carries a holder; clear/reseed live-replay`);
-  }
-
   if (!bucketZero.empty) {
-    failures.push(`${path}/splitBuckets/0 has ${bucketZero.size} entries but the climb seeds no completions`);
+    failures.push(`${path}/splitBuckets/0 has ${bucketZero.size} entries but the summary reports no completions`);
+  }
+}
+
+/**
+ * Audits the summary's seeded replay row count against the rows actually seeded.
+ *
+ * `replayEntryCount` counts the synthetic rows this seed pack wrote, and only the
+ * seed maintains it - the Cloud Function's summary merge leaves it alone. So it
+ * is checked against the seeded rows rather than required to be positive: a
+ * climb seeded with an open slot legitimately keeps zero synthetic rows after a
+ * real climber finishes it and pushes `completedCount` to 1, which is exactly
+ * what those fixtures exist for.
+ * @param {Record<string, unknown>} data Summary fields.
+ * @param {string} path Summary document path, for failure messages.
+ * @param {object} bucketZero Bucket-zero entries snapshot.
+ * @param {string} seedPackId Seed pack being audited.
+ * @param {string[]} failures Accumulated audit failures.
+ */
+function auditSeededReplayRowCount(data, path, bucketZero, seedPackId, failures) {
+  const seededRows = bucketZero.docs.filter(
+    (entry) => entry.data().seedPackId === seedPackId
+  ).length;
+
+  if (numberValue(data.replayEntryCount) !== seededRows) {
+    failures.push(
+      `${path} replayEntryCount is ${data.replayEntryCount} but ${seededRows} seeded bucket-zero entries exist`
+    );
   }
 }
 

--- a/scripts/audit-seed-data.mjs
+++ b/scripts/audit-seed-data.mjs
@@ -19,6 +19,10 @@ import {
   resolveProjectId,
 } from "./seed/lib/environments.mjs";
 import {
+  FIRST_ASCENT_OPEN_ACTIVITY_TIER,
+  summaryHasFirstAscent,
+} from "./seed/lib/live-replay-first-ascent.mjs";
+import {
   buildLeaderboardSeedWrites,
   currentPeriod,
   expectedLeaderboardDocIds,
@@ -306,12 +310,18 @@ async function auditLiveReplay(db, projectId, failures) {
     requirePresent(data, "replayEntryCount", path, failures);
     requirePresent(data, "bucketIntervalSeconds", path, failures);
 
+    const bucketZero = await doc.ref.collection("splitBuckets").doc("0").collection("entries").get();
+    bucketZeroEntries += bucketZero.size;
+
+    if (data.activityTier === FIRST_ASCENT_OPEN_ACTIVITY_TIER) {
+      auditOpenFirstAscentSummary(data, path, bucketZero, failures);
+      continue;
+    }
+
     if (!positiveNumber(data.completedCount)) failures.push(`${path} completedCount must be positive`);
     if (!positiveNumber(data.totalClimbers)) failures.push(`${path} totalClimbers must be positive`);
     if (!positiveNumber(data.replayEntryCount)) failures.push(`${path} replayEntryCount must be positive`);
 
-    const bucketZero = await doc.ref.collection("splitBuckets").doc("0").collection("entries").get();
-    bucketZeroEntries += bucketZero.size;
     if (bucketZero.empty) {
       failures.push(`${path}/splitBuckets/0 has no entries`);
       continue;
@@ -330,6 +340,36 @@ async function auditLiveReplay(db, projectId, failures) {
   }
 
   return `live-replay: ${snapshot.size} summaries, ${bucketZeroEntries} bucket-zero entries checked`;
+}
+
+/**
+ * Audits a summary seeded with an open First Ascent slot.
+ *
+ * An open slot is only claimable while the climb has zero completions and no
+ * holder, so these summaries carry deliberate zeros rather than the seeded
+ * traffic every other climb has. They stay strictly audited: a count or a holder
+ * that leaked in - from a stale seed, or another script merging a completion
+ * into the same summary - puts the climb back in the dead state where the UI
+ * reads "open" but the server refuses the claim.
+ * @param {Record<string, unknown>} data Summary fields.
+ * @param {string} path Summary document path, for failure messages.
+ * @param {object} bucketZero Bucket-zero entries snapshot.
+ * @param {string[]} failures Accumulated audit failures.
+ */
+function auditOpenFirstAscentSummary(data, path, bucketZero, failures) {
+  for (const field of ["completedCount", "totalClimbers", "replayEntryCount"]) {
+    if (Number(data[field]) !== 0) {
+      failures.push(`${path} has an open First Ascent but ${field} is ${data[field]}; the slot could never be claimed`);
+    }
+  }
+
+  if (summaryHasFirstAscent(data)) {
+    failures.push(`${path} has an open First Ascent but already carries a holder; clear/reseed live-replay`);
+  }
+
+  if (!bucketZero.empty) {
+    failures.push(`${path}/splitBuckets/0 has ${bucketZero.size} entries but the climb seeds no completions`);
+  }
 }
 
 async function auditRoutineTemplates(db, projectId, failures) {

--- a/scripts/seed-demo-user.mjs
+++ b/scripts/seed-demo-user.mjs
@@ -24,6 +24,7 @@ import {applicationDefault, initializeApp} from "firebase-admin/app";
 import {getAuth} from "firebase-admin/auth";
 import {FieldValue, getFirestore, Timestamp} from "firebase-admin/firestore";
 import {canonicalWorkoutDocumentId} from "./lib/workout-document-id.mjs";
+import {firstAscentSeedFields} from "./seed/lib/live-replay-first-ascent.mjs";
 
 const DEV_PROJECT_ID = "ascend-f2e4f";
 const STAGING_PROJECT_ID = "ascend-staging-fa7d5";
@@ -741,14 +742,16 @@ async function addReplayWrites(db, writes, deletes, user, liveContexts, args) {
     };
 
     if (forceFirstAscent) {
-      Object.assign(summaryData, {
-        firstAscentAvatarToken: user.avatarToken,
-        firstAscentCompletedAt: Timestamp.fromDate(context.completedAt),
-        firstAscentDisplayName: user.displayName,
-        firstAscentPhotoURL: user.photoURL,
-        firstAscentUserId: user.uid,
-        firstAscentWorkoutId: context.workoutId,
-      });
+      Object.assign(summaryData, firstAscentSeedFields(
+        {
+          avatarToken: user.avatarToken,
+          displayName: user.displayName,
+          id: context.workoutId,
+          photoURL: user.photoURL,
+          userId: user.uid,
+        },
+        Timestamp.fromDate(context.completedAt)
+      ));
     }
 
     writes.push([leaderboardRef, summaryData]);

--- a/scripts/seed-live-replay-leaderboards.mjs
+++ b/scripts/seed-live-replay-leaderboards.mjs
@@ -85,6 +85,7 @@ const WARM_CLIMBS = [
   {id: "elizabeth-tower", totalClimbers: 34, replayEntries: 20, completionRate: 0.58},
   {id: "tokyo-tower", totalClimbers: 32, replayEntries: 20, completionRate: 0.40},
   {id: "shanghai-tower", totalClimbers: 29, replayEntries: 18, completionRate: 0.34},
+  {id: "taipei-101", totalClimbers: 28, replayEntries: 18, completionRate: 0.34},
   {id: "canton-tower", totalClimbers: 27, replayEntries: 18, completionRate: 0.34},
   {id: "leaning-tower-of-pisa", totalClimbers: 24, replayEntries: 16, completionRate: 0.56},
   {id: "cairo-tower", totalClimbers: 23, replayEntries: 16, completionRate: 0.44},
@@ -557,8 +558,9 @@ function buildSeedPlan(climbsById, paceSamples, args, avatarURLs) {
       (_, index) => seedAttemptId(args.seedPackId, climb.id, index)
     );
 
-    // The First Ascent is the earliest completion, and attempts are generated in
-    // completion order, so the slot belongs to the first one.
+    // Attempts carry a completion duration but no wall-clock completion time, so
+    // none of them is the earliest. The holder is an arbitrary but deterministic
+    // pick, which is all a fixture needs; `firstAscentClaimedAt` dates the claim.
     const firstAscentAttempt = attempts[0] ?? null;
 
     // Checked at plan time so a bad fixture fails the dry run, before any writes.

--- a/scripts/seed-live-replay-leaderboards.mjs
+++ b/scripts/seed-live-replay-leaderboards.mjs
@@ -36,9 +36,11 @@ import {hashString, mulberry32} from "./seed/lib/deterministic.mjs";
 import {
   FIRST_ASCENT_OPEN_ACTIVITY_TIER,
   assertFirstAscentInvariant,
+  clearOpenFirstAscentEntries,
   clearedFirstAscentFields,
   firstAscentClaimedAt,
   firstAscentSeedFields,
+  isOpenFirstAscentSummary,
 } from "./seed/lib/live-replay-first-ascent.mjs";
 
 const DEV_PROJECT_ID = "ascend-f2e4f";
@@ -729,7 +731,7 @@ function printPlan(seedPlan, args, avatarFileCount, avatarURLCount) {
 
 async function clearSeedPack(db, seedPlan, args) {
   const writer = bulkWriter(db);
-  let deleted = clearSeedEntriesFromPlan(db, writer, seedPlan);
+  let deleted = await clearSeedEntriesFromPlan(db, writer, seedPlan);
   const activeContextKeys = contextKeysForPlan(seedPlan);
   deleted += await clearStaleSeedContexts(
     db,
@@ -808,10 +810,21 @@ async function clearStaleSeedContexts(db, writer, seedPackId, activeContextKeys)
   return deleted;
 }
 
-function clearSeedEntriesFromPlan(db, writer, seedPlan) {
+async function clearSeedEntriesFromPlan(db, writer, seedPlan) {
   let deleted = 0;
 
   for (const plan of seedPlan.climbPlans) {
+    if (isOpenFirstAscentSummary({
+      completedCount: plan.completedCount,
+      hasFirstAscent: plan.firstAscentAttempt !== null,
+    })) {
+      deleted += await clearOpenFirstAscentEntries(
+        splitBucketsCollection(db, plan.climb.id),
+        writer
+      );
+      continue;
+    }
+
     for (let bucketIndex = 0; bucketIndex <= MAX_BUCKET_INDEX; bucketIndex += 1) {
       for (const attemptId of plan.clearAttemptIds) {
         writer.delete(entriesCollection(db, plan.climb.id, bucketIndex).doc(attemptId));
@@ -1037,6 +1050,10 @@ function contextLeaderboardRef(db, contextType, contextId) {
   return db
     .collection(LIVE_REPLAY_COLLECTION)
     .doc(contextKey(contextType, contextId));
+}
+
+function splitBucketsCollection(db, climbId) {
+  return leaderboardRef(db, climbId).collection("splitBuckets");
 }
 
 function entriesCollection(db, climbId, bucketIndex) {

--- a/scripts/seed-live-replay-leaderboards.mjs
+++ b/scripts/seed-live-replay-leaderboards.mjs
@@ -34,6 +34,7 @@ import {FieldValue, getFirestore} from "firebase-admin/firestore";
 import {getStorage} from "firebase-admin/storage";
 import {hashString, mulberry32} from "./seed/lib/deterministic.mjs";
 import {
+  FIRST_ASCENT_OPEN_ACTIVITY_TIER,
   assertFirstAscentInvariant,
   clearedFirstAscentFields,
   firstAscentClaimedAt,
@@ -100,14 +101,19 @@ const WARM_CLIMBS = [
  * never renders as a claimable opportunity. These give the open state a real
  * document to read.
  *
- * The spread covers gold/diamond/legendary/mythic tiers across five continents.
+ * The spread covers gold/diamond/legendary/mythic tiers across four continents.
  * Sky Tower is deliberately the cheapest (1,804 steps) so a QA session can
  * actually finish it and claim a First Ascent end to end.
+ *
+ * Exactly four, and no climb that `seed-demo-user.mjs` completes. Four because
+ * `ProfileFirstAscentService` fills its open list in catalog order and caps at
+ * four, so a fifth would push out whichever climb sorts last - Sky Tower, the
+ * one QA needs. Disjoint from the demo user's climbs because both scripts merge
+ * into the same summary, and whichever runs last would strand the other's state.
  */
 const FIRST_ASCENT_OPEN_CLIMBS = [
   {id: "sky-tower-auckland"},
-  {id: "berlin-tv-tower"},
-  {id: "taipei-101"},
+  {id: "oriental-pearl-tower"},
   {id: "table-mountain"},
   {id: "machu-picchu"},
 ].map((config) => ({
@@ -512,7 +518,10 @@ function buildSeedPlan(climbsById, paceSamples, args, avatarURLs) {
   const configs = [
     ...ACTIVE_CLIMBS.map((config) => ({...config, activityTier: "active"})),
     ...WARM_CLIMBS.map((config) => ({...config, activityTier: "warm"})),
-    ...FIRST_ASCENT_OPEN_CLIMBS.map((config) => ({...config, activityTier: "open"})),
+    ...FIRST_ASCENT_OPEN_CLIMBS.map((config) => ({
+      ...config,
+      activityTier: FIRST_ASCENT_OPEN_ACTIVITY_TIER,
+    })),
   ];
 
   const missingConfigs = configs.filter((config) => !climbsById.has(config.id));

--- a/scripts/seed-live-replay-leaderboards.mjs
+++ b/scripts/seed-live-replay-leaderboards.mjs
@@ -32,6 +32,13 @@ import {fileURLToPath} from "node:url";
 import {applicationDefault, initializeApp} from "firebase-admin/app";
 import {FieldValue, getFirestore} from "firebase-admin/firestore";
 import {getStorage} from "firebase-admin/storage";
+import {hashString, mulberry32} from "./seed/lib/deterministic.mjs";
+import {
+  assertFirstAscentInvariant,
+  clearedFirstAscentFields,
+  firstAscentClaimedAt,
+  firstAscentSeedFields,
+} from "./seed/lib/live-replay-first-ascent.mjs";
 
 const DEV_PROJECT_ID = "ascend-f2e4f";
 const STAGING_PROJECT_ID = "ascend-staging-fa7d5";
@@ -82,6 +89,33 @@ const WARM_CLIMBS = [
   {id: "cairo-tower", totalClimbers: 23, replayEntries: 16, completionRate: 0.44},
   {id: "sydney-tower", totalClimbers: 21, replayEntries: 16, completionRate: 0.56},
 ];
+
+/**
+ * Climbs seeded with a summary but no completions, so their First Ascent slot is
+ * genuinely open.
+ *
+ * A climb with no summary document at all is not equivalent: the open-First
+ * Ascent surfaces key off an existing summary (`ProfileFirstAscentService`
+ * requires `updatedAt != nil && completedCount == 0`), so an unseeded climb
+ * never renders as a claimable opportunity. These give the open state a real
+ * document to read.
+ *
+ * The spread covers gold/diamond/legendary/mythic tiers across five continents.
+ * Sky Tower is deliberately the cheapest (1,804 steps) so a QA session can
+ * actually finish it and claim a First Ascent end to end.
+ */
+const FIRST_ASCENT_OPEN_CLIMBS = [
+  {id: "sky-tower-auckland"},
+  {id: "berlin-tv-tower"},
+  {id: "taipei-101"},
+  {id: "table-mountain"},
+  {id: "machu-picchu"},
+].map((config) => ({
+  ...config,
+  totalClimbers: 0,
+  replayEntries: 0,
+  completionRate: 0,
+}));
 
 const SEEDED_DISPLAY_NAMES = [
   "Sarah K.", "Marcus T.", "Jenny W.", "Alex M.", "Priya S.", "Jordan L.",
@@ -478,6 +512,7 @@ function buildSeedPlan(climbsById, paceSamples, args, avatarURLs) {
   const configs = [
     ...ACTIVE_CLIMBS.map((config) => ({...config, activityTier: "active"})),
     ...WARM_CLIMBS.map((config) => ({...config, activityTier: "warm"})),
+    ...FIRST_ASCENT_OPEN_CLIMBS.map((config) => ({...config, activityTier: "open"})),
   ];
 
   const missingConfigs = configs.filter((config) => !climbsById.has(config.id));
@@ -503,11 +538,26 @@ function buildSeedPlan(climbsById, paceSamples, args, avatarURLs) {
       args.seedPackId,
       avatarURLs
     );
-    const maxBucketIndex = bucketLimitForAttempts(attempts);
+    // A climb with no completions has no buckets to publish, and the bucket
+    // limit is undefined over an empty duration set.
+    const maxBucketIndex = attempts.length > 0 ?
+      bucketLimitForAttempts(attempts) :
+      -1;
     const clearAttemptIds = Array.from(
       {length: Math.max(config.replayEntries, completedCount)},
       (_, index) => seedAttemptId(args.seedPackId, climb.id, index)
     );
+
+    // The First Ascent is the earliest completion, and attempts are generated in
+    // completion order, so the slot belongs to the first one.
+    const firstAscentAttempt = attempts[0] ?? null;
+
+    // Checked at plan time so a bad fixture fails the dry run, before any writes.
+    assertFirstAscentInvariant({
+      climbId: climb.id,
+      completedCount,
+      hasFirstAscent: firstAscentAttempt !== null,
+    });
 
     return [{
       config,
@@ -516,6 +566,7 @@ function buildSeedPlan(climbsById, paceSamples, args, avatarURLs) {
       completedCount,
       clearAttemptIds,
       maxBucketIndex,
+      firstAscentAttempt,
       entryDocumentCount: attempts.length * (maxBucketIndex + 1),
     }];
   });
@@ -647,6 +698,9 @@ function printPlan(seedPlan, args, avatarFileCount, avatarURLCount) {
         `${plan.completedCount} completed`,
         `${plan.attempts.length} replay rows`,
         `${plan.maxBucketIndex + 1} buckets`,
+        plan.firstAscentAttempt ?
+          `FA held by ${plan.firstAscentAttempt.displayName}` :
+          "FA open",
       ].join(" | ")
     );
   }
@@ -683,6 +737,9 @@ async function clearSeedPack(db, seedPlan, args) {
       seededAttemptCount: 0,
       totalClimbers: 0,
       updatedAt: now,
+      // Zeroing completions without dropping the holder would leave the slot
+      // readable as open while the server still refuses to claim it.
+      ...clearedFirstAscentFields(FieldValue.delete()),
     }, {merge: true});
   }
 
@@ -770,7 +827,7 @@ async function writeSeedPlan(db, seedPlan, args) {
   for (const plan of seedPlan.climbPlans) {
     const targetSteps = referenceStepCount(plan.climb);
     const summaryRef = leaderboardRef(db, plan.climb.id);
-    writer.set(summaryRef, {
+    const summary = {
       activityTier: plan.config.activityTier,
       bucketIntervalSeconds: BUCKET_INTERVAL_SECONDS,
       completedCount: plan.completedCount,
@@ -784,7 +841,18 @@ async function writeSeedPlan(db, seedPlan, args) {
       targetStepCount: targetSteps,
       totalClimbers: plan.attempts.length,
       updatedAt: now,
-    }, {merge: true});
+    };
+
+    Object.assign(summary, plan.firstAscentAttempt ?
+      firstAscentSeedFields(
+        plan.firstAscentAttempt,
+        firstAscentClaimedAt(args.seedPackId, plan.climb.id)
+      ) :
+      // An earlier seed may have left a holder here; an open slot has to be
+      // genuinely empty for the next finisher to claim it.
+      clearedFirstAscentFields(FieldValue.delete()));
+
+    writer.set(summaryRef, summary, {merge: true});
     writes += 1;
 
     for (let bucketIndex = 0; bucketIndex <= plan.maxBucketIndex; bucketIndex += 1) {
@@ -1061,24 +1129,6 @@ function avatarToken(displayName) {
     .toUpperCase();
 
   return token || "A";
-}
-
-function hashString(value) {
-  let hash = 2166136261;
-  for (let index = 0; index < value.length; index += 1) {
-    hash ^= value.charCodeAt(index);
-    hash = Math.imul(hash, 16777619);
-  }
-  return hash >>> 0;
-}
-
-function mulberry32(seed) {
-  return function random() {
-    let value = seed += 0x6D2B79F5;
-    value = Math.imul(value ^ value >>> 15, value | 1);
-    value ^= value + Math.imul(value ^ value >>> 7, value | 61);
-    return ((value ^ value >>> 14) >>> 0) / 4294967296;
-  };
 }
 
 function randomInRange(rng, min, max) {

--- a/scripts/seed/lib/deterministic.mjs
+++ b/scripts/seed/lib/deterministic.mjs
@@ -1,0 +1,35 @@
+/**
+ * Deterministic hashing and pseudo-random helpers shared by seed scripts.
+ *
+ * Seed fixtures must be reproducible: re-running a seed with the same seed pack
+ * has to produce the same synthetic climbers, curves, and dates so repeated
+ * seeds merge onto identical documents instead of rewriting fixture history.
+ */
+
+/**
+ * FNV-1a hash of a string, as an unsigned 32-bit integer.
+ * @param {string} value Value to hash.
+ * @return {number} Unsigned 32-bit hash.
+ */
+export function hashString(value) {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Builds a mulberry32 pseudo-random generator for a numeric seed.
+ * @param {number} seed Numeric seed.
+ * @return {() => number} Generator returning values in [0, 1).
+ */
+export function mulberry32(seed) {
+  return function random() {
+    let value = seed += 0x6D2B79F5;
+    value = Math.imul(value ^ value >>> 15, value | 1);
+    value ^= value + Math.imul(value ^ value >>> 7, value | 61);
+    return ((value ^ value >>> 14) >>> 0) / 4294967296;
+  };
+}

--- a/scripts/seed/lib/live-replay-first-ascent.mjs
+++ b/scripts/seed/lib/live-replay-first-ascent.mjs
@@ -128,6 +128,35 @@ export function clearedFirstAscentFields(deleteSentinel) {
 }
 
 /**
+ * Deletes every replay entry under a climb seeded with an open First Ascent.
+ *
+ * The seed can address its own rows by their deterministic IDs, but a real
+ * climber's it cannot: the Cloud Function keys each entry by workoutId and
+ * writes one per split bucket. Re-seeding by known ID would leave those rows
+ * beside a summary reset to zero completions - the inverse dead state, on the
+ * one fixture whose whole purpose is to be claimed and reset. So an open climb's
+ * entries are found by query and dropped wholesale, which is safe precisely
+ * because the fixture promises the climb has no completions at all.
+ * @param {object} splitBucketsRef `splitBuckets` collection reference.
+ * @param {object} writer BulkWriter that performs the deletes.
+ * @return {Promise<number>} Count of entry documents deleted.
+ */
+export async function clearOpenFirstAscentEntries(splitBucketsRef, writer) {
+  let deleted = 0;
+  const bucketRefs = await splitBucketsRef.listDocuments();
+
+  for (const bucketRef of bucketRefs) {
+    const entries = await bucketRef.collection("entries").get();
+    for (const entry of entries.docs) {
+      writer.delete(entry.ref);
+      deleted += 1;
+    }
+  }
+
+  return deleted;
+}
+
+/**
  * Reports whether a climb's First Ascent slot is still open.
  *
  * Derived from the counts and the holder, never from `activityTier`: those are

--- a/scripts/seed/lib/live-replay-first-ascent.mjs
+++ b/scripts/seed/lib/live-replay-first-ascent.mjs
@@ -1,0 +1,126 @@
+/**
+ * First Ascent contract for seeded live replay leaderboard summaries.
+ *
+ * A climb's First Ascent slot only has two states the app can ever produce:
+ *
+ *   open  - no completions and no holder. The next finisher claims it.
+ *   held  - at least one completion and a permanent holder.
+ *
+ * `publishLiveClimbCompletion` in functions/src/liveReplayLeaderboard.ts claims
+ * the slot only when `!hasFirstAscent && previousCompletedCount === 0`. So a
+ * summary carrying completions but no holder is unreachable *and* unleavable:
+ * it renders as neither held nor open, and no later finisher can ever claim it.
+ * Seeding that state gives every seeded climb a permanently dead slot.
+ *
+ * These helpers keep seeded summaries on one of the two reachable states. The
+ * field names mirror `firstAscentWrite` in the Cloud Function - the seed script
+ * and the server must publish the identical shape or the client reads one but
+ * not the other.
+ */
+
+import {hashString} from "./deterministic.mjs";
+
+/**
+ * Every First Ascent field a replay summary can carry.
+ *
+ * Clearing a seed pack must remove all of them: leaving any behind while
+ * resetting `completedCount` to 0 strands the summary in the inverse dead
+ * state, where the UI reads "open" but the server refuses the claim.
+ */
+export const FIRST_ASCENT_FIELD_NAMES = Object.freeze([
+  "firstAscentAvatarToken",
+  "firstAscentCompletedAt",
+  "firstAscentDisplayName",
+  "firstAscentPhotoURL",
+  "firstAscentUserId",
+  "firstAscentWorkoutId",
+]);
+
+/**
+ * Anchor for synthetic First Ascent dates.
+ *
+ * A First Ascent is a permanent historical fact, so seeded holders get a fixed
+ * past date rather than one relative to the seed run. Re-seeding then merges the
+ * same date back instead of quietly rewriting when the climb was first topped.
+ */
+const FIRST_ASCENT_EPOCH_MS = Date.UTC(2026, 0, 5);
+const FIRST_ASCENT_SPREAD_DAYS = 120;
+const MILLISECONDS_PER_DAY = 86_400_000;
+
+/**
+ * Resolves the permanent claim date for a seeded climb's First Ascent.
+ *
+ * Dates are spread deterministically per climb so held First Ascents sort into a
+ * stable, non-uniform order on profile surfaces.
+ * @param {string} seedPackId Seed pack identifier.
+ * @param {string} climbId Climb identifier.
+ * @return {Date} Deterministic claim date.
+ */
+export function firstAscentClaimedAt(seedPackId, climbId) {
+  const dayOffset = hashString(`${seedPackId}:first-ascent:${climbId}`) %
+    FIRST_ASCENT_SPREAD_DAYS;
+  return new Date(FIRST_ASCENT_EPOCH_MS - dayOffset * MILLISECONDS_PER_DAY);
+}
+
+/**
+ * Builds the First Ascent fields for a seeded holder.
+ *
+ * Mirrors the server's `firstAscentWrite` payload so seeded holders are
+ * indistinguishable from claimed ones on the client.
+ * @param {object} attempt Seeded attempt that holds the First Ascent.
+ * @param {Date} claimedAt Permanent claim date.
+ * @return {Record<string, unknown>} Firestore fields to merge.
+ */
+export function firstAscentSeedFields(attempt, claimedAt) {
+  return {
+    firstAscentAvatarToken: attempt.avatarToken,
+    firstAscentCompletedAt: claimedAt,
+    firstAscentDisplayName: attempt.displayName,
+    firstAscentPhotoURL: attempt.photoURL ?? "",
+    firstAscentUserId: attempt.userId,
+    firstAscentWorkoutId: attempt.id,
+  };
+}
+
+/**
+ * Builds the field map that removes every First Ascent field from a summary.
+ * @param {unknown} deleteSentinel Sentinel that deletes a field (FieldValue.delete()).
+ * @return {Record<string, unknown>} Firestore fields to merge.
+ */
+export function clearedFirstAscentFields(deleteSentinel) {
+  return Object.fromEntries(
+    FIRST_ASCENT_FIELD_NAMES.map((field) => [field, deleteSentinel])
+  );
+}
+
+/**
+ * Throws when a seeded climb is in a First Ascent state the app can never
+ * produce.
+ *
+ * Takes the state explicitly rather than reading it back off a write map: a
+ * cleared summary carries delete sentinels rather than absent fields, so the
+ * written values cannot distinguish "no holder" from "holder" on their own.
+ *
+ * Run for every seeded climb while building the plan, so a bad fixture fails the
+ * dry run rather than silently killing that climb's First Ascent slot.
+ * @param {object} state Seeded First Ascent state.
+ * @param {string} state.climbId Climb identifier, for the error message.
+ * @param {number} state.completedCount Seeded completions for the climb.
+ * @param {boolean} state.hasFirstAscent Whether a holder is being seeded.
+ */
+export function assertFirstAscentInvariant({climbId, completedCount, hasFirstAscent}) {
+  if (completedCount > 0 && !hasFirstAscent) {
+    throw new Error(
+      `${climbId}: ${completedCount} seeded completions but no First Ascent ` +
+        "holder. The slot would render as neither held nor open and could " +
+        "never be claimed."
+    );
+  }
+
+  if (completedCount === 0 && hasFirstAscent) {
+    throw new Error(
+      `${climbId}: First Ascent holder with 0 completions. The slot would ` +
+        "render as open but the server would refuse the claim."
+    );
+  }
+}

--- a/scripts/seed/lib/live-replay-first-ascent.mjs
+++ b/scripts/seed/lib/live-replay-first-ascent.mjs
@@ -39,9 +39,10 @@ export const FIRST_ASCENT_FIELD_NAMES = Object.freeze([
 /**
  * `activityTier` marking a summary seeded with an open First Ascent slot.
  *
- * Seeded summaries declare their intent through this tier, so the seed writer
- * and the audit agree on which climbs are supposed to carry zero completions
- * rather than each inferring it from the counts they are meant to be checking.
+ * Records what the seed intended for the climb, and nothing more. It is not the
+ * slot's state: the seed writes the tier once and the Cloud Function's summary
+ * merge never resets it, so a climb seeded open still reads "open" after a real
+ * climber claims it. Read the state with `isOpenFirstAscentSummary`.
  */
 export const FIRST_ASCENT_OPEN_ACTIVITY_TIER = "open";
 
@@ -127,12 +128,56 @@ export function clearedFirstAscentFields(deleteSentinel) {
 }
 
 /**
- * Throws when a seeded climb is in a First Ascent state the app can never
- * produce.
+ * Reports whether a climb's First Ascent slot is still open.
+ *
+ * Derived from the counts and the holder, never from `activityTier`: those are
+ * the only fields both the seed and the Cloud Function maintain, so they are the
+ * only ones that still describe the slot after a real climber claims it.
+ * @param {object} state First Ascent state.
+ * @param {number} state.completedCount Completions recorded for the climb.
+ * @param {boolean} state.hasFirstAscent Whether a holder is recorded.
+ * @return {boolean} True when the next finisher would claim the slot.
+ */
+export function isOpenFirstAscentSummary({completedCount, hasFirstAscent}) {
+  return completedCount === 0 && !hasFirstAscent;
+}
+
+/**
+ * Describes why a climb's First Ascent state is one the app can never produce,
+ * or returns null when the state is reachable.
+ *
+ * The single definition of the contract. Both dead states are unreachable *and*
+ * unleavable, so the seed asserts against this while building its plan and the
+ * audit reports against it - one of them throwing and the other accumulating is
+ * a difference in reporting, not in what counts as valid.
  *
  * Takes the state explicitly rather than reading it back off a write map: a
  * cleared summary carries delete sentinels rather than absent fields, so the
  * written values cannot distinguish "no holder" from "holder" on their own.
+ * @param {object} state First Ascent state.
+ * @param {string} state.climbId Climb identifier, for the message.
+ * @param {number} state.completedCount Completions recorded for the climb.
+ * @param {boolean} state.hasFirstAscent Whether a holder is recorded.
+ * @return {string | null} Failure message, or null when the state is reachable.
+ */
+export function firstAscentInvariantFailure({climbId, completedCount, hasFirstAscent}) {
+  if (completedCount > 0 && !hasFirstAscent) {
+    return `${climbId}: ${completedCount} completions but no First Ascent ` +
+      "holder. The slot would render as neither held nor open and could " +
+      "never be claimed.";
+  }
+
+  if (completedCount === 0 && hasFirstAscent) {
+    return `${climbId}: First Ascent holder with 0 completions. The slot ` +
+      "would render as open but the server would refuse the claim.";
+  }
+
+  return null;
+}
+
+/**
+ * Throws when a seeded climb is in a First Ascent state the app can never
+ * produce.
  *
  * Run for every seeded climb while building the plan, so a bad fixture fails the
  * dry run rather than silently killing that climb's First Ascent slot.
@@ -141,19 +186,9 @@ export function clearedFirstAscentFields(deleteSentinel) {
  * @param {number} state.completedCount Seeded completions for the climb.
  * @param {boolean} state.hasFirstAscent Whether a holder is being seeded.
  */
-export function assertFirstAscentInvariant({climbId, completedCount, hasFirstAscent}) {
-  if (completedCount > 0 && !hasFirstAscent) {
-    throw new Error(
-      `${climbId}: ${completedCount} seeded completions but no First Ascent ` +
-        "holder. The slot would render as neither held nor open and could " +
-        "never be claimed."
-    );
-  }
-
-  if (completedCount === 0 && hasFirstAscent) {
-    throw new Error(
-      `${climbId}: First Ascent holder with 0 completions. The slot would ` +
-        "render as open but the server would refuse the claim."
-    );
+export function assertFirstAscentInvariant(state) {
+  const failure = firstAscentInvariantFailure(state);
+  if (failure) {
+    throw new Error(failure);
   }
 }

--- a/scripts/seed/lib/live-replay-first-ascent.mjs
+++ b/scripts/seed/lib/live-replay-first-ascent.mjs
@@ -37,6 +37,32 @@ export const FIRST_ASCENT_FIELD_NAMES = Object.freeze([
 ]);
 
 /**
+ * `activityTier` marking a summary seeded with an open First Ascent slot.
+ *
+ * Seeded summaries declare their intent through this tier, so the seed writer
+ * and the audit agree on which climbs are supposed to carry zero completions
+ * rather than each inferring it from the counts they are meant to be checking.
+ */
+export const FIRST_ASCENT_OPEN_ACTIVITY_TIER = "open";
+
+/**
+ * Reports whether a summary already carries a First Ascent holder.
+ *
+ * Mirrors `leaderboardHasFirstAscent` in the Cloud Function, which is the
+ * predicate that decides whether a finisher can still claim the slot. Reading
+ * the state any other way would pass a summary the server would refuse.
+ * @param {Record<string, unknown> | undefined} summary Replay summary fields.
+ * @return {boolean} True when the slot is already held.
+ */
+export function summaryHasFirstAscent(summary) {
+  if (!summary) return false;
+
+  return summary.firstAscentCompletedAt !== undefined ||
+    (typeof summary.firstAscentUserId === "string" &&
+      summary.firstAscentUserId.length > 0);
+}
+
+/**
  * Anchor for synthetic First Ascent dates.
  *
  * A First Ascent is a permanent historical fact, so seeded holders get a fixed
@@ -66,19 +92,26 @@ export function firstAscentClaimedAt(seedPackId, climbId) {
  * Builds the First Ascent fields for a seeded holder.
  *
  * Mirrors the server's `firstAscentWrite` payload so seeded holders are
- * indistinguishable from claimed ones on the client.
- * @param {object} attempt Seeded attempt that holds the First Ascent.
- * @param {Date} claimedAt Permanent claim date.
+ * indistinguishable from claimed ones on the client. Every seed script that
+ * publishes a holder goes through here - a hand-rolled literal is another copy
+ * of the contract that drifts silently.
+ * @param {object} holder Completion that holds the First Ascent.
+ * @param {string} holder.id Workout/entry ID of the holding completion.
+ * @param {string} holder.userId Holder's user ID.
+ * @param {string} holder.displayName Holder's public display name.
+ * @param {string} holder.avatarToken Holder's avatar token.
+ * @param {string} [holder.photoURL] Holder's public photo URL, if any.
+ * @param {Date|object} claimedAt Permanent claim date.
  * @return {Record<string, unknown>} Firestore fields to merge.
  */
-export function firstAscentSeedFields(attempt, claimedAt) {
+export function firstAscentSeedFields(holder, claimedAt) {
   return {
-    firstAscentAvatarToken: attempt.avatarToken,
+    firstAscentAvatarToken: holder.avatarToken,
     firstAscentCompletedAt: claimedAt,
-    firstAscentDisplayName: attempt.displayName,
-    firstAscentPhotoURL: attempt.photoURL ?? "",
-    firstAscentUserId: attempt.userId,
-    firstAscentWorkoutId: attempt.id,
+    firstAscentDisplayName: holder.displayName,
+    firstAscentPhotoURL: holder.photoURL ?? "",
+    firstAscentUserId: holder.userId,
+    firstAscentWorkoutId: holder.id,
   };
 }
 

--- a/scripts/test/live-replay-first-ascent.test.mjs
+++ b/scripts/test/live-replay-first-ascent.test.mjs
@@ -10,6 +10,7 @@ import {
   clearedFirstAscentFields,
   firstAscentClaimedAt,
   firstAscentSeedFields,
+  summaryHasFirstAscent,
 } from "../seed/lib/live-replay-first-ascent.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -74,6 +75,57 @@ test("seed script publishes the same First Ascent fields as the Cloud Function",
     .sort();
 
   assert.deepEqual(serverFields, [...FIRST_ASCENT_FIELD_NAMES].sort());
+});
+
+test("every seed script that publishes a holder routes through the module", () => {
+  // A second hand-rolled literal is a copy of the contract the cross-file test
+  // above cannot see: it would keep passing while the copy drifts.
+  for (const script of ["scripts/seed-demo-user.mjs", "scripts/seed-live-replay-leaderboards.mjs"]) {
+    const source = readFileSync(resolve(REPO_ROOT, script), "utf8");
+
+    assert.match(
+      source,
+      /import\s*\{[^}]*firstAscentSeedFields[^}]*\}\s*from\s*["'][^"']*live-replay-first-ascent\.mjs["']/,
+      `${script} must build First Ascent fields through the shared module`
+    );
+
+    for (const field of FIRST_ASCENT_FIELD_NAMES) {
+      assert.doesNotMatch(
+        source,
+        new RegExp(`${field}\\s*:`),
+        `${script} re-declares ${field} instead of using firstAscentSeedFields`
+      );
+    }
+  }
+});
+
+test("holder detection matches the predicate the server claims against", () => {
+  // canClaimFirstAscent keys off leaderboardHasFirstAscent, so reading the state
+  // any other way would pass a summary the server would refuse to hand over.
+  const source = readFileSync(
+    resolve(REPO_ROOT, "functions/src/liveReplayLeaderboard.ts"),
+    "utf8"
+  );
+  const predicateBody = source.match(
+    /function leaderboardHasFirstAscent\([\s\S]*?\n\}/
+  )?.[0];
+  assert.ok(predicateBody, "could not locate leaderboardHasFirstAscent in the Cloud Function");
+
+  const serverFields = [...new Set(
+    [...predicateBody.matchAll(/data\.(firstAscent\w+)/g)].map((match) => match[1])
+  )].sort();
+
+  assert.deepEqual(serverFields, ["firstAscentCompletedAt", "firstAscentUserId"]);
+
+  assert.equal(summaryHasFirstAscent(undefined), false);
+  assert.equal(summaryHasFirstAscent({}), false);
+  assert.equal(summaryHasFirstAscent({firstAscentUserId: ""}), false);
+  assert.equal(summaryHasFirstAscent({firstAscentUserId: "user-1"}), true);
+  assert.equal(summaryHasFirstAscent({firstAscentCompletedAt: new Date()}), true);
+  assert.equal(
+    summaryHasFirstAscent(firstAscentSeedFields(attempt, new Date("2026-01-01T00:00:00Z"))),
+    true
+  );
 });
 
 test("clearing removes every First Ascent field", () => {

--- a/scripts/test/live-replay-first-ascent.test.mjs
+++ b/scripts/test/live-replay-first-ascent.test.mjs
@@ -9,11 +9,27 @@ import {
   assertFirstAscentInvariant,
   clearedFirstAscentFields,
   firstAscentClaimedAt,
+  firstAscentInvariantFailure,
   firstAscentSeedFields,
+  isOpenFirstAscentSummary,
   summaryHasFirstAscent,
 } from "../seed/lib/live-replay-first-ascent.mjs";
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function readScript(relativePath) {
+  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+}
+
+function arrayLiteralIds(source, constName, key) {
+  const literal = source.match(
+    new RegExp(`const ${constName} = \\[([\\s\\S]*?)\\n\\];`)
+  )?.[1];
+  assert.ok(literal, `could not locate ${constName}`);
+
+  return [...literal.matchAll(new RegExp(`${key}:\\s*"([^"]+)"`, "g"))]
+    .map((match) => match[1]);
+}
 
 const attempt = {
   id: "seed-attempt-1",
@@ -75,6 +91,55 @@ test("seed script publishes the same First Ascent fields as the Cloud Function",
     .sort();
 
   assert.deepEqual(serverFields, [...FIRST_ASCENT_FIELD_NAMES].sort());
+});
+
+test("every climb the demo user completes is seeded a First Ascent holder", () => {
+  // seed-demo-user merges completions into the same summary the replay seed
+  // owns, but only claims the slot for its one --first-ascent-climb. A climb it
+  // completes that no list gives a holder to lands in the dead state this
+  // module exists to prevent - which is how taipei-101 kept one.
+  const demoSource = readScript("scripts/seed-demo-user.mjs");
+  const replaySource = readScript("scripts/seed-live-replay-leaderboards.mjs");
+
+  const demoClimbIds = arrayLiteralIds(demoSource, "LIVE_CLIMB_SPECS", "climbId");
+  assert.ok(demoClimbIds.length > 0, "expected demo user live climb specs");
+
+  const demoFirstAscentClimbId = demoSource.match(
+    /const DEFAULT_FIRST_ASCENT_CLIMB_ID = "([^"]+)"/
+  )?.[1];
+  assert.ok(demoFirstAscentClimbId, "could not locate DEFAULT_FIRST_ASCENT_CLIMB_ID");
+
+  const holderClimbIds = new Set([
+    ...arrayLiteralIds(replaySource, "ACTIVE_CLIMBS", "id"),
+    ...arrayLiteralIds(replaySource, "WARM_CLIMBS", "id"),
+    demoFirstAscentClimbId,
+  ]);
+
+  for (const climbId of demoClimbIds) {
+    assert.ok(
+      holderClimbIds.has(climbId),
+      `${climbId} gets demo completions but no script seeds it a First Ascent holder`
+    );
+  }
+});
+
+test("open First Ascent climbs are disjoint from the demo user's climbs", () => {
+  // Both scripts merge into the same summary, so a shared climb would have
+  // whichever ran last strand the other's state: demo completions with no
+  // holder, or an open slot the demo user already filled.
+  const replaySource = readScript("scripts/seed-live-replay-leaderboards.mjs");
+  const demoClimbIds = new Set(
+    arrayLiteralIds(readScript("scripts/seed-demo-user.mjs"), "LIVE_CLIMB_SPECS", "climbId")
+  );
+  const openClimbIds = arrayLiteralIds(replaySource, "FIRST_ASCENT_OPEN_CLIMBS", "id");
+
+  assert.ok(openClimbIds.length > 0, "expected open First Ascent climbs");
+  for (const climbId of openClimbIds) {
+    assert.ok(
+      !demoClimbIds.has(climbId),
+      `${climbId} seeds an open First Ascent but the demo user completes it`
+    );
+  }
 });
 
 test("every seed script that publishes a holder routes through the module", () => {
@@ -203,4 +268,64 @@ test("the two reachable First Ascent states are accepted", () => {
     completedCount: 0,
     hasFirstAscent: false,
   }));
+});
+
+test("the assert and the audit report against one definition of the contract", () => {
+  // The seed throws while building its plan and the audit accumulates failures.
+  // That is a difference in reporting, not in what counts as valid.
+  const dead = {climbId: "mount-everest", completedCount: 89, hasFirstAscent: false};
+
+  assert.match(firstAscentInvariantFailure(dead), /no First Ascent holder/);
+  assert.throws(() => assertFirstAscentInvariant(dead), new RegExp(firstAscentInvariantFailure(dead)));
+
+  assert.equal(
+    firstAscentInvariantFailure({climbId: "mount-everest", completedCount: 89, hasFirstAscent: true}),
+    null
+  );
+  assert.equal(
+    firstAscentInvariantFailure({climbId: "sky-tower-auckland", completedCount: 0, hasFirstAscent: false}),
+    null
+  );
+});
+
+test("a summary is open only with zero completions and no holder", () => {
+  assert.equal(isOpenFirstAscentSummary({completedCount: 0, hasFirstAscent: false}), true);
+  assert.equal(isOpenFirstAscentSummary({completedCount: 89, hasFirstAscent: true}), false);
+  assert.equal(isOpenFirstAscentSummary({completedCount: 0, hasFirstAscent: true}), false);
+  assert.equal(isOpenFirstAscentSummary({completedCount: 89, hasFirstAscent: false}), false);
+});
+
+test("a QA climber claiming a seeded open slot reads as held, not open", () => {
+  // Sky Tower is seeded cheapest so a QA session can finish it and claim the
+  // First Ascent end to end. The server merges the completion and the holder but
+  // never resets activityTier, so the summary keeps reading tier "open" while
+  // being legitimately held - auditing the tier would fail the one flow the
+  // fixture exists for.
+  const claimed = {
+    activityTier: "open",
+    completedCount: 1,
+    ...firstAscentSeedFields(attempt, new Date("2026-02-01T00:00:00Z")),
+  };
+  const state = {
+    climbId: "sky-tower-auckland",
+    completedCount: claimed.completedCount,
+    hasFirstAscent: summaryHasFirstAscent(claimed),
+  };
+
+  assert.equal(isOpenFirstAscentSummary(state), false);
+  assert.equal(firstAscentInvariantFailure(state), null);
+});
+
+test("the audit reads the First Ascent state off the data, not activityTier", () => {
+  // activityTier is stale by design: the seed writes it once and the Cloud
+  // Function's summary merge never resets it.
+  const source = readScript("scripts/audit-seed-data.mjs");
+
+  assert.match(source, /isOpenFirstAscentSummary\(/);
+  assert.match(source, /firstAscentInvariantFailure\(/);
+  assert.doesNotMatch(
+    source,
+    /activityTier/,
+    "the audit must not branch on activityTier"
+  );
 });

--- a/scripts/test/live-replay-first-ascent.test.mjs
+++ b/scripts/test/live-replay-first-ascent.test.mjs
@@ -7,6 +7,7 @@ import {test} from "node:test";
 import {
   FIRST_ASCENT_FIELD_NAMES,
   assertFirstAscentInvariant,
+  clearOpenFirstAscentEntries,
   clearedFirstAscentFields,
   firstAscentClaimedAt,
   firstAscentInvariantFailure,
@@ -371,6 +372,79 @@ test("a QA climber claiming a seeded open slot reads as held, not open", () => {
 
   assert.equal(isOpenFirstAscentSummary(state), false);
   assert.equal(firstAscentInvariantFailure(state), null);
+});
+
+// Split buckets holding entries keyed the way the Cloud Function keys them: by
+// workoutId, one document per bucket. `entries` deliberately exposes no `where`,
+// so a seedPackId-filtered read throws rather than quietly skipping the real
+// climber rows this clear exists to remove.
+function fakeSplitBuckets(bucketsById) {
+  return {
+    listDocuments: async () => Object.entries(bucketsById).map(([bucketId, entryIds]) => ({
+      id: bucketId,
+      collection: (name) => {
+        assert.equal(name, "entries", "open climbs must clear the entries collection");
+        return {
+          get: async () => ({
+            docs: entryIds.map((entryId) => ({
+              id: entryId,
+              ref: {path: `splitBuckets/${bucketId}/entries/${entryId}`},
+            })),
+          }),
+        };
+      },
+    })),
+  };
+}
+
+test("clearing an open First Ascent climb deletes every entry in every bucket", async () => {
+  // The Cloud Function writes one entry per split bucket, so a QA climber who
+  // claims the seeded open slot leaves rows well past bucket zero. Clearing only
+  // bucket zero would green the audit - it inspects bucket zero alone - while the
+  // phantom opponent still shows up mid-race.
+  const deletedPaths = [];
+  const writer = {delete: (ref) => deletedPaths.push(ref.path)};
+
+  const deleted = await clearOpenFirstAscentEntries(
+    fakeSplitBuckets({0: ["qa-workout-1"], 7: ["qa-workout-1"], 14: ["qa-workout-1"]}),
+    writer
+  );
+
+  assert.equal(deleted, 3);
+  assert.deepEqual(deletedPaths, [
+    "splitBuckets/0/entries/qa-workout-1",
+    "splitBuckets/7/entries/qa-workout-1",
+    "splitBuckets/14/entries/qa-workout-1",
+  ]);
+});
+
+test("clearing an open First Ascent climb reports zero when nothing was seeded", async () => {
+  const writer = {delete: () => assert.fail("nothing to delete")};
+
+  assert.equal(await clearOpenFirstAscentEntries(fakeSplitBuckets({}), writer), 0);
+});
+
+test("the seed clears open First Ascent climbs by query, not by seeded ID", () => {
+  // A real climber's entry IDs are their workoutId and are unknown to the seed,
+  // and an open climb seeds zero attempts, so `clearAttemptIds` is empty for it.
+  // Delete-by-seeded-id therefore deletes nothing and re-seeding strands the
+  // claimed rows next to a summary reset to zero completions.
+  const source = readScript("scripts/seed-live-replay-leaderboards.mjs");
+  const clearBody = source.match(
+    /async function clearSeedEntriesFromPlan\([\s\S]*?\n\}/
+  )?.[0];
+  assert.ok(clearBody, "could not locate clearSeedEntriesFromPlan in the seed script");
+
+  assert.match(
+    clearBody,
+    /isOpenFirstAscentSummary\(/,
+    "the clear path must branch on the plan's First Ascent state"
+  );
+  assert.match(
+    clearBody,
+    /clearOpenFirstAscentEntries\(/,
+    "open climbs must have their entries cleared by query"
+  );
 });
 
 test("the audit reads the First Ascent state off the data, not activityTier", () => {

--- a/scripts/test/live-replay-first-ascent.test.mjs
+++ b/scripts/test/live-replay-first-ascent.test.mjs
@@ -21,11 +21,49 @@ function readScript(relativePath) {
   return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
 }
 
+// Matches the array literal to its own closing bracket rather than to a
+// terminator guessed in advance: the seed lists end in both `];` and
+// `].map(...)`, and a lazy regex for one of them runs on into the next
+// declaration and quietly reads the wrong array.
+function arrayLiteralSource(source, constName) {
+  const declaration = `const ${constName} = [`;
+  const start = source.indexOf(declaration);
+  assert.notEqual(start, -1, `could not locate ${constName}`);
+
+  const open = start + declaration.length - 1;
+  let depth = 0;
+  let quote = null;
+
+  for (let index = open; index < source.length; index += 1) {
+    const character = source[index];
+
+    if (quote) {
+      if (character === "\\") index += 1;
+      else if (character === quote) quote = null;
+      continue;
+    }
+
+    if (character === "\"" || character === "'" || character === "`") {
+      quote = character;
+    } else if (character === "[") {
+      depth += 1;
+    } else if (character === "]") {
+      depth -= 1;
+      if (depth === 0) return source.slice(open + 1, index);
+    }
+  }
+
+  throw new Error(`${constName} array literal is unterminated`);
+}
+
 function arrayLiteralIds(source, constName, key) {
-  const literal = source.match(
-    new RegExp(`const ${constName} = \\[([\\s\\S]*?)\\n\\];`)
-  )?.[1];
-  assert.ok(literal, `could not locate ${constName}`);
+  const literal = arrayLiteralSource(source, constName);
+
+  assert.doesNotMatch(
+    literal,
+    /\nconst /,
+    `${constName} extraction ran past the literal into a later declaration`
+  );
 
   return [...literal.matchAll(new RegExp(`${key}:\\s*"([^"]+)"`, "g"))]
     .map((match) => match[1]);
@@ -121,6 +159,25 @@ test("every climb the demo user completes is seeded a First Ascent holder", () =
       `${climbId} gets demo completions but no script seeds it a First Ascent holder`
     );
   }
+});
+
+test("exactly four climbs seed an open First Ascent slot", () => {
+  // ProfileFirstAscentService caps its open list at four while iterating in
+  // catalog order and sorts by targetSteps only afterwards, so a fifth would
+  // push out whichever sorts last - sky-tower-auckland, the cheap-to-claim pick
+  // a QA session needs to take a First Ascent end to end.
+  const openClimbIds = arrayLiteralIds(
+    readScript("scripts/seed-live-replay-leaderboards.mjs"),
+    "FIRST_ASCENT_OPEN_CLIMBS",
+    "id"
+  );
+
+  assert.deepEqual(openClimbIds, [
+    "sky-tower-auckland",
+    "oriental-pearl-tower",
+    "table-mountain",
+    "machu-picchu",
+  ]);
 });
 
 test("open First Ascent climbs are disjoint from the demo user's climbs", () => {
@@ -325,7 +382,7 @@ test("the audit reads the First Ascent state off the data, not activityTier", ()
   assert.match(source, /firstAscentInvariantFailure\(/);
   assert.doesNotMatch(
     source,
-    /activityTier/,
-    "the audit must not branch on activityTier"
+    /\.activityTier\b/,
+    "the audit must not read activityTier off a summary"
   );
 });

--- a/scripts/test/live-replay-first-ascent.test.mjs
+++ b/scripts/test/live-replay-first-ascent.test.mjs
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import {readFileSync} from "node:fs";
+import {dirname, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+import {test} from "node:test";
+
+import {
+  FIRST_ASCENT_FIELD_NAMES,
+  assertFirstAscentInvariant,
+  clearedFirstAscentFields,
+  firstAscentClaimedAt,
+  firstAscentSeedFields,
+} from "../seed/lib/live-replay-first-ascent.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const attempt = {
+  id: "seed-attempt-1",
+  userId: "seeded:pack:mount-everest:0",
+  displayName: "Sarah K.",
+  avatarToken: "SK",
+  photoURL: "https://example.test/sarah.jpg",
+};
+
+test("seeded First Ascent fields match the server's published shape", () => {
+  const claimedAt = new Date("2026-01-01T00:00:00Z");
+  const fields = firstAscentSeedFields(attempt, claimedAt);
+
+  assert.deepEqual(fields, {
+    firstAscentAvatarToken: "SK",
+    firstAscentCompletedAt: claimedAt,
+    firstAscentDisplayName: "Sarah K.",
+    firstAscentPhotoURL: "https://example.test/sarah.jpg",
+    firstAscentUserId: "seeded:pack:mount-everest:0",
+    firstAscentWorkoutId: "seed-attempt-1",
+  });
+});
+
+test("a holder without a photo seeds an empty string, never undefined", () => {
+  // The client reads photoURL off the summary; undefined would drop the field
+  // and diverge from the server, which always writes "".
+  const fields = firstAscentSeedFields(
+    {...attempt, photoURL: undefined},
+    new Date("2026-01-01T00:00:00Z")
+  );
+
+  assert.equal(fields.firstAscentPhotoURL, "");
+});
+
+test("seeded First Ascent fields cover exactly the declared field names", () => {
+  const fields = firstAscentSeedFields(attempt, new Date("2026-01-01T00:00:00Z"));
+
+  assert.deepEqual(
+    Object.keys(fields).sort(),
+    [...FIRST_ASCENT_FIELD_NAMES].sort()
+  );
+});
+
+test("seed script publishes the same First Ascent fields as the Cloud Function", () => {
+  // The seed script and `firstAscentWrite` must publish identical shapes: the
+  // client reads one contract, so a field added on one side and not the other
+  // silently changes how seeded climbs render versus real ones.
+  const source = readFileSync(
+    resolve(REPO_ROOT, "functions/src/liveReplayLeaderboard.ts"),
+    "utf8"
+  );
+  const writeBody = source.match(
+    /function firstAscentWrite\([\s\S]*?\n\}/
+  )?.[0];
+  assert.ok(writeBody, "could not locate firstAscentWrite in the Cloud Function");
+
+  const serverFields = [...writeBody.matchAll(/(firstAscent\w+):/g)]
+    .map((match) => match[1])
+    .sort();
+
+  assert.deepEqual(serverFields, [...FIRST_ASCENT_FIELD_NAMES].sort());
+});
+
+test("clearing removes every First Ascent field", () => {
+  const sentinel = Symbol("delete");
+  const cleared = clearedFirstAscentFields(sentinel);
+
+  assert.deepEqual(Object.keys(cleared).sort(), [...FIRST_ASCENT_FIELD_NAMES].sort());
+  for (const field of FIRST_ASCENT_FIELD_NAMES) {
+    assert.equal(cleared[field], sentinel, `${field} must be cleared`);
+  }
+});
+
+test("claim dates are deterministic across seed runs", () => {
+  assert.deepEqual(
+    firstAscentClaimedAt("pack", "mount-everest"),
+    firstAscentClaimedAt("pack", "mount-everest")
+  );
+});
+
+test("claim dates differ per climb so held First Ascents sort stably", () => {
+  const climbIds = [
+    "mount-everest",
+    "empire-state-building",
+    "burj-khalifa",
+    "eiffel-tower",
+    "cn-tower",
+  ];
+  const claimedAt = climbIds.map((id) => firstAscentClaimedAt("pack", id).getTime());
+
+  assert.equal(new Set(claimedAt).size, climbIds.length);
+});
+
+test("claim dates are in the past", () => {
+  // A First Ascent is a completed historical event; a future date would render
+  // as a climb topped tomorrow.
+  const claimedAt = firstAscentClaimedAt("pack", "mount-everest");
+
+  assert.ok(claimedAt.getTime() < Date.now(), `${claimedAt.toISOString()} is not in the past`);
+});
+
+test("completions without a holder are rejected", () => {
+  // The exact state the seed script used to publish: canClaimFirstAscent is
+  // `!hasFirstAscent && previousCompletedCount === 0`, so 89 completions with no
+  // holder can never be claimed and never renders as held.
+  assert.throws(
+    () => assertFirstAscentInvariant({
+      climbId: "mount-everest",
+      completedCount: 89,
+      hasFirstAscent: false,
+    }),
+    /no First Ascent holder/
+  );
+});
+
+test("a holder without completions is rejected", () => {
+  assert.throws(
+    () => assertFirstAscentInvariant({
+      climbId: "mount-everest",
+      completedCount: 0,
+      hasFirstAscent: true,
+    }),
+    /0 completions/
+  );
+});
+
+test("the two reachable First Ascent states are accepted", () => {
+  assert.doesNotThrow(() => assertFirstAscentInvariant({
+    climbId: "mount-everest",
+    completedCount: 89,
+    hasFirstAscent: true,
+  }));
+
+  assert.doesNotThrow(() => assertFirstAscentInvariant({
+    climbId: "sky-tower-auckland",
+    completedCount: 0,
+    hasFirstAscent: false,
+  }));
+});


### PR DESCRIPTION
## Intent

Fix seeded dev/staging climbs having a permanently dead First Ascent slot.

scripts/seed-live-replay-leaderboards.mjs writes completedCount (e.g. 89 for Everest) but no firstAscent* fields. The server claims the slot only when canClaimFirstAscent = !hasFirstAscent && previousCompletedCount === 0 (functions/src/liveReplayLeaderboard.ts), so 89 completions with no holder is permanently false. The first real climber in dev/staging gets globalCompletionOrder 90 rather than 1, and the climb renders as neither held nor open. First Ascent is untestable end to end against every seeded climb.

The fix keeps every seeded summary on one of the two states the app can actually reach: open (zero completions, no holder) or held (completions plus a permanent holder). Some climbs seed an open slot so a QA session can claim a First Ascent end to end; the rest seed a holder so the already-claimed UI is testable. A shared module owns the contract and fails the seed plan when it is violated, with tests covering it including cross-file contract tests that detect drift against the Cloud Function.

## What Changed

- Added `scripts/seed/lib/live-replay-first-ascent.mjs` as the single owner of the seeded First Ascent contract: a summary is either open (zero completions, no holder) or held (completions plus a deterministic permanent holder). It mirrors the `firstAscentWrite` field shape from `functions/src/liveReplayLeaderboard.ts`, and `assertFirstAscentInvariant` fails the seed plan before any writes. `scripts/seed-live-replay-leaderboards.mjs` and `scripts/seed-demo-user.mjs` now build every `firstAscent*` payload through it instead of hand-rolled literals, and the shared `hashString`/`mulberry32` helpers moved into `scripts/seed/lib/deterministic.mjs`.
- Introduced a `FIRST_ASCENT_OPEN_CLIMBS` list (Sky Tower, Oriental Pearl Tower, Table Mountain, Machu Picchu) that seeds a real summary with no completions so a QA session can claim a First Ascent end to end, added `taipei-101` to `WARM_CLIMBS`, and made the clear path for open climbs delete bucket entries by query rather than by deterministic seed ID so a re-seed after a real claim leaves no stale rows behind. Clearing a seed pack now drops all six `firstAscent*` fields alongside the counts, and the dry-run plan prints each climb as `FA held by <name>` or `FA open`.
- `scripts/audit-seed-data.mjs` now checks the invariant per `live_climb` summary (reading counts and holder, never `activityTier`), verifies open-slot summaries carry zeroed `totalClimbers`/`replayEntryCount` and no bucket-zero entries, and compares `replayEntryCount` against rows actually seeded by the pack instead of requiring it to be positive. Added `scripts/test/live-replay-first-ascent.test.mjs` (23 tests via a new `npm --prefix scripts test`) covering the contract module plus cross-file drift checks against the Cloud Function, and documented the rule in CLAUDE.md and the climb-content skill.

The Document check flagged that no CI job runs `npm --prefix scripts test`, so the drift tests are not yet load-bearing on PRs — wiring a `scripts-verify` job is a workflow change left out of this branch.

## Risk Assessment

✅ Low: The change is confined to dev/staging seed tooling with no app, Cloud Function, or Firestore rules surface; the round-1 stale-entry defect is now correctly fixed with query-based deletion across all buckets on both the clear and seed paths, and the two remaining gaps are deliberate owner-accepted tradeoffs filed as issues #219 and #221.

## Testing

Beyond the unit suites (23 scripts + 109 functions tests, all passing), I demonstrated the intent end-to-end against a real Firestore emulator: I ran the base-commit seed script into a staging namespace to reproduce the bug (25/25 climbs permanently dead; a first real climber assigned globalCompletionOrder 84 with no claim), then ran the fixed seed into a dev namespace and drove the real onWorkoutReplaySplitsWritten Cloud Function over it, showing a climber claim a First Ascent at globalCompletionOrder 1 on a seeded-open climb while a seeded-held climb preserved its permanent holder. I also verified the re-seed path from the final commit clears a QA climber's claim and all their split-bucket rows and reopens the slot for another claim, and that the shipped audit exits 1 on base-commit data and passes on the fixed seed. No screenshots: the diff touches only seed/audit scripts and CLAUDE.md with no iOS UI code, so the end-user-visible surface is the persisted Firestore state the app reads, which I captured directly as before/after dumps and Cloud Function responses. All transient artifacts (emulator, node_modules, functions/lib, three temp harness scripts) were removed; git status is clean.

<details>
<summary>Evidence: Evidence bundle summary (before/after, all artifacts indexed)</summary>

```text
# First Ascent seed fix - end-to-end evidence

All evidence produced against a real Firestore emulator, using the REAL seed
script and the REAL `onWorkoutReplaySplitsWritten` Cloud Function trigger.
The base-commit seed script (8ed6bf8) was run into the emulator's staging
namespace to reproduce the bug; the fixed script into the dev namespace.

## The bug, reproduced (base commit 8ed6bf8)

`01-firestore-state-BEFORE-base-commit.txt`
  25 of 25 seeded climbs -> DEAD (completions, no holder). Not one is
  claimable, not one renders as held.

`03-cloud-function-BEFORE-base-commit.json`
  A first real climber on empire-state-building (83 seeded completions, no
  holder) is assigned globalCompletionOrder 84 and claims nothing. The slot
  stays dead forever.

## The fix (target commit c1ae032)

`02-firestore-state-AFTER-fix.txt`
  30 seeded climbs | 26 held | 4 open | 0 permanently dead.

`04-cloud-function-AFTER-fix.json`
  - Seeded HELD climb (empire-state-building): climber becomes finisher 84,
    seeded holder "Ari N." (2025-10-16) is preserved -> already-claimed UI.
  - Seeded OPEN climb (table-mountain): climber "Dana Q." is assigned
    globalCompletionOrder 1 and CLAIMS the First Ascent -> First Ascent is
    testable end to end.

`06-reseed-restores-open-slot-then-reclaimable.json`
  After a QA climber claims a seeded-open slot, re-running the seed clears the
  claim and every one of their replay rows across all split buckets, and the
  slot is claimable again at globalCompletionOrder 1. Repeatable QA loop.

`05-audit-catches-base-commit-seed.txt` / `07-audit-passes-on-fixed-seed.txt`
  The shipped audit exits 1 on base-commit seed data (naming every dead climb)
  and passes on the fixed seed.
```
</details>
<details>
<summary>Evidence: BEFORE (base commit 8ed6bf8): persisted Firestore state - every seeded climb permanently dead</summary>

<code>CLIMB COMPLETED FA STATE FA HOLDER CLAIMED REACHABLE BY THE APP?&#10;------------------------------------------------------------------------------------------------&#10;mount-everest 89 DEAD - - NO - mount-everest: 89 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.&#10;empire-state-building 83 DEAD - - NO - empire-state-building: 83 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.&#10;...&#10;------------------------------------------------------------------------------------------------&#10;25 seeded climbs | 0 held | 0 open (claimable end to end) | 25 permanently dead</code>

```text
CLIMB                     COMPLETED  FA STATE  FA HOLDER     CLAIMED     REACHABLE BY THE APP?
------------------------------------------------------------------------------------------------
mount-everest             89         DEAD      -             -           NO - mount-everest: 89 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
empire-state-building     83         DEAD      -             -           NO - empire-state-building: 83 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
gateway-arch              80         DEAD      -             -           NO - gateway-arch: 80 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
eiffel-tower              69         DEAD      -             -           NO - eiffel-tower: 69 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
statue-of-liberty         69         DEAD      -             -           NO - statue-of-liberty: 69 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
burj-khalifa              59         DEAD      -             -           NO - burj-khalifa: 59 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
petronas-towers           54         DEAD      -             -           NO - petronas-towers: 54 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
cn-tower                  49         DEAD      -             -           NO - cn-tower: 49 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
marina-bay-sands          48         DEAD      -             -           NO - marina-bay-sands: 48 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
tokyo-skytree             41         DEAD      -             -           NO - tokyo-skytree: 41 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
washington-monument       28         DEAD      -             -           NO - washington-monument: 28 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
space-needle              27         DEAD      -             -           NO - space-needle: 27 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
acropolis-of-athens       21         DEAD      -             -           NO - acropolis-of-athens: 21 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
elizabeth-tower           20         DEAD      -             -           NO - elizabeth-tower: 20 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
willis-tower              19         DEAD      -             -           NO - willis-tower: 19 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
chrysler-building         18         DEAD      -             -           NO - chrysler-building: 18 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
sagrada-familia           18         DEAD      -             -           NO - sagrada-familia: 18 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
one-world-trade-center    17         DEAD      -             -           NO - one-world-trade-center: 17 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
the-shard                 17         DEAD      -             -           NO - the-shard: 17 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
leaning-tower-of-pisa     13         DEAD      -             -           NO - leaning-tower-of-pisa: 13 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
tokyo-tower               13         DEAD      -             -           NO - tokyo-tower: 13 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
sydney-tower              12         DEAD      -             -           NO - sydney-tower: 12 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
cairo-tower               10         DEAD      -             -           NO - cairo-tower: 10 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
shanghai-tower            10         DEAD      -             -           NO - shanghai-tower: 10 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
canton-tower              9          DEAD      -             -           NO - canton-tower: 9 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
------------------------------------------------------------------------------------------------
25 seeded climbs | 0 held | 0 open (claimable end to end) | 25 permanently dead
```
</details>
<details>
<summary>Evidence: AFTER (fix): persisted Firestore state - zero dead slots, 4 claimable open slots</summary>

<code>CLIMB COMPLETED FA STATE FA HOLDER CLAIMED REACHABLE BY THE APP?&#10;------------------------------------------------------------------------------------------------&#10;mount-everest 89 HELD Lia P. 2025-10-31 yes&#10;empire-state-building 83 HELD Ari N. 2025-10-16 yes&#10;taipei-101 10 HELD Skye M. 2025-10-02 yes&#10;machu-picchu 0 OPEN - - yes&#10;oriental-pearl-tower 0 OPEN - - yes&#10;sky-tower-auckland 0 OPEN - - yes&#10;table-mountain 0 OPEN - - yes&#10;------------------------------------------------------------------------------------------------&#10;30 seeded climbs | 26 held | 4 open (claimable end to end) | 0 permanently dead</code>

```text
CLIMB                     COMPLETED  FA STATE  FA HOLDER     CLAIMED     REACHABLE BY THE APP?
------------------------------------------------------------------------------------------------
mount-everest             89         HELD      Lia P.        2025-10-31  yes
empire-state-building     83         HELD      Ari N.        2025-10-16  yes
gateway-arch              80         HELD      Maya C.       2025-12-29  yes
eiffel-tower              69         HELD      Nate R.       2025-12-27  yes
statue-of-liberty         69         HELD      Jace M.       2025-12-22  yes
burj-khalifa              59         HELD      Leo S.        2025-10-23  yes
petronas-towers           54         HELD      Rae C.        2025-11-27  yes
cn-tower                  49         HELD      Cal N.        2025-12-25  yes
marina-bay-sands          48         HELD      Cal N.        2025-09-20  yes
tokyo-skytree             41         HELD      Cole A.       2025-10-21  yes
washington-monument       28         HELD      Owen B.       2025-12-26  yes
space-needle              27         HELD      Lia P.        2025-11-30  yes
acropolis-of-athens       21         HELD      Max W.        2025-11-02  yes
elizabeth-tower           20         HELD      Finn R.       2025-09-21  yes
willis-tower              19         HELD      Jules R.      2025-12-06  yes
chrysler-building         18         HELD      Gia F.        2025-09-24  yes
sagrada-familia           18         HELD      Zara T.       2025-10-30  yes
one-world-trade-center    17         HELD      Leo S.        2025-09-13  yes
the-shard                 17         HELD      Mila B.       2025-10-29  yes
leaning-tower-of-pisa     13         HELD      Marcus T.     2025-11-22  yes
tokyo-tower               13         HELD      Sean P.       2025-11-14  yes
sydney-tower              12         HELD      Theo J.       2025-10-31  yes
cairo-tower               10         HELD      Iris M.       2025-12-06  yes
shanghai-tower            10         HELD      Eva D.        2025-10-06  yes
taipei-101                10         HELD      Skye M.       2025-10-02  yes
canton-tower              9          HELD      Zara T.       2025-10-04  yes
machu-picchu              0          OPEN      -             -           yes
oriental-pearl-tower      0          OPEN      -             -           yes
sky-tower-auckland        0          OPEN      -             -           yes
table-mountain            0          OPEN      -             -           yes
------------------------------------------------------------------------------------------------
30 seeded climbs | 26 held | 4 open (claimable end to end) | 0 permanently dead
```
</details>
<details>
<summary>Evidence: BEFORE: real Cloud Function assigns finisher 84 and claims nothing (dead slot)</summary>

<code>{&#10;&#34;climbId&#34;: &#34;empire-state-building&#34;,&#10;&#34;seededAs&#34;: &#34;BASE COMMIT SEED (89-style: completions, no holder)&#34;,&#10;&#34;before&#34;: { &#34;completedCount&#34;: 83, &#34;firstAscentHolder&#34;: &#34;(none)&#34; },&#10;&#34;after&#34;: { &#34;completedCount&#34;: 84, &#34;firstAscentHolder&#34;: &#34;(none)&#34; },&#10;&#34;qaClimberGlobalCompletionOrder&#34;: 84,&#10;&#34;qaClimberClaimedFirstAscent&#34;: false&#10;}</code>

```text
[
  {
    "climbId": "empire-state-building",
    "seededAs": "BASE COMMIT SEED (89-style: completions, no holder)",
    "before": {
      "completedCount": 83,
      "activityTier": "active",
      "firstAscentHolder": "(none)",
      "firstAscentCompletedAt": "(none)",
      "firstAscentWorkoutId": "(none)"
    },
    "after": {
      "completedCount": 84,
      "activityTier": "active",
      "firstAscentHolder": "(none)",
      "firstAscentCompletedAt": "(none)",
      "firstAscentWorkoutId": "(none)"
    },
    "qaClimberGlobalCompletionOrder": 84,
    "qaClimberClaimedFirstAscent": false
  }
]
```
</details>
<details>
<summary>Evidence: AFTER: real Cloud Function - held climb preserves holder; open climb claimed at order 1</summary>

<code>[&#10;{&#10;&#34;climbId&#34;: &#34;empire-state-building&#34;, &#34;seededAs&#34;: &#34;SEEDED HELD&#34;,&#10;&#34;before&#34;: { &#34;completedCount&#34;: 83, &#34;firstAscentHolder&#34;: &#34;Ari N. (seeded:live-replay-v1-dev:empire-state-building:0)&#34; },&#10;&#34;after&#34;: { &#34;completedCount&#34;: 84, &#34;firstAscentHolder&#34;: &#34;Ari N. (seeded:live-replay-v1-dev:empire-state-building:0)&#34; },&#10;&#34;qaClimberGlobalCompletionOrder&#34;: 84,&#10;&#34;qaClimberClaimedFirstAscent&#34;: false&#10;},&#10;{&#10;&#34;climbId&#34;: &#34;table-mountain&#34;, &#34;seededAs&#34;: &#34;SEEDED OPEN&#34;,&#10;&#34;before&#34;: { &#34;completedCount&#34;: 0, &#34;firstAscentHolder&#34;: &#34;(none)&#34; },&#10;&#34;after&#34;: { &#34;completedCount&#34;: 1, &#34;firstAscentHolder&#34;: &#34;Dana Q. (qa-clean-uid)&#34;, &#34;firstAscentCompletedAt&#34;: &#34;2026-07-17T12:23:58.220Z&#34; },&#10;&#34;qaClimberGlobalCompletionOrder&#34;: 1,&#10;&#34;qaClimberClaimedFirstAscent&#34;: true&#10;}&#10;]</code>

```text
[
  {
    "climbId": "empire-state-building",
    "seededAs": "SEEDED HELD",
    "before": {
      "completedCount": 83,
      "activityTier": "active",
      "firstAscentHolder": "Ari N. (seeded:live-replay-v1-dev:empire-state-building:0)",
      "firstAscentCompletedAt": "2025-10-16T00:00:00.000Z",
      "firstAscentWorkoutId": "seed_live-replay-v1-dev_empire-state-building_0000"
    },
    "after": {
      "completedCount": 84,
      "activityTier": "active",
      "firstAscentHolder": "Ari N. (seeded:live-replay-v1-dev:empire-state-building:0)",
      "firstAscentCompletedAt": "2025-10-16T00:00:00.000Z",
      "firstAscentWorkoutId": "seed_live-replay-v1-dev_empire-state-building_0000"
    },
    "qaClimberGlobalCompletionOrder": 84,
    "qaClimberClaimedFirstAscent": false
  },
  {
    "climbId": "table-mountain",
    "seededAs": "SEEDED OPEN",
    "before": {
      "completedCount": 0,
      "activityTier": "open",
      "firstAscentHolder": "(none)",
      "firstAscentCompletedAt": "(none)",
      "firstAscentWorkoutId": "(none)"
    },
    "after": {
      "completedCount": 1,
      "activityTier": "open",
      "firstAscentHolder": "Dana Q. (qa-clean-uid)",
      "firstAscentCompletedAt": "2026-07-17T12:23:58.220Z",
      "firstAscentWorkoutId": "qa-clean-workout-1"
    },
    "qaClimberGlobalCompletionOrder": 1,
    "qaClimberClaimedFirstAscent": true
  }
]
```
</details>
<details>
<summary>Evidence: Re-seed clears a QA claim and reopens the slot, which is then reclaimable at order 1 (commit c1ae032)</summary>

<code>Re-seed: &#34;Cleared 775,574 existing seeded replay entries.&#34; / &#34;Seeded 555,754 Firestore documents into ascend-f2e4f.&#34;&#10;table-mountain after clear: {activityTier: open, completedCount: 0, totalClimbers: 0} &lt;- all firstAscent* fields gone&#10;qa-clean-uid rows in split buckets 0/5/11: 0, 0, 0 &lt;- every replay row removed, not just bucket zero&#10;&#10;Then a fresh climber re-claims both open slots:&#10;table-mountain -&gt; globalCompletionOrder 1, claimed by &#34;Rae V.&#34;&#10;sky-tower-auckland -&gt; globalCompletionOrder 1, claimed by &#34;Rae V.&#34;</code>

```text
[
  {
    "climbId": "table-mountain",
    "seededAs": "SEEDED OPEN (after re-seed)",
    "before": {
      "completedCount": 0,
      "activityTier": "open",
      "firstAscentHolder": "(none)",
      "firstAscentCompletedAt": "(none)",
      "firstAscentWorkoutId": "(none)"
    },
    "after": {
      "completedCount": 1,
      "activityTier": "open",
      "firstAscentHolder": "Rae V. (qa-round2-uid)",
      "firstAscentCompletedAt": "2026-07-17T13:04:37.536Z",
      "firstAscentWorkoutId": "qa-round2-workout"
    },
    "qaClimberGlobalCompletionOrder": 1,
    "qaClimberClaimedFirstAscent": true
  },
  {
    "climbId": "sky-tower-auckland",
    "seededAs": "SEEDED OPEN (cheapest, QA claim target)",
    "before": {
      "completedCount": 0,
      "activityTier": "open",
      "firstAscentHolder": "(none)",
      "firstAscentCompletedAt": "(none)",
      "firstAscentWorkoutId": "(none)"
    },
    "after": {
      "completedCount": 1,
      "activityTier": "open",
      "firstAscentHolder": "Rae V. (qa-round2-uid)",
      "firstAscentCompletedAt": "2026-07-17T13:04:38.749Z",
      "firstAscentWorkoutId": "qa-round2-workout"
    },
    "qaClimberGlobalCompletionOrder": 1,
    "qaClimberClaimedFirstAscent": true
  }
]
```
</details>
<details>
<summary>Evidence: Shipped audit exits 1 on base-commit seed data, naming every dead climb</summary>

<code>Project: ascend-staging-fa7d5&#10;Audit targets: live-replay&#10;&#10;Audit summary:&#10;live-replay: 26 summaries, 1788 bucket-zero entries checked&#10;&#10;Seed audit failed:&#10;- live_replay_leaderboards/live_climb__mount-everest: 89 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.&#10;- live_replay_leaderboards/live_climb__empire-state-building: 84 completions but no First Ascent holder. ...&#10;(25 climbs total)&#10;&#10;audit exit code on base-commit seed: 1</code>

```text
Project: ascend-staging-fa7d5
Audit targets: live-replay

Audit summary:
  live-replay: 26 summaries, 1788 bucket-zero entries checked

Seed audit failed:
  - live_replay_leaderboards/live_climb__acropolis-of-athens: 21 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__burj-khalifa: 59 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__cairo-tower: 10 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__canton-tower: 9 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__chrysler-building: 18 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__cn-tower: 49 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__eiffel-tower: 69 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__elizabeth-tower: 20 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__empire-state-building: 84 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__gateway-arch: 80 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__leaning-tower-of-pisa: 13 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__marina-bay-sands: 48 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__mount-everest: 89 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__one-world-trade-center: 17 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__petronas-towers: 54 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__sagrada-familia: 18 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__shanghai-tower: 10 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__space-needle: 27 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__statue-of-liberty: 69 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__sydney-tower: 12 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__the-shard: 17 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__tokyo-skytree: 41 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
  - live_replay_leaderboards/live_climb__tokyo-tower: 13 completions but no First Ascent holder. The slot would render as neither held nor open and could never be claimed.
```
</details>
<details>
<summary>Evidence: Shipped audit passes on the fixed seed</summary>

<code>Project: ascend-f2e4f&#10;Audit targets: live-replay&#10;&#10;Audit summary:&#10;live-replay: 31 summaries, 1810 bucket-zero entries checked&#10;&#10;Seed audit passed.</code>

```text
Project: ascend-f2e4f
Audit targets: live-replay

Audit summary:
  live-replay: 31 summaries, 1810 bucket-zero entries checked

Seed audit passed.
```
</details>
<details>
<summary>Evidence: Seed plan: every climb lands on a reachable First Ascent state</summary>

<code>ACTIVE | mount-everest | 89 completed | 89 replay rows | 361 buckets | FA held by Lia P.&#10;ACTIVE | empire-state-building | 83 completed | 83 replay rows | 326 buckets | FA held by Ari N.&#10;WARM | taipei-101 | 10 completed | 10 replay rows | 361 buckets | FA held by Skye M.&#10;OPEN | sky-tower-auckland | 0 completed | 0 replay rows | 0 buckets | FA open&#10;OPEN | oriental-pearl-tower | 0 completed | 0 replay rows | 0 buckets | FA open&#10;OPEN | table-mountain | 0 completed | 0 replay rows | 0 buckets | FA open&#10;OPEN | machu-picchu | 0 completed | 0 replay rows | 0 buckets | FA open&#10;GLOBAL | just-climb-global | 903 completed | 903 replay rows | 361 buckets</code>

```text
No --source-user or ASCEND_SEED_SOURCE_USER_ID provided. Using fallback pace samples.
Project: ascend-f2e4f
Seed pack: live-replay-v1-dev
Apple Health step factor: 0.78
Mode: seed
Planned docs: 31 summaries, 555,723 replay entries
ACTIVE | mount-everest             | 89 completed | 89 replay rows | 361 buckets | FA held by Lia P.
ACTIVE | empire-state-building     | 83 completed | 83 replay rows | 326 buckets | FA held by Ari N.
ACTIVE | burj-khalifa              | 59 completed | 59 replay rows | 361 buckets | FA held by Leo S.
ACTIVE | gateway-arch              | 80 completed | 80 replay rows | 169 buckets | FA held by Maya C.
ACTIVE | eiffel-tower              | 69 completed | 69 replay rows | 268 buckets | FA held by Nate R.
ACTIVE | petronas-towers           | 54 completed | 54 replay rows | 361 buckets | FA held by Rae C.
ACTIVE | cn-tower                  | 49 completed | 49 replay rows | 361 buckets | FA held by Cal N.
ACTIVE | statue-of-liberty         | 69 completed | 69 replay rows | 85 buckets | FA held by Jace M.
ACTIVE | tokyo-skytree             | 41 completed | 41 replay rows | 361 buckets | FA held by Cole A.
ACTIVE | marina-bay-sands          | 48 completed | 48 replay rows | 172 buckets | FA held by Cal N.
WARM   | space-needle              | 27 completed | 27 replay rows | 122 buckets | FA held by Lia P.
WARM   | washington-monument       | 28 completed | 28 replay rows | 108 buckets | FA held by Owen B.
WARM   | willis-tower              | 19 completed | 19 replay rows | 361 buckets | FA held by Jules R.
WARM   | one-world-trade-center    | 17 completed | 17 replay rows | 361 buckets | FA held by Leo S.
WARM   | chrysler-building         | 18 completed | 18 replay rows | 216 buckets | FA held by Gia F.
WARM   | the-shard                 | 17 completed | 17 replay rows | 270 buckets | FA held by Mila B.
WARM   | sagrada-familia           | 18 completed | 18 replay rows | 149 buckets | FA held by Zara T.
WARM   | acropolis-of-athens       | 21 completed | 21 replay rows | 101 buckets | FA held by Max W.
WARM   | elizabeth-tower           | 20 completed | 20 replay rows | 63 buckets | FA held by Finn R.
WARM   | tokyo-tower               | 13 completed | 13 replay rows | 271 buckets | FA held by Sean P.
WARM   | shanghai-tower            | 10 completed | 10 replay rows | 309 buckets | FA held by Eva D.
WARM   | taipei-101                | 10 completed | 10 replay rows | 361 buckets | FA held by Skye M.
WARM   | canton-tower              | 9 completed | 9 replay rows | 361 buckets | FA held by Zara T.
WARM   | leaning-tower-of-pisa     | 13 completed | 13 replay rows | 52 buckets | FA held by Marcus T.
WARM   | cairo-tower               | 10 completed | 10 replay rows | 95 buckets | FA held by Iris M.
WARM   | sydney-tower              | 12 completed | 12 replay rows | 182 buckets | FA held by Theo J.
OPEN   | sky-tower-auckland        | 0 completed | 0 replay rows | 0 buckets | FA open
OPEN   | oriental-pearl-tower      | 0 completed | 0 replay rows | 0 buckets | FA open
OPEN   | table-mountain            | 0 completed | 0 replay rows | 0 buckets | FA open
OPEN   | machu-picchu              | 0 completed | 0 replay rows | 0 buckets | FA open
GLOBAL | just-climb-global         | 903 completed | 903 replay rows | 361 buckets
Seeded 555,754 Firestore documents into ascend-f2e4f.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `scripts/seed-demo-user.mjs:722` - seed-demo-user.mjs can still publish the exact dead First Ascent state this change exists to prevent. It sets completedCount = bucketZeroSnapshot.size + 1 for all six LIVE_CLIMB_SPECS climbs but only writes firstAscent* fields for the single --first-ascent-climb, and it never reads the summary&#39;s existing holder or calls assertFirstAscentInvariant. It relies entirely on seed-live-replay-leaderboards.mjs having already planted a holder, which the new test only checks at the source-list level (&#39;every climb the demo user completes is seeded a First Ascent holder&#39; compares ID lists, not actual database state). Consider either asserting the invariant here after reading the summary, or claiming the slot for the demo user when it is genuinely open.
- ⚠️ `scripts/seed-live-replay-leaderboards.mjs:556` - Re-seeding after a QA climber claims a seeded open First Ascent leaves a stale real bucket-zero entry that permanently fails the new open-slot audit rule at scripts/audit-seed-data.mjs:385. For FIRST_ASCENT_OPEN_CLIMBS, clearAttemptIds is Array.from({length: Math.max(0, 0)}) = [], so clearSeedEntriesFromPlan deletes nothing, and clearStaleSeedContexts skips the climb because it is in activeContextKeys. writeSeedPlan then resets completedCount/replayEntryCount/totalClimbers to 0 and deletes the firstAscent* fields, leaving a summary that reports no completions next to a real bucket-zero entry. This is precisely the loop the open fixtures were added for (claim a First Ascent end to end, then reset). The clear path for open climbs likely needs to query and delete bucket entries rather than delete by deterministic seed attempt ID.
- ⚠️ `scripts/package.json:6` - The new `test` script is never executed by CI, so the cross-file contract tests that detect drift against the Cloud Function never actually detect drift. .github/workflows/ci.yml only triggers on AscendApp/**, AscendAppTests/**, AscendApp.xcodeproj/**, functions/**, and .github/workflows/**, and its only Node job runs `npm --prefix functions test`. A PR that renames or adds a field in `firstAscentWrite` (functions/src/liveReplayLeaderboard.ts) triggers functions-verify only and merges green while FIRST_ASCENT_FIELD_NAMES silently diverges. Wiring a scripts-verify job gated on a `scripts/**` + `functions/**` path filter would make the drift detector load-bearing.

🔧 Fix: Clear stale entries when re-seeding open First Ascents
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm --prefix scripts test` (node --test test/live-replay-first-ascent.test.mjs) - 23 pass, covers the shared contract module plus the cross-file drift tests against functions/src/liveReplayLeaderboard.ts</code>
- <code>`npm --prefix functions test` - 109 pass, no regression in the Cloud Function</code>
- <code>`node seed-live-replay-leaderboards.mjs seed --project dev --dry-run` - plan shows every climb as either `FA held by &lt;name&gt;` or `FA open`</code>
- <code>`FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 node seed-live-replay-leaderboards.mjs seed --project dev` - seeded 555,754 real documents into the emulator</code>
- `Reproduced the bug: ran the base-commit (8ed6bf8) seed script into the emulator's staging namespace; dumped persisted state showing 25/25 climbs DEAD (completions, no holder)`
- <code>Drove the REAL `onWorkoutReplaySplitsWritten` trigger (via firebase-functions-test wrap over emulator Firestore) for a first real climber against the base-commit seed: globalCompletionOrder 84, no First Ascent claim</code>
- `Drove the same real trigger against the fixed seed: seeded-HELD climb (empire-state-building) -> finisher 84 with holder 'Ari N.' preserved; seeded-OPEN climb (table-mountain) -> globalCompletionOrder 1 and First Ascent CLAIMED`
- <code>`FIRESTORE_EMULATOR_HOST=... node seed-live-replay-leaderboards.mjs seed --project dev` re-seed after a QA claim - cleared 775,574 entries, dropped the QA claim, verified zero qa-uid rows remained in split buckets 0/5/11, and confirmed the open slot was reclaimable at order 1 (validates commit c1ae032)</code>
- <code>`node audit-seed-data.mjs --target live-replay --project staging` on base-commit data - exit 1, names every dead climb</code>
- <code>`node audit-seed-data.mjs --target live-replay --project dev` on fixed data - `Seed audit passed.`</code>
- `Verified seeded holder claim dates are byte-identical across two independent seed runs (deterministic, non-rewriting)`

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `.github/workflows/ci.yml:6` - This change adds `npm --prefix scripts test` and scripts/test/live-replay-first-ascent.test.mjs, whose stated purpose includes cross-file contract tests that detect drift against `firstAscentWrite` in functions/src/liveReplayLeaderboard.ts. No CI job runs it: ci.yml&#39;s `on.pull_request.paths` and its `changes` filter only cover AscendApp/**, AscendAppTests/**, AscendApp.xcodeproj/**, functions/**, and .github/workflows/**, so a scripts-only PR triggers no workflow at all, and even a functions-only PR that renames a firstAscent* field would go green while the drift test that would have caught it never executes. Adding a `scripts-verify` job is a functional workflow change and out of scope for a documentation and lint pass; it would also need a matching update to the CI/CD &amp; Deployment section of CLAUDE.md, which currently documents CI as functions-verify plus the two iOS jobs.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `scripts/seed/lib/live-replay-first-ascent.mjs:1` - No configured linter or formatter covers the files this change touches. The repo&#39;s only ESLint config is functions/.eslintrc.js, which sets `root: true` and is scoped to functions/ (untouched here); scripts/ has no eslint, prettier, or editorconfig. Static checking was therefore limited to `node --check` on all six changed .mjs files and a JSON parse of scripts/package.json, all of which passed with nothing to fix. Reported for transparency about lint coverage, not as a defect in this change; the new code already follows the surrounding google-eslint-style JSDoc and double-quote conventions by hand.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
