### PR TITLE
ci: add a develop branch as the staging integration trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop, main]
     paths:
       - "AscendApp/**"
       - "AscendAppTests/**"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,6 +18,10 @@ on:
       - ".firebaserc"
       - ".github/workflows/deploy-staging.yml"
 
+# Never cancel a staging deploy in flight. Every push to develop now triggers
+# one, so back-to-back pushes would abort a run partway through the Firebase
+# deploy or the TestFlight upload and leave staging half-deployed. Overlapping
+# runs queue behind the running one instead.
 concurrency:
   group: deploy-staging-${{ github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,10 +1,22 @@
 name: Deploy Staging
 
-# Staging deploys are manual until staging gets a trigger that cannot collide
-# with production. deploy-production.yml already runs on pushes to main, so
-# pointing staging at main would deploy both on one event. See issue #203.
 on:
   workflow_dispatch:
+  push:
+    branches: [develop]
+    paths:
+      - "AscendApp/**"
+      - "AscendApp.xcodeproj/**"
+      - "fastlane/**"
+      - "Gemfile"
+      - "Gemfile.lock"
+      - "functions/**"
+      - "web/**"
+      - "firebase.json"
+      - "firestore.rules"
+      - "storage.rules"
+      - ".firebaserc"
+      - ".github/workflows/deploy-staging.yml"
 
 concurrency:
   group: deploy-staging-${{ github.ref }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -20,7 +20,7 @@ on:
 
 concurrency:
   group: deploy-staging-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -662,9 +662,9 @@ Load these skills before writing or reviewing code in their domains. Each listin
 ## CI/CD & Deployment
 
 ### Branching Strategy
-- `main` - the default branch, production-ready, and the base for all work.
-- `feature/*`, `fix/*`, `chore/*` - individual work, branch off `main`, PR into `main`.
-- There is no long-lived integration branch. `develop` was merged into `main` and deleted; do not recreate it or target it.
+- `main` - production-ready. Only receives merges from `develop` when ready to ship.
+- `develop` - long-lived staging integration branch. Contains everything `main` has plus in-progress work. Pushes here auto-trigger staging builds.
+- `feature/*`, `fix/*`, `chore/*` - individual work, branch off `develop`, PR into `develop`.
 
 ### Issue-First Workflow
 - Resolve work to a GitHub issue before implementing code.
@@ -678,19 +678,19 @@ Load these skills before writing or reviewing code in their domains. Each listin
   - `feature/issue-<number>-<short-slug>`
   - `fix/issue-<number>-<short-slug>`
   - `chore/issue-<number>-<short-slug>`
-- PRs should target `main` and include `Closes #<number>` in the PR body.
+- PRs should target `develop` and include `Closes #<number>` in the PR body.
 
 ### Workflows
-- `.github/workflows/ci.yml` runs on PRs to `main`. A `changes` job gates each verify job on the changed paths, so a functions-only PR skips the iOS jobs and an iOS-only PR skips the functions job:
+- `.github/workflows/ci.yml` runs on PRs to `develop` and `main`. A `changes` job gates each verify job on the changed paths, so a functions-only PR skips the iOS jobs and an iOS-only PR skips the functions job:
   - `functions-verify` installs `functions/` and runs its test suite.
   - `ios-verify` builds the `AscendApp-Staging` scheme in the `Staging` configuration on an iPhone simulator with `ENABLE_TESTABILITY=YES` and runs the `AscendAppTests` suite. It picks the simulator at runtime from `xcodebuild -showdestinations`, preferring recent iPhone models and failing if none are available.
   - `ios-verify-release` builds the `AscendApp` scheme in the `Release` configuration against `-sdk iphoneos` with `CODE_SIGNING_ALLOWED=NO`. It only builds, and exists so Release-only and device-only compile errors surface on the PR instead of first appearing in the production deploy.
-- CI is the only automated gate before `main`, so a workflow trigger that points at a branch which no longer exists silently disables it. When the branching model changes, change this trigger in the same PR.
-- `.github/workflows/deploy-staging.yml` runs on manual dispatch only, and has three jobs:
+- CI is the only automated gate before `develop` and `main`, so a workflow trigger that points at a branch which no longer exists silently disables it. When the branching model changes, change this trigger in the same PR.
+- `.github/workflows/deploy-staging.yml` runs on pushes to `develop` and on manual dispatch, and has three jobs:
   1. Build iOS app (Staging scheme, produce IPA)
   2. Deploy Firebase in one step (Functions, Firestore rules, Firestore indexes, Storage rules, Hosting). This runs in parallel with the IPA build: the backend deploy does not depend on the iOS binary, and staging tolerates the backend landing even when the app build fails.
   3. Upload to TestFlight. It needs both jobs above, so it runs last (hardest to reverse).
-- Staging has no automatic trigger. It cannot simply run on pushes to `main`, because `deploy-production.yml` already does, and one push would deploy both. Giving staging its own non-colliding trigger is tracked in issue #203.
+- `develop` is what makes the staging trigger safe: staging cannot run on pushes to `main`, because `deploy-production.yml` already does and one push would deploy both. Keep the two deploy workflows on disjoint branches - pointing either at the other's branch reintroduces the double-deploy.
 - `.github/workflows/deploy-production.yml` runs on pushes to `main` and manual dispatch. It deploys the same targets as staging, including Firestore indexes, with Release configuration. Unlike staging, it stays strictly sequential (stop on failure) - every job needs the one before it - and remains gated behind `PRODUCTION_READY=true` plus GitHub `production` environment protection.
 
 ### Deploy Authentication (OIDC)


### PR DESCRIPTION
## Intent

Set up a long-lived 'develop' branch as a staging integration branch, resolving GitHub issue #203 (staging deploy needs its own non-colliding trigger).

The captain's model: 'develop' is long-lived and always stays, holding everything main has plus in-progress work. PRs target develop instead of main. Pushes to develop auto-trigger staging builds (TestFlight + Firebase staging deploy). When ready to ship, develop merges into main for production. main stays production-only.

Why develop is the fix for #203: staging previously had NO automatic trigger at all (workflow_dispatch only). It could not simply run on pushes to main, because deploy-production.yml already does, so one push to main would deploy BOTH environments on a single event. develop is the non-colliding branch that makes an automatic staging trigger safe. The two deploy workflows must stay on disjoint branches (staging=develop, production=main).

Changes the captain specified:
1. CLAUDE.md Branching Strategy section rewritten to the captain's exact supplied text (main = production-only receiving merges from develop; develop = long-lived staging integration; feature/fix/chore branch off develop and PR into develop).
2. ci.yml PR trigger changed from branches: [main] to branches: [develop, main].
3. deploy-staging.yml gained a push trigger on develop using the SAME paths filter as deploy-production.yml, and the stale comment explaining staging was manual-only pending #203 was removed.
4. deploy-production.yml: no functional change needed (already push-on-main). It contained no #203 reference (that comment lived only in deploy-staging.yml), so it is untouched and absent from the diff by design.
5. develop branch created from current main HEAD (8ed6bf8) and pushed to origin.
6. Open PRs 214, 220, 223, 226 retargeted from main to develop via gh-axi.
7. CLAUDE.md workflow descriptions updated to the develop auto-trigger, with the #203 tracking note removed.

DELIBERATE DECISIONS a reviewer reading only the diff would not know:

(a) The diff REVERSES a previously explicit rule. CLAUDE.md line 667 read: 'There is no long-lived integration branch. develop was merged into main and deleted; do not recreate it or target it.' Recreating develop is the captain's explicit, current decision and supersedes that line. This is intended, not an oversight or a regression.

(b) I updated TWO CLAUDE.md lines BEYOND the captain's literal spec, because changing the branching model made them self-contradictory: the Issue-First Workflow line said 'PRs should target main' (now develop), and the Workflows line said 'CI is the only automated gate before main' (now develop and main). Leaving the project guide internally inconsistent about its own branching model would be worse than the small scope expansion.

(c) AGENTS.md is deliberately NOT in the diff. In this repo CLAUDE.md is the canonical real file and AGENTS.md is a symlink to it, so editing CLAUDE.md edits both. CLAUDE.md explicitly forbids breaking that symlink. The firstmate fm-ensure-agents-md.sh helper errored ('expected AGENTS.md to be the real file') because it assumes the inverse layout; the project rule wins and the script made no changes.

(d) Commit message intentionally has no Co-Authored-By trailer, per the user's global instruction to never auto-add the agent as co-author. Body uses plain dashes, never em dashes, per the same global instruction.

KNOWN, ACCEPTED CONSEQUENCE (already reported to the captain, not a defect to fix here): the four retargeted PRs will not run CI on their next push until this PR merges into develop and each branch merges develop in. For a pull_request event GitHub evaluates the trigger from the merge commit, and those head branches still carry branches: [main] while their base is now develop, so the filter does not match. This resolves itself through normal merge order and needs no code change.

Acceptance criteria: develop exists on remote at main HEAD; CI runs on PRs to both develop and main; staging auto-deploys on develop pushes with path filtering; production still only triggers on main pushes; all 4 PRs retargeted; CLAUDE.md updated; commit message closes #203.

This is a CI/workflow and docs-only change - no Swift, TypeScript, or product code is touched, so no app behavior changes.

## What Changed

- `deploy-staging.yml` gains a `push` trigger on `develop` with the same paths filter production uses, replacing the manual-dispatch-only setup and dropping the stale comment that explained why staging had no automatic trigger. Its concurrency now sets `cancel-in-progress: false`, matching production, so back-to-back pushes queue instead of aborting a run partway through the Firebase deploy or the TestFlight upload.
- `ci.yml` now runs on pull requests to `develop` as well as `main`.
- `CLAUDE.md` rewrites the Branching Strategy section around a long-lived `develop` integration branch (reversing the prior "do not recreate `develop`" rule), retargets the Issue-First Workflow line to `develop`, and updates the Workflows descriptions to the new trigger, replacing the issue-tracking note with the reason the two deploy workflows must stay on disjoint branches.

Closes #203.

## Risk Assessment

✅ Low: The only new change is a single-line concurrency flip in deploy-staging.yml that resolves the round-1 warning exactly as the captain directed, brings staging into structural parity with production, and introduces no new failure mode since GitHub cancels stale pending runs so the newest commit still wins the final deploy.

## Testing

Exercised the change as a developer would experience it - "what does GitHub actually start when I push?" - by writing a trigger evaluator that parses the real workflow `on:` blocks and implements GitHub's branch/path glob semantics, then running base and head workflows through identical realistic events. It shows the bug and the fix side by side: a push of app code to develop started nothing before and starts Deploy Staging after, PRs into develop went ungated before and run CI after, while main-push still starts only Deploy Production and a docs-only develop push correctly starts nothing. All 8 acceptance criteria pass, including the disjoint-branch check proving no automatic event starts both deploy workflows. I also verified live GitHub state rather than trusting the diff: develop exists on origin containing main HEAD, all 4 PRs are retargeted with zero open PRs on main, and the AGENTS.md symlink is intact. Real run history independently corroborates both sides - staging has zero recent runs against constant production-on-main runs (exactly #203), and Deploy Staging previously ran green on develop pushes through full IPA/Firebase/TestFlight cycles until develop was deleted, so this restores a proven mechanism. That history also validates the follow-up commit c67d484: run 28809262400 had all three staging jobs cancelled mid-Firebase-deploy and mid-TestFlight-upload under cancel-in-progress: true, a risk that grows once the auto-trigger raises push frequency on develop. I found one benign nuance: develop is at 94fb7fc rather than the stated 8ed6bf8 because #223/#226 merged into it since creation, which is the intended "main plus in-progress work" model working, and 8ed6bf8 is still an ancestor. No screenshot or rendered-UI artifact applies - this is a CI/workflow and docs-only change with no product code and no user-facing UI surface, so the reviewer-visible evidence is the trigger decision matrix and live GitHub API state. I deliberately skipped the Swift and TypeScript suites: the diff touches only two workflow files and one doc, so those suites would exercise nothing related to this change. No defects found; worktree left clean.

<details>
<summary>Evidence: Workflow trigger decision matrix (before/after) with acceptance criteria - 8/8 pass</summary>

<code>glob engine self-check: 10/10 cases pass&#10;&#10;==&#10;BEFORE (base 8ed6bf8) - issue #203: staging never fires&#10;==&#10;Scenario event branch CI Deploy Staging Deploy Production&#10;--------------------------------------------------------------------------------------&#10;Dev pushes app code to develop push develop - - -&#10;Release: develop merges into main push main - - RUN&#10;Dev opens a PR into develop pull_request develop - - -&#10;Dev opens a PR into main pull_request main RUN - -&#10;Docs-only push to develop push develop - - -&#10;Feature branch push (no PR) push feature/i - - -&#10;&#10;==&#10;AFTER (this change) - develop is the staging trigger&#10;==&#10;Scenario event branch CI Deploy Staging Deploy Production&#10;--------------------------------------------------------------------------------------&#10;Dev pushes app code to develop push develop - RUN -&#10;Release: develop merges into main push main - - RUN&#10;Dev opens a PR into develop pull_request develop RUN - -&#10;Dev opens a PR into main pull_request main RUN - -&#10;Docs-only push to develop push develop - - -&#10;Feature branch push (no PR) push feature/i - - -&#10;&#10;==&#10;ACCEPTANCE CRITERIA&#10;==&#10;[PASS] Staging auto-deploys on push to develop before=False -&gt; after=True&#10;[PASS] No auto event deploys BOTH staging and prod collisions=none&#10;[PASS] Staging keeps manual workflow_dispatch present=True&#10;[PASS] Production fires on main push, not develop main=True, develop=False&#10;[PASS] CI runs on PRs to develop AND main develop: False -&gt; True, main=True&#10;[PASS] Staging path filter skips docs-only pushes docs-only push -&gt; staging=False&#10;[PASS] Staging paths filter matches production&#39;s 11 shared patterns identical + each workflow&#39;s own file&#10;[PASS] Deploy workflows on disjoint branches staging=[&#39;develop&#39;], production=[&#39;main&#39;], overlap=none&#10;&#10;==&#10;8/8 acceptance criteria pass&#10;==</code>

```text
glob engine self-check: 10/10 cases pass

======================================================================================
BEFORE (base 8ed6bf8) - issue #203: staging never fires
======================================================================================
Scenario                              event           branch    CI                Deploy Staging    Deploy Production 
--------------------------------------------------------------------------------------
Dev pushes app code to develop        push            develop     -                 -                 -               
Release: develop merges into main     push            main        -                 -                RUN              
Dev opens a PR into develop           pull_request    develop     -                 -                 -               
Dev opens a PR into main              pull_request    main       RUN                -                 -               
Docs-only push to develop             push            develop     -                 -                 -               
Feature branch push (no PR)           push            feature/i   -                 -                 -               

======================================================================================
AFTER (this change) - develop is the staging trigger
======================================================================================
Scenario                              event           branch    CI                Deploy Staging    Deploy Production 
--------------------------------------------------------------------------------------
Dev pushes app code to develop        push            develop     -                RUN                -               
Release: develop merges into main     push            main        -                 -                RUN              
Dev opens a PR into develop           pull_request    develop    RUN                -                 -               
Dev opens a PR into main              pull_request    main       RUN                -                 -               
Docs-only push to develop             push            develop     -                 -                 -               
Feature branch push (no PR)           push            feature/i   -                 -                 -               

======================================================================================
ACCEPTANCE CRITERIA
======================================================================================
  [PASS]  Staging auto-deploys on push to develop       before=False -> after=True
  [PASS]  No auto event deploys BOTH staging and prod   collisions=none
  [PASS]  Staging keeps manual workflow_dispatch        present=True
  [PASS]  Production fires on main push, not develop    main=True, develop=False
  [PASS]  CI runs on PRs to develop AND main            develop: False -> True, main=True
  [PASS]  Staging path filter skips docs-only pushes    docs-only push -> staging=False
  [PASS]  Staging paths filter matches production's     11 shared patterns identical + each workflow's own file
  [PASS]  Deploy workflows on disjoint branches         staging=['develop'], production=['main'], overlap=none

======================================================================================
8/8 acceptance criteria pass
======================================================================================
```
</details>
<details>
<summary>Evidence: Live GitHub state verification (develop lineage, PR retargeting, run history proving bug + fix precedent, symlink)</summary>

```text
# Live GitHub state verification — develop staging trigger (#203)

Captured 2026-07-17 against `tpavay/AscendApp`. All facts pulled from the live
remote / GitHub API, not from the diff.

## 1. `develop` exists on origin and contains main HEAD

`` `
$ git ls-remote origin refs/heads/develop refs/heads/main
94fb7fc5bd6b9a2af454b83cfd70c60c8ee7fd53	refs/heads/develop
8ed6bf85bdf1ddd212bde01e2feec8cf416112f1	refs/heads/main

$ git merge-base --is-ancestor 8ed6bf8 origin/develop
YES - develop contains main HEAD 8ed6bf8

$ git log --oneline origin/main..origin/develop
94fb7fc fix(routines): stop interval skips from banking a routine completion (#226)
3278fcf chore(onboarding): close the gaps in the onboarding analytics funnel (#223)
`` `

`develop` was branched from main HEAD `8ed6bf8` and has since advanced by two
merges. This matches the captain's model exactly: develop = everything main has
plus in-progress work. (The intent's "at main HEAD" describes creation time;
develop has legitimately moved ahead since.)

## 2. All four PRs retargeted to develop

`` `
$ gh-axi pr list --state all --base develop
  226  fix(routines): stop interval skips...                merged
  223  chore(onboarding): close the gaps...                 merged
  220  fix(leaderboards): collapse live replay opponents     open
  214  docs: decompose CLAUDE.md into a lean core...         open

$ gh-axi pr list --state open --base main
count: 0
`` `

All 4 retargeted. Zero open PRs still target main. #223 and #226 have already
merged **into develop** (confirmed by develop's history above), which is the
retarget working end-to-end.

## 3. The bug (#203) confirmed in live run history

`` `
$ gh-axi run list --limit 15
  ... Deploy Production, main, push, 1h ago
  ... Deploy Production, main, push, 3h ago
  ... CI, <feature branch>, pull_request  (x9)
`` `

No `Deploy Staging` run in recent history. Production fires on every main push;
staging fires never. That is exactly issue #203.

## 4. The fix has proven precedent — this trigger worked before

`Deploy Staging` previously ran on `push` to `develop` and succeeded, until
develop was deleted (#212 removed the then-dead trigger):

`` `
$ gh-axi run list --workflow "Deploy Staging" --limit 10
  28855331023  Merge PR #196  success    Deploy Staging  develop  push  10d ago
  28818868896  Merge PR #195  success    Deploy Staging  develop  push  10d ago
  28813833480  Merge PR #194  success    Deploy Staging  develop  push  10d ago
  28809262400  Merge PR #193  cancelled  Deploy Staging  develop  push  10d ago
`` `

This change restores a mechanism with a real green track record in this repo,
including full `Build iOS IPA -> Deploy Firebase -> Upload to TestFlight` runs.

## 5. The follow-up commit `c67d484` is validated by that same history

Run `28809262400` shows the `cancel-in-progress: true` bug it fixes, live:

`` `
$ gh-axi run view 28809262400
  conclusion: cancelled
  jobs:
    Build iOS IPA (Staging)      cancelled
    Deploy Firebase (Staging)    cancelled
    Upload to TestFlight (Staging)  cancelled
`` `

A follow-up push to develop killed an in-flight staging deploy mid-Firebase-deploy
and mid-TestFlight-upload. `c67d484` sets `cancel-in-progress: false`, matching
deploy-production.yml. This matters more after this change, not less: restoring
the auto-trigger raises push frequency on develop, so the cancellation window
reopens exactly as it did 10 days ago.

## 6. AGENTS.md symlink preserved (intent item (c))

`` `
$ ls -la AGENTS.md CLAUDE.md
AGENTS.md -> CLAUDE.md
-rw-r--r--  CLAUDE.md

$ grep -n "long-lived staging integration branch" AGENTS.md
666:- `develop` - long-lived staging integration branch. ...
`` `

AGENTS.md resolves to the updated text through the symlink, so it is correctly
absent from the diff. The symlink is intact.

## 7. Stale references removed

`` `
$ grep -rn "#203\|issue 203" .github/ CLAUDE.md          -> none
$ grep -rn "do not recreate it or target it" CLAUDE.md   -> none (superseded)
$ grep -rn "PRs should target" CLAUDE.md
CLAUDE.md:681:- PRs should target `develop` ...
`` `

Commit message closes the issue:
`` `
$ git log -1 bd43275 --format=%b | tail -1
Closes #203
`` `
```
</details>
<details>
<summary>Evidence: Trigger evaluator source (re-runnable: python3 trigger_matrix.py &lt;base_workflows_dir&gt; &lt;head_workflows_dir&gt;)</summary>

```text
#!/usr/bin/env python3
"""
GitHub Actions trigger evaluator for the Ascend deploy/CI workflows.

Parses the real `on:` blocks out of the workflow YAML and decides, for a given
event, which workflows GitHub would actually start. Implements the two filters
that matter here:

  * branch filter  -- `on.<event>.branches`, glob-matched against the branch name
  * paths filter   -- `on.<event>.paths`, glob-matched against the changed files;
                      the workflow runs if AT LEAST ONE changed file matches.

Used to demonstrate issue #203 (staging had no automatic trigger, and could not
share main with production without double-deploying) and its fix.
"""

import re
import sys
import yaml
from pathlib import Path

WORKFLOWS = ["ci", "deploy-staging", "deploy-production"]
NAMES = {
    "ci": "CI",
    "deploy-staging": "Deploy Staging",
    "deploy-production": "Deploy Production",
}


def glob_to_regex(pattern: str) -> re.Pattern:
    """GitHub filter-pattern semantics: ** spans /, * does not, ? is one non-/ char."""
    out, i = [], 0
    while i < len(pattern):
        c = pattern[i]
        if c == "*":
            if pattern[i : i + 2] == "**":
                out.append(".*")
                i += 2
                continue
            out.append("[^/]*")
        elif c == "?":
            out.append("[^/]")
        else:
            out.append(re.escape(c))
        i += 1
    return re.compile("^" + "".join(out) + "$")


def matches_any(value: str, patterns) -> bool:
    return any(glob_to_regex(p).match(value) for p in patterns)


def load_on_block(workflow_dir: Path, name: str) -> dict:
    raw = yaml.safe_load((workflow_dir / f"{name}.yml").read_text())
    # PyYAML resolves the bare YAML 1.1 key `on:` to the boolean True.
    return raw.get("on", raw.get(True, {})) or {}


def would_run(on_block: dict, event: str, branch: str, changed_files) -> bool:
    """Decide whether GitHub starts this workflow for the given event."""
    if event not in on_block:
        return False

    cfg = on_block[event]
    if cfg is None:  # e.g. `workflow_dispatch:` with no config -- no filters
        return True

    # `branches` filter: for pull_request this is the BASE branch.
    branches = cfg.get("branches")
    if branches is not None and not matches_any(branch, branches):
        return False

    # `paths` filter: run if at least one changed file matches any pattern.
    paths = cfg.get("paths")
    if paths is not None:
        if not any(matches_any(f, paths) for f in changed_files):
            return False

    return True


def evaluate(workflow_dir: Path, event: str, branch: str, changed_files):
    return {
        NAMES[w]: would_run(load_on_block(workflow_dir, w), event, branch, changed_files)
        for w in WORKFLOWS
    }


# --- Self-check of the glob engine against known GitHub semantics -------------
def self_check():
    cases = [
        ("AscendApp/Features/Home/HomeView.swift", "AscendApp/**", True),
        ("AscendApp/File.swift", "AscendApp/**", True),
        ("functions/src/index.ts", "AscendApp/**", False),
        ("Gemfile", "Gemfile", True),
        ("Gemfile.lock", "Gemfile", False),
        (".github/workflows/ci.yml", ".github/workflows/**", True),
        (".github/workflows/ci.yml", ".github/workflows/deploy-staging.yml", False),
        ("README.md", "AscendApp/**", False),
        ("develop", "develop", True),
        ("main", "develop", False),
    ]
    for value, pattern, expected in cases:
        got = bool(glob_to_regex(pattern).match(value))
        assert got == expected, f"glob self-check FAILED: {value} vs {pattern}: {got} != {expected}"
    print(f"glob engine self-check: {len(cases)}/{len(cases)} cases pass\n")


# --- Scenarios ---------------------------------------------------------------
IOS_CHANGE = ["AscendApp/Features/Home/HomeView.swift"]
DOCS_CHANGE = ["CLAUDE.md", "README.md"]

# Only automatic events are modelled as repo-wide: GitHub evaluates a push /
# pull_request against EVERY workflow at once, which is exactly why two deploy
# workflows sharing a branch would double-deploy (issue #203). workflow_dispatch
# is deliberately excluded -- it is aimed at one named workflow by a human, so it
# can never fan out to both deploy workflows on a single event.
SCENARIOS = [
    ("Dev pushes app code to develop",       "push",         "develop", IOS_CHANGE),
    ("Release: develop merges into main",    "push",         "main",    IOS_CHANGE),
    ("Dev opens a PR into develop",          "pull_request", "develop", IOS_CHANGE),
    ("Dev opens a PR into main",             "pull_request", "main",    IOS_CHANGE),
    ("Docs-only push to develop",            "push",         "develop", DOCS_CHANGE),
    ("Feature branch push (no PR)",          "push",         "feature/issue-203-x", IOS_CHANGE),
]


def fmt(v):
    return " RUN " if v else "  -  "


def render(title, workflow_dir):
    print(f"{'=' * 86}\n{title}\n{'=' * 86}")
    hdr = f"{'Scenario':<38}{'event':<16}{'branch':<10}"
    print(hdr + "".join(f"{NAMES[w]:<18}" for w in WORKFLOWS))
    print("-" * 86)
    rows = []
    for label, event, branch, files in SCENARIOS:
        r = evaluate(workflow_dir, event, branch, files)
        rows.append((label, event, branch, r))
        line = f"{label:<38}{event:<16}{branch[:9]:<10}"
        line += "".join(f"{fmt(r[NAMES[w]]):<18}" for w in WORKFLOWS)
        print(line)
    print()
    return rows


if __name__ == "__main__":
    self_check()
    base_dir = Path(sys.argv[1])
    head_dir = Path(sys.argv[2])

    base_rows = render("BEFORE (base 8ed6bf8) - issue #203: staging never fires", base_dir)
    head_rows = render("AFTER (this change) - develop is the staging trigger", head_dir)

    print("=" * 86)
    print("ACCEPTANCE CRITERIA")
    print("=" * 86)

    def row(rows, label):
        return next(r for l, _, _, r in rows if l == label)

    checks = []

    # 1. Staging auto-deploys on develop pushes (the #203 fix).
    before = row(base_rows, "Dev pushes app code to develop")["Deploy Staging"]
    after = row(head_rows, "Dev pushes app code to develop")["Deploy Staging"]
    checks.append(("Staging auto-deploys on push to develop", not before and after,
                   f"before={before} -> after={after}"))

    # 2. No double-deploy: no single automatic event starts BOTH deploy workflows.
    collisions = [l for l, _, _, r in head_rows if r["Deploy Staging"] and r["Deploy Production"]]
    checks.append(("No auto event deploys BOTH staging and prod", not collisions,
                   f"collisions={collisions or 'none'}"))

    # 2b. Manual dispatch still available on staging (aimed at one named workflow).
    dispatch = "workflow_dispatch" in load_on_block(head_dir, "deploy-staging")
    checks.append(("Staging keeps manual workflow_dispatch", dispatch, f"present={dispatch}"))

    # 3. Production still only triggers on main pushes.
    prod_main = row(head_rows, "Release: develop merges into main")["Deploy Production"]
    prod_dev = row(head_rows, "Dev pushes app code to develop")["Deploy Production"]
    checks.append(("Production fires on main push, not develop", prod_main and not prod_dev,
                   f"main={prod_main}, develop={prod_dev}"))

    # 4. CI gates PRs to both develop and main.
    ci_dev = row(head_rows, "Dev opens a PR into develop")["CI"]
    ci_main = row(head_rows, "Dev opens a PR into main")["CI"]
    ci_dev_before = row(base_rows, "Dev opens a PR into develop")["CI"]
    checks.append(("CI runs on PRs to develop AND main", ci_dev and ci_main,
                   f"develop: {ci_dev_before} -> {ci_dev}, main={ci_main}"))

    # 5. Path filtering active on the staging trigger.
    docs = row(head_rows, "Docs-only push to develop")["Deploy Staging"]
    checks.append(("Staging path filter skips docs-only pushes", not docs,
                   f"docs-only push -> staging={docs}"))

    # 6. Staging paths filter is at parity with production's.
    s = load_on_block(head_dir, "deploy-staging")["push"]["paths"]
    p = load_on_block(head_dir, "deploy-production")["push"]["paths"]
    s_norm = [x for x in s if not x.startswith(".github/")]
    p_norm = [x for x in p if not x.startswith(".github/")]
    checks.append(("Staging paths filter matches production's", s_norm == p_norm,
                   f"{len(s_norm)} shared patterns identical + each workflow's own file"))

    # 7. Deploy workflows on disjoint branches.
    s_br = set(load_on_block(head_dir, "deploy-staging")["push"]["branches"])
    p_br = set(load_on_block(head_dir, "deploy-production")["push"]["branches"])
    checks.append(("Deploy workflows on disjoint branches", not (s_br & p_br),
                   f"staging={sorted(s_br)}, production={sorted(p_br)}, overlap={sorted(s_br & p_br) or 'none'}"))

    for label, ok, detail in checks:
        print(f"  [{'PASS' if ok else 'FAIL'}]  {label:<45} {detail}")

    failed = [c for c in checks if not c[1]]
    print(f"\n{'=' * 86}\n{len(checks) - len(failed)}/{len(checks)} acceptance criteria pass"
          f"{'' if not failed else ' -- FAILURES PRESENT'}\n{'=' * 86}")
    sys.exit(1 if failed else 0)
```
</details>
- Evidence: Baseline (8ed6bf8) workflow files used as the before-state input (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXR2X63MYBQC7HJRM04WDCHW/base_workflows</code>)
<details>
<summary>Evidence: Cancelled staging run 28809262400 - the cancel-in-progress bug that c67d484 fixes, observed live</summary>

Source: [Cancelled staging run 28809262400 - the cancel-in-progress bug that c67d484 fixes, observed live](https://github.com/tpavay/AscendApp/actions/runs/28809262400)

```text
$ gh-axi run view 28809262400
run:
id: 28809262400
title: Merge pull request #193 from tpavay/fix/sentry-error-noise
status: completed
conclusion: cancelled
workflow: Deploy Staging
branch: develop
created: 10d ago
jobs[3]{id,name,status,conclusion}:
85433400688,Build iOS IPA (Staging),completed,cancelled
85435360313,Deploy Firebase (Staging),completed,cancelled
85435361095,Upload to TestFlight (Staging),completed,cancelled
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `.github/workflows/deploy-staging.yml:23` - The new push trigger on `develop` makes the pre-existing `cancel-in-progress: true` newly consequential. The concurrency group is keyed on `github.ref`, so every push to `develop` collapses into one group and a new push cancels the in-flight run. If the cancellation lands mid `firebase deploy --only functions,firestore:rules,firestore:indexes,storage,hosting` (a multi-step operation), staging can be left partially deployed - e.g. some functions on new code with `firestore.rules` not yet applied, which CLAUDE.md&#39;s Firestore Schema-Change Rule says will cause the server to reject writes. It is mostly self-healing because the superseding run redeploys the full superset from a newer commit, but a failing second run strands the partial state. `deploy-production.yml:23` deliberately sets `cancel-in-progress: false` for this exact reason; consider matching it, or scoping the group so the Firebase deploy job is not cancellable. Flagged rather than auto-fixed because trading runner minutes for deploy atomicity is a deliberate tradeoff.
- ℹ️ `.github/workflows/ci.yml:6` - The `pull_request` paths filter covers only `AscendApp/**`, `AscendAppTests/**`, `AscendApp.xcodeproj/**`, `functions/**`, and `.github/workflows/**`, while `deploy-staging.yml` now auto-deploys on `web/**`, `firebase.json`, `firestore.rules`, `storage.rules`, `.firebaserc`, `fastlane/**`, and `Gemfile*`. A PR to `develop` touching only `firestore.rules` therefore runs no CI at all and then deploys those rules straight to staging Firebase on merge, which sits awkwardly next to the CLAUDE.md:688 claim that &#34;CI is the only automated gate before `develop` and `main`&#34;. This is pre-existing (the identical gap applied to `main` before this change) and is arguably mitigated here, since routing work through `develop` adds a staging bake step ahead of production. Noted as context for a possible follow-up widening of the CI paths filter, not as a regression introduced by this diff.

🔧 Fix: ci: stop cancelling in-flight staging deploys
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`python3 trigger_matrix.py base_workflows .github/workflows` - GitHub Actions trigger evaluator parsing the real `on:` blocks; implements branch + paths glob semantics, self-checks the glob engine against 10 known cases, evaluates 6 realistic events against base (8ed6bf8) and head workflows, asserts 8 acceptance criteria (exit 0)</code>
- <code>`git ls-remote origin refs/heads/develop refs/heads/main` + `git merge-base --is-ancestor 8ed6bf8 origin/develop` - confirmed develop exists on origin and contains main HEAD</code>
- <code>`git log --oneline origin/main..origin/develop` - confirmed develop holds main plus in-progress work (#223, #226)</code>
- <code>`gh-axi pr list --state all --base develop` and `gh-axi pr list --state open --base main` - confirmed PRs 214/220/223/226 retargeted, zero open PRs still target main</code>
- <code>`gh-axi run list --workflow &#34;Deploy Staging&#34; --limit 10` - confirmed the restored trigger has green precedent (push-&gt;develop staging deploys succeeded until develop was deleted)</code>
- <code>`gh-axi run list --limit 15` - confirmed the #203 bug live: no Deploy Staging runs, Deploy Production fires on every main push</code>
- <code>`gh-axi run view 28809262400` - confirmed the cancel-in-progress bug that follow-up commit c67d484 fixes (all 3 staging jobs killed mid-Firebase-deploy/mid-TestFlight-upload)</code>
- <code>`ls -la AGENTS.md CLAUDE.md` + `grep -n &#34;long-lived staging integration branch&#34; AGENTS.md` - confirmed symlink intact and resolving to updated text (intent item (c))</code>
- <code>`grep -rn &#34;#203|do not recreate it or target it|PRs should target&#34; .github/ CLAUDE.md` - confirmed stale references removed and CLAUDE.md internally consistent on the new branching model</code>
- <code>`git log 8ed6bf8..HEAD --format=%b` - confirmed commit body closes #203, no Co-Authored-By trailer, no em dashes</code>
- `PyYAML structural parse of all 3 workflows - confirmed valid YAML and intact job graphs (staging parallel with TestFlight last; production strictly sequential), matching CLAUDE.md descriptions`
- <code>`git diff --name-only 8ed6bf8..HEAD -- .github/workflows/deploy-production.yml` - confirmed production workflow untouched (intent item 4)</code>
- <code>`git status --porcelain` - confirmed no transient artifacts left in the worktree</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `CLAUDE.md:697` - CLAUDE.md &#34;Deploy Authentication (OIDC)&#34; states GitHub Actions deploys &#34;must use OIDC + GCP Workload Identity Federation&#34;, says &#34;Do not use long-lived Firebase/GCP JSON key secrets for CI deploy auth&#34;, and lists GCP_WORKLOAD_IDENTITY_PROVIDER / GCP_SERVICE_ACCOUNT_EMAIL (+ _PRODUCTION variants) as required secrets. Both deploy workflows contradict this: deploy-staging.yml:180 and deploy-production.yml:196 authenticate with `--token &#34;$FIREBASE_TOKEN&#34;` from the long-lived `secrets.FIREBASE_TOKEN`, and neither workflow references any workload-identity secret or a google-github-actions/auth step. Commit a3c4021 (&#34;Use Firebase CI token for deploys&#34;) made this switch and the doc was never updated. This is pre-existing rather than caused by this change, but the change raises its stakes: staging now runs this auth path automatically on every push to develop instead of only on manual dispatch. Not resolved here because both fixes exceed this pass&#39;s mandate and require your decision: restoring OIDC is a functional workflow change (forbidden in a docs/lint pass), and rewriting the doc to bless FIREBASE_TOKEN would weaken a stated security rationale without authority. Please confirm whether the OIDC policy is still intended (workflows regressed and should be migrated back) or abandoned (the section should be rewritten to describe token auth, and the WIF secrets moved to a deprecated list).

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
