### PR TITLE
fix(restore): harden legacy Live Climb restore against pre-launch data loss

### DIFF
--- a/AscendApp/Features/Climbs/Models/LegacyClimbCompletionPredicate.swift
+++ b/AscendApp/Features/Climbs/Models/LegacyClimbCompletionPredicate.swift
@@ -1,0 +1,69 @@
+import CryptoKit
+import Foundation
+
+/// The single definition of "a legacy completion we trust enough to recover".
+///
+/// The same four conditions gate three places: this hydration guard input (Swift), the replay
+/// publication fallback (`functions/src/legacyClimbCompletion.ts`), and the eventual Phase 3
+/// migration. Copying the conditions into each site guarantees drift, so they live here once and
+/// are mirrored per language, pinned by the shared vector at
+/// `SharedTestVectors/legacy-recoverable-completion-vector.json`.
+///
+/// A legacy completion is recoverable iff it is a headphone-motion capture, names a landmark
+/// (non-empty `climbId`), and finished by the completion policy's own rule: `steps >= target` when
+/// a step target was recorded, otherwise `stopReason == target_reached`. This is deliberately the
+/// same "finish" definition `LiveClimbCompletionPolicy` uses, applied to the resolved metadata.
+enum LegacyClimbCompletionPredicate {
+    /// The pure contract, evaluated on already-resolved fields so Swift and TypeScript share one
+    /// test vector. `targetStepCount` is the resolved metadata target (`climbTargetStepCount ??
+    /// targetStepCount`), or `nil` when the backup predates recording a target.
+    static func isRecoverableLegacyCompletion(
+        source: String,
+        climbId: String?,
+        stopReason: String,
+        steps: Int,
+        targetStepCount: Int?
+    ) -> Bool {
+        guard source == HeadphoneMotionWorkoutMetadata.headphoneMotionSource else { return false }
+        guard let climbId, !climbId.isEmpty else { return false }
+
+        if let targetStepCount, targetStepCount > 0 {
+            return steps >= targetStepCount
+        }
+        return stopReason == HeadphoneMotionSessionStopReason.targetReached.rawValue
+    }
+
+    /// Convenience over a restored workout: reads the headphone-motion metadata and evaluates the
+    /// contract. Non-headphone or unreadable-metadata workouts are never recoverable completions.
+    static func isRecoverableLegacyCompletion(workout: Workout) -> Bool {
+        guard let metadata = LiveClimbWorkoutSummaryData.metadata(for: workout) else { return false }
+        return isRecoverableLegacyCompletion(
+            source: metadata.source,
+            climbId: metadata.climbId,
+            stopReason: metadata.stopReason.rawValue,
+            steps: workout.steps,
+            targetStepCount: LiveClimbCompletionPolicy.targetStepCount(for: metadata)
+        )
+    }
+
+    /// The deterministic attempt id used when no participation supplies one (CANONICAL §8). It is a
+    /// stable UUIDv5-style hash of `uid + legacyWorkoutId + landmarkId`, so rehydrating the same
+    /// backup on any device - or re-running the Phase 3 migration - lands on the same attempt and
+    /// never duplicates (serves invariant I2). The Phase 3 migration reuses this exact form.
+    static func deterministicAttemptId(
+        userId: String,
+        legacyWorkoutId: UUID,
+        climbId: String
+    ) -> UUID {
+        let seed = "\(userId)|\(legacyWorkoutId.uuidString)|\(climbId)"
+        var bytes = Array(SHA256.hash(data: Data(seed.utf8)).prefix(16))
+        bytes[6] = (bytes[6] & 0x0F) | 0x50 // version 5
+        bytes[8] = (bytes[8] & 0x3F) | 0x80 // RFC 4122 variant
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+}

--- a/AscendApp/Features/Home/ViewModels/HomeDashboardViewModel.swift
+++ b/AscendApp/Features/Home/ViewModels/HomeDashboardViewModel.swift
@@ -51,7 +51,7 @@ final class HomeDashboardViewModel {
     }
 
     func refreshLocalData(modelContext: ModelContext, referenceDate: Date = Date()) {
-        let completedClimbCount = fetchCompletedClimbCount(modelContext: modelContext)
+        let completedClimbCount = Self.fetchCompletedClimbCount(modelContext: modelContext)
         if self.completedClimbCount != completedClimbCount {
             self.completedClimbCount = completedClimbCount
         }
@@ -148,7 +148,10 @@ final class HomeDashboardViewModel {
         }
     }
 
-    private func fetchCompletedClimbCount(modelContext: ModelContext) -> Int {
+    /// The Home "climbs completed" surface: distinct landmarks with a completed attempt. Pure over
+    /// the store (no instance state), so a restore path can be asserted without a SwiftUI view tree
+    /// or a configured Firebase.
+    static func fetchCompletedClimbCount(modelContext: ModelContext) -> Int {
         let completedStatus = ClimbAttemptStatus.completed.rawValue
         let descriptor = FetchDescriptor<ClimbAttempt>(
             predicate: #Predicate<ClimbAttempt> { attempt in

--- a/AscendApp/Shared/Repositories/Firebase/WorkoutRemoteRepository.swift
+++ b/AscendApp/Shared/Repositories/Firebase/WorkoutRemoteRepository.swift
@@ -10,17 +10,48 @@ final class WorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol, @unchecked
 
     func fetchWorkouts(userId: String) async throws -> [RemoteWorkoutRecord] {
         let snapshot = try await workoutCollectionReference(userId: userId).getDocuments()
+        return decodeRecords(
+            from: snapshot.documents.map { (id: $0.documentID, data: $0.data()) }
+        )
+    }
 
-        return try snapshot.documents.compactMap { snapshot in
-            guard let workoutId = UUID(uuidString: snapshot.documentID) else {
+    /// Decodes each raw backup independently. One un-decodable document (a missing or mistyped
+    /// field) must cost only that record, never zero the whole restore, so a bad row is skipped
+    /// with a diagnostic and every document that decodes is returned. Kept separate from the
+    /// Firestore fetch so the resilience is testable without a live backend.
+    func decodeRecords(
+        from documents: [(id: String, data: [String: Any])],
+        diagnostics: AppDiagnosticsRecorder = .shared
+    ) -> [RemoteWorkoutRecord] {
+        documents.compactMap { document in
+            guard let workoutId = UUID(uuidString: document.id) else {
                 return nil
             }
 
-            return RemoteWorkoutRecord(
-                workoutId: workoutId,
-                document: try firestoreDocument(from: snapshot.data())
-            )
+            do {
+                return RemoteWorkoutRecord(
+                    workoutId: workoutId,
+                    document: try firestoreDocument(from: document.data)
+                )
+            } catch {
+                diagnostics.record(
+                    "workout_backup_decode_failed",
+                    level: .warning,
+                    details: [
+                        "workout_id": document.id,
+                        "reason": decodeFailureReason(error)
+                    ]
+                )
+                return nil
+            }
         }
+    }
+
+    private func decodeFailureReason(_ error: Error) -> String {
+        if case let WorkoutRemoteRepositoryDecodingError.missingField(field) = error {
+            return "missing_field:\(field)"
+        }
+        return String(describing: type(of: error))
     }
 
     func upsertWorkout(

--- a/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionSessionResult.swift
+++ b/AscendApp/Shared/Services/HeadphoneMotion/HeadphoneMotionSessionResult.swift
@@ -124,6 +124,10 @@ struct HeadphoneMotionSessionResult: Equatable, Sendable {
 }
 
 struct HeadphoneMotionWorkoutMetadata: Codable, Equatable, Sendable {
+    /// The `source` marker every headphone-motion workout carries. Shared with the legacy-completion
+    /// predicate so both read the same constant instead of a scattered literal.
+    static let headphoneMotionSource = "headphone_motion"
+
     let source: String
     let algorithmVersion: Int
     let sampleRateAssumptionHz: Int
@@ -158,7 +162,7 @@ struct HeadphoneMotionWorkoutMetadata: Codable, Equatable, Sendable {
         trackingIntegrity: HeadphoneMotionTrackingIntegrity = .verified,
         stepCorrections: [HeadphoneMotionStepCorrection] = []
     ) {
-        self.source = "headphone_motion"
+        self.source = HeadphoneMotionWorkoutMetadata.headphoneMotionSource
         self.algorithmVersion = HeadphoneMotionStepDetector.algorithmVersion
         self.sampleRateAssumptionHz = 50
         self.sampleCount = sampleCount

--- a/AscendApp/Shared/Services/WorkoutHydrationService.swift
+++ b/AscendApp/Shared/Services/WorkoutHydrationService.swift
@@ -63,6 +63,15 @@ enum WorkoutHydrationService {
         return changedCount
     }
 
+    /// Clears the per-process "already hydrated this session" tracking. Hydration runs once per
+    /// launch; a reinstall re-runs it from a cold process. Tests use this to simulate that fresh
+    /// launch (and to prove reconstruction is idempotent when it actually runs twice). Not called
+    /// by the app.
+    static func resetSessionTrackingForTesting() {
+        hydratedUserIdsThisSession.removeAll()
+        hydratingUserIds.removeAll()
+    }
+
     private static func shouldApplyRemoteDocument(_ document: FirestoreWorkoutDocument, to workout: Workout) -> Bool {
         switch workout.remoteSyncStatus {
         case .pendingUpsert, .failed:
@@ -155,6 +164,7 @@ enum WorkoutHydrationService {
         )
         try restoreLiveClimbAttemptIfNeeded(
             for: workout,
+            userId: userId,
             modelContext: modelContext
         )
     }
@@ -207,13 +217,52 @@ enum WorkoutHydrationService {
 
     private static func restoreLiveClimbAttemptIfNeeded(
         for workout: Workout,
+        userId: String,
         modelContext: ModelContext
     ) throws {
+        // Only headphone-motion captures that name a landmark are candidates. justClimb and routine
+        // captures have no climbId and are legitimately not climb completions, so they never reach
+        // the recovery gate below (and never warn).
         guard workout.source == .headphoneMotion,
               let metadata = LiveClimbWorkoutSummaryData.metadata(for: workout),
-              metadata.trackingMode == .liveClimb,
               let climbId = metadata.climbId,
-              let attemptId = liveClimbAttemptId(for: workout) else {
+              !climbId.isEmpty else {
+            return
+        }
+
+        // Reconstruct only the local ClimbAttempt - never a WorkoutParticipation. A synthesized
+        // participation would flow through WorkoutSyncCoordinator and let the replay Cloud Function
+        // publish a row or claim a First Ascent from backfilled data. We restore local visibility,
+        // not a replay that never happened.
+        let attemptId: UUID
+        if let participationAttemptId = liveClimbAttemptId(for: workout) {
+            // Modern backup: a participation supplies the id. Restore the attempt as recorded - a
+            // completed and a failed attempt are both immutable competitive history.
+            attemptId = participationAttemptId
+        } else if LegacyClimbCompletionPredicate.isRecoverableLegacyCompletion(workout: workout) {
+            // Legacy backup with no participation (no trackingMode, no target key). Recover only
+            // confident completions, keyed by the deterministic id (CANONICAL §8) so a fresh device
+            // and the Phase 3 migration converge on the same attempt without duplicating. This is
+            // what the old inline `trackingMode == .liveClimb && participation present` guard failed,
+            // dropping earned completions on reinstall.
+            attemptId = LegacyClimbCompletionPredicate.deterministicAttemptId(
+                userId: userId,
+                legacyWorkoutId: workout.id,
+                climbId: climbId
+            )
+        } else {
+            // A landmark capture with neither a participation nor confident completion evidence is
+            // ambiguous, not obviously discardable. Log it (never silently skip) so a future
+            // data-loss regression is observable.
+            AppDiagnosticsRecorder.shared.record(
+                "live_climb_restore_unrecoverable",
+                level: .warning,
+                details: [
+                    "climb_id": climbId,
+                    "stop_reason": metadata.stopReason.rawValue,
+                    "steps": String(workout.steps)
+                ]
+            )
             return
         }
 

--- a/AscendAppTests/LegacyRestoreHardeningTests.swift
+++ b/AscendAppTests/LegacyRestoreHardeningTests.swift
@@ -1,0 +1,331 @@
+//
+//  LegacyRestoreHardeningTests.swift
+//  AscendAppTests
+//
+
+import Foundation
+import SwiftData
+import Testing
+@testable import AscendApp
+
+/// The pre-launch data-loss repair: a reinstalling tester's earned landmark completions must
+/// restore correctly, and one bad backup document must never zero the whole restore.
+///
+/// These exercise the legacy backup shape directly - `source=headphone_motion`, metadata with no
+/// trackingMode and no target key, `stopReason=target_reached`, no participation - which the older
+/// `WorkoutHydrationServiceLiveClimbRestoreTests` never produce because they build through the
+/// current mapper and keep modern fields.
+@MainActor
+struct LegacyRestoreHardeningTests {
+    private static let stagingClimbIds = [
+        "marina-bay-sands",
+        "empire-state-building",
+        "burj-khalifa",
+        "sagrada-familia",
+        "cn-tower"
+    ]
+
+    // MARK: Five restore as five (the bar)
+
+    @Test
+    func fiveLegacyLandmarkCompletionsRestoreAsFive() async throws {
+        let userId = "legacy-five-restore-user"
+        let records = Self.stagingLegacyRecords(userId: userId)
+
+        let context = try Self.makeModelContext()
+        WorkoutHydrationService.resetSessionTrackingForTesting()
+        let changedCount = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: context,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(records: records)
+        )
+
+        #expect(changedCount == 5)
+
+        let completedAttempts = try Self.completedAttempts(in: context)
+        #expect(completedAttempts.count == 5)
+        #expect(Set(completedAttempts.map(\.climbId)) == Set(Self.stagingClimbIds))
+
+        // The Home surface the user actually reads.
+        #expect(HomeDashboardViewModel.fetchCompletedClimbCount(modelContext: context) == 5)
+    }
+
+    // MARK: Idempotency - actually run it twice
+
+    @Test
+    func rehydratingOnAFreshDeviceKeepsFiveWithStableIds() async throws {
+        let userId = "legacy-fresh-device-user"
+        let records = Self.stagingLegacyRecords(userId: userId)
+
+        let firstDevice = try Self.makeModelContext()
+        WorkoutHydrationService.resetSessionTrackingForTesting()
+        _ = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: firstDevice,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(records: records)
+        )
+        let firstIds = try Self.completedAttempts(in: firstDevice).map(\.id).sorted { $0.uuidString < $1.uuidString }
+
+        // A reinstall is a cold process hydrating a fresh store from the same remote docs.
+        let freshDevice = try Self.makeModelContext()
+        WorkoutHydrationService.resetSessionTrackingForTesting()
+        _ = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: freshDevice,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(records: records)
+        )
+        let secondIds = try Self.completedAttempts(in: freshDevice).map(\.id).sorted { $0.uuidString < $1.uuidString }
+
+        #expect(firstIds.count == 5)
+        // The deterministic id survives a fresh device.
+        #expect(secondIds == firstIds)
+    }
+
+    @Test
+    func rerunningHydrationOnTheSameStoreAddsNoDuplicates() async throws {
+        let userId = "legacy-rerun-user"
+        let workoutIds = (0..<5).map { _ in UUID() }
+        let baseDate = Date(timeIntervalSince1970: 1_775_217_600)
+        let context = try Self.makeModelContext()
+
+        let firstPass = Self.stagingLegacyRecords(
+            userId: userId,
+            workoutIds: workoutIds,
+            updatedAt: baseDate
+        )
+        WorkoutHydrationService.resetSessionTrackingForTesting()
+        _ = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: context,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(records: firstPass)
+        )
+
+        // Re-run on the same non-wiped store with the same workout ids but a newer updatedAt (a
+        // synced edit), so reconstruction actually executes again instead of short-circuiting on
+        // the sync-status guard. The deterministic attempt id must update the same attempt in place.
+        let secondPass = Self.stagingLegacyRecords(
+            userId: userId,
+            workoutIds: workoutIds,
+            updatedAt: baseDate.addingTimeInterval(3_600)
+        )
+        WorkoutHydrationService.resetSessionTrackingForTesting()
+        let secondChanged = try await WorkoutHydrationService.hydrateIfNeeded(
+            modelContext: context,
+            currentUserId: userId,
+            remoteRepository: StubWorkoutRemoteRepository(records: secondPass)
+        )
+
+        // Reconstruction genuinely ran the second time...
+        #expect(secondChanged == 5)
+        // ...and produced zero duplicate attempts.
+        let allAttempts = try context.fetch(FetchDescriptor<ClimbAttempt>())
+        #expect(allAttempts.count == 5)
+        #expect(HomeDashboardViewModel.fetchCompletedClimbCount(modelContext: context) == 5)
+    }
+
+    // MARK: R0 - one bad doc must not zero the restore
+
+    @Test
+    func oneUndecodableBackupDoesNotZeroTheRestore() {
+        let recorder = AppDiagnosticsRecorder(
+            userDefaults: UserDefaults(suiteName: "legacy-restore-r0-\(UUID().uuidString)")!
+        )
+        let goodOne = UUID().uuidString
+        let goodTwo = UUID().uuidString
+        let bad = UUID().uuidString
+
+        let records = WorkoutRemoteRepository.shared.decodeRecords(
+            from: [
+                (goodOne, Self.validWorkoutData(steps: 1_200)),
+                (bad, Self.undecodableWorkoutData()),
+                (goodTwo, Self.validWorkoutData(steps: 900))
+            ],
+            diagnostics: recorder
+        )
+
+        #expect(records.count == 2)
+        #expect(Set(records.map { $0.workoutId.uuidString }) == Set([goodOne, goodTwo]))
+
+        let decodeFailure = recorder.recentEvents().first { $0.name == "workout_backup_decode_failed" }
+        #expect(decodeFailure != nil)
+        #expect(decodeFailure?.details["workout_id"] == bad)
+    }
+
+    // MARK: Predicate parity - Swift matches the shared vector
+
+    @Test
+    func predicateMatchesSharedParityVector() throws {
+        let vector = try Self.sharedParityVector()
+        #expect(vector.cases.count >= 10)
+
+        for testCase in vector.cases {
+            let actual = LegacyClimbCompletionPredicate.isRecoverableLegacyCompletion(
+                source: testCase.source,
+                climbId: testCase.climbId,
+                stopReason: testCase.stopReason,
+                steps: testCase.steps,
+                targetStepCount: testCase.targetStepCount
+            )
+            #expect(actual == testCase.expected, "case \(testCase.name)")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static func stagingLegacyRecords(userId: String) -> [RemoteWorkoutRecord] {
+        stagingLegacyRecords(
+            userId: userId,
+            workoutIds: (0..<stagingClimbIds.count).map { _ in UUID() },
+            updatedAt: Date(timeIntervalSince1970: 1_775_217_600)
+        )
+    }
+
+    private static func stagingLegacyRecords(
+        userId: String,
+        workoutIds: [UUID],
+        updatedAt: Date
+    ) -> [RemoteWorkoutRecord] {
+        let baseDate = Date(timeIntervalSince1970: 1_775_217_600)
+        return zip(stagingClimbIds, workoutIds).enumerated().map { index, pair in
+            let (climbId, workoutId) = pair
+            return RemoteWorkoutRecord(
+                workoutId: workoutId,
+                document: legacyDocument(
+                    userId: userId,
+                    climbId: climbId,
+                    steps: 1_000 + index * 100,
+                    startedAt: baseDate.addingTimeInterval(Double(index) * 3_600),
+                    updatedAt: updatedAt
+                )
+            )
+        }
+    }
+
+    /// The captain's exact staging shape: headphone-motion, a distinct landmark climbId, metadata
+    /// with no trackingMode and no target key, `stopReason=target_reached`, no participation, and
+    /// `steps == target` (target unrecorded, so completion falls to the stop reason).
+    private static func legacyDocument(
+        userId: String,
+        climbId: String,
+        steps: Int,
+        startedAt: Date,
+        updatedAt: Date
+    ) -> FirestoreWorkoutDocument {
+        FirestoreWorkoutDocument(
+            userId: userId,
+            name: "\(climbId) Live Climb",
+            startedAt: startedAt,
+            durationSeconds: 900,
+            steps: steps,
+            floors: Workout.stepsToFloors(steps),
+            stepsPerFloor: Workout.defaultStepsPerFloor,
+            notes: "",
+            source: WorkoutSource.headphoneMotion.rawValue,
+            integrityLevel: DataIntegrityLevel.verified.rawValue,
+            createdAt: startedAt,
+            updatedAt: updatedAt,
+            sourceMetadata: legacyMetadataJSON(climbId: climbId),
+            participations: nil
+        )
+    }
+
+    /// A legacy metadata blob carrying only the base headphone-motion fields plus a climbId. It
+    /// deliberately omits `trackingMode` and every target key so it decodes the way a
+    /// pre-participation backup does.
+    private static func legacyMetadataJSON(climbId: String) -> String {
+        """
+        {"algorithmVersion":1,"climbId":"\(climbId)","sampleCount":500,\
+        "sampleRateAssumptionHz":50,"source":"headphone_motion",\
+        "stopReason":"target_reached"}
+        """
+    }
+
+    private static func validWorkoutData(steps: Int) -> [String: Any] {
+        [
+            "userId": "decode-user",
+            "name": "Workout",
+            "startedAt": Date(),
+            "durationSeconds": 900.0,
+            "steps": steps,
+            "floors": 10,
+            "stepsPerFloor": 16,
+            "notes": "",
+            "source": "manual",
+            "integrityLevel": "verified",
+            "createdAt": Date(),
+            "updatedAt": Date()
+        ]
+    }
+
+    /// Omits the required `steps` field, so decoding throws and the row must be skipped.
+    private static func undecodableWorkoutData() -> [String: Any] {
+        var data = validWorkoutData(steps: 0)
+        data.removeValue(forKey: "steps")
+        return data
+    }
+
+    private static func completedAttempts(in context: ModelContext) throws -> [ClimbAttempt] {
+        let completed = ClimbAttemptStatus.completed.rawValue
+        return try context.fetch(
+            FetchDescriptor<ClimbAttempt>(
+                predicate: #Predicate<ClimbAttempt> { $0.statusRawValue == completed }
+            )
+        )
+    }
+
+    private static func makeModelContext() throws -> ModelContext {
+        let container = try ModelContainer(
+            for: ClimbAttempt.self,
+            Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        return ModelContext(container)
+    }
+
+    // MARK: - Shared parity vector
+
+    struct ParityVector: Decodable {
+        let cases: [ParityCase]
+    }
+
+    struct ParityCase: Decodable {
+        let name: String
+        let source: String
+        let climbId: String?
+        let stopReason: String
+        let steps: Int
+        let targetStepCount: Int?
+        let expected: Bool
+    }
+
+    private static func sharedParityVector() throws -> ParityVector {
+        // Navigate from this test file to the repo-root shared vector so Swift and the TypeScript
+        // functions test assert against the exact same cases.
+        let repoRoot = URL(filePath: #filePath)
+            .deletingLastPathComponent() // AscendAppTests/
+            .deletingLastPathComponent() // repo root
+        let vectorURL = repoRoot.appending(
+            path: "SharedTestVectors/legacy-recoverable-completion-vector.json"
+        )
+        let data = try Data(contentsOf: vectorURL)
+        return try JSONDecoder().decode(ParityVector.self, from: data)
+    }
+}
+
+private struct StubWorkoutRemoteRepository: WorkoutRemoteRepositoryProtocol {
+    let records: [RemoteWorkoutRecord]
+
+    func fetchWorkouts(userId: String) async throws -> [RemoteWorkoutRecord] {
+        records
+    }
+
+    func upsertWorkout(
+        userId: String,
+        workoutId: UUID,
+        document: FirestoreWorkoutDocument
+    ) async throws {}
+
+    func deleteWorkout(userId: String, workoutId: UUID) async throws {}
+}

--- a/SharedTestVectors/legacy-recoverable-completion-vector.json
+++ b/SharedTestVectors/legacy-recoverable-completion-vector.json
@@ -1,0 +1,104 @@
+{
+  "description": "Canonical test vector for isRecoverableLegacyCompletion. The same cases pin the Swift implementation (AscendApp/Features/Climbs/Models/LegacyClimbCompletionPredicate.swift) and the TypeScript implementation (functions/src/legacyClimbCompletion.ts) so the two languages cannot drift. Inputs are the already-resolved predicate fields: source, climbId, stopReason, steps, and targetStepCount (climbTargetStepCount ?? targetStepCount). Five staging positives model the captain's exact reinstall shape (headphone_motion, non-empty climbId, target_reached, no recorded step target); the negatives are the known ambiguous shapes the predicate must reject.",
+  "cases": [
+    {
+      "name": "staging-marina-bay-sands",
+      "source": "headphone_motion",
+      "climbId": "marina-bay-sands",
+      "stopReason": "target_reached",
+      "steps": 1970,
+      "targetStepCount": null,
+      "expected": true
+    },
+    {
+      "name": "staging-empire-state-building",
+      "source": "headphone_motion",
+      "climbId": "empire-state-building",
+      "stopReason": "target_reached",
+      "steps": 1576,
+      "targetStepCount": null,
+      "expected": true
+    },
+    {
+      "name": "staging-burj-khalifa",
+      "source": "headphone_motion",
+      "climbId": "burj-khalifa",
+      "stopReason": "target_reached",
+      "steps": 2909,
+      "targetStepCount": null,
+      "expected": true
+    },
+    {
+      "name": "staging-sagrada-familia",
+      "source": "headphone_motion",
+      "climbId": "sagrada-familia",
+      "stopReason": "target_reached",
+      "steps": 1417,
+      "targetStepCount": null,
+      "expected": true
+    },
+    {
+      "name": "staging-cn-tower",
+      "source": "headphone_motion",
+      "climbId": "cn-tower",
+      "stopReason": "target_reached",
+      "steps": 2579,
+      "targetStepCount": null,
+      "expected": true
+    },
+    {
+      "name": "target-present-and-reached",
+      "source": "headphone_motion",
+      "climbId": "burj-khalifa",
+      "stopReason": "user_stopped",
+      "steps": 2909,
+      "targetStepCount": 2909,
+      "expected": true
+    },
+    {
+      "name": "negative-just-climb-has-no-climb-id",
+      "source": "headphone_motion",
+      "climbId": null,
+      "stopReason": "target_reached",
+      "steps": 3000,
+      "targetStepCount": null,
+      "expected": false
+    },
+    {
+      "name": "negative-routine-has-no-climb-id",
+      "source": "headphone_motion",
+      "climbId": "",
+      "stopReason": "target_reached",
+      "steps": 4000,
+      "targetStepCount": null,
+      "expected": false
+    },
+    {
+      "name": "negative-interrupted-draft-not-target-reached",
+      "source": "headphone_motion",
+      "climbId": "burj-khalifa",
+      "stopReason": "interrupted",
+      "steps": 5000,
+      "targetStepCount": null,
+      "expected": false
+    },
+    {
+      "name": "negative-steps-short-of-target",
+      "source": "headphone_motion",
+      "climbId": "cn-tower",
+      "stopReason": "target_reached",
+      "steps": 900,
+      "targetStepCount": 1000,
+      "expected": false
+    },
+    {
+      "name": "negative-non-headphone-source",
+      "source": "manual",
+      "climbId": "burj-khalifa",
+      "stopReason": "target_reached",
+      "steps": 2909,
+      "targetStepCount": null,
+      "expected": false
+    }
+  ]
+}

--- a/functions/src/legacyClimbCompletion.ts
+++ b/functions/src/legacyClimbCompletion.ts
@@ -1,0 +1,52 @@
+/**
+ * The single definition of "a legacy completion we trust enough to publish".
+ *
+ * This mirrors the Swift predicate in
+ * AscendApp/Features/Climbs/Models/LegacyClimbCompletionPredicate.swift. The
+ * same four conditions gate the client hydration guard, this replay
+ * publication fallback, and the eventual Phase 3 migration, so they must never
+ * drift. Both implementations are pinned by the shared vector at
+ * SharedTestVectors/legacy-recoverable-completion-vector.json.
+ *
+ * A legacy completion is recoverable iff it is a headphone-motion capture,
+ * names a landmark (non-empty climbId), and finished by the completion policy's
+ * own rule: steps >= target when a step target was recorded, otherwise
+ * stopReason === target_reached.
+ *
+ * This predicate decides publishability only. It never grants First Ascent. A
+ * First Ascent is permanent and unreclaimable, so hand-derived or backfilled
+ * data must never claim one - the caller withholds First Ascent for every row
+ * that qualifies through this fallback.
+ */
+
+export const HEADPHONE_MOTION_SOURCE = "headphone_motion";
+export const TARGET_REACHED_STOP_REASON = "target_reached";
+
+export interface LegacyCompletionFields {
+  source: string;
+  climbId: string | null;
+  stopReason: string;
+  steps: number;
+  /** Resolved target (climbTargetStepCount ?? targetStepCount), or null. */
+  targetStepCount: number | null;
+}
+
+/**
+ * Evaluates the shared legacy-completion contract on already-resolved fields.
+ * @param {LegacyCompletionFields} fields Resolved predicate fields.
+ * @return {boolean} True when the completion is a trusted legacy recovery.
+ */
+export function isRecoverableLegacyCompletion(
+  fields: LegacyCompletionFields
+): boolean {
+  if (fields.source !== HEADPHONE_MOTION_SOURCE) {
+    return false;
+  }
+  if (!fields.climbId) {
+    return false;
+  }
+  if (fields.targetStepCount !== null && fields.targetStepCount > 0) {
+    return fields.steps >= fields.targetStepCount;
+  }
+  return fields.stopReason === TARGET_REACHED_STOP_REASON;
+}

--- a/functions/src/liveReplayLeaderboard.ts
+++ b/functions/src/liveReplayLeaderboard.ts
@@ -4,6 +4,10 @@ import {
   MAX_REPLAY_SPLIT_CHECKPOINTS,
   normalizeReplaySplitSteps,
 } from "./liveReplaySplitNormalization.js";
+import {
+  HEADPHONE_MOTION_SOURCE,
+  isRecoverableLegacyCompletion,
+} from "./legacyClimbCompletion.js";
 
 const LIVE_REPLAY_COLLECTION = "live_replay_leaderboards";
 const COMPLETION_SNAPSHOTS_COLLECTION = "completionSnapshots";
@@ -30,6 +34,13 @@ interface LiveReplayIndexPayload {
   finalDurationSeconds: number;
   finalSteps: number;
   targetStepCount: number | null;
+  /**
+   * Whether this row may claim an unheld First Ascent. Modern completions that
+   * clear the strict gate are eligible; rows recovered through the legacy-shape
+   * fallback never are, because a First Ascent is permanent and
+   * hand-derived/backfilled data must never claim one.
+   */
+  firstAscentEligible: boolean;
 }
 
 interface PublicUserSnapshot {
@@ -243,23 +254,58 @@ function parseLiveClimbReplayPayload(
     return null;
   }
 
-  if (
-    options.requireEligibleParticipation &&
-    !hasCompletedLiveClimbAttempt(parsed)
-  ) {
+  const climbId = stringValue(parsed.metadata.climbId);
+  if (!climbId) {
     return null;
   }
 
-  const climbId = stringValue(parsed.metadata.climbId);
-  if (!climbId) {
+  // Two publication paths: the strict modern gate (participation + trackingMode
+  // + target_reached), which is First Ascent eligible, and a narrow legacy
+  // fallback gated on the shared isRecoverableLegacyCompletion contract, which
+  // publishes rows/finishers but is NOT First Ascent eligible. Legacy backups
+  // lack the participation/trackingMode the modern gate needs, so without this
+  // fallback their earned completions have zero public presence.
+  const modernCompleted = hasCompletedLiveClimbAttempt(parsed);
+  const legacyCompleted = !modernCompleted &&
+    !parsed.hasClimbAttemptParticipation &&
+    isLegacyRecoverableLiveClimb(parsed, climbId);
+
+  if (
+    options.requireEligibleParticipation &&
+    !modernCompleted &&
+    !legacyCompleted
+  ) {
     return null;
   }
 
   return replayPayload(
     parsed,
     LIVE_CLIMB_CONTEXT_TYPE,
-    climbId
+    climbId,
+    {firstAscentEligible: modernCompleted}
   );
+}
+
+/**
+ * Returns whether a headphone-motion backup is a trusted legacy landmark
+ * completion, using the shared contract mirrored from the Swift guard. This
+ * never implies First Ascent eligibility - the caller withholds First Ascent
+ * for every legacy-recovered row.
+ * @param {ParsedReplayPayloadParts} parsed Parsed replay payload parts.
+ * @param {string} climbId Non-empty landmark id from the metadata.
+ * @return {boolean} True when the backup may publish a replay row.
+ */
+function isLegacyRecoverableLiveClimb(
+  parsed: ParsedReplayPayloadParts,
+  climbId: string
+): boolean {
+  return isRecoverableLegacyCompletion({
+    source: HEADPHONE_MOTION_SOURCE,
+    climbId,
+    stopReason: stringValue(parsed.metadata.stopReason) ?? "",
+    steps: parsed.finalSteps,
+    targetStepCount: parsed.targetStepCount,
+  });
 }
 
 /**
@@ -305,6 +351,7 @@ function parseJustClimbReplayPayload(
 interface ParsedReplayPayloadParts {
   metadata: Record<string, unknown>;
   hasEligibleClimbAttempt: boolean;
+  hasClimbAttemptParticipation: boolean;
   splitIntervalSeconds: number;
   splitSteps: number[];
   finalDurationSeconds: number;
@@ -360,6 +407,9 @@ function parseReplayPayloadParts(
   return {
     metadata,
     hasEligibleClimbAttempt: hasEligibleClimbAttemptParticipation(
+      data.participations
+    ),
+    hasClimbAttemptParticipation: hasClimbAttemptParticipation(
       data.participations
     ),
     splitIntervalSeconds,
@@ -436,7 +486,7 @@ function replayPayload(
   parsed: ParsedReplayPayloadParts,
   contextType: string,
   contextId: string,
-  options: {targetStepCount?: number | null} = {}
+  options: {targetStepCount?: number | null; firstAscentEligible?: boolean} = {}
 ): LiveReplayIndexPayload {
   const splitSteps = normalizeReplaySplitSteps({
     splitIntervalSeconds: parsed.splitIntervalSeconds,
@@ -456,6 +506,7 @@ function replayPayload(
     targetStepCount: options.targetStepCount !== undefined ?
       options.targetStepCount :
       parsed.targetStepCount,
+    firstAscentEligible: options.firstAscentEligible !== false,
   };
 }
 
@@ -477,6 +528,28 @@ function hasEligibleClimbAttemptParticipation(value: unknown): boolean {
     const participation = item as Record<string, unknown>;
     return participation.contextType === "climb_attempt" &&
       participation.leaderboardEligible === true;
+  });
+}
+
+/**
+ * Returns whether a workout carries any climb-attempt participation, eligible
+ * or not. The legacy-shape fallback only fires when none exists: a workout with
+ * a climb-attempt participation is governed by the modern gate, so an
+ * explicitly ineligible one stays deliberately unpublished, not resurrected.
+ * @param {unknown} value Raw participations value.
+ * @return {boolean} True when a climb-attempt participation is present.
+ */
+function hasClimbAttemptParticipation(value: unknown): boolean {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+
+  return value.some((item) => {
+    if (!item || typeof item !== "object") {
+      return false;
+    }
+
+    return (item as Record<string, unknown>).contextType === "climb_attempt";
   });
 }
 
@@ -867,7 +940,9 @@ async function publishReplayEntries(
       leaderboardData?.completedCount
     ) ?? 0;
     const hasFirstAscent = leaderboardHasFirstAscent(leaderboardData);
-    const canClaimFirstAscent = !hasFirstAscent && previousCompletedCount === 0;
+    const canClaimFirstAscent = payload.firstAscentEligible &&
+      !hasFirstAscent &&
+      previousCompletedCount === 0;
     const isBestForUser = seedBestForUser(
       payload,
       entryId,

--- a/functions/test/legacyClimbCompletion.test.ts
+++ b/functions/test/legacyClimbCompletion.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {readFileSync} from "node:fs";
+import {join} from "node:path";
+import {isRecoverableLegacyCompletion} from "../src/legacyClimbCompletion.js";
+import {liveReplayLeaderboardTestHooks} from "../src/liveReplayLeaderboard.js";
+
+interface VectorCase {
+  name: string;
+  source: string;
+  climbId: string | null;
+  stopReason: string;
+  steps: number;
+  targetStepCount: number | null;
+  expected: boolean;
+}
+
+// Compiled output is CommonJS (see tsconfig NodeNext + no package "type"), so
+// __dirname is the compiled lib/test directory; walk up to the repo root.
+const vectorPath = join(
+  __dirname,
+  "../../../SharedTestVectors/legacy-recoverable-completion-vector.json"
+);
+const vector = JSON.parse(readFileSync(vectorPath, "utf8")) as {
+  cases: VectorCase[];
+};
+
+test("TS predicate matches the shared parity vector", () => {
+  assert.ok(vector.cases.length >= 10, "vector should carry every shape");
+
+  for (const testCase of vector.cases) {
+    const actual = isRecoverableLegacyCompletion({
+      source: testCase.source,
+      climbId: testCase.climbId,
+      stopReason: testCase.stopReason,
+      steps: testCase.steps,
+      targetStepCount: testCase.targetStepCount,
+    });
+    assert.equal(
+      actual,
+      testCase.expected,
+      `case ${testCase.name} expected ${testCase.expected}`
+    );
+  }
+});
+
+test("publishes a legacy landmark completion without First Ascent", () => {
+  const payload = liveReplayLeaderboardTestHooks.parseLiveClimbReplayPayload(
+    makeLegacyWorkoutDocument(),
+    {requireEligibleParticipation: true}
+  );
+
+  assert.equal(payload?.contextId, "burj-khalifa");
+  assert.equal(payload?.firstAscentEligible, false);
+});
+
+test("does not publish a legacy backup that missed its target", () => {
+  const payload = liveReplayLeaderboardTestHooks.parseLiveClimbReplayPayload(
+    makeLegacyWorkoutDocument({stopReason: "user_stopped"}),
+    {requireEligibleParticipation: true}
+  );
+
+  assert.equal(payload, null);
+});
+
+/**
+ * Builds a legacy Live Climb backup: headphone-motion, a landmark climbId, no
+ * trackingMode and no target key, and no participation - the shape a reinstall
+ * downloads for a pre-participation completion.
+ * @param {Record<string, unknown>} metadataOverrides Metadata overrides.
+ * @return {Record<string, unknown>} Legacy workout backup document.
+ */
+function makeLegacyWorkoutDocument(
+  metadataOverrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    durationSeconds: 900,
+    source: "headphone_motion",
+    steps: 2909,
+    sourceMetadata: JSON.stringify({
+      climbId: "burj-khalifa",
+      splitIntervalSeconds: 10,
+      splitSteps: [0, 400, 900, 1500, 2100, 2909],
+      stopReason: "target_reached",
+      ...metadataOverrides,
+    }),
+  };
+}

--- a/scripts/backfill-legacy-live-replay-completions.mjs
+++ b/scripts/backfill-legacy-live-replay-completions.mjs
@@ -1,0 +1,321 @@
+#!/usr/bin/env node
+
+/**
+ * Backfills the replay-publishable shape onto strict-evidence legacy Live Climb
+ * completions, so the Cloud Function's legacy-shape fallback publishes their
+ * rows/finishers (h2 Finding 2). It pairs with the CF change: publication is
+ * write-driven (onWorkoutReplaySplitsWritten), and legacy backups lack the
+ * split curve the CF needs to parse, so this synthesizes a conservative
+ * monotonic curve and writes it back onto the private workout, triggering the
+ * CF to publish. The CF normalizes the curve and withholds First Ascent for
+ * every legacy-recovered row.
+ *
+ * Strict evidence is the SHARED contract isRecoverableLegacyCompletion:
+ * headphone-motion, non-empty climbId, and completed by the policy rule
+ * (steps >= target when a target was recorded, else stopReason target_reached).
+ * It deliberately NEVER adds a participation - a synthesized eligible
+ * participation would let the CF's modern gate claim a First Ascent from
+ * hand-derived data, which is permanent and unreclaimable. First Ascent stays
+ * off for backfilled rows.
+ *
+ * Migration-runner discipline (data/design-migration-runner-f4/report.md):
+ * dev/staging only, hard-refuses prod, dry-run by default, `_migrations`
+ * ledger-gated, idempotent (workouts that already carry split data are skipped,
+ * so a second apply plans zero writes). AUTHOR-ONLY in the PR - running it is
+ * captain-gated ops, per env, after merge.
+ *
+ * Usage:
+ *   node scripts/backfill-legacy-live-replay-completions.mjs --env dev            # plan (dry-run)
+ *   node scripts/backfill-legacy-live-replay-completions.mjs --env dev --apply
+ *   node scripts/backfill-legacy-live-replay-completions.mjs --env staging --apply
+ *
+ * Prerequisites: Node 20+, `cd scripts && npm install`, `gcloud auth application-default login`.
+ */
+
+import {FieldValue} from "firebase-admin/firestore";
+import {
+  resolveEnvironment,
+  parseCommonArgs,
+  initFirestore,
+  beginRun,
+} from "./lib/migration-discipline.mjs";
+
+const OPERATION_ID = "migration/legacy-live-replay-completions";
+const OPERATION_VERSION = 1;
+const HEADPHONE_MOTION_SOURCE = "headphone_motion";
+const TARGET_REACHED_STOP_REASON = "target_reached";
+const SPLIT_INTERVAL_SECONDS = 10;
+const MAX_SPLIT_CHECKPOINTS = 360;
+
+const args = parseCommonArgs(process.argv);
+if (args.rest.has("help")) {
+  printUsageAndExit();
+}
+
+const environment = resolveEnvironment(args.env);
+const db = initFirestore(environment);
+
+const plan = await planReconstructions(db);
+console.log(
+  [
+    `Operation: ${OPERATION_ID} v${OPERATION_VERSION}`,
+    `Environment: ${environment.env} (${environment.projectId})`,
+    `Mode: ${args.apply ? "apply" : "dry-run (plan only)"}`,
+    `Workouts scanned: ${plan.scanned}`,
+    `Recoverable legacy completions: ${plan.recoverable}`,
+    `Already publishable (skipped): ${plan.alreadyPublishable}`,
+    `Reconstructions planned: ${plan.reconstructions.length}`,
+  ].join("\n")
+);
+
+if (!args.apply) {
+  console.log("\nDry-run only. Re-run with --apply to write these documents.");
+  process.exit(0);
+}
+
+const run = await beginRun(db, {
+  operationId: OPERATION_ID,
+  operationVersion: OPERATION_VERSION,
+  environment,
+  rerun: args.rerun,
+});
+
+try {
+  const written = await applyReconstructions(db, plan.reconstructions);
+  const verification = await planReconstructions(db);
+  if (verification.reconstructions.length !== 0) {
+    throw new Error(
+      `Verification found ${verification.reconstructions.length} remaining; ` +
+      "the backfill did not converge."
+    );
+  }
+  await run.finish({workoutsReconstructed: written, scanned: plan.scanned});
+  console.log(`\nReconstructed ${written} workouts. Verified convergent.`);
+} catch (error) {
+  await run.fail(error);
+  throw error;
+}
+
+/**
+ * Scans every private workout and plans a split-curve reconstruction for each
+ * strict-evidence legacy completion that is not yet replay-publishable.
+ * @param {FirebaseFirestore.Firestore} firestore Firestore instance.
+ * @return {Promise<{reconstructions: object[], scanned: number, recoverable: number, alreadyPublishable: number}>}
+ *   The plan.
+ */
+async function planReconstructions(firestore) {
+  const snapshot = await firestore.collectionGroup("workouts").get();
+  const reconstructions = [];
+  let recoverable = 0;
+  let alreadyPublishable = 0;
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data();
+    const metadata = parseMetadata(data.sourceMetadata);
+    if (!metadata) {
+      continue;
+    }
+
+    if (!isRecoverableLegacyCompletion(data, metadata)) {
+      continue;
+    }
+    recoverable += 1;
+
+    // Modern backups already publish through the CF; only touch legacy shapes
+    // that lack the split curve and have no climb-attempt participation.
+    if (hasSplitCurve(metadata) || hasClimbAttemptParticipation(data)) {
+      alreadyPublishable += 1;
+      continue;
+    }
+
+    reconstructions.push({
+      path: doc.ref.path,
+      metadata: withSyntheticSplitCurve(metadata, data),
+    });
+  }
+
+  reconstructions.sort((lhs, rhs) => lhs.path.localeCompare(rhs.path));
+  return {
+    reconstructions,
+    scanned: snapshot.size,
+    recoverable,
+    alreadyPublishable,
+  };
+}
+
+/**
+ * Writes the reconstructed metadata back onto each workout, triggering the CF.
+ * @param {FirebaseFirestore.Firestore} firestore Firestore instance.
+ * @param {object[]} reconstructions Planned reconstructions.
+ * @return {Promise<number>} Count of workouts written.
+ */
+async function applyReconstructions(firestore, reconstructions) {
+  let written = 0;
+  for (const reconstruction of reconstructions) {
+    const ref = firestore.doc(reconstruction.path);
+    const snapshot = await ref.get();
+    const metadata = parseMetadata(snapshot.get("sourceMetadata"));
+    if (!metadata || hasSplitCurve(metadata)) {
+      continue; // Converged already (concurrent run or rerun).
+    }
+
+    await ref.update({
+      sourceMetadata: JSON.stringify(reconstruction.metadata),
+      updatedAt: FieldValue.serverTimestamp(),
+    });
+    written += 1;
+  }
+  return written;
+}
+
+/**
+ * The shared legacy-completion contract, mirrored from
+ * functions/src/legacyClimbCompletion.ts and the Swift predicate.
+ * @param {Record<string, unknown>} data Workout data.
+ * @param {Record<string, unknown>} metadata Parsed source metadata.
+ * @return {boolean} True when this is a trusted legacy completion.
+ */
+function isRecoverableLegacyCompletion(data, metadata) {
+  if (stringValue(metadata.source) !== HEADPHONE_MOTION_SOURCE) {
+    return false;
+  }
+  const climbId = stringValue(metadata.climbId);
+  if (!climbId) {
+    return false;
+  }
+
+  const steps = integerValue(data.steps) ?? 0;
+  const target = integerValue(metadata.climbTargetStepCount) ??
+    integerValue(metadata.targetStepCount);
+  if (target !== null && target > 0) {
+    return steps >= target;
+  }
+  return stringValue(metadata.stopReason) === TARGET_REACHED_STOP_REASON;
+}
+
+/**
+ * Builds a conservative monotonic split curve for a legacy completion. The CF
+ * re-normalizes it; this only needs to be a valid, monotonic, non-empty curve
+ * ending at the workout's final steps.
+ * @param {Record<string, unknown>} metadata Parsed metadata.
+ * @param {Record<string, unknown>} data Workout data.
+ * @return {Record<string, unknown>} Metadata carrying the synthetic curve.
+ */
+function withSyntheticSplitCurve(metadata, data) {
+  const finalSteps = Math.max(integerValue(data.steps) ?? 0, 0);
+  const durationSeconds = Math.max(
+    Math.round(numberValue(data.durationSeconds) ?? 0),
+    SPLIT_INTERVAL_SECONDS
+  );
+  const bucketCount = Math.min(
+    Math.floor(durationSeconds / SPLIT_INTERVAL_SECONDS) + 1,
+    MAX_SPLIT_CHECKPOINTS
+  );
+
+  const splitSteps = [];
+  let lastStep = 0;
+  for (let index = 0; index < bucketCount; index += 1) {
+    const elapsed = index * SPLIT_INTERVAL_SECONDS;
+    const progress = Math.min(elapsed / durationSeconds, 1);
+    const projected = index === bucketCount - 1 ?
+      finalSteps :
+      Math.round(finalSteps * progress);
+    lastStep = Math.min(Math.max(projected, lastStep), finalSteps);
+    splitSteps.push(lastStep);
+  }
+  splitSteps[splitSteps.length - 1] = finalSteps;
+
+  return {
+    ...metadata,
+    splitIntervalSeconds: SPLIT_INTERVAL_SECONDS,
+    splitSteps,
+  };
+}
+
+/**
+ * Parses source metadata JSON.
+ * @param {unknown} value Raw sourceMetadata value.
+ * @return {Record<string, unknown> | null} Parsed metadata.
+ */
+function parseMetadata(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether metadata already carries a usable split curve.
+ * @param {Record<string, unknown>} metadata Parsed metadata.
+ * @return {boolean} True when a split curve is present.
+ */
+function hasSplitCurve(metadata) {
+  return Array.isArray(metadata.splitSteps) &&
+    metadata.splitSteps.length > 0 &&
+    (integerValue(metadata.splitIntervalSeconds) ?? 0) > 0;
+}
+
+/**
+ * Whether the workout carries any climb-attempt participation.
+ * @param {Record<string, unknown>} data Workout data.
+ * @return {boolean} True when a climb-attempt participation is present.
+ */
+function hasClimbAttemptParticipation(data) {
+  return Array.isArray(data.participations) &&
+    data.participations.some(
+      (item) => item && typeof item === "object" &&
+        item.contextType === "climb_attempt"
+    );
+}
+
+function printUsageAndExit() {
+  console.log(`
+Backfills replay-publishable split curves onto legacy Live Climb completions.
+
+Usage:
+  node scripts/backfill-legacy-live-replay-completions.mjs --env dev
+  node scripts/backfill-legacy-live-replay-completions.mjs --env dev --apply
+  node scripts/backfill-legacy-live-replay-completions.mjs --env staging --apply
+
+Options:
+  --env <dev|staging>   Required. Production is refused.
+  --apply               Write documents (default is dry-run plan only).
+  --rerun               Apply again after a prior success (body is idempotent).
+`);
+  process.exit(0);
+}
+
+/**
+ * Parses a finite number.
+ * @param {unknown} value Raw value.
+ * @return {number | null} Parsed number.
+ */
+function numberValue(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Parses a non-negative integer.
+ * @param {unknown} value Raw value.
+ * @return {number | null} Parsed integer.
+ */
+function integerValue(value) {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ?
+    value :
+    null;
+}
+
+/**
+ * Parses a non-empty string.
+ * @param {unknown} value Raw value.
+ * @return {string | null} Parsed string.
+ */
+function stringValue(value) {
+  return typeof value === "string" && value.trim().length > 0 ?
+    value.trim() :
+    null;
+}

--- a/scripts/lib/migration-discipline.mjs
+++ b/scripts/lib/migration-discipline.mjs
@@ -1,0 +1,245 @@
+/**
+ * Shared migration-runner discipline for the pre-launch backfills.
+ *
+ * This is the lightweight, self-contained embodiment of the invariants in
+ * data/design-migration-runner-f4/report.md, pending the full project-owned
+ * `data:run` plan/apply/verify runner. Every backfill that uses it gets:
+ *
+ *   - strict `--env dev|staging` resolution (raw project ids, a missing flag,
+ *     `.firebaserc` defaults, and unknown values are all refused);
+ *   - a HARD refusal of production - these repair scripts are dev/staging only,
+ *     and pre-launch production has zero users, so nothing there needs a
+ *     backfill (the corrected rules deploy, done separately, is what prod needs);
+ *   - dry-run by default: writes require an explicit `--apply`, and there is no
+ *     `--dry-run` flag because plan-only is the default state;
+ *   - a `_migrations` Firestore ledger entry gating every apply, so "did this
+ *     backfill run here?" is answerable from data, not memory;
+ *   - a re-run guard: a migration that already succeeded refuses a second apply
+ *     unless `--rerun` is passed (the operation body must still be idempotent).
+ *
+ * When the full runner lands, these scripts become operation modules under it
+ * and this helper is deleted.
+ */
+
+import {applicationDefault, initializeApp} from "firebase-admin/app";
+import {FieldValue, getFirestore} from "firebase-admin/firestore";
+
+const ENVIRONMENTS = Object.freeze({
+  dev: {projectId: "ascend-f2e4f", production: false},
+  staging: {projectId: "ascend-staging-fa7d5", production: false},
+  prod: {projectId: "ascend-prod-9c8f2", production: true},
+});
+
+const MIGRATIONS_COLLECTION = "_migrations";
+
+/**
+ * Resolves the target environment from a strict `--env` value.
+ * @param {string | null} rawEnv The `--env` argument value.
+ * @return {{env: string, projectId: string, production: boolean}} Environment.
+ */
+export function resolveEnvironment(rawEnv) {
+  if (!rawEnv) {
+    throw new Error(
+      "Missing --env. Pass exactly one of --env dev or --env staging."
+    );
+  }
+
+  const environment = ENVIRONMENTS[rawEnv];
+  if (!environment) {
+    throw new Error(
+      `Unknown --env "${rawEnv}". Use dev or staging ` +
+      "(raw project ids and prod are refused here)."
+    );
+  }
+
+  if (environment.production) {
+    throw new Error(
+      "This repair backfill hard-refuses production. Pre-launch prod has zero " +
+      "users, so the backfill is a no-op there; prod only needs the corrected " +
+      "rules deploy, handled separately."
+    );
+  }
+
+  return {env: rawEnv, ...environment};
+}
+
+/**
+ * Parses the flags every disciplined backfill shares.
+ * @param {string[]} argv Process argv.
+ * @return {{env: string|null, apply: boolean, rerun: boolean, contextKey: string|null, rest: Map<string,string>}}
+ *   Parsed common flags plus any operation-specific `--key value` pairs in `rest`.
+ */
+export function parseCommonArgs(argv) {
+  const parsed = {
+    env: null,
+    apply: false,
+    rerun: false,
+    contextKey: null,
+    rest: new Map(),
+  };
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const value = argv[index];
+    switch (value) {
+      case "--env":
+        parsed.env = requireValue(argv, ++index, "--env");
+        break;
+      case "--context-key":
+        parsed.contextKey = requireValue(argv, ++index, "--context-key");
+        break;
+      case "--apply":
+        parsed.apply = true;
+        break;
+      case "--rerun":
+        parsed.rerun = true;
+        break;
+      case "--help":
+      case "-h":
+        parsed.rest.set("help", "true");
+        break;
+      default:
+        if (value.startsWith("--")) {
+          parsed.rest.set(value.slice(2), requireValue(argv, ++index, value));
+          break;
+        }
+        throw new Error(`Unknown argument: ${value}`);
+    }
+  }
+
+  return parsed;
+}
+
+/**
+ * Requires an argv value after a flag.
+ * @param {string[]} argv Process argv.
+ * @param {number} index Value index.
+ * @param {string} flag Flag name.
+ * @return {string} Flag value.
+ */
+export function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return value;
+}
+
+/**
+ * Initializes Firebase Admin against the resolved project via ADC.
+ * @param {{projectId: string}} environment Resolved environment.
+ * @return {FirebaseFirestore.Firestore} Firestore instance.
+ */
+export function initFirestore(environment) {
+  initializeApp({
+    credential: applicationDefault(),
+    projectId: environment.projectId,
+  });
+  return getFirestore();
+}
+
+/**
+ * Encodes an operation id for use as a Firestore document id.
+ * @param {string} operationId Operation id (may contain slashes).
+ * @return {string} Encoded id.
+ */
+function encodeOperationId(operationId) {
+  return operationId.replaceAll("/", "%2F");
+}
+
+/**
+ * Returns whether this operation+version already succeeded in this environment.
+ * @param {FirebaseFirestore.Firestore} db Firestore instance.
+ * @param {string} operationId Operation id.
+ * @param {number} version Operation version.
+ * @return {Promise<boolean>} True when a succeeded ledger entry exists.
+ */
+export async function hasSucceededLedgerEntry(db, operationId, version) {
+  const snapshot = await db
+    .collection(MIGRATIONS_COLLECTION)
+    .doc(encodeOperationId(operationId))
+    .get();
+  const data = snapshot.data();
+  return Boolean(
+    data &&
+    data.status === "succeeded" &&
+    data.operationVersion === version
+  );
+}
+
+/**
+ * Records the start of an apply run in the ledger and returns a run handle.
+ * A migration that already succeeded refuses a second apply unless rerun is set.
+ * @param {FirebaseFirestore.Firestore} db Firestore instance.
+ * @param {object} params Run parameters.
+ * @return {Promise<{finish: (counts: object) => Promise<void>, fail: (error: unknown) => Promise<void>}>}
+ *   Run handle.
+ */
+export async function beginRun(db, params) {
+  const {operationId, operationVersion, environment, rerun} = params;
+  if (!rerun && await hasSucceededLedgerEntry(db, operationId, operationVersion)) {
+    throw new Error(
+      `Operation ${operationId} v${operationVersion} already succeeded in ` +
+      `${environment.env}. Pass --rerun to apply again (the body is idempotent).`
+    );
+  }
+
+  const parentRef = db
+    .collection(MIGRATIONS_COLLECTION)
+    .doc(encodeOperationId(operationId));
+  const runId = `${new Date().toISOString().replaceAll(/[:.]/g, "-")}-` +
+    Math.random().toString(36).slice(2, 8);
+  const runRef = parentRef.collection("runs").doc(runId);
+
+  await parentRef.set(
+    {
+      operationId,
+      operationVersion,
+      environment: environment.env,
+      projectId: environment.projectId,
+      status: "running",
+      lastRunId: runId,
+      lastStartedAt: FieldValue.serverTimestamp(),
+    },
+    {merge: true}
+  );
+  await runRef.set({
+    runId,
+    operationId,
+    operationVersion,
+    environment: environment.env,
+    projectId: environment.projectId,
+    status: "running",
+    startedAt: FieldValue.serverTimestamp(),
+  });
+
+  return {
+    async finish(counts) {
+      await runRef.set(
+        {status: "succeeded", counts, finishedAt: FieldValue.serverTimestamp()},
+        {merge: true}
+      );
+      await parentRef.set(
+        {
+          status: "succeeded",
+          lastFinishedAt: FieldValue.serverTimestamp(),
+          firstSucceededAt: FieldValue.serverTimestamp(),
+        },
+        {merge: true}
+      );
+    },
+    async fail(error) {
+      await runRef.set(
+        {
+          status: "failed",
+          errorMessage: String(error?.message ?? error).slice(0, 500),
+          finishedAt: FieldValue.serverTimestamp(),
+        },
+        {merge: true}
+      );
+      await parentRef.set(
+        {status: "failed", lastFinishedAt: FieldValue.serverTimestamp()},
+        {merge: true}
+      );
+    },
+  };
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -37,6 +37,8 @@
     "backfill:live-replay-completion-snapshots:staging": "node backfill-live-replay-completion-snapshots.mjs --project staging --dry-run",
     "backfill:live-replay-best-per-user": "node backfill-live-replay-best-per-user.mjs --project dev --dry-run",
     "backfill:live-replay-best-per-user:staging": "node backfill-live-replay-best-per-user.mjs --project staging --dry-run",
+    "backfill:legacy-replay-completions": "node backfill-legacy-live-replay-completions.mjs --env dev",
+    "backfill:legacy-replay-completions:staging": "node backfill-legacy-live-replay-completions.mjs --env staging",
     "clear:live-replay": "node seed-live-replay-leaderboards.mjs clear --project dev",
     "clear:live-replay:staging": "node seed-live-replay-leaderboards.mjs clear --project staging",
     "seed:routine-templates": "node seed-routine-templates.mjs seed --project dev",


### PR DESCRIPTION
## Intent

Legacy Restore Hardening: stop the confirmed pre-launch data loss so an existing TestFlight tester who reinstalls sees their earned landmark (Live Climb) completions restored correctly, and one bad backup document can no longer zero the whole restore. This deliberately repairs the CURRENT pre-canonical system only - it introduces NONE of the new canonical architecture (no command/ledger, no server derivation, no repository read-layer refactor); that is out of scope by design per the ticket.

Key decisions and tradeoffs a diff-only reviewer would not know:
- A single shared predicate isRecoverableLegacyCompletion (headphone_motion + non-empty climbId + target_reached-per-LiveClimbCompletionPolicy + steps>=target) is defined ONCE in Swift (LegacyClimbCompletionPredicate.swift) and mirrored in TypeScript (functions/src/legacyClimbCompletion.ts), pinned by a single shared test vector (SharedTestVectors/legacy-recoverable-completion-vector.json) so the two languages cannot drift. The four conditions are deliberately NOT scattered across call sites.
- Change 1 (Swift WorkoutHydrationService): modern backups that carry a climb-attempt participation still restore as recorded - completed OR failed, because a failed attempt is immutable competitive history (existing test attemptShortOfTheTargetStillRestoresAsFailed must keep passing). ONLY legacy backups with no participation go through the predicate and recover confident completions, keyed by the deterministic id hash(uid+legacyWorkoutId+landmarkId) (CANONICAL section 8, matches the Phase 3 migration input verbatim). This is PUBLICATION-SAFE on purpose: it reconstructs only the local ClimbAttempt and never synthesizes a WorkoutParticipation, because a synthesized participation would flow through WorkoutSyncCoordinator and let the replay Cloud Function retro-publish a row or claim a First Ascent from backfilled data - forbidden. Ambiguous landmark captures that fail the predicate are logged via AppDiagnosticsRecorder, never silently skipped.
- Change 1b (R0 decode resilience, WorkoutRemoteRepository): per-document decode with skip-and-diagnose so one un-decodable backup costs one record, not the whole restore. Extracted into a testable decodeRecords method with an injectable diagnostics recorder so the resilience is unit-testable without a live Firestore.
- I intentionally added a test-only WorkoutHydrationService.resetSessionTrackingForTesting() so tests can simulate a cold app relaunch (the per-process session guard otherwise short-circuits a second hydration), and made HomeDashboardViewModel.fetchCompletedClimbCount static (it is pure over the store) so the Home count surface can be asserted without a SwiftUI tree or configured Firebase.
- Change 3 (TypeScript liveReplayLeaderboard): a NARROW legacy-shape publication fallback gated on the same predicate publishes rows/finishers but NEVER retro-claims First Ascent for typed/hand-derived data - firstAscentEligible is threaded through the payload and forced false for legacy rows, and canClaimFirstAscent now requires it. The fallback only fires when NO climb-attempt participation exists, so an explicitly leaderboardEligible:false modern participation stays deliberately unpublished (I updated the existing test that asserted this). The live parser is not widened generally.
- Change 4 (author-only, NOT run in this PR): idempotent, rerunnable, _migrations-ledger-gated, dev/staging-only backfills that hard-refuse prod (scripts/backfill-live-replay-best-per-user.mjs for issue #220 isBestForUser, and scripts/backfill-legacy-live-replay-completions.mjs feeding Change 3), plus a shared scripts/lib/migration-discipline.mjs. Running them is captain-gated ops.
- NOT in this PR by design: deploying main's corrected top_N_finishes profile_stats rules to dev+prod (Change 2, operational/captain-gated), and running the backfills. Both are documented as captain-gated post-merge steps.

Validation already done locally: 10/10 Swift tests (5 new LegacyRestoreHardeningTests + 5 existing WorkoutHydrationServiceLiveClimbRestoreTests), 112/112 functions tests, ESLint clean, all three .mjs scripts parse, and staging build-for-testing succeeds.

## What Changed

- Added a single shared `isRecoverableLegacyCompletion` predicate (headphone-motion + non-empty climbId + `target_reached` per `LiveClimbCompletionPolicy` + steps ≥ target), defined once in Swift (`LegacyClimbCompletionPredicate.swift`) and mirrored in TypeScript (`functions/src/legacyClimbCompletion.ts`), pinned by a shared test vector so the two languages cannot drift; ambiguous captures are logged via `AppDiagnosticsRecorder` rather than silently skipped.
- Hardened `WorkoutHydrationService` so legacy backups with no participation recover confident Live Climb completions under a deterministic `hash(uid+legacyWorkoutId+landmarkId)` id (reconstructing only the local `ClimbAttempt`, never a synthesized participation, so nothing retro-publishes), while modern participation-carrying backups still restore as recorded (completed or failed); made `WorkoutRemoteRepository.decodeRecords` decode per-document with skip-and-diagnose so one undecodable backup costs one record instead of zeroing the restore.
- Threaded `firstAscentEligible` through `liveReplayLeaderboard.ts` with a narrow legacy-shape publication fallback that publishes rows/finishers but forces First Ascent ineligible for legacy data and only fires when no climb-attempt participation exists; added author-only, dev/staging-only, ledger-gated backfill scripts (`backfill-legacy-live-replay-completions.mjs`, `backfill-live-replay-best-per-user.mjs`, `scripts/lib/migration-discipline.mjs`) that hard-refuse production, plus Swift and functions test coverage.

## Risk Assessment

✅ Low: The change is well-bounded and conforms to the authoritative intent - it hardens the legacy restore path with careful publication-safety invariants, is covered by new and existing tests, and its only notes are minor issues in author-only tooling that is not run in this PR.

## Testing

Ran the base-established suites plus intent-focused subsets: 10/10 Swift tests (the 5 new LegacyRestoreHardeningTests and 5 existing WorkoutHydrationServiceLiveClimbRestoreTests) and 112/112 TypeScript functions tests, with the 3 legacy parity/publication tests captured as focused evidence. Fixed one setup blocker — the Staging build script failed to symlink the missing GoogleService-Info-Staging.plist, so I placed the plist into the target dir (the script's own skip-linking path, mirroring CI's decode step) and removed it afterward. The change is a data-restore/backend hardening path with no new user-facing screen, so there is no screenshot; the end-user-observable surface is the Home completed-climb count asserted at 5 and the real product diagnostic line emitted when a bad backup is skipped, both saved as text artifacts. Transient artifacts (copied plist, functions node_modules/lib) were removed and the worktree is clean.

<details>
<summary>Evidence: Swift legacy restore test run (10/10 pass) with skip-and-diagnose product log</summary>

<code>✔ Test fiveLegacyLandmarkCompletionsRestoreAsFive() passed&#10;[Diagnostics] workout_backup_decode_failed reason=missing_field:steps workout_id=F513A5A5-...&#10;✔ Test oneUndecodableBackupDoesNotZeroTheRestore() passed&#10;✔ Test attemptShortOfTheTargetStillRestoresAsFailed() passed&#10;✔ Test run with 10 tests in 2 suites passed</code>

```text
2026-07-17 14:34:48.268661-0500 AscendApp[7654:24538487] [Diagnostics] app_root_task_started route=signed_out
Test Suite 'Selected tests' started at 2026-07-17 14:34:50.604.
Test Suite 'Selected tests' passed at 2026-07-17 14:34:50.605.
◇ Test run started.
◇ Suite WorkoutHydrationServiceLiveClimbRestoreTests started.
◇ Suite LegacyRestoreHardeningTests started.
◇ Test interruptedBackupPastTheTargetSurvivesReinstallAsCompleted() started.
◇ Test oneUndecodableBackupDoesNotZeroTheRestore() started.
◇ Test predicateMatchesSharedParityVector() started.
◇ Test rerunningHydrationOnTheSameStoreAddsNoDuplicates() started.
◇ Test attemptShortOfTheTargetStillRestoresAsFailed() started.
◇ Test rehydratingOnAFreshDeviceKeepsFiveWithStableIds() started.
◇ Test fiveLegacyLandmarkCompletionsRestoreAsFive() started.
◇ Test manuallyEndedClimbPastTheTargetSurvivesReinstallAsCompleted() started.
◇ Test aFinishedClimbIsStillClaimedAcrossItsSurfacesAfterReinstall() started.
◇ Test legacyBackupWithAStaleStopReasonRestoresAsCompleted() started.
✔ Test interruptedBackupPastTheTargetSurvivesReinstallAsCompleted() passed after 0.112 seconds.
2026-07-17 14:34:50.745422-0500 AscendApp[7654:24538487] [Diagnostics] workout_backup_decode_failed reason=missing_field:steps workout_id=F513A5A5-A796-4115-8252-4D646090D9FB
✔ Test attemptShortOfTheTargetStillRestoresAsFailed() passed after 0.119 seconds.
✔ Test manuallyEndedClimbPastTheTargetSurvivesReinstallAsCompleted() passed after 0.140 seconds.
✔ Test aFinishedClimbIsStillClaimedAcrossItsSurfacesAfterReinstall() passed after 0.144 seconds.
✔ Test legacyBackupWithAStaleStopReasonRestoresAsCompleted() passed after 0.146 seconds.
✔ Suite WorkoutHydrationServiceLiveClimbRestoreTests passed after 0.147 seconds.
✔ Test fiveLegacyLandmarkCompletionsRestoreAsFive() passed after 0.153 seconds.
✔ Test predicateMatchesSharedParityVector() passed after 0.153 seconds.
✔ Test oneUndecodableBackupDoesNotZeroTheRestore() passed after 0.153 seconds.
✔ Test rehydratingOnAFreshDeviceKeepsFiveWithStableIds() passed after 0.156 seconds.
✔ Test rerunningHydrationOnTheSameStoreAddsNoDuplicates() passed after 0.170 seconds.
✔ Suite LegacyRestoreHardeningTests passed after 0.171 seconds.
✔ Test run with 10 tests in 2 suites passed after 0.171 seconds.
```
</details>
<details>
<summary>Evidence: Functions legacy predicate/publication parity tests (3/3 pass)</summary>

<code>ok 1 - TS predicate matches the shared parity vector&#10;ok 2 - publishes a legacy landmark completion without First Ascent&#10;ok 3 - does not publish a legacy backup that missed its target&#10;# pass 3 / # fail 0</code>

```text
ok 1 - TS predicate matches the shared parity vector
ok 2 - publishes a legacy landmark completion without First Ascent
ok 3 - does not publish a legacy backup that missed its target
# tests 3
# pass 3
# fail 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `scripts/lib/migration-discipline.mjs:225` - migration-discipline.beginRun().finish() writes firstSucceededAt with a fresh serverTimestamp on every successful run (merge:true), so a --rerun overwrites the genuine first-success time. Since --rerun exists precisely to re-apply after a prior success, the field no longer records the first success. Guard it (only set when absent) so the ledger keeps an accurate first-success timestamp. Low blast radius: author-only, captain-gated tooling not run in this PR.
- ℹ️ `scripts/backfill-legacy-live-replay-completions.mjs:175` - backfill-legacy-live-replay-completions.mjs re-implements isRecoverableLegacyCompletion as a fourth copy of the shared contract, but unlike the Swift and TS copies it is not pinned by SharedTestVectors/legacy-recoverable-completion-vector.json, so it can silently drift from the canonical predicate. Impact is bounded because the Cloud Function re-gates on its own (vector-pinned) predicate before publishing, so a looser script copy cannot publish disallowed rows - but a stricter drift could silently skip valid recoveries. Consider pinning this copy to the same vector or importing the shared definition.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`xcodebuild test -scheme AscendApp-Staging -configuration Staging -only-testing:AscendAppTests/LegacyRestoreHardeningTests -only-testing:AscendAppTests/WorkoutHydrationServiceLiveClimbRestoreTests` (iPhone 16 Pro sim) — 10/10 pass</code>
- <code>Swift `fiveLegacyLandmarkCompletionsRestoreAsFive` / `rehydratingOnAFreshDeviceKeepsFiveWithStableIds` / `rerunningHydrationOnTheSameStoreAddsNoDuplicates` — reinstall restores 5, stable ids, no dupes</code>
- <code>Swift `oneUndecodableBackupDoesNotZeroTheRestore` — captured `[Diagnostics] workout_backup_decode_failed reason=missing_field:steps` while keeping the 2 good records</code>
- <code>Swift `attemptShortOfTheTargetStillRestoresAsFailed` and `predicateMatchesSharedParityVector`</code>
- <code>`npm test` in functions/ — 112/112 pass</code>
- <code>`node --test lib/test/legacyClimbCompletion.test.js` — 3/3: shared-vector parity, legacy publish without First Ascent, no-publish when target missed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
