### PR TITLE
fix(paywall): correct subscription claims

### DIFF
--- a/AscendApp/Features/Onboarding/Views/OnboardingValuePages.swift
+++ b/AscendApp/Features/Onboarding/Views/OnboardingValuePages.swift
@@ -14,7 +14,7 @@ enum OnboardingValuePages {
         OnboardingValuePage(
             id: "reason_to_come_back",
             headline: "Never get bored on the climb",
-            subtitle: "Choose from hundreds of landmarks to climb and compete against others.",
+            subtitle: "Choose from 75 landmarks to climb and compete against others.",
             heroImageName: "OnboardingConsistencyHero",
             background: .solid(Color(red: 0x11 / 255, green: 0x11 / 255, blue: 0x11 / 255)),
             heroPresentation: .fullBleed,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file is the always-on core. Domain detail lives in `.claude/skills/` - see 
 
 Ascend is a competitive stair stepper companion for iOS. It's built for people who already use the stair stepper (or are about to start) and want their work to count. Users race the world up real landmarks, top per-climb leaderboards, log every session, and watch their progress compound over time. The leaderboard is the conversation.
 
-**Solo dev + AI assisted** (Tyler Pavay). Planned monetization (not yet built): hard paywall, no freemium tier. Two subscription paths - a yearly plan (discounted, includes a free trial that extends as the user completes climbs) and a shorter recurring plan (monthly or weekly - TBD).
+**Solo dev + AI assisted** (Tyler Pavay). Planned monetization (not yet built): hard paywall, no freemium tier. Two subscription paths - a yearly plan (discounted, includes a free trial) and a shorter recurring plan (monthly or weekly - TBD).
 
 ## What Ascend Is NOT
 

--- a/docs/app-store-brief.md
+++ b/docs/app-store-brief.md
@@ -57,7 +57,7 @@ First Ascent slot. This is the core retention loop.
 ## Monetization (relevant to onboarding)
 
 **Hard paywall, no freemium tier.** Two paths: a discounted **yearly** plan with a free
-trial that *extends as the user completes climbs*, and a shorter recurring plan
+trial, and a shorter recurring plan
 (monthly/weekly, TBD). Onboarding is a **conversion funnel that ends at a hard paywall** —
 not a tutorial.
 

--- a/docs/launch-readiness-audit.md
+++ b/docs/launch-readiness-audit.md
@@ -8,7 +8,7 @@ Method: four parallel read-only passes — monetization, Live Climb hero loop, a
 | Area | Verdict |
 |---|---|
 | Live Climb hero loop | **Ship-ready** — wired end-to-end, zero TODO/fatalError on the critical path |
-| Monetization | **Plumbing wired; commerce config + trial promise missing** |
+| Monetization | **Plumbing wired; commerce configuration pending** |
 | Auth & account lifecycle | ~~Two App Review blockers in account deletion~~ - **both fixed** (see blockers 1-2) |
 | Environments & release pipeline | **Solid** — one bundling verification + secrets checklist |
 
@@ -31,7 +31,8 @@ Method: four parallel read-only passes — monetization, Live Climb hero loop, a
 
 ## 🟠 Promise vs. reality
 
-8. **Trial-extension ("trial extends as you complete climbs") has zero implementation** — no model, no extension call on workout completion, no UI. Cut the claim for v1 or scope the feature. (Same overclaim class as the paywall's "100+ landmarks" line — see superwall-paywall notes.)
+8. **Paywall overclaims removed.** Repo-controlled paywall and onboarding copy now use the exact 75-landmark catalog count and make no climb-earned trial promise.
+   Verify the same copy in the Superwall dashboard before launch.
 9. **No paywall-priming stage** in `PostAuthOnboardingStage` (stages: displayName, gender, age, weight, location, notifications, planLoading, firstClimb). Flow hits the hard gate cold after onboarding. Conversion polish, not a blocker.
 10. **No fallback UI** on `AppAccessPaywallPlaceholderView` if Superwall config fails — users would see "unavailable" with no purchase path.
 

--- a/docs/onboarding-design-guide.md
+++ b/docs/onboarding-design-guide.md
@@ -624,7 +624,7 @@ Recommended paywall structure:
    - `Sync and protect your climb history`
 4. Plan selector:
    - Yearly highlighted: `Best value`
-   - Trial copy: `Start with a free trial. Extend it by completing climbs.`
+   - Trial copy: `Start with a free trial.`
    - Monthly: `Pay as you go`
 5. CTA:
    - Trial available: `Start Free Trial`
@@ -638,7 +638,6 @@ Pricing display:
 - Show yearly as the default selected plan.
 - Show monthly as the comparison plan.
 - Avoid weekly in V1 unless the pricing strategy is locked.
-- If trial extension depends on climb completion, explain the rule in one tappable info row, not in dense legal copy.
 
 ## App Workflow Map
 

--- a/docs/superwall-paywall-setup.md
+++ b/docs/superwall-paywall-setup.md
@@ -47,7 +47,7 @@ Copy:
 
 - Headline: `Try 7 Days Free`
 - Benefits:
-  - `Choose from 100+ landmarks to climb`
+  - `Choose from 75 landmarks to climb`
   - `Improve with personalized climbing plan`
   - `Track records and ascents`
 - Yearly plan:

--- a/web/public/superwall/onboarding-paywall.html
+++ b/web/public/superwall/onboarding-paywall.html
@@ -22,7 +22,7 @@
         <h1 class="headline" data-pw-var="headline">Try 7 Days Free</h1>
 
         <ul class="benefits" data-pw-skip-inner-html="true">
-          <li data-pw-var="benefit_1">Choose from 100+ landmarks to climb</li>
+          <li data-pw-var="benefit_1">Choose from 75 landmarks to climb</li>
           <li data-pw-var="benefit_2">Improve with personalized climbing plan</li>
           <li data-pw-var="benefit_3">Track records and ascents</li>
         </ul>


### PR DESCRIPTION
## Summary

- Correct the hosted paywall, setup documentation, and in-app onboarding copy to say exactly 75 landmarks.
- Remove the unimplemented climb-earned trial-extension promise from repo-controlled product and planning copy.
- Preserve the legitimate fixed free-trial offer and document the remaining Superwall dashboard verification.

## Source of truth

`web/public/climbs/catalog-v1.json` is the authoritative remote catalog.
It contains exactly 75 entries, all available, and matches the bundled fallback catalog.

## Validation

- Parsed both catalogs and verified 75 available entries in each.
- Confirmed the remote and bundled catalogs match.
- Searched the full repository for stale `100+ landmarks`, `hundreds of landmarks`, and trial-extension variants.
- Built the website successfully.
- Rendered the mobile paywall in Chrome and confirmed the corrected copy and layout.

## Dashboard caveat

Both inaccurate claims were found and fixed in repo-controlled files.
Superwall dashboard variables can override the hosted defaults, so dashboard copy still needs an external verification before launch.
