### PR TITLE
fix(climbs): teach first-time users that headphones are the step tracker

### DIFF
--- a/AscendApp/Features/Climbs/Analytics/LiveClimbAnalyticsEvent.swift
+++ b/AscendApp/Features/Climbs/Analytics/LiveClimbAnalyticsEvent.swift
@@ -15,6 +15,8 @@ enum LiveClimbAnalyticsEvent: TelemetryEvent {
         canStart: Bool
     )
     case detailStartBlocked(climb: Climb, entryPoint: EntryPoint, reason: BlockedReason)
+    case headphoneHelpOpened(climb: Climb?, entryPoint: EntryPoint, surface: HeadphoneHelpSurface)
+    case browseHelpOpened
     case attemptStarted(
         climb: Climb,
         entryPoint: EntryPoint
@@ -123,6 +125,21 @@ enum LiveClimbAnalyticsEvent: TelemetryEvent {
                     "blocked_reason": .string(reason.rawValue)
                 ]
             )
+
+        case .headphoneHelpOpened(let climb, let entryPoint, let surface):
+            let parameters: [String: TelemetryValue] = [
+                "entry_point": .string(entryPoint.rawValue),
+                "surface": .string(surface.rawValue)
+            ]
+
+            if let climb {
+                return record(name: "live_climb_headphone_help_open", climb: climb, parameters: parameters)
+            }
+
+            return record(name: "live_climb_headphone_help_open", parameters: parameters)
+
+        case .browseHelpOpened:
+            return record(name: "live_climb_browse_help_open")
 
         case .attemptStarted(let climb, let entryPoint):
             return record(
@@ -285,6 +302,11 @@ extension LiveClimbAnalyticsEvent {
 
     enum BlockedReason: String {
         case headphonesUnavailable = "headphones_unavailable"
+    }
+
+    enum HeadphoneHelpSurface: String {
+        case detailHelpButton = "detail_help_button"
+        case sessionGate = "session_gate"
     }
 
     enum AttemptOutcome: String {

--- a/AscendApp/Features/Climbs/Views/ClimbBrowseView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbBrowseView.swift
@@ -178,6 +178,7 @@ struct ClimbBrowseView: View {
             systemName: "questionmark",
             accessibilityLabel: "How Live Climbs work"
         ) {
+            TelemetryManager.shared.track(LiveClimbAnalyticsEvent.browseHelpOpened)
             showingHelpSheet = true
         }
         .accessibilityHint("Open help for climb tiers, map icons, and progress rules")

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -25,7 +25,7 @@ private enum ClimbDetailCoachStep: Int, CaseIterable {
     var message: String {
         switch self {
         case .start:
-            return "When you are on the stair stepper, tap the climb button to start the live attempt."
+            return "Put on your AirPods or other compatible headphones. Ascend counts your steps from headphone motion. When you are on the stair stepper, tap the climb button to start the live attempt."
         case .leaderboard:
             return "The leaderboard shows completed times for this landmark. Finish the climb to put your name on it."
         case .browse:
@@ -51,7 +51,7 @@ private enum ClimbDetailCoachStep: Int, CaseIterable {
     var cardHeight: CGFloat {
         switch self {
         case .start:
-            return 236
+            return 280
         case .leaderboard:
             return 250
         case .browse:
@@ -207,7 +207,7 @@ struct ClimbDetailView: View {
             )
         }
         .sheet(isPresented: $showingHeadphoneHelp) {
-            liveClimbHeadphoneHelpSheet
+            CompatibleHeadphonesHelpSheet()
                 .appSheetStyle(.fitted())
         }
         .alert("Climb Action Error", isPresented: Binding(
@@ -1802,6 +1802,13 @@ struct ClimbDetailView: View {
             }
 
             Button {
+                TelemetryManager.shared.track(
+                    LiveClimbAnalyticsEvent.headphoneHelpOpened(
+                        climb: viewModel.climb,
+                        entryPoint: analyticsEntryPoint,
+                        surface: .detailHelpButton
+                    )
+                )
                 showingHeadphoneHelp = true
             } label: {
                 Image(systemName: "questionmark")
@@ -1825,89 +1832,6 @@ struct ClimbDetailView: View {
     private var isPrimaryActionEnabled: Bool {
         viewModel.isActionEnabled
     }
-
-    private var liveClimbHeadphoneHelpSheet: some View {
-        VStack(alignment: .leading, spacing: 18) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text("Compatible Headphones")
-                    .font(.montserratBold(size: 24))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-
-                Text("Ascend uses headphone motion to track steps in real time during Live Climbs.")
-                    .font(.montserratRegular(size: 14))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.68) : .black.opacity(0.58))
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            compatibleHeadphoneGroup(
-                title: "AirPods",
-                headphones: [
-                    "AirPods 3",
-                    "AirPods 4",
-                    "AirPods 4 with Active Noise Cancellation",
-                    "AirPods Pro 1",
-                    "AirPods Pro 2",
-                    "AirPods Pro 3",
-                    "AirPods Max"
-                ]
-            )
-
-            compatibleHeadphoneGroup(
-                title: "Beats",
-                headphones: [
-                    "Beats Fit Pro",
-                    "Beats Studio Pro",
-                    "Beats Solo 4",
-                    "Powerbeats Pro 2",
-                    "Powerbeats Fit"
-                ]
-            )
-
-            Link(destination: Self.appleHeadphoneCompatibilityURL) {
-                Text("Don't see yours? Check Apple's current list.")
-                    .font(.montserratSemiBold(size: 13))
-                    .foregroundStyle(.accent)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
-            }
-        }
-        .padding(.horizontal, 20)
-        .padding(.top, 28)
-        .padding(.bottom, 10)
-        .appSheetBackground()
-    }
-
-    private func compatibleHeadphoneGroup(title: String, headphones: [String]) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text(title.uppercased())
-                .font(.montserratSemiBold(size: 11))
-                .tracking(1.1)
-                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.58) : .black.opacity(0.48))
-
-            VStack(alignment: .leading, spacing: 8) {
-                ForEach(headphones, id: \.self) { headphone in
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Circle()
-                            .fill(.accent)
-                            .frame(width: 5, height: 5)
-
-                        Text(headphone)
-                            .font(.montserratRegular(size: 13))
-                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.76) : .black.opacity(0.66))
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                }
-            }
-            .padding(14)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(.white.opacity(0.04))
-            )
-        }
-    }
-
-    private static let appleHeadphoneCompatibilityURL = URL(string: "https://support.apple.com/en-us/102596")!
 
     private func handlePrimaryAction() {
         let canStart = headphoneMotionService.readiness.canStartLiveClimb

--- a/AscendApp/Features/Climbs/Views/CompatibleHeadphonesHelpSheet.swift
+++ b/AscendApp/Features/Climbs/Views/CompatibleHeadphonesHelpSheet.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+struct CompatibleHeadphonesHelpSheet: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var themeManager = ThemeManager.shared
+
+    private var effectiveColorScheme: ColorScheme {
+        themeManager.effectiveColorScheme(for: colorScheme)
+    }
+
+    private static let appleHeadphoneCompatibilityURL = URL(string: "https://support.apple.com/en-us/102596")!
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Compatible Headphones")
+                    .font(.montserratBold(size: 24))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
+
+                Text("Ascend uses headphone motion to track steps in real time during Live Climbs.")
+                    .font(.montserratRegular(size: 14))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.68) : .black.opacity(0.58))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            compatibleHeadphoneGroup(
+                title: "AirPods",
+                headphones: [
+                    "AirPods 3",
+                    "AirPods 4",
+                    "AirPods 4 with Active Noise Cancellation",
+                    "AirPods Pro 1",
+                    "AirPods Pro 2",
+                    "AirPods Pro 3",
+                    "AirPods Max"
+                ]
+            )
+
+            compatibleHeadphoneGroup(
+                title: "Beats",
+                headphones: [
+                    "Beats Fit Pro",
+                    "Beats Studio Pro",
+                    "Beats Solo 4",
+                    "Powerbeats Pro 2",
+                    "Powerbeats Fit"
+                ]
+            )
+
+            Link(destination: Self.appleHeadphoneCompatibilityURL) {
+                Text("Don't see yours? Check Apple's current list.")
+                    .font(.montserratSemiBold(size: 13))
+                    .foregroundStyle(.accent)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 28)
+        .padding(.bottom, 10)
+        .appSheetBackground()
+    }
+
+    private func compatibleHeadphoneGroup(title: String, headphones: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title.uppercased())
+                .font(.montserratSemiBold(size: 11))
+                .tracking(1.1)
+                .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.58) : .black.opacity(0.48))
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(headphones, id: \.self) { headphone in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Circle()
+                            .fill(.accent)
+                            .frame(width: 5, height: 5)
+
+                        Text(headphone)
+                            .font(.montserratRegular(size: 13))
+                            .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.76) : .black.opacity(0.66))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(.white.opacity(0.04))
+            )
+        }
+    }
+}
+
+#Preview {
+    CompatibleHeadphonesHelpSheet()
+        .appSheetStyle(.fitted())
+}

