### PR TITLE
fix(climbs): make headphone-tracking education reachable and name the Watch

### DIFF
--- a/.claude/skills/ascend-live-climbs/SKILL.md
+++ b/.claude/skills/ascend-live-climbs/SKILL.md
@@ -18,7 +18,7 @@ For adding, editing, releasing, or validating catalog content and images, use th
 - Browse treats the globe and bottom drawer as distinct navigation modes: globe pin taps open a compact preview card; search/list/section taps open Climb Detail directly. Search lives in the drawer and expands above the keyboard when focused. Globe state (zoom, preview, search) clears when re-entering Browse from elsewhere.
 - Climb Detail uses a flippable hero card (landmark image on the front, tier + fun fact on the back) and three swipeable pages: overview, personal history, per-climb leaderboard. The leaderboard page uses the per-climb leaderboard pattern defined in the `ascend-leaderboards` skill.
 - Globe pins are state-driven: hollow outline for available climbs, filled with double-pin glow for the active climb, filled check badge for completed climbs.
-- Hardware-capability gating (headphones required) belongs at the *start-attempt* moment, not as warnings on Home or Browse. Surface help inline at the gate, not as ambient warnings.
+- Hardware-capability gating (headphones required) belongs at the *start-attempt* moment, not as warnings on Home or Browse. The blocking gate stays inline at start-attempt, but headphone-tracking education (headphones track steps, not a watch or phone) is a persistent, worded row on the Climb Detail overview so it reaches every navigation path, not only the onboarding first-climb coach mark.
 
 ## Attempt model
 - The climb attempt is the source of truth for progress and history. It replaces any older completion-only model.

--- a/AscendApp/Features/Climbs/Analytics/LiveClimbAnalyticsEvent.swift
+++ b/AscendApp/Features/Climbs/Analytics/LiveClimbAnalyticsEvent.swift
@@ -306,6 +306,7 @@ extension LiveClimbAnalyticsEvent {
 
     enum HeadphoneHelpSurface: String {
         case detailHelpButton = "detail_help_button"
+        case detailTrackingRow = "detail_tracking_row"
         case sessionGate = "session_gate"
     }
 

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -887,6 +887,8 @@ struct ClimbDetailView: View {
             }
 
             primaryActionRow
+
+            trackingExplainerRow
         }
         .padding(.horizontal, 4)
         .padding(.vertical, 2)
@@ -1782,47 +1784,71 @@ struct ClimbDetailView: View {
     }
 
     private var primaryActionRow: some View {
-        HStack(spacing: 10) {
-            Button(action: handlePrimaryAction) {
-                Text(primaryActionTitle)
-                    .font(.montserratBold(size: 18))
-                    .foregroundStyle(isPrimaryActionEnabled ? .black : .white.opacity(0.7))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 18)
-                    .background(
-                        RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .fill(isPrimaryActionEnabled ? Color.accent : .white.opacity(0.08))
-                    )
-            }
-            .buttonStyle(.plain)
-            .disabled(!isPrimaryActionEnabled)
-            .background(coachTargetFrameReader(for: .start))
-            .overlay {
-                coachTargetRoundedHighlight(for: .start, cornerRadius: 22)
-            }
-
-            Button {
-                TelemetryManager.shared.track(
-                    LiveClimbAnalyticsEvent.headphoneHelpOpened(
-                        climb: viewModel.climb,
-                        entryPoint: analyticsEntryPoint,
-                        surface: .detailHelpButton
-                    )
+        Button(action: handlePrimaryAction) {
+            Text(primaryActionTitle)
+                .font(.montserratBold(size: 18))
+                .foregroundStyle(isPrimaryActionEnabled ? .black : .white.opacity(0.7))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 18)
+                .background(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .fill(isPrimaryActionEnabled ? Color.accent : .white.opacity(0.08))
                 )
-                showingHeadphoneHelp = true
-            } label: {
-                Image(systemName: "questionmark")
-                    .font(.system(size: 16, weight: .bold))
-                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.82) : .black.opacity(0.68))
-                    .frame(width: 54, height: 54)
-                    .background(
-                        RoundedRectangle(cornerRadius: 18, style: .continuous)
-                            .fill(.white.opacity(0.06))
-                    )
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Live climb headphone help")
         }
