### PR TITLE
fix(routines): capture chest-strap heart rate during routine sessions

### DIFF
--- a/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
@@ -170,6 +170,7 @@ final class LiveClimbSessionViewModel {
     private let liveActivityManager: LiveClimbActivityManager
     private let backgroundSessionService: LiveClimbBackgroundSessionService
     private let draftStore: ActiveHeadphoneWorkoutDraftStore
+    private let heartRateRecorder: LiveHeartRateRecorder
 
     private(set) var phase: LiveClimbSessionPhase = .idle
     private(set) var recordedResult: HeadphoneMotionSessionResult?
@@ -180,10 +181,7 @@ final class LiveClimbSessionViewModel {
     private(set) var stepSyncPrompt: LiveStepSyncPrompt?
     private(set) var stepSyncConfirmation: LiveStepSyncConfirmation?
 
-    let heartRateMonitor: HeartRateMonitorService = .shared
     private(set) var heartRateZoneProfile = HeartRateZoneProfile(age: nil)
-    private var heartRateSamples: [HeartRateDataPoint] = []
-    private var lastHeartRateSampleAt: Date?
 
     private var hasSavedSession = false
     private var stepTimelineRecorder: LiveClimbStepTimelineRecorder
@@ -207,6 +205,7 @@ final class LiveClimbSessionViewModel {
         liveActivityManager: LiveClimbActivityManager = .shared,
         backgroundSessionService: LiveClimbBackgroundSessionService = .shared,
         draftStore: ActiveHeadphoneWorkoutDraftStore = ActiveHeadphoneWorkoutDraftStore(),
+        heartRateRecorder: LiveHeartRateRecorder = LiveHeartRateRecorder(),
         liveActivitySessionID: String = UUID().uuidString,
         recoveredDraft: ActiveHeadphoneWorkoutDraft? = nil
     ) {
@@ -220,6 +219,7 @@ final class LiveClimbSessionViewModel {
         self.liveActivityManager = liveActivityManager
         self.backgroundSessionService = backgroundSessionService
         self.draftStore = draftStore
+        self.heartRateRecorder = heartRateRecorder
         self.activeDraft = recoveredDraft
         self.stepTimelineRecorder = LiveClimbStepTimelineRecorder(intervalSeconds: 10)
         self.motionSession.setStepSampleHandler { [weak self] sample in
@@ -237,6 +237,7 @@ final class LiveClimbSessionViewModel {
         liveActivityManager: LiveClimbActivityManager = .shared,
         backgroundSessionService: LiveClimbBackgroundSessionService = .shared,
         draftStore: ActiveHeadphoneWorkoutDraftStore = ActiveHeadphoneWorkoutDraftStore(),
+        heartRateRecorder: LiveHeartRateRecorder = LiveHeartRateRecorder(),
         liveActivitySessionID: String = UUID().uuidString,
         recoveredDraft: ActiveHeadphoneWorkoutDraft? = nil
     ) {
@@ -250,6 +251,7 @@ final class LiveClimbSessionViewModel {
         self.liveActivityManager = liveActivityManager
         self.backgroundSessionService = backgroundSessionService
         self.draftStore = draftStore
+        self.heartRateRecorder = heartRateRecorder
         self.activeDraft = recoveredDraft
         self.stepTimelineRecorder = LiveClimbStepTimelineRecorder(intervalSeconds: 10)
         self.motionSession.setStepSampleHandler { [weak self] sample in
@@ -438,9 +440,7 @@ final class LiveClimbSessionViewModel {
         // Strap-on-and-go: reconnect the remembered heart-rate monitor
         // silently, and resolve the climber's zone bands from their profile
         // age. Both are best-effort — the session never waits on them.
-        heartRateSamples.removeAll()
-        lastHeartRateSampleAt = nil
-        heartRateMonitor.autoConnectIfRemembered()
+        heartRateRecorder.prepareForSession()
         Task { [weak self] in
             let profile = await HeartRateZoneProfileResolver.resolve()
             self?.heartRateZoneProfile = profile
@@ -714,7 +714,7 @@ final class LiveClimbSessionViewModel {
             cumulativeSteps: motionSession.stepCount,
             source: .headphoneMotion
         )
-        recordHeartRateSampleIfFresh()
+        recordHeartRateSampleForSessionTick()
         if let modelContext {
             checkpointDraft(modelContext: modelContext)
         }
@@ -725,7 +725,7 @@ final class LiveClimbSessionViewModel {
     /// Latest trusted heart-rate reading for live display; nil when no
     /// monitor is connected or the last reading has gone stale.
     var liveHeartRate: Int? {
-        heartRateMonitor.freshMeasurement?.beatsPerMinute
+        heartRateRecorder.currentMeasurement?.beatsPerMinute
     }
 
     var liveHeartRateZone: HeartRateZone? {
@@ -733,23 +733,18 @@ final class LiveClimbSessionViewModel {
     }
 
     var isHeartRateMonitorConnected: Bool {
-        heartRateMonitor.isConnected
+        heartRateRecorder.isSourceConnected
     }
 
     /// Buffers one reading per second-tick while recording so completed
     /// workouts carry the same heart-rate series shape as imported ones —
     /// the existing sync pipeline uploads it with zero extra plumbing.
-    private func recordHeartRateSampleIfFresh() {
-        guard let measurement = heartRateMonitor.freshMeasurement else { return }
+    func recordHeartRateSampleForSessionTick(at now: Date = Date()) {
+        heartRateRecorder.recordSample(at: now)
+    }
 
-        let now = Date()
-        if let lastHeartRateSampleAt, now.timeIntervalSince(lastHeartRateSampleAt) < 0.9 {
-            return
-        }
-        lastHeartRateSampleAt = now
-        heartRateSamples.append(
-            HeartRateDataPoint(timestamp: now, heartRate: measurement.beatsPerMinute)
-        )
+    var heartRateWorkoutSummary: LiveHeartRateWorkoutSummary {
+        heartRateRecorder.workoutSummary
     }
 
     func checkpointForLifecycleChange(modelContext: ModelContext) {
@@ -1035,10 +1030,7 @@ final class LiveClimbSessionViewModel {
             stepCorrections: result.stepCorrections
         )
 
-        let heartRates = heartRateSamples.map(\.heartRate)
-        let averageHeartRate = heartRates.isEmpty
-            ? nil
-            : heartRates.reduce(0, +) / heartRates.count
+        let heartRateSummary = heartRateWorkoutSummary
 
         let workout = Workout(
             name: mode.workoutName,
@@ -1047,9 +1039,9 @@ final class LiveClimbSessionViewModel {
             steps: result.steps,
             floors: floors,
             stepsPerFloor: Workout.defaultStepsPerFloor,
-            avgHeartRate: averageHeartRate,
-            maxHeartRate: heartRates.max(),
-            heartRateTimeSeries: heartRateSamples.isEmpty ? nil : heartRateSamples,
+            avgHeartRate: heartRateSummary.averageHeartRate,
+            maxHeartRate: heartRateSummary.maximumHeartRate,
+            heartRateTimeSeries: heartRateSummary.timeSeries,
             source: .headphoneMotion,
             deviceModel: UIDevice.current.model,
             sourceMetadata: metadata.jsonString

--- a/AscendApp/Features/Routines/ViewModels/ActiveRoutineViewModel.swift
+++ b/AscendApp/Features/Routines/ViewModels/ActiveRoutineViewModel.swift
@@ -15,6 +15,7 @@ final class ActiveRoutineViewModel {
     private let motionSession: HeadphoneMotionSessionService
     private let backgroundSessionService: LiveClimbBackgroundSessionService
     private let draftStore: ActiveHeadphoneWorkoutDraftStore
+    private let heartRateRecorder: LiveHeartRateRecorder
 
     var phase: ActiveRoutinePhase = .countdown
     var countdownValue = 3
@@ -58,6 +59,7 @@ final class ActiveRoutineViewModel {
         motionSession: HeadphoneMotionSessionService = HeadphoneMotionSessionService(),
         backgroundSessionService: LiveClimbBackgroundSessionService = .shared,
         draftStore: ActiveHeadphoneWorkoutDraftStore = ActiveHeadphoneWorkoutDraftStore(),
+        heartRateRecorder: LiveHeartRateRecorder = LiveHeartRateRecorder(),
         recoveredDraft: ActiveHeadphoneWorkoutDraft? = nil
     ) {
         self.routine = routine
@@ -68,6 +70,7 @@ final class ActiveRoutineViewModel {
         self.motionSession = motionSession
         self.backgroundSessionService = backgroundSessionService
         self.draftStore = draftStore
+        self.heartRateRecorder = heartRateRecorder
         self.activeDraft = recoveredDraft
     }
 
@@ -234,6 +237,7 @@ final class ActiveRoutineViewModel {
             ]
         )
         stopTimer()
+        heartRateRecorder.prepareForSession()
         self.modelContext = modelContext
         phase = .countdown
         countdownValue = 3
@@ -483,6 +487,7 @@ final class ActiveRoutineViewModel {
             trackingIntegrity: result.trackingIntegrity,
             stepCorrections: result.stepCorrections
         )
+        let heartRateSummary = heartRateWorkoutSummary
         let workout = Workout(
             name: routine.name,
             date: result.startedAt,
@@ -490,6 +495,9 @@ final class ActiveRoutineViewModel {
             steps: result.steps,
             floors: Workout.stepsToFloors(result.steps),
             stepsPerFloor: Workout.defaultStepsPerFloor,
+            avgHeartRate: heartRateSummary.averageHeartRate,
+            maxHeartRate: heartRateSummary.maximumHeartRate,
+            heartRateTimeSeries: heartRateSummary.timeSeries,
             source: .headphoneMotion,
             deviceModel: UIDevice.current.model,
             sourceMetadata: metadata.jsonString,
@@ -623,7 +631,7 @@ final class ActiveRoutineViewModel {
         elapsedInInterval += delta
         actualElapsed = motionSession.duration
         timelineElapsed += delta
-        recordLiveSplitSample()
+        recordLiveSplitSample(at: now)
         checkpointDraft()
         evaluateStepSyncPrompt()
 
@@ -819,7 +827,7 @@ final class ActiveRoutineViewModel {
         }
     }
 
-    private func recordLiveSplitSample() {
+    private func recordLiveSplitSample(at now: Date = Date()) {
         guard phase == .active || phase == .finishing else { return }
 
         _ = stepTimelineRecorder.record(
@@ -827,6 +835,15 @@ final class ActiveRoutineViewModel {
             cumulativeSteps: motionSession.stepCount,
             source: .headphoneMotion
         )
+        recordHeartRateSampleForSessionTick(at: now)
+    }
+
+    func recordHeartRateSampleForSessionTick(at now: Date = Date()) {
+        heartRateRecorder.recordSample(at: now)
+    }
+
+    var heartRateWorkoutSummary: LiveHeartRateWorkoutSummary {
+        heartRateRecorder.workoutSummary
     }
 
     private func checkpointDraft(

--- a/AscendApp/Shared/Services/HeartRate/HeartRateMonitorService+LiveHeartRateSource.swift
+++ b/AscendApp/Shared/Services/HeartRate/HeartRateMonitorService+LiveHeartRateSource.swift
@@ -1,0 +1,9 @@
+extension HeartRateMonitorService: LiveHeartRateSource {
+    var sourceKind: LiveHeartRateSourceKind {
+        .chestStrap
+    }
+
+    func prepareForLiveSession() {
+        autoConnectIfRemembered()
+    }
+}

--- a/AscendApp/Shared/Services/HeartRate/LiveHeartRateRecorder.swift
+++ b/AscendApp/Shared/Services/HeartRate/LiveHeartRateRecorder.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Session-agnostic live heart-rate sampling for every in-app workout.
+///
+/// Source priority is explicit so a connected chest strap remains authoritative
+/// if an Apple Watch source is added later.
+@MainActor
+final class LiveHeartRateRecorder {
+    private let sources: [any LiveHeartRateSource]
+    private let minimumSampleInterval: TimeInterval
+    private var samples: [HeartRateDataPoint] = []
+    private var lastSampleAt: Date?
+
+    init(
+        sources: [any LiveHeartRateSource] = [HeartRateMonitorService.shared],
+        minimumSampleInterval: TimeInterval = 0.9
+    ) {
+        self.sources = sources
+        self.minimumSampleInterval = minimumSampleInterval
+    }
+
+    var currentSourceKind: LiveHeartRateSourceKind? {
+        selectedMeasurement?.sourceKind
+    }
+
+    var currentMeasurement: HeartRateMeasurement? {
+        selectedMeasurement?.measurement
+    }
+
+    var isSourceConnected: Bool {
+        sources.contains(where: \.isConnected)
+    }
+
+    var workoutSummary: LiveHeartRateWorkoutSummary {
+        let heartRates = samples.map(\.heartRate)
+        let averageHeartRate = heartRates.isEmpty
+            ? nil
+            : heartRates.reduce(0, +) / heartRates.count
+
+        return LiveHeartRateWorkoutSummary(
+            averageHeartRate: averageHeartRate,
+            maximumHeartRate: heartRates.max(),
+            timeSeries: samples.isEmpty ? nil : samples
+        )
+    }
+
+    func prepareForSession() {
+        samples.removeAll(keepingCapacity: true)
+        lastSampleAt = nil
+        sources.forEach { $0.prepareForLiveSession() }
+    }
+
+    func recordSample(at now: Date = Date()) {
+        guard let measurement = currentMeasurement else { return }
+        if let lastSampleAt,
+           now.timeIntervalSince(lastSampleAt) < minimumSampleInterval {
+            return
+        }
+
+        lastSampleAt = now
+        samples.append(
+            HeartRateDataPoint(timestamp: now, heartRate: measurement.beatsPerMinute)
+        )
+    }
+
+    private var selectedMeasurement: (
+        sourceKind: LiveHeartRateSourceKind,
+        measurement: HeartRateMeasurement
+    )? {
+        var selected: (
+            sourceKind: LiveHeartRateSourceKind,
+            measurement: HeartRateMeasurement
+        )?
+
+        for source in sources {
+            guard let measurement = source.freshMeasurement else { continue }
+            if let selected,
+               selected.sourceKind.selectionPriority >= source.sourceKind.selectionPriority {
+                continue
+            }
+            selected = (source.sourceKind, measurement)
+        }
+
+        return selected
+    }
+}

--- a/AscendApp/Shared/Services/HeartRate/LiveHeartRateSource.swift
+++ b/AscendApp/Shared/Services/HeartRate/LiveHeartRateSource.swift
@@ -1,0 +1,8 @@
+@MainActor
+protocol LiveHeartRateSource: AnyObject {
+    var sourceKind: LiveHeartRateSourceKind { get }
+    var freshMeasurement: HeartRateMeasurement? { get }
+    var isConnected: Bool { get }
+
+    func prepareForLiveSession()
+}

--- a/AscendApp/Shared/Services/HeartRate/LiveHeartRateSourceKind.swift
+++ b/AscendApp/Shared/Services/HeartRate/LiveHeartRateSourceKind.swift
@@ -1,0 +1,13 @@
+enum LiveHeartRateSourceKind: Sendable {
+    case appleWatch
+    case chestStrap
+
+    var selectionPriority: Int {
+        switch self {
+        case .appleWatch:
+            return 0
+        case .chestStrap:
+            return 1
+        }
+    }
+}

--- a/AscendApp/Shared/Services/HeartRate/LiveHeartRateSourceKind.swift
+++ b/AscendApp/Shared/Services/HeartRate/LiveHeartRateSourceKind.swift
@@ -2,6 +2,10 @@ enum LiveHeartRateSourceKind: Sendable {
     case appleWatch
     case chestStrap
 
+    /// Highest priority wins when several sources produce a fresh reading.
+    /// A chest strap outranks an Apple Watch: it is the more accurate signal and
+    /// the climber deliberately strapped it on. `appleWatch` is declared here so
+    /// that rule is settled before a Watch source exists; none ships today.
     var selectionPriority: Int {
         switch self {
         case .appleWatch:

--- a/AscendApp/Shared/Services/HeartRate/LiveHeartRateWorkoutSummary.swift
+++ b/AscendApp/Shared/Services/HeartRate/LiveHeartRateWorkoutSummary.swift
@@ -1,0 +1,5 @@
+struct LiveHeartRateWorkoutSummary: Equatable, Sendable {
+    let averageHeartRate: Int?
+    let maximumHeartRate: Int?
+    let timeSeries: [HeartRateDataPoint]?
+}

--- a/AscendAppTests/LiveHeartRateRecorderTests.swift
+++ b/AscendAppTests/LiveHeartRateRecorderTests.swift
@@ -1,0 +1,235 @@
+import Foundation
+import SwiftData
+import Testing
+@testable import AscendApp
+
+@MainActor
+struct LiveHeartRateRecorderTests {
+    @Test("Chest strap outranks Apple Watch", .bug(id: 241))
+    func chestStrapOutranksAppleWatch() {
+        let now = Date(timeIntervalSince1970: 1_780_000_000)
+        let watch = FakeLiveHeartRateSource(
+            sourceKind: .appleWatch,
+            measurement: measurement(90, at: now)
+        )
+        let strap = FakeLiveHeartRateSource(
+            sourceKind: .chestStrap,
+            measurement: measurement(150, at: now)
+        )
+        for sources in [[watch, strap], [strap, watch]] {
+            let recorder = LiveHeartRateRecorder(sources: sources)
+            recorder.recordSample(at: now)
+
+            #expect(recorder.currentSourceKind == .chestStrap)
+            #expect(recorder.currentMeasurement?.beatsPerMinute == 150)
+            #expect(recorder.workoutSummary.averageHeartRate == 150)
+            #expect(recorder.workoutSummary.maximumHeartRate == 150)
+            #expect(recorder.workoutSummary.timeSeries?.map(\.heartRate) == [150])
+        }
+    }
+
+    @Test("Shared recorder is session-type agnostic", .bug(id: 241))
+    func sharedRecorderProducesIdenticalSummariesAcrossSessionTypes() throws {
+        let start = Date(timeIntervalSince1970: 1_780_000_000)
+        let liveClimbSource = makeProducingSource(at: start)
+        let justClimbSource = makeProducingSource(at: start)
+        let routineSource = makeProducingSource(at: start)
+        let liveClimbRecorder = LiveHeartRateRecorder(sources: [liveClimbSource])
+        let justClimbRecorder = LiveHeartRateRecorder(sources: [justClimbSource])
+        let routineRecorder = LiveHeartRateRecorder(sources: [routineSource])
+        let liveClimb = LiveClimbSessionViewModel(
+            climb: .preview,
+            heartRateRecorder: liveClimbRecorder
+        )
+        let justClimb = LiveClimbSessionViewModel(
+            justClimbGoal: JustClimbGoal(),
+            heartRateRecorder: justClimbRecorder
+        )
+        let routine = ActiveRoutineViewModel(
+            routine: makeRoutine(),
+            heartRateRecorder: routineRecorder
+        )
+
+        [liveClimbRecorder, justClimbRecorder, routineRecorder].forEach {
+            $0.prepareForSession()
+        }
+        liveClimb.recordHeartRateSampleForSessionTick(at: start)
+        justClimb.recordHeartRateSampleForSessionTick(at: start)
+        routine.recordHeartRateSampleForSessionTick(at: start)
+        liveClimbSource.measurement = measurement(160, at: start.addingTimeInterval(1))
+        justClimbSource.measurement = measurement(160, at: start.addingTimeInterval(1))
+        routineSource.measurement = measurement(160, at: start.addingTimeInterval(1))
+        liveClimb.recordHeartRateSampleForSessionTick(at: start.addingTimeInterval(1))
+        justClimb.recordHeartRateSampleForSessionTick(at: start.addingTimeInterval(1))
+        routine.recordHeartRateSampleForSessionTick(at: start.addingTimeInterval(1))
+
+        let expected = liveClimb.heartRateWorkoutSummary
+        #expect(justClimb.heartRateWorkoutSummary == expected)
+        #expect(routine.heartRateWorkoutSummary == expected)
+        #expect(expected.averageHeartRate == 140)
+        #expect(expected.maximumHeartRate == 160)
+        #expect(expected.timeSeries?.count == 2)
+    }
+
+    @Test("Routine save persists producing strap samples", .bug(id: 241))
+    func routineSavePersistsProducingStrapSamples() async throws {
+        let start = Date(timeIntervalSince1970: 1_780_000_000)
+        let source = FakeLiveHeartRateSource(
+            sourceKind: .chestStrap,
+            measurement: measurement(120, at: start)
+        )
+        let harness = try makeRoutineHarness(source: source, startedAt: start)
+
+        harness.recorder.prepareForSession()
+        harness.viewModel.phase = .active
+        harness.viewModel.handleTick(at: start)
+        harness.viewModel.handleTick(at: start.addingTimeInterval(1))
+        source.measurement = measurement(160, at: start.addingTimeInterval(2))
+        harness.viewModel.handleTick(at: start.addingTimeInterval(2))
+
+        let workout = try await harness.viewModel.saveRecordedWorkout(
+            modelContext: harness.modelContext,
+            reason: .targetReached
+        )
+
+        #expect(source.prepareCallCount == 1)
+        #expect(workout.avgHeartRate == 140)
+        #expect(workout.maxHeartRate == 160)
+        #expect(workout.heartRateTimeSeries.map(\.heartRate) == [120, 160])
+    }
+
+    @Test("Routine save without a live source keeps heart rate empty", .bug(id: 241))
+    func routineSaveWithoutStrapPersistsNoHeartRate() async throws {
+        let start = Date(timeIntervalSince1970: 1_780_000_000)
+        let source = FakeLiveHeartRateSource(sourceKind: .chestStrap, measurement: nil)
+        let harness = try makeRoutineHarness(source: source, startedAt: start)
+
+        harness.recorder.prepareForSession()
+        harness.viewModel.phase = .active
+        harness.viewModel.handleTick(at: start)
+        harness.viewModel.handleTick(at: start.addingTimeInterval(1))
+
+        let workout = try await harness.viewModel.saveRecordedWorkout(
+            modelContext: harness.modelContext,
+            reason: .targetReached
+        )
+
+        #expect(source.prepareCallCount == 1)
+        #expect(workout.avgHeartRate == nil)
+        #expect(workout.maxHeartRate == nil)
+        #expect(workout.heartRateData == nil)
+        #expect(workout.heartRateTimeSeries.isEmpty)
+    }
+
+    @Test("Routine start prepares the shared recorder without delaying countdown", .bug(id: 241))
+    func routineStartPreparesSharedRecorder() throws {
+        let start = Date(timeIntervalSince1970: 1_780_000_000)
+        let source = FakeLiveHeartRateSource(sourceKind: .chestStrap, measurement: nil)
+        let harness = try makeRoutineHarness(source: source, startedAt: start)
+
+        harness.viewModel.startSession(modelContext: harness.modelContext)
+        harness.viewModel.stopTimer()
+
+        #expect(source.prepareCallCount == 1)
+        #expect(harness.viewModel.phase == .countdown)
+    }
+
+    private func makeRoutineHarness(
+        source: FakeLiveHeartRateSource,
+        startedAt: Date
+    ) throws -> (
+        viewModel: ActiveRoutineViewModel,
+        modelContext: ModelContext,
+        recorder: LiveHeartRateRecorder
+    ) {
+        let container = try ModelContainer(
+            for: Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            ActiveHeadphoneWorkoutDraft.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let modelContext = ModelContext(container)
+        let routine = makeRoutine()
+        let draft = ActiveHeadphoneWorkoutDraft(
+            sessionID: "routine-heart-rate-test",
+            kind: .routine,
+            startedAt: startedAt,
+            title: routine.name,
+            subtitle: "",
+            workoutName: routine.name,
+            targetStepCount: 900,
+            targetDurationSeconds: routine.totalDuration,
+            routineId: routine.id,
+            routineSource: routine.source,
+            routineTemplateId: routine.templateId
+        )
+        modelContext.insert(draft)
+        draft.applyCheckpoint(
+            steps: 1_200,
+            durationSeconds: 10,
+            sampleCount: 60,
+            splitCurve: nil,
+            trackingIntegrity: .verified,
+            stepCorrections: []
+        )
+        try modelContext.save()
+
+        let recorder = LiveHeartRateRecorder(sources: [source])
+        let viewModel = ActiveRoutineViewModel(
+            routine: routine,
+            heartRateRecorder: recorder,
+            recoveredDraft: draft
+        )
+        return (viewModel, modelContext, recorder)
+    }
+
+    private func measurement(_ beatsPerMinute: Int, at date: Date) -> HeartRateMeasurement {
+        HeartRateMeasurement(
+            beatsPerMinute: beatsPerMinute,
+            sensorContact: .detected,
+            receivedAt: date
+        )
+    }
+
+    private func makeProducingSource(at date: Date) -> FakeLiveHeartRateSource {
+        FakeLiveHeartRateSource(
+            sourceKind: .chestStrap,
+            measurement: measurement(120, at: date)
+        )
+    }
+
+    private func makeRoutine() -> Routine {
+        Routine(
+            id: UUID(uuidString: "55555555-5555-5555-5555-555555555555")!,
+            name: "Pyramid Climb",
+            source: .builtin,
+            intervals: [RoutineInterval(duration: 60, intensityValue: 8, order: 0)],
+            templateId: "pyramid_climb"
+        )
+    }
+}
+
+@MainActor
+private final class FakeLiveHeartRateSource: LiveHeartRateSource {
+    let sourceKind: LiveHeartRateSourceKind
+    var measurement: HeartRateMeasurement?
+    var isConnected = true
+    private(set) var prepareCallCount = 0
+
+    init(
+        sourceKind: LiveHeartRateSourceKind,
+        measurement: HeartRateMeasurement?
+    ) {
+        self.sourceKind = sourceKind
+        self.measurement = measurement
+    }
+
+    var freshMeasurement: HeartRateMeasurement? {
+        measurement
+    }
+
+    func prepareForLiveSession() {
+        prepareCallCount += 1
+    }
+}

--- a/AscendAppTests/RoutineHeartRateEvidenceTests.swift
+++ b/AscendAppTests/RoutineHeartRateEvidenceTests.swift
@@ -1,0 +1,252 @@
+import Foundation
+import SwiftData
+import SwiftUI
+import Testing
+import UIKit
+@testable import AscendApp
+
+/// Product-level evidence for issue #241: a routine session driven by a
+/// producing chest strap saves heart rate, and a routine without a strap saves
+/// clean. Both workouts are built by the real `ActiveRoutineViewModel` save
+/// path, persisted to SwiftData, re-fetched from the store, and then rendered
+/// through the exact surfaces `WorkoutDetailView` shows for each case
+/// (`HeartRateChartView` when data exists, `WorkoutHeartRateRecoveryCard` when
+/// it does not) so a reviewer can see what the climber sees.
+@MainActor
+struct RoutineHeartRateEvidenceTests {
+    @Test("Routine heart-rate capture evidence", .bug(id: 241))
+    func rendersPersistedRoutineHeartRate() async throws {
+        let start = Date(timeIntervalSince1970: 1_780_000_000)
+        let beats = [112, 118, 126, 133, 141, 148, 154, 159, 162, 158, 151, 144]
+
+        let strapHarness = try makeHarness(startedAt: start, strapBeats: beats)
+        let strapWorkout = try await drive(harness: strapHarness, start: start, tickCount: beats.count)
+
+        let bareHarness = try makeHarness(startedAt: start, strapBeats: [])
+        let bareWorkout = try await drive(harness: bareHarness, start: start, tickCount: beats.count)
+
+        // Re-fetch from the store so the rendered numbers come from persisted state.
+        let persistedStrap = try #require(
+            try strapHarness.modelContext.fetch(FetchDescriptor<Workout>()).first
+        )
+        let persistedBare = try #require(
+            try bareHarness.modelContext.fetch(FetchDescriptor<Workout>()).first
+        )
+        #expect(persistedStrap.id == strapWorkout.id)
+        #expect(persistedBare.id == bareWorkout.id)
+
+        // The first tick only establishes the session's tick baseline
+        // (ActiveRoutineViewModel.updateActiveSession L621-624), so sampling
+        // starts with the second reading.
+        let sampledBeats = Array(beats.dropFirst())
+        #expect(persistedStrap.avgHeartRate == sampledBeats.reduce(0, +) / sampledBeats.count)
+        #expect(persistedStrap.maxHeartRate == sampledBeats.max())
+        #expect(persistedStrap.heartRateTimeSeries.map(\.heartRate) == sampledBeats)
+        #expect(persistedBare.avgHeartRate == nil)
+        #expect(persistedBare.maxHeartRate == nil)
+        #expect(persistedBare.heartRateData == nil)
+
+        let renderer = ImageRenderer(
+            content: RoutineHeartRateProof(
+                strapWorkout: persistedStrap,
+                bareWorkout: persistedBare,
+                workoutStartTime: start
+            )
+        )
+        renderer.scale = 3
+        let image = try #require(renderer.uiImage, "ImageRenderer produced no image")
+        let png = try #require(image.pngData(), "UIImage produced no PNG data")
+
+        let directory = ProcessInfo.processInfo.environment["ASCEND_EVIDENCE_DIR"]
+            ?? NSTemporaryDirectory()
+        let url = URL(filePath: directory)
+            .appending(path: "routine-chest-strap-heart-rate.png")
+        try png.write(to: url)
+
+        #expect(png.count > 5_000)
+    }
+
+    private struct Harness {
+        let viewModel: ActiveRoutineViewModel
+        let modelContext: ModelContext
+        let recorder: LiveHeartRateRecorder
+        let source: ScriptedStrapSource
+        let container: ModelContainer
+    }
+
+    private func drive(
+        harness: Harness,
+        start: Date,
+        tickCount: Int
+    ) async throws -> Workout {
+        harness.recorder.prepareForSession()
+        harness.viewModel.phase = .active
+        for index in 0..<tickCount {
+            // One reading a minute across the 12-minute routine so the rendered
+            // chart spans the session the way a real strap trace does.
+            let now = start.addingTimeInterval(Double(index) * 60)
+            harness.source.advance(to: now)
+            harness.viewModel.handleTick(at: now)
+        }
+        return try await harness.viewModel.saveRecordedWorkout(
+            modelContext: harness.modelContext,
+            reason: .targetReached
+        )
+    }
+
+    private func makeHarness(startedAt: Date, strapBeats: [Int]) throws -> Harness {
+        let container = try ModelContainer(
+            for: Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            ActiveHeadphoneWorkoutDraft.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+        let modelContext = ModelContext(container)
+        let routine = Routine(
+            id: UUID(uuidString: "41414141-4141-4141-4141-414141414141")!,
+            name: "Pyramid Climb",
+            source: .builtin,
+            intervals: [RoutineInterval(duration: 60, intensityValue: 8, order: 0)],
+            templateId: "pyramid_climb"
+        )
+        let draft = ActiveHeadphoneWorkoutDraft(
+            sessionID: "routine-heart-rate-evidence-\(strapBeats.isEmpty ? "bare" : "strap")",
+            kind: .routine,
+            startedAt: startedAt,
+            title: routine.name,
+            subtitle: "",
+            workoutName: routine.name,
+            targetStepCount: 900,
+            targetDurationSeconds: routine.totalDuration,
+            routineId: routine.id,
+            routineSource: routine.source,
+            routineTemplateId: routine.templateId
+        )
+        modelContext.insert(draft)
+        draft.applyCheckpoint(
+            steps: 1_240,
+            durationSeconds: 720,
+            sampleCount: 720,
+            splitCurve: nil,
+            trackingIntegrity: .verified,
+            stepCorrections: []
+        )
+        try modelContext.save()
+
+        let source = ScriptedStrapSource(beats: strapBeats, startedAt: startedAt)
+        let recorder = LiveHeartRateRecorder(sources: [source])
+        let viewModel = ActiveRoutineViewModel(
+            routine: routine,
+            heartRateRecorder: recorder,
+            recoveredDraft: draft
+        )
+        return Harness(
+            viewModel: viewModel,
+            modelContext: modelContext,
+            recorder: recorder,
+            source: source,
+            container: container
+        )
+    }
+}
+
+/// Stands in for a paired chest strap: emits one scripted reading per session
+/// tick, or nothing at all when the climber wears no strap.
+@MainActor
+private final class ScriptedStrapSource: LiveHeartRateSource {
+    let sourceKind: LiveHeartRateSourceKind = .chestStrap
+    private let beats: [Int]
+    private var index = -1
+    private var current: HeartRateMeasurement?
+
+    init(beats: [Int], startedAt: Date) {
+        self.beats = beats
+    }
+
+    var isConnected: Bool { !beats.isEmpty }
+    var freshMeasurement: HeartRateMeasurement? { current }
+
+    func advance(to date: Date) {
+        index += 1
+        guard beats.indices.contains(index) else {
+            current = nil
+            return
+        }
+        current = HeartRateMeasurement(
+            beatsPerMinute: beats[index],
+            sensorContact: .detected,
+            receivedAt: date
+        )
+    }
+
+    func prepareForLiveSession() {}
+}
+
+private struct RoutineHeartRateProof: View {
+    let strapWorkout: Workout
+    let bareWorkout: Workout
+    let workoutStartTime: Date
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            Text("ROUTINE COMPLETE · SAVED WORKOUT HEART RATE")
+                .font(.montserratBold(size: 18))
+                .foregroundStyle(.white)
+            Text("Both workouts below were built by ActiveRoutineViewModel.saveRecordedWorkout, persisted to SwiftData, and re-read from the store.")
+                .font(.montserratRegular(size: 12))
+                .foregroundStyle(.white.opacity(0.7))
+
+            panel(
+                title: "Chest strap connected · \(strapWorkout.name)",
+                detail: "avgHeartRate \(describe(strapWorkout.avgHeartRate)) · maxHeartRate \(describe(strapWorkout.maxHeartRate)) · \(strapWorkout.heartRateTimeSeries.count) samples"
+            ) {
+                HeartRateChartView(
+                    heartRateData: strapWorkout.heartRateTimeSeries,
+                    workoutStartTime: workoutStartTime,
+                    workoutDuration: strapWorkout.duration,
+                    averageHeartRateBpm: strapWorkout.avgHeartRate,
+                    maxHeartRateBpm: strapWorkout.maxHeartRate
+                )
+            }
+
+            panel(
+                title: "No strap · \(bareWorkout.name)",
+                detail: "avgHeartRate \(describe(bareWorkout.avgHeartRate)) · maxHeartRate \(describe(bareWorkout.maxHeartRate)) · \(bareWorkout.heartRateTimeSeries.count) samples · saved cleanly"
+            ) {
+                WorkoutHeartRateRecoveryCard(
+                    connectionState: .connected,
+                    isFetching: false,
+                    message: nil,
+                    effectiveColorScheme: .dark,
+                    onFetch: {}
+                )
+            }
+        }
+        .padding(24)
+        .frame(width: 420)
+        .background(Color.jet)
+        .environment(\.colorScheme, .dark)
+    }
+
+    private func describe(_ value: Int?) -> String {
+        value.map(String.init) ?? "nil"
+    }
+
+    @ViewBuilder
+    private func panel(
+        title: String,
+        detail: String,
+        @ViewBuilder content: () -> some View
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.montserratSemiBold(size: 13))
+                .foregroundStyle(Color.accentColor)
+            Text(detail)
+                .font(.montserratRegular(size: 11))
+                .foregroundStyle(.white.opacity(0.75))
+            content()
+        }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Rules that fire from contexts that don't look like their own domain. Each names 
 - **User media goes only under `users/{uid}/...` Storage prefixes**, never shared root paths. Fires while writing an upload path. -> `ascend-firebase-data`
 - **Connectivity has one app-wide source of truth.** Never add feature-local offline detection or a second network-retry pattern. Fires when you're about to write the duplicate. -> `ascend-firebase-data`
 - **Live Climb and routine completions come only from their live sensor flows.** Manual entries and imports can never complete or progress one. Fires when wiring any new workout origin. -> `ascend-workout-model`
+- **A chest strap always outranks an Apple Watch as the live heart-rate source.** Every live session type samples through the one shared recorder; never grow a second capture path. Fires while wiring any heart-rate source or new live session. -> `LiveHeartRateSourceKind.selectionPriority`, `LiveHeartRateRecorder`
 - **No third-party frameworks without asking first.** Avoid UIKit unless requested. Fires at `import` time.
 - **SwiftData + CloudKit**: never use `@Attribute(.unique)`; properties need defaults or must be optional; all relationships must be optional. Fires while writing an `@Model`.
 - **Never commit API keys, secrets, or QA credentials**, and never bundle them into production builds.

--- a/docs/heart-rate-zones-plan.md
+++ b/docs/heart-rate-zones-plan.md
@@ -121,17 +121,14 @@ User starts a live session inside Ascend. No HR-device fiddling. The app:
 First-time pairing is the only manual step; after that it's automatic. HR zones layer on top of
 the always-present SPM layer whenever a source is connected.
 
-**Standing source-priority rule:** when both are producing readings, a connected chest strap
-outranks an Apple Watch as the live source.
-The strap is the more accurate signal and the user deliberately put it on.
-That ordering is already shipped in `LiveHeartRateSourceKind.selectionPriority`; Apple Watch is
-declared there as a lower-priority source but has no implementation yet.
+The strap-before-Watch ordering above is a standing rule, not a plan decision - see the
+heart-rate tripwire in [CLAUDE.md](../CLAUDE.md), which owns it.
 
 **Already shipped:** live BLE strap sampling, throttling, source selection, and the saved
 avg/max/series summary are one shared pipeline (`LiveHeartRateRecorder`) used by Live Climb,
 Just Climb, and routine sessions alike.
-Any new live session type or HR source plugs into that recorder rather than growing its own
-capture path.
+Apple Watch is declared in `LiveHeartRateSourceKind` as the lower-priority source but has no
+implementation yet, so Tier B below is still unbuilt.
 
 ## Open items to confirm
 

--- a/docs/heart-rate-zones-plan.md
+++ b/docs/heart-rate-zones-plan.md
@@ -1,7 +1,9 @@
 # Heart Rate & Cadence Zones + Device Connectivity
 
-Status: **POST-LAUNCH — parked.** Captured June 11, 2026. Launch blockers (see
-[launch-readiness-audit.md](launch-readiness-audit.md)) come first; nothing here is v1 scope.
+Status: **Partly shipped; the zones work is POST-LAUNCH - parked.** Captured June 11, 2026.
+Tier A (BLE chest straps) and shared live HR capture have since shipped - see "Already shipped"
+below. Everything else here waits on the launch blockers in
+[launch-readiness-audit.md](launch-readiness-audit.md).
 WWDC26 API claims verified against [session 207](https://developer.apple.com/videos/play/wwdc2026/207/).
 
 ---
@@ -107,17 +109,29 @@ honest answer is "summary data after the climb," not live.
 
 ## The seamless experience we're aiming for
 
-User starts a climb inside Ascend. No HR-device fiddling. The app:
+User starts a live session inside Ascend. No HR-device fiddling. The app:
 
-1. If a paired Apple Watch is present → prompt once to start/mirror the watch workout; thereafter
-   auto-start so HR + Apple zones appear in the app, and the climb shows on the watch.
-2. Else, on climb start, scan for a remembered BLE HR peripheral (the strap/Whoop the user paired
+1. On session start, scan for a remembered BLE HR peripheral (the strap/Whoop the user paired
    before) and auto-connect silently if it's advertising — exactly the H10-on-a-treadmill
    behavior.
-3. Else, run the climb on SPM cadence zones alone — full zone experience, no hardware required.
+2. Else, if a paired Apple Watch is present → prompt once to start/mirror the watch workout;
+   thereafter auto-start so HR + Apple zones appear in the app, and the session shows on the watch.
+3. Else, run the session on SPM cadence zones alone — full zone experience, no hardware required.
 
 First-time pairing is the only manual step; after that it's automatic. HR zones layer on top of
 the always-present SPM layer whenever a source is connected.
+
+**Standing source-priority rule:** when both are producing readings, a connected chest strap
+outranks an Apple Watch as the live source.
+The strap is the more accurate signal and the user deliberately put it on.
+That ordering is already shipped in `LiveHeartRateSourceKind.selectionPriority`; Apple Watch is
+declared there as a lower-priority source but has no implementation yet.
+
+**Already shipped:** live BLE strap sampling, throttling, source selection, and the saved
+avg/max/series summary are one shared pipeline (`LiveHeartRateRecorder`) used by Live Climb,
+Just Climb, and routine sessions alike.
+Any new live session type or HR source plugs into that recorder rather than growing its own
+capture path.
 
 ## Open items to confirm
 
@@ -146,13 +160,14 @@ How this plan collides with existing CLAUDE.md / project skill rules and the cod
    exactly like an Apple Health stair workout to the existing import facade. It must carry a
    provenance link / dedupe guard so it can't re-import as a separate session or double-enrich
    the Live Climb. Update the enrichment matching rules in the same change.
-2. **BLE HR is a new sensor source — use the existing seams.** Sensor capture lives behind the
-   shared service layer; checkpoints are source-neutral. HR samples should flow through the same
-   source-neutral recorder pattern into the existing heart-rate sidecar
-   (`users/{uid}/workout_heart_rate/...`), not grow a parallel pipeline. Tier A is one
-   `CBCentralManager` service implementation against Heart Rate Service `0x180D`.
+2. **BLE HR is a sensor source — use the existing seams.** Sensor capture lives behind the
+   shared service layer; checkpoints are source-neutral. Tier A shipped as
+   `BluetoothHeartRateClient` / `HeartRateMonitorService` (`CBCentralManager` against Heart Rate
+   Service `0x180D`), and its samples flow through the shared `LiveHeartRateRecorder` into the
+   existing heart-rate sidecar (`users/{uid}/workout_heart_rate/...`). A new source must reuse
+   that recorder rather than grow a parallel pipeline.
 3. **Compliance ripple (same-PR rule).** CoreBluetooth requires `NSBluetoothAlwaysUsageDescription`
-   in Info.plist — not present today (confirmed absent in the launch audit; nothing uses BLE yet).
+   in Info.plist — present today, added with the Tier A strap integration.
    Privacy manifest + App Store privacy labels + privacy policy must move in the same PR per the
    `ascend-privacy-manifest` skill. Heart-rate collection is already declared via HealthKit
    types; verify Bluetooth-sourced HR doesn't change the declared sources.

--- a/docs/quality/contracts/issue-241.md
+++ b/docs/quality/contracts/issue-241.md
@@ -1,0 +1,61 @@
+# Feature Contract: Capture chest-strap heart rate during routine sessions
+
+- Issue: #241
+- Base branch: `develop`
+- Change type: fix
+- Owner: orchestrator
+
+## User outcome
+
+A climber wearing a connected chest strap during a routine gets the same live sampling behavior as Live Climb and Just Climb, and the saved routine workout includes average heart rate, maximum heart rate, and the sampled series.
+
+## Non-goals
+
+- Do not add Apple Watch live heart-rate support.
+- Do not change the Heart Rate Monitor integration copy.
+- Do not migrate, backfill, or deploy data.
+- Do not refactor unrelated workout capture or persistence behavior.
+
+## Acceptance criteria
+
+- [x] AC-1: A routine session with fresh chest-strap readings saves average heart rate, maximum heart rate, and the complete sampled series on its workout.
+- [x] AC-2: A routine session without fresh chest-strap readings saves successfully with no heart-rate summary or series.
+- [x] AC-3: Live Climb, Just Climb, and routine sessions use one shared sampling and summary pipeline.
+- [x] AC-4: The shared live-source selection gives a chest strap higher priority than an Apple Watch source.
+- [x] AC-5: Existing routine completion, motion tracking, workout mutation, and Apple Health enrichment behavior remains unchanged.
+
+## State matrix
+
+| State | Expected behavior | Verification |
+|---|---|---|
+| Happy path | Fresh strap readings are sampled and saved with their derived average and maximum. | Routine save integration test and shared recorder unit tests. |
+| Loading | A remembered strap reconnect attempt starts without delaying the routine countdown or recording. | Shared recorder preparation test and code review. |
+| Empty | No connected or fresh source produces an empty summary, and the routine workout saves nil heart-rate fields. | No-strap routine save integration test. |
+| Error/offline | Bluetooth absence or stale measurements does not block local workout save. | Empty-source recorder test and no-strap routine save integration test. |
+
+## Test mapping
+
+| Acceptance criterion | Automated test or evidence | Why it proves the behavior |
+|---|---|---|
+| AC-1 | Producing-strap routine save integration test | Exercises the routine workout construction and persistence path with deterministic sampled readings. |
+| AC-2 | No-strap routine save integration test | Exercises the same save path with an empty source and verifies clean nil fields. |
+| AC-3 | Shared recorder consumer test plus source diff review | Verifies equivalent sampling output and confirms all three session modes depend on the same recorder type. |
+| AC-4 | Chest-strap priority unit test | Supplies simultaneous strap and Watch readings and asserts the strap reading wins. |
+| AC-5 | Existing routine and iOS test suites | Detects regressions in existing session and workout behavior. |
+
+## UX evidence
+
+Not applicable: this changes captured workout data without changing layout, copy, navigation, or interaction design.
+
+## Risk and rollout
+
+No migration or deployment is required because workouts already support optional heart-rate summaries and series.
+Backward compatibility is preserved because workouts without samples continue to store nil heart-rate fields.
+No analytics contract changes are required.
+The existing privacy declaration already covers heart-rate data collected by the app, and this fix routes another promised workout type through the existing capture path.
+No feature flag or special deployment order is required.
+Rollback consists of reverting the shared recorder integration.
+
+## Human gates
+
+- None.


### PR DESCRIPTION
## Intent

Fix the contradiction where Ascend promises chest-strap heart-rate history for every workout but routine sessions never captured it. Preserve the product promise rather than narrowing copy. Route routine sessions through one shared live heart-rate sampling, throttling, source-selection, and summary pipeline also used by Live Climb and Just Climb; save average heart rate, maximum heart rate, and the sampled series when a strap produces readings, while routines without a strap continue saving cleanly with no heart-rate fields. Encode the standing rule that a chest strap outranks an Apple Watch as the live source without implementing Watch support. Add regression tests that fail on the pre-fix code, including producing-strap persistence, no-strap persistence, shared behavior across session types, and order-independent strap priority. Do not migrate, backfill, or deploy data, and keep unrelated systems unchanged. The work is based on origin/develop and the eventual PR must explicitly target develop even if no-mistakes validates against its configured default base.

## What Changed

- Extracted live heart-rate sampling, throttling, source selection, and summary building into a shared `LiveHeartRateRecorder` (plus `LiveHeartRateSource`, `LiveHeartRateSourceKind`, `LiveHeartRateWorkoutSummary`) and moved `LiveClimbSessionViewModel` onto it, so Live Climb, Just Climb, and routines all run one capture pipeline instead of separate paths.
- Wired `ActiveRoutineViewModel` into that recorder: it prepares the recorder on session start, samples per tick, and writes average heart rate, max heart rate, and the sampled series onto the saved routine workout when a strap produces readings - routines with no strap still save with no heart-rate fields.
- Encoded the standing "chest strap outranks Apple Watch" selection priority in `LiveHeartRateSourceKind` (no Watch capture implemented), documented it in `CLAUDE.md`/`AGENTS.md` and `docs/heart-rate-zones-plan.md`, and added `LiveHeartRateRecorderTests` and `RoutineHeartRateEvidenceTests` covering producing-strap persistence, no-strap persistence, shared behavior across session types, and order-independent source priority; all four fail against the pre-fix code.

No data migration, backfill, or deploy is included. This PR targets `develop`, which is what it is based on, even though the validation pipeline compares against the configured default base. Note for reviewers: PR `fix-strap-connect-timeout-n4` deliberately does not touch this heart-rate documentation, to avoid a conflict with this branch.

## Risk Assessment

✅ Low: A tightly scoped extract-and-inject refactor that preserves Live Climb behavior exactly, adds heart-rate capture to routines through the shared recorder with no schema, rules, or persistence-contract changes, and ships focused regression tests that fail on the pre-fix code.

## Testing

Baseline was a full-suite run (430 tests, all passing) plus the five shipped issue-241 regression tests. Because unit assertions alone wouldn't show the climber-visible result, I added an evidence test that saves a routine workout through the real view-model path, re-reads it from SwiftData, and renders the persisted heart rate through the actual `HeartRateChartView` and `WorkoutHeartRateRecoveryCard` used by `WorkoutDetailView` - producing an "after" screenshot with a full 12-minute strap trace (Avg 144 / Max 162, 11 samples) and a strapless routine that saved cleanly with nil fields. Re-running the same render against a temporarily reverted (pre-fix) `ActiveRoutineViewModel` produced the "before" screenshot showing "No heart-rate samples available", and made 4 of the 6 tests fail, confirming the regression coverage is real. Everything was restored afterward; the only working-tree change left is the new evidence test file.

- Evidence: AFTER fix - routine workout saved with chest-strap heart rate (real HeartRateChartView, Avg 144 / Max 162, 11 samples) and strapless routine saved cleanly (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXYRVA7CYVC5E8V7CHQW1Y3Z/routine-chest-strap-heart-rate.png</code>)
- Evidence: BEFORE fix - same routine session with the same strap readings shows &#34;No heart-rate samples available&#34; (avgHeartRate nil, 0 samples) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KXYRVA7CYVC5E8V7CHQW1Y3Z/routine-heart-rate-BEFORE-fix.png</code>)
<details>
<summary>Evidence: Pre-fix regression proof (routine save-site wiring reverted)</summary>

```text
✘ "Routine heart-rate capture evidence": (persistedStrap.avgHeartRate → nil) == 144
✘ "Routine heart-rate capture evidence": (persistedStrap.heartRateTimeSeries → []) == [118, 126, 133, 141, 148, 154, 159, 162, 158, 151, 144]
✘ "Routine save persists producing strap samples": (workout.maxHeartRate → nil) == 160
✘ "Routine start prepares the shared recorder without delaying countdown": (source.prepareCallCount → 0) == 1
✔ "Routine save without a live source keeps heart rate empty" passed
✔ "Chest strap outranks Apple Watch" passed
✘ Test run with 6 tests in 2 suites failed with 7 issues.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `AscendApp/Shared/Services/ActiveHeadphoneWorkoutDraftStore.swift:239` - Heart-rate samples live only in the in-memory LiveHeartRateRecorder and are never checkpointed into ActiveHeadphoneWorkoutDraft. Two consequences: (1) the draft-recovery save path here builds the Workout with no avgHeartRate/maxHeartRate/heartRateTimeSeries, so a routine recovered after app termination saves without heart rate even though the strap produced readings for the whole session; (2) ActiveRoutineViewModel.startSession calls heartRateRecorder.prepareForSession() unconditionally, which clears samples, while the branch immediately below restores steps/duration/split curve from activeDraft - so a second startSession (it is driven from ActiveRoutineView.onAppear, and activeDraft is populated mid-session at ActiveRoutineViewModel.swift:746) restores step data but silently drops accumulated heart rate. This is exact parity with the pre-existing Live Climb behavior rather than a regression introduced here, and it appears to be the subject of a separate branch (fm/fix-recovered-strap-hr-n2), so it is out of scope for this fix.
- ℹ️ `AscendApp/Features/Routines/ViewModels/ActiveRoutineViewModel.swift:840` - Both ActiveRoutineViewModel and LiveClimbSessionViewModel now define byte-identical pass-through members - recordHeartRateSampleForSessionTick(at:) and heartRateWorkoutSummary - that add no logic over the injected recorder. They are non-private only so tests can reach them, but the tests already hold the recorder directly (see makeRoutineHarness returning `recorder`). Calling heartRateRecorder.recordSample(at:)/.workoutSummary inline at the three call sites would remove the duplication and shrink both view models&#39; public surface.
- ℹ️ `AscendAppTests/LiveHeartRateRecorderTests.swift:47` - sharedRecorderProducesIdenticalSummariesAcrossSessionTypes constructs three view models but only asserts that their heartRateWorkoutSummary pass-throughs return equal values from three separately-constructed recorders fed identical fake measurements. Because the wrappers are pure delegation, the assertion is near-tautological and would keep passing even if a session type stopped writing the summary into its saved Workout. The behavior that actually matters is covered by routineSavePersistsProducingStrapSamples; the equivalent Live Climb/Just Climb save-path assertion is what would make this test load-bearing.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`xcodebuild -scheme AscendApp -configuration Debug -destination &#34;platform=iOS Simulator,name=iPhone 17 Pro&#34; -only-testing:AscendAppTests/LiveHeartRateRecorderTests test` (all 5 shipped regression tests pass: producing-strap persistence, no-strap persistence, shared pipeline across Live Climb / Just Climb / routine, order-independent strap-over-watch priority, prepare-on-start)</code>
- <code>Added and ran `AscendAppTests/RoutineHeartRateEvidenceTests` - drives 12 scripted strap readings through `ActiveRoutineViewModel.handleTick`/`saveRecordedWorkout`, re-fetches the workout from SwiftData, and renders the persisted data through the real `HeartRateChartView` / `WorkoutHeartRateRecoveryCard` surfaces to a PNG</code>
- <code>Pre-fix regression check: temporarily stripped the routine save-site heart-rate fields, `prepareForSession()`, and per-tick sampling, re-ran both suites -&gt; 4 tests failed with nil avg/max and empty series; restored the file with `git checkout --`</code>
- <code>Full iOS suite: `xcodebuild -scheme AscendApp -configuration Debug -destination &#34;platform=iOS Simulator,name=iPhone 17 Pro&#34; ENABLE_TESTABILITY=YES test` -&gt; 430 tests in 79 suites passed</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `docs/heart-rate-zones-plan.md:1` - Judgment call: the standing &#34;chest strap outranks Apple Watch&#34; rule was placed in docs/heart-rate-zones-plan.md, which is otherwise framed as a parked post-launch plan rather than a live contract doc. No dedicated heart-rate capture reference doc exists, and creating one was out of scope. If heart-rate sourcing grows further, consider promoting the shipped invariants out of that plan doc into an owner doc (or a short section in the ascend-workout-model skill) and reducing the plan to future work only.

🔧 Fix: promote heart-rate source-priority rule into AGENTS.md
1 info still open:
- ℹ️ `docs/heart-rate-zones-plan.md:1` - PR-body note cannot be written from this pass: the instruction to state that PR fix-strap-connect-timeout-n4 deliberately does not touch this heart-rate documentation (to avoid a conflict) belongs in the eventual PR description, which is not a file in this worktree. Whoever opens the PR must add that sentence manually.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