--- a/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
+++ b/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
@@ -14,6 +14,7 @@ struct LiveClimbSessionView: View {
     @State private var hasStartedRecording = false
     @State private var countdownRunID = 0
     @State private var showingHeadphoneRequirement = false
+    @State private var showingCompatibleHeadphones = false
     @State private var headphoneMotionService = HeadphoneMotionReadinessService.shared
     @State private var didTrackHeadphoneRequirement = false
     @State private var stepSyncValue = ""
@@ -85,6 +86,10 @@ struct LiveClimbSessionView: View {
         .preferredColorScheme(.dark)
         .keepsScreenAwake(shouldKeepScreenAwake, reason: "Live climb tracking")
         .navigationBarBackButtonHidden(true)
+        .sheet(isPresented: $showingCompatibleHeadphones) {
+            CompatibleHeadphonesHelpSheet()
+                .appSheetStyle(.fitted())
+        }
         .onAppear {
             if viewModel.phase != .idle {
                 hasStartedRecording = true
@@ -708,13 +713,26 @@ struct LiveClimbSessionView: View {
             iconName: "airpodspro",
             title: "Headphones required",
             message: viewModel.mode.isLandmarkClimb
-                ? "Connect compatible headphones to start this live climb."
-                : "Connect compatible headphones to start climbing.",
+                ? "Motion sensors in your headphones count your steps. Connect a compatible pair to start this live climb."
+                : "Motion sensors in your headphones count your steps. Connect a compatible pair to start climbing.",
             primaryTitle: "Try Again",
             primaryAction: retryHeadphoneCountdown,
             secondaryTitle: "Close",
-            secondaryAction: { dismiss() }
+            secondaryAction: { dismiss() },
+            tertiaryTitle: "See compatible headphones",
+            tertiaryAction: presentCompatibleHeadphones
         )
+    }
+
+    private func presentCompatibleHeadphones() {
+        TelemetryManager.shared.track(
+            LiveClimbAnalyticsEvent.headphoneHelpOpened(
+                climb: viewModel.mode.climb,
+                entryPoint: viewModel.analyticsEntryPoint,
+                surface: .sessionGate
+            )
+        )
+        showingCompatibleHeadphones = true
     }
 
     private func stepSyncOverlay(prompt: LiveStepSyncPrompt) -> some View {
@@ -814,7 +832,9 @@ struct LiveClimbSessionView: View {
         primaryTitle: String,
         primaryAction: @escaping () -> Void,
         secondaryTitle: String,
-        secondaryAction: @escaping () -> Void
+        secondaryAction: @escaping () -> Void,
+        tertiaryTitle: String? = nil,
+        tertiaryAction: (() -> Void)? = nil
     ) -> some View {
         ZStack {
             Color.black
@@ -860,6 +880,18 @@ struct LiveClimbSessionView: View {
                             .contentShape(Capsule())
                     }
                     .buttonStyle(.plain)
+
+                    if let tertiaryTitle, let tertiaryAction {
+                        Button(action: tertiaryAction) {
+                            Text(tertiaryTitle)
+                                .font(.montserratSemiBold(size: 13))
+                                .foregroundStyle(.accent)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 38)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
                 .padding(.top, 2)
             }

--- a/AscendApp/Features/Onboarding/Views/PreAuthOnboardingValueCarouselScreen.swift
+++ b/AscendApp/Features/Onboarding/Views/PreAuthOnboardingValueCarouselScreen.swift
@@ -885,8 +885,8 @@ private struct PreAuthGuideScreen: Identifiable {
         PreAuthGuideScreen(
             id: "real_time",
             kind: .liveTracking,
-            headline: "Track your climb in\nreal time",
-            subtitle: "Connect your AirPods Pro or Max to track your climbs in real time."
+            headline: "Your headphones\nare the tracker",
+            subtitle: "Not your watch, not your phone. Motion sensors in most AirPods and Beats count every step in real time."
         ),
         PreAuthGuideScreen(
             id: "daily_climbs",

--- a/AscendAppTests/LiveClimbAnalyticsEventTests.swift
+++ b/AscendAppTests/LiveClimbAnalyticsEventTests.swift
@@ -57,6 +57,47 @@ struct LiveClimbAnalyticsEventTests {
     }
 
     @Test
+    func headphoneHelpOpenIncludesClimbSurfaceAndEntryPoint() {
+        let record = LiveClimbAnalyticsEvent
+            .headphoneHelpOpened(
+                climb: .preview,
+                entryPoint: .homeDaily,
+                surface: .detailHelpButton
+            )
+            .record
+
+        #expect(record.name == "live_climb_headphone_help_open")
+        #expect(record.destinations == [.analytics])
+        #expect(record.parameters["climb_id"] == .string("empire-state-building"))
+        #expect(record.parameters["entry_point"] == .string("home_daily"))
+        #expect(record.parameters["surface"] == .string("detail_help_button"))
+    }
+
+    @Test
+    func headphoneHelpOpenWithoutClimbOmitsClimbParameters() {
+        let record = LiveClimbAnalyticsEvent
+            .headphoneHelpOpened(
+                climb: nil,
+                entryPoint: .unknown,
+                surface: .sessionGate
+            )
+            .record
+
+        #expect(record.name == "live_climb_headphone_help_open")
+        #expect(record.parameters["climb_id"] == nil)
+        #expect(record.parameters["surface"] == .string("session_gate"))
+    }
+
+    @Test
+    func browseHelpOpenRecordsAnalyticsEvent() {
+        let record = LiveClimbAnalyticsEvent.browseHelpOpened.record
+
+        #expect(record.name == "live_climb_browse_help_open")
+        #expect(record.destinations == [.analytics])
+        #expect(record.parameters.isEmpty)
+    }
+
+    @Test
     func shareActionTapIncludesSurfaceAndCardType() {
         let record = LiveClimbAnalyticsEvent
             .shareActionTapped(


### PR DESCRIPTION
## Problem

A real user thought live step tracking was "a watch thing" and could not figure out how to make steps track.
The hard gate at start-attempt already exists, but nothing before that moment builds the mental model that the headphones themselves are the tracker.

Closes #154 (the education half; the detection gate and blocked-start analytics shipped earlier).

## Changes

**Pre-auth carousel (`real_time` screen)**
- Headline: `Your headphones are the tracker`.
- Subtitle: `Not your watch, not your phone. Motion sensors in most AirPods and Beats count every step in real time.`
- Fixes the factually-too-narrow "AirPods Pro or Max" claim without over-promising exact model coverage (the "?" sheet stays the canonical list).

**First-climb coach mark ("Start here")**
- Now leads with putting on compatible headphones and that steps are counted from headphone motion, then the original tap-to-start instruction. Card height bumped for the longer message.

**Headphones-required gate overlay (live session)**
- Message now explains why: `Motion sensors in your headphones count your steps. Connect a compatible pair to start...`
- New `See compatible headphones` affordance opens the full device list (incl. the Apple support link), so the user stuck at the gate can self-serve.
- The device list is extracted from `ClimbDetailView` into a shared `CompatibleHeadphonesHelpSheet` (DRY; both the detail "?" button and the gate present it).

**Analytics** (typed events per `LiveClimbAnalyticsEvent` pattern; no duplication of the existing `live_climb_detail_start_tap` / `live_climb_start_blocked` / `live_climb_attempt_started` funnel)
- `live_climb_headphone_help_open` with `surface` (`detail_help_button` / `session_gate`), `entry_point`, and climb params when a climb is present.
- `live_climb_browse_help_open` for the Browse "How Live Climbs work" sheet.
- Unit tests added in `LiveClimbAnalyticsEventTests`.

## Guardrails respected

- Hardware gating stays at the start-attempt moment; no ambient warnings added to Home or Browse.
- Brand voice: imperative, declarative, specific.
- No new data collection; events are low-cardinality analytics only (no privacy manifest change needed).

## Verification

- `xcodebuild test` (AscendApp-Staging, Staging config, iPhone 16 Pro sim): build succeeded, all 7 `LiveClimbAnalyticsEventTests` passed (3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