+        .buttonStyle(.plain)
+        .disabled(!isPrimaryActionEnabled)
+        .background(coachTargetFrameReader(for: .start))
+        .overlay {
+            coachTargetRoundedHighlight(for: .start, cornerRadius: 22)
+        }
+    }
+
+    /// Persistent, worded explanation of how live tracking works. Unlike the
+    /// first-climb coach mark (which only fires via the onboarding handoff),
+    /// this row is always visible on the overview, so climbers arriving from
+    /// Browse, Home, or a push climb drop still learn that their headphones -
+    /// not a watch or phone - are the step tracker before their first attempt.
+    private var trackingExplainerRow: some View {
+        Button {
+            TelemetryManager.shared.track(
+                LiveClimbAnalyticsEvent.headphoneHelpOpened(
+                    climb: viewModel.climb,
+                    entryPoint: analyticsEntryPoint,
+                    surface: .detailTrackingRow
+                )
+            )
+            showingHeadphoneHelp = true
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "airpodspro")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(.accent)
+
+                Text("Your headphones track your steps, not a watch or phone.")
+                    .font(.montserratMedium(size: 13))
+                    .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.72) : .black.opacity(0.62))
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: 6)
+
+                Text("How it works")
+                    .font(.montserratSemiBold(size: 13))
+                    .foregroundStyle(.accent)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 12)
+            .padding(.horizontal, 14)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(.white.opacity(0.05))
+            )
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("How live climb tracking works. Your headphones track your steps, not a watch or phone.")
+        .accessibilityHint("Opens the compatible headphones list.")
     }
 
     private var primaryActionTitle: String {

--- a/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
+++ b/AscendApp/Features/Climbs/Views/LiveClimbSessionView.swift
@@ -713,8 +713,8 @@ struct LiveClimbSessionView: View {
             iconName: "airpodspro",
             title: "Headphones required",
             message: viewModel.mode.isLandmarkClimb
-                ? "Motion sensors in your headphones count your steps. Connect a compatible pair to start this live climb."
-                : "Motion sensors in your headphones count your steps. Connect a compatible pair to start climbing.",
+                ? "Ascend counts your steps from motion sensors in your AirPods or Beats. An Apple Watch or phone won't track a climb. Connect a compatible pair to start this live climb."
+                : "Ascend counts your steps from motion sensors in your AirPods or Beats. An Apple Watch or phone won't track a session. Connect a compatible pair to start climbing.",
             primaryTitle: "Try Again",
             primaryAction: retryHeadphoneCountdown,
             secondaryTitle: "Close",

--- a/AscendApp/Features/Integrations/HeartRateMonitor/Views/HeartRateMonitorManageSheet.swift
+++ b/AscendApp/Features/Integrations/HeartRateMonitor/Views/HeartRateMonitorManageSheet.swift
@@ -27,6 +27,11 @@ struct HeartRateMonitorManageSheet: View {
                 Spacer()
             }
 
+            Text("Live heart rate needs a Bluetooth chest strap. An Apple Watch can't stream live heart rate to Ascend, though it can add heart rate to a climb afterward through Apple Health.")
+                .font(.montserratMedium(size: 13))
+                .foregroundStyle(.white.opacity(0.6))
+                .fixedSize(horizontal: false, vertical: true)
+
             content
 
             Button("Close") {

--- a/AscendAppTests/LiveClimbAnalyticsEventTests.swift
+++ b/AscendAppTests/LiveClimbAnalyticsEventTests.swift
@@ -74,6 +74,21 @@ struct LiveClimbAnalyticsEventTests {
     }
 
     @Test
+    func headphoneHelpOpenFromPersistentTrackingRowRecordsSurface() {
+        let record = LiveClimbAnalyticsEvent
+            .headphoneHelpOpened(
+                climb: .preview,
+                entryPoint: .detailBrowse,
+                surface: .detailTrackingRow
+            )
+            .record
+
+        #expect(record.name == "live_climb_headphone_help_open")
+        #expect(record.parameters["entry_point"] == .string("detail_browse"))
+        #expect(record.parameters["surface"] == .string("detail_tracking_row"))
+    }
+
+    @Test
     func headphoneHelpOpenWithoutClimbOmitsClimbParameters() {
         let record = LiveClimbAnalyticsEvent
             .headphoneHelpOpened(


### PR DESCRIPTION
## Intent

Ship the P1 + P2 education/copy fixes from the Live Climb tracking scout. A real tester tried to track a stair-stepper climb with her Apple Watch and could not, because Ascend tracks steps from AirPods/Beats headphone motion (`CMHeadphoneMotionManager`), not the Watch or phone. The existing headphone-tracking education only reached users who arrived at a climb via the onboarding first-climb handoff (the coach mark is gated on `onboardingCoach == .firstClimb`; every other route - Browse, Home explore, push climb drop - passed nil), and no surface plainly said the Watch is unsupported.

## Changes

- **Climb Detail:** replaced the unlabeled `?` help icon next to the climb button with a persistent, worded row - *"Your headphones track your steps, not a watch or phone"* + a "How it works" affordance that opens the existing `CompatibleHeadphonesHelpSheet`. It shows on every overview, independent of the onboarding handoff, so climbers arriving from Browse, Home, or a push climb drop see it too. Replacing the icon-only button also removes an accessibility/clarity smell.
- **Headphones-required gate** (`LiveClimbSessionView`): reworded to state what won't work - *"An Apple Watch or phone won't track a climb"* - keeping the existing "See compatible headphones" link.
- **Heart Rate Monitor pairing sheet:** added a concise, non-alarming note that live heart rate needs a Bluetooth chest strap and an Apple Watch isn't a live source (it can only enrich a climb afterward via Apple Health), matching how live HR actually works (`HeartRateMonitorService` reads a BLE strap; Watch HR arrives post-hoc via enrichment).
- **Analytics:** added a typed `detail_tracking_row` surface to `LiveClimbAnalyticsEvent.HeadphoneHelpSurface` for the new row, with a matching unit test.

## Scope

Deliberately limited to the P1 + P2 education fixes only. The P0 background-execution issue and P3 enrichment-timing issue from the scout are out of scope and tracked separately. Copy uses plain hyphens (no em dashes) per project convention and matches the pre-auth carousel voice ("Not your watch, not your phone").

## Verification

Staging test build succeeded; full `AscendAppTests` suite (392 tests, 68 suites) passed, including the new `headphoneHelpOpenFromPersistentTrackingRowRecordsSurface()` test.
