### PR TITLE
fix(leaderboards): derive live replay publication eligibility on the server

### DIFF
--- a/.claude/skills/ascend-leaderboards/SKILL.md
+++ b/.claude/skills/ascend-leaderboards/SKILL.md
@@ -30,6 +30,7 @@ Two distinct surfaces - the global tab (community-wide aggregate stats) and per-
 - Leaderboard publication is mutation-driven: workout create / import / delete always affects publication; workout edits affect publication only when leaderboard-relevant fields change (date, duration, steps, floors). Photo, notes, heart-rate, calorie, or MET edits don't touch leaderboard publication.
 - The leaderboard refresh UI must never own the only publication path. Users must appear remotely even if they never open the leaderboard tab.
 - Local leaderboard state updates incrementally for current periods only. Full-history rebuilds are reserved for migration, repair, or schema backfill.
+- **Publication eligibility is derived server-side, never asserted by the client.** `functions/src/liveReplayLeaderboard.ts` re-derives every condition from the backed-up workout and ignores the participation's `leaderboardEligible` boolean; `WorkoutParticipation.leaderboardEligible` is a local record of what the device concluded, not an instruction the server obeys. Any new leaderboard gate follows the same rule: check evidence fields, never a client-written verdict.
 
 ## Leaderboard UX Flow
 

--- a/AscendApp/Shared/Models/WorkoutParticipation.swift
+++ b/AscendApp/Shared/Models/WorkoutParticipation.swift
@@ -65,6 +65,9 @@ final class WorkoutParticipation {
     var contextVersion: Int
     var rulesVersion: Int
     var roleRawValue: String
+    /// What this device concluded about competitive credit. A local record only - the server
+    /// derives publication eligibility from the workout itself in `liveReplayLeaderboard.ts`
+    /// and never reads this flag, because a client cannot be trusted to rate its own entry.
     var leaderboardEligible: Bool
     var verificationTierRawValue: String
     var metricsSnapshotData: Data?

--- a/functions/src/liveReplayLeaderboard.ts
+++ b/functions/src/liveReplayLeaderboard.ts
@@ -441,6 +441,15 @@ function parseReplayPayloadParts(
  * climb collection this trigger could read. Stating that out loud is the point:
  * it is an acknowledged gap in this gate, not a silent fallback. Closing it
  * needs a server-readable catalog, which is its own change.
+ *
+ * Deliberate consequence: the gate grandfathers a completion recorded against
+ * the step target that existed when it was climbed. A catalog correction must
+ * never retroactively void an earned completion or its First Ascent, so the
+ * client's `leaderboardEligible: false` stays ignored even when a later,
+ * higher catalog target would fail the device's local completion check. That
+ * case is close to hypothetical anyway - no climb's referenceStepCount has
+ * ever changed across the catalog's history, and all 75 current climbs
+ * resolve their target from totalSteps with realStairCount null.
  * @param {ParsedReplayPayloadParts} parsed Parsed replay payload parts.
  * @return {boolean} True when the row may be published publicly.
  */

--- a/functions/src/liveReplayLeaderboard.ts
+++ b/functions/src/liveReplayLeaderboard.ts
@@ -350,7 +350,6 @@ function parseJustClimbReplayPayload(
 
 interface ParsedReplayPayloadParts {
   metadata: Record<string, unknown>;
-  hasEligibleClimbAttempt: boolean;
   hasClimbAttemptParticipation: boolean;
   splitIntervalSeconds: number;
   splitSteps: number[];
@@ -406,9 +405,6 @@ function parseReplayPayloadParts(
 
   return {
     metadata,
-    hasEligibleClimbAttempt: hasEligibleClimbAttemptParticipation(
-      data.participations
-    ),
     hasClimbAttemptParticipation: hasClimbAttemptParticipation(
       data.participations
     ),
@@ -430,13 +426,28 @@ function parseReplayPayloadParts(
  * permanent and never reclaimable, so a typed number must never claim one. The
  * client normalizes a manual stop past the target to target_reached at save
  * time, so that path agrees with this gate without a change here.
+ *
+ * Every condition below is re-derived here from the backed-up workout. The gate
+ * never reads the participation's `leaderboardEligible` boolean, which is the
+ * client asserting its own eligibility with nothing behind it. This matches
+ * parseCompletedLandmarkWorkout, which already derives "finished a landmark"
+ * from the same evidence fields and likewise ignores the flag.
+ *
+ * Known residual: `parsed.targetStepCount` is the client's own
+ * `climbTargetStepCount`/`targetStepCount` metadata, so `finalSteps >= target`
+ * compares a claimed step count against a claimed target. The server cannot
+ * derive the canonical target today - the landmark catalog ships as a static
+ * Hosting asset (web/public/climbs/catalog-v1.json), and Firestore holds no
+ * climb collection this trigger could read. Stating that out loud is the point:
+ * it is an acknowledged gap in this gate, not a silent fallback. Closing it
+ * needs a server-readable catalog, which is its own change.
  * @param {ParsedReplayPayloadParts} parsed Parsed replay payload parts.
  * @return {boolean} True when the row may be published publicly.
  */
 function hasCompletedLiveClimbAttempt(
   parsed: ParsedReplayPayloadParts
 ): boolean {
-  if (!parsed.hasEligibleClimbAttempt) {
+  if (!parsed.hasClimbAttemptParticipation) {
     return false;
   }
 
@@ -511,31 +522,19 @@ function replayPayload(
 }
 
 /**
- * Returns whether a workout has a completed leaderboard-eligible climb attempt.
- * @param {unknown} value Raw participations value.
- * @return {boolean} True when the workout can be indexed for replay.
- */
-function hasEligibleClimbAttemptParticipation(value: unknown): boolean {
-  if (!Array.isArray(value)) {
-    return false;
-  }
-
-  return value.some((item) => {
-    if (!item || typeof item !== "object") {
-      return false;
-    }
-
-    const participation = item as Record<string, unknown>;
-    return participation.contextType === "climb_attempt" &&
-      participation.leaderboardEligible === true;
-  });
-}
-
-/**
- * Returns whether a workout carries any climb-attempt participation, eligible
- * or not. The legacy-shape fallback only fires when none exists: a workout with
- * a climb-attempt participation is governed by the modern gate, so an
- * explicitly ineligible one stays deliberately unpublished, not resurrected.
+ * Returns whether a workout carries a climb-attempt participation.
+ *
+ * This is a shape check, not an eligibility check. The participation's
+ * `leaderboardEligible` boolean is deliberately NOT read: it is a bare
+ * assertion the client writes about itself, carrying no evidence the server
+ * can check, so a modified client could grant itself a leaderboard row by
+ * flipping it. Eligibility is derived instead - see
+ * hasCompletedLiveClimbAttempt.
+ *
+ * Presence still matters for one thing: it separates the modern document shape
+ * from the legacy one. The legacy-shape fallback only fires when no
+ * climb-attempt participation exists, so a modern workout is always judged by
+ * the derived gate rather than resurrected through the legacy path.
  * @param {unknown} value Raw participations value.
  * @return {boolean} True when a climb-attempt participation is present.
  */

--- a/functions/test/liveReplayLeaderboard.test.ts
+++ b/functions/test/liveReplayLeaderboard.test.ts
@@ -105,7 +105,10 @@ test("rejects resumed partial target hits", () => {
   assert.equal(payload, null);
 });
 
-test("rejects target-reached rows without eligible climb participation", () => {
+// The client's `leaderboardEligible` boolean is an unbacked assertion, so the
+// gate derives eligibility from the workout instead and ignores the flag in
+// both directions: it can neither grant a row nor withhold one.
+test("ignores a client leaderboardEligible: false on a real completion", () => {
   const payload = liveReplayLeaderboardTestHooks.parseLiveClimbReplayPayload(
     makeWorkoutDocument({
       participations: [makeParticipation({leaderboardEligible: false})],
@@ -113,7 +116,34 @@ test("rejects target-reached rows without eligible climb participation", () => {
     {requireEligibleParticipation: true}
   );
 
+  assert.equal(payload?.contextId, "empire-state-building");
+  assert.equal(payload?.firstAscentEligible, true);
+});
+
+test("ignores a client leaderboardEligible: true without the evidence", () => {
+  const payload = liveReplayLeaderboardTestHooks.parseLiveClimbReplayPayload(
+    makeWorkoutDocument({
+      steps: 92,
+      participations: [makeParticipation({leaderboardEligible: true})],
+      sourceMetadata: makeSourceMetadata({stopReason: "user_stopped"}),
+    }),
+    {requireEligibleParticipation: true}
+  );
+
   assert.equal(payload, null);
+});
+
+// A missing climb-attempt participation is the legacy document shape, not an
+// eligibility signal: it drops out of the modern gate and into the legacy
+// fallback, which publishes a row but never a First Ascent.
+test("routes participation-less backups through the legacy fallback", () => {
+  const payload = liveReplayLeaderboardTestHooks.parseLiveClimbReplayPayload(
+    makeWorkoutDocument({participations: []}),
+    {requireEligibleParticipation: true}
+  );
+
+  assert.equal(payload?.contextId, "empire-state-building");
+  assert.equal(payload?.firstAscentEligible, false);
 });
 
 test("detects permanent First Ascent claims on replay summaries", () => {


### PR DESCRIPTION
## Intent

Stop trusting the client's word on leaderboard eligibility. functions/src/liveReplayLeaderboard.ts read a client-supplied participation.leaderboardEligible boolean and acted on it, so a modified client could assert its own eligibility for a live-replay leaderboard entry. Goal: derive publication eligibility on the server from canonical data instead of accepting the client's assertion.

Decisions made while doing the work:
- Deleted hasEligibleClimbAttemptParticipation entirely. hasCompletedLiveClimbAttempt now gates on the PRESENCE of a climb_attempt participation plus the conditions the server already re-derives from the backed-up workout (trackingMode == live_climb, stopReason == target_reached, a recorded target, finalSteps >= target, zero attemptBaselineSteps).
- The participation presence check was deliberately KEPT, but re-documented as a document-shape check rather than an eligibility check: it is what separates modern backups from legacy ones so the legacy fallback cannot resurrect a modern workout. It is intentionally not a trust signal.
- This deliberately mirrors parseCompletedLandmarkWorkout in functions/src/climbCompletions.ts, which already derives 'finished a landmark' from the same evidence fields and never read the flag. Aligning the two gates was the intent, not accidental duplication.
- Behaviour delta was analysed and is intentional: the new accept set is a STRICT SUPERSET of the old one (the old flag check implied the presence check), so nothing currently accepted becomes excluded. The only new accepts are workouts where the client wrote leaderboardEligible:false while the evidence fields show a completed live climb. This widening is expected and is pinned by tests, not a regression. (Corrected during review: this bullet originally claimed ClimbService.apply never produces that pair. That was wrong - review found a real path, and it is now settled as a deliberate product decision. See "Decision: completions are grandfathered" below.)
- Known residual, deliberately left and documented at the gate rather than silently patched: parsed.targetStepCount still comes from client metadata (climbTargetStepCount/targetStepCount), so finalSteps >= target compares a claim against a claim. The server cannot derive the canonical target today because the landmark catalog ships as a static Hosting asset (web/public/climbs/catalog-v1.json) and Firestore holds no climb collection this trigger can read. Closing that needs a server-readable catalog and is explicitly out of scope for this change. The long comment block stating this is intentional and should not be trimmed.
- WorkoutParticipation.leaderboardEligible is KEPT and still written by the client, now documented as a local record of what the device concluded rather than an instruction the server obeys. Removing the field would be a firestore.rules hasOnly/hasAll plus SwiftData schema migration and is deliberately out of scope. It is intentionally write-only now, not dead code to delete.
- Existing data: already-published rows in live_replay_leaderboards are untouched. The trigger is onDocumentWritten and only re-evaluates a workout when that workout is written again. Because the gate only widened, no published row is retroactively invalid, so no backfill and no migration is part of this change. That was a conscious call, not an oversight.
- Tests: replaced the old 'rejects target-reached rows without eligible climb participation' test with three that pin the new contract - the flag being ignored in both directions, and participation-less backups routing through the legacy fallback with firstAscentEligible false.
- The Swift change is a comment only. The .claude/skills/ascend-leaderboards/SKILL.md line records the derive-don't-trust rule for future work.

Constraints: base is origin/develop and the PR targets develop, not main. No CI gate may be weakened or skipped.

## Decision: completions are grandfathered against the target that existed at the time

This PR deliberately widens the live-replay publication gate, and that widening is a product decision, not an unremarked side effect. Calling it out plainly:

**What widens.** The old gate required the client's `leaderboardEligible: true`. The new gate derives eligibility from the workout instead, so a workout the client marked ineligible now publishes when the evidence shows a completed live climb. Review identified a real path that produces exactly that pair, correcting an earlier claim in this PR that it could not happen: if a landmark's `referenceStepCount` is later **raised** in the hosted catalog, `ClimbService.apply` re-evaluates `isCompletion(steps, newTarget)` as false and marks the local attempt failed, while the stored `sourceMetadata` still records `target_reached` against the old target. The old flag check blocked that row; the derived gate publishes it, First Ascent included.

**The ruling.** A completion recorded against the step target that existed when it was climbed stays a completion. A catalog correction must never retroactively void an earned completion or its First Ascent - the climber did reach the target as it stood when they climbed it. The gate therefore grandfathers these, and ignores `leaderboardEligible: false` even when a later, higher catalog target would fail the device's local completion check. This is recorded in the gate's own doc comment so the next reader does not mistake it for an oversight.

**How often this can bite: expected to be essentially never, and zero retroactively.** Raising a published landmark's step target is not something we expect to do. The evidence agrees:

- `referenceStepCount` (`realStairCount ?? totalSteps`) has **never** changed for any climb across the hosted catalog's entire history - 5 revisions, 2026-04-04 to 2026-06-02. Climbs were only removed (100 -> 88 -> 75). The manifest is still at `catalogVersion: 6`, `updatedAt: 2026-06-02`.
- The population affected today is **exactly zero**, by construction: the path requires a target to have already risen after a session was recorded, which has never happened. This is forward-looking policy on a rare event, not a live data problem, and it needs no migration or backfill.
- Only a *raised* target triggers it. A correction that lowers a target keeps the local completion check true and changes nothing.

**Not closed by this PR.** The server still compares two client-written numbers (`steps` against `climbTargetStepCount`), because Cloud Functions cannot read the landmark catalog - it ships as a static Hosting asset and Firestore holds no climb collection. Giving the server a readable catalog closes both this gate's target check and that residual trust gap. Tracked separately; deliberately out of scope here.

## What Changed

- `functions/src/liveReplayLeaderboard.ts` no longer reads the client-written `participation.leaderboardEligible` flag when deciding whether a live-replay row may be published. `hasEligibleClimbAttemptParticipation` is deleted, and `hasCompletedLiveClimbAttempt` now gates on the presence of a `climb_attempt` participation plus the conditions the server already re-derives from the backed-up workout (`trackingMode == live_climb`, `stopReason == target_reached`, a recorded target, `finalSteps >= target`, zero attempt baseline steps) - mirroring how `parseCompletedLandmarkWorkout` in `climbCompletions.ts` already derives completion. The participation-presence check is kept and re-documented as a document-shape check that keeps modern backups out of the legacy fallback, not as a trust signal.
- Comments at the gate record two deliberate calls: `targetStepCount` still comes from client metadata because no server-readable landmark catalog exists today (the catalog ships as a static Hosting asset), and a completion is grandfathered against the target that existed when it was climbed rather than re-checked against a later catalog value.
- `functions/test/liveReplayLeaderboard.test.ts` replaces the old "rejects rows without eligible climb participation" case with three tests pinning the new contract: the flag is ignored in both directions, and participation-less backups route through the legacy fallback with `firstAscentEligible: false`. `WorkoutParticipation.leaderboardEligible` and the `ascend-leaderboards` skill are documented accordingly - the field stays written by the client as a local record only.

Pipeline: the functions suite passes 145/145 including the new gate tests, and the change was exercised end-to-end against the Firestore emulator (forged `leaderboardEligible` on quit and resumed attempts, honest completions with the flag both ways, and a legacy participation-less backup) against both this commit and the base commit to confirm the behavior delta.

## Risk Assessment

✅ Low: The only delta since the reviewed state is a documentation comment that records an accepted product decision, with no behavioral, control-flow, or test change, and its factual claims about the climb catalog verify against the shipped catalog file.

## Testing

Installed the functions dependencies and ran the full Cloud Functions unit suite (145/145 pass, including the three tests that replace the old flag-trusting test). For product-level evidence I stood up the Firebase Firestore emulator and drove the real compiled onWorkoutReplaySplitsWritten trigger with workout backup documents shaped exactly as the iOS client writes them, then read back the persisted public leaderboard state (finisher rows, First Ascent holder, completedCount). Under the target commit a modified client claiming leaderboardEligible:true with quit or resumed-attempt evidence produces no leaderboard row at all, an evidence-backed completion publishes and claims the First Ascent even though the client wrote leaderboardEligible:false, and a participation-less legacy backup publishes a row while leaving First Ascent unclaimed. Running the identical scenarios against a build of base commit 9be9b23 shows the pre-fix gate withholding that honest completion and awarding the First Ascent to the next climber, confirming the change ignores the client flag in both directions and only widens the accept set. The Swift file in the diff is a comment-only change with no user-visible surface, so no screenshot applies; the leaderboard evidence is the persisted Firestore state transcripts. All emulator data, build output, the dummy emulator secret file and installed node_modules were removed afterwards and the worktree is clean.

<details>
<summary>Evidence: E2E transcript - target commit 33146f8 (server-derived eligibility)</summary>

<code>MODIFIED CLIENT asserts leaderboardEligible: true, evidence shows a quit at 92/2096 steps&#10;client claim leaderboardEligible : true&#10;server-derived evidence : stopReason=user_stopped steps=92 target=2096 baseline=0&#10;-&gt; public leaderboard row : NONE&#10;-&gt; holds this climb&#39;s First Ascent: false [PASS]&#10;&#10;MODIFIED CLIENT asserts leaderboardEligible: true on a resumed attempt (2004 baseline steps)&#10;-&gt; public leaderboard row : NONE [PASS]&#10;&#10;REAL COMPLETION, client wrote leaderboardEligible: false (target_reached, 2096/2096, 12:18)&#10;-&gt; public leaderboard row : PUBLISHED (Robin, 738s, finisher #1)&#10;-&gt; holds this climb&#39;s First Ascent: true [PASS]&#10;&#10;REAL COMPLETION, client wrote leaderboardEligible: true (target_reached, 2200/2096, 11:40)&#10;-&gt; public leaderboard row : PUBLISHED (Tyler, 700s, finisher #2) [PASS]&#10;&#10;LEGACY BACKUP on an untouched climb: no climb_attempt participation at all&#10;-&gt; public leaderboard row : PUBLISHED (Casey, 900s, finisher #1)&#10;-&gt; holds this climb&#39;s First Ascent: false [PASS]&#10;&#10;--- Public leaderboard: empire-state-building ---&#10;completedCount : 2&#10;First Ascent : Robin&#10;1. Robin - 738s&#10;2. Tyler - 700s&#10;&#10;--- Public leaderboard: eiffel-tower ---&#10;completedCount : 1&#10;First Ascent : (unclaimed)&#10;1. Casey - 900s</code>

```text
============================================================================
LIVE REPLAY LEADERBOARD PUBLICATION GATE - END TO END
real onWorkoutReplaySplitsWritten trigger + Firestore emulator
build under test: TARGET commit 33146f8 (server-derived eligibility)
============================================================================

MODIFIED CLIENT asserts leaderboardEligible: true, evidence shows a quit at 92/2096 steps
  climb                        : empire-state-building
  client claim leaderboardEligible : true
  server-derived evidence          : stopReason=user_stopped steps=92 target=2096 baseline=0
  -> public leaderboard row        : NONE
  -> holds this climb's First Ascent: false
  -> expected                      : no row, firstAscent=false   [PASS]

MODIFIED CLIENT asserts leaderboardEligible: true on a resumed attempt (2004 baseline steps carried in)
  climb                        : empire-state-building
  client claim leaderboardEligible : true
  server-derived evidence          : stopReason=target_reached steps=92 target=92 baseline=2004
  -> public leaderboard row        : NONE
  -> holds this climb's First Ascent: false
  -> expected                      : no row, firstAscent=false   [PASS]

REAL COMPLETION, client wrote leaderboardEligible: false (target_reached, 2096/2096, 12:18)
  climb                        : empire-state-building
  client claim leaderboardEligible : false
  server-derived evidence          : stopReason=target_reached steps=2096 target=2096 baseline=0
  -> public leaderboard row        : PUBLISHED  (Robin, 738s, finisher #1)
  -> holds this climb's First Ascent: true
  -> expected                      : published, firstAscent=true   [PASS]

REAL COMPLETION, client wrote leaderboardEligible: true (target_reached, 2200/2096, 11:40)
  climb                        : empire-state-building
  client claim leaderboardEligible : true
  server-derived evidence          : stopReason=target_reached steps=2200 target=2096 baseline=0
  -> public leaderboard row        : PUBLISHED  (Tyler, 700s, finisher #2)
  -> holds this climb's First Ascent: false
  -> expected                      : published, firstAscent=false   [PASS]

LEGACY BACKUP on an untouched climb: no climb_attempt participation at all
  climb                        : eiffel-tower
  client claim leaderboardEligible : (no climb_attempt participation)
  server-derived evidence          : stopReason=target_reached steps=2096 target=2096 baseline=0
  -> public leaderboard row        : PUBLISHED  (Casey, 900s, finisher #1)
  -> holds this climb's First Ascent: false
  -> expected                      : published, firstAscent=false   [PASS]

--- Public leaderboard: empire-state-building ---
  completedCount        : 2
  First Ascent          : Robin
  1. Robin - 738s
  2. Tyler - 700s

--- Public leaderboard: eiffel-tower ---
  completedCount        : 1
  First Ascent          : (unclaimed)
  1. Casey - 900s

============================================================================
ALL SCENARIOS AS EXPECTED - publication is derived from the backed-up workout;
the client's leaderboardEligible claim changes nothing in either direction.
============================================================================
```
</details>
<details>
<summary>Evidence: E2E transcript - base commit 9be9b23 (pre-fix, trusted the client flag)</summary>

<code>REAL COMPLETION, client wrote leaderboardEligible: false (target_reached, 2096/2096, 12:18)&#10;-&gt; public leaderboard row : NONE&#10;-&gt; holds this climb&#39;s First Ascent: false&#10;&#10;REAL COMPLETION, client wrote leaderboardEligible: true (target_reached, 2200/2096, 11:40)&#10;-&gt; public leaderboard row : PUBLISHED (Tyler, 700s, finisher #1)&#10;-&gt; holds this climb&#39;s First Ascent: true&#10;&#10;--- Public leaderboard: empire-state-building ---&#10;completedCount : 1&#10;First Ascent : Tyler&#10;1. Tyler - 700s&#10;&#10;2 SCENARIO(S) DIFFER FROM THE POST-FIX CONTRACT</code>

```text
============================================================================
LIVE REPLAY LEADERBOARD PUBLICATION GATE - END TO END
real onWorkoutReplaySplitsWritten trigger + Firestore emulator
build under test: BASE commit 9be9b23 (pre-fix, trusts client flag)
============================================================================

MODIFIED CLIENT asserts leaderboardEligible: true, evidence shows a quit at 92/2096 steps
  climb                        : empire-state-building
  client claim leaderboardEligible : true
  server-derived evidence          : stopReason=user_stopped steps=92 target=2096 baseline=0
  -> public leaderboard row        : NONE
  -> holds this climb's First Ascent: false
  -> expected                      : no row, firstAscent=false   [PASS]

MODIFIED CLIENT asserts leaderboardEligible: true on a resumed attempt (2004 baseline steps carried in)
  climb                        : empire-state-building
  client claim leaderboardEligible : true
  server-derived evidence          : stopReason=target_reached steps=92 target=92 baseline=2004
  -> public leaderboard row        : NONE
  -> holds this climb's First Ascent: false
  -> expected                      : no row, firstAscent=false   [PASS]

REAL COMPLETION, client wrote leaderboardEligible: false (target_reached, 2096/2096, 12:18)
  climb                        : empire-state-building
  client claim leaderboardEligible : false
  server-derived evidence          : stopReason=target_reached steps=2096 target=2096 baseline=0
  -> public leaderboard row        : NONE
  -> holds this climb's First Ascent: false
  -> expected                      : published, firstAscent=true   [FAIL]

REAL COMPLETION, client wrote leaderboardEligible: true (target_reached, 2200/2096, 11:40)
  climb                        : empire-state-building
  client claim leaderboardEligible : true
  server-derived evidence          : stopReason=target_reached steps=2200 target=2096 baseline=0
  -> public leaderboard row        : PUBLISHED  (Tyler, 700s, finisher #1)
  -> holds this climb's First Ascent: true
  -> expected                      : published, firstAscent=false   [FAIL]

LEGACY BACKUP on an untouched climb: no climb_attempt participation at all
  climb                        : eiffel-tower
  client claim leaderboardEligible : (no climb_attempt participation)
  server-derived evidence          : stopReason=target_reached steps=2096 target=2096 baseline=0
  -> public leaderboard row        : PUBLISHED  (Casey, 900s, finisher #1)
  -> holds this climb's First Ascent: false
  -> expected                      : published, firstAscent=false   [PASS]

--- Public leaderboard: empire-state-building ---
  completedCount        : 1
  First Ascent          : Tyler
  1. Tyler - 700s

--- Public leaderboard: eiffel-tower ---
  completedCount        : 1
  First Ascent          : (unclaimed)
  1. Casey - 900s

============================================================================
2 SCENARIO(S) DIFFER FROM THE POST-FIX CONTRACT
============================================================================
```
</details>
<details>
<summary>Evidence: E2E harness driving the real trigger against the Firestore emulator</summary>

```text
// End-to-end check of the live-replay publication gate.
//
// Runs the REAL compiled onWorkoutReplaySplitsWritten trigger against a live
// Firestore emulator: each scenario writes a workout backup shaped exactly as
// the iOS client backs one up, fires the trigger the way Firestore fires it,
// then reads back the public leaderboard state the server actually persisted.
const ROOT =
  "/Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KY2MK01GKYEWRVRBYEPB8TTG";

process.env.FIRESTORE_EMULATOR_HOST = "127.0.0.1:8080";
process.env.GCLOUD_PROJECT = "ascend-f2e4f";

const admin =
  (await import(`${ROOT}/functions/node_modules/firebase-admin/lib/index.js`))
    .default;
admin.initializeApp({projectId: "ascend-f2e4f"});
const TRIGGER = process.env.TRIGGER_MODULE ??
  `${ROOT}/functions/lib/src/liveReplayLeaderboard.js`;
const {onWorkoutReplaySplitsWritten} = await import(TRIGGER);
const db = admin.firestore();

// Start from an empty public leaderboard so every row below is one this run
// produced.
await fetch("http://127.0.0.1:8080/emulator/v1/projects/ascend-f2e4f" +
  "/databases/(default)/documents", {method: "DELETE"});

const metadata = (over = {}) => JSON.stringify({
  climbId: "empire-state-building",
  climbTargetStepCount: 2096,
  splitIntervalSeconds: 10,
  splitSteps: [0, 400, 900, 1400, 1800, 2096],
  stopReason: "target_reached",
  targetStepCount: 2096,
  trackingMode: "live_climb",
  ...over,
});

const scenarios = [
  {
    uid: "mallory-forged-flag",
    name: "Mallory",
    climb: "empire-state-building",
    title: "MODIFIED CLIENT asserts leaderboardEligible: true, " +
      "evidence shows a quit at 92/2096 steps",
    doc: {
      durationSeconds: 61,
      participations: [
        {contextType: "climb_attempt", leaderboardEligible: true},
      ],
      source: "headphone_motion",
      sourceMetadata: metadata({stopReason: "user_stopped"}),
      steps: 92,
    },
    expect: {published: false},
  },
  {
    uid: "mallory-forged-resume",
    name: "Mallory",
    climb: "empire-state-building",
    title: "MODIFIED CLIENT asserts leaderboardEligible: true on a resumed " +
      "attempt (2004 baseline steps carried in)",
    doc: {
      durationSeconds: 45,
      participations: [
        {contextType: "climb_attempt", leaderboardEligible: true},
      ],
      source: "headphone_motion",
      sourceMetadata: metadata({
        attemptBaselineSteps: 2004,
        targetStepCount: 92,
      }),
      steps: 92,
    },
    expect: {published: false},
  },
  {
    uid: "robin-honest-flag-false",
    name: "Robin",
    climb: "empire-state-building",
    title: "REAL COMPLETION, client wrote leaderboardEligible: false " +
      "(target_reached, 2096/2096, 12:18)",
    doc: {
      durationSeconds: 738,
      participations: [
        {contextType: "climb_attempt", leaderboardEligible: false},
      ],
      source: "headphone_motion",
      sourceMetadata: metadata(),
      steps: 2096,
    },
    expect: {published: true, firstAscent: true},
  },
  {
    uid: "tyler-honest-flag-true",
    name: "Tyler",
    climb: "empire-state-building",
    title: "REAL COMPLETION, client wrote leaderboardEligible: true " +
      "(target_reached, 2200/2096, 11:40)",
    doc: {
      durationSeconds: 700,
      participations: [
        {contextType: "climb_attempt", leaderboardEligible: true},
      ],
      source: "headphone_motion",
      sourceMetadata: metadata(),
      steps: 2200,
    },
    expect: {published: true, firstAscent: false},
  },
  {
    uid: "casey-legacy-backup",
    name: "Casey",
    climb: "eiffel-tower",
    title: "LEGACY BACKUP on an untouched climb: no climb_attempt " +
      "participation at all",
    doc: {
      durationSeconds: 900,
      participations: [],
      source: "headphone_motion",
      sourceMetadata: metadata({climbId: "eiffel-tower"}),
      steps: 2096,
    },
    expect: {published: true, firstAscent: false},
  },
];

for (const s of scenarios) {
  const workoutId = `${s.uid}-workout`;
  await db.collection("users").doc(s.uid).set({displayName: s.name});
  await db.collection("users").doc(s.uid)
    .collection("workouts").doc(workoutId).set(s.doc);
  await onWorkoutReplaySplitsWritten.run({
    data: {before: {data: () => undefined}, after: {data: () => s.doc}},
    params: {userId: s.uid, workoutId},
  });
}

const line = "=".repeat(76);
console.log(line);
console.log("LIVE REPLAY LEADERBOARD PUBLICATION GATE - END TO END");
console.log("real onWorkoutReplaySplitsWritten trigger + Firestore emulator");
console.log(`build under test: ${process.env.BUILD_LABEL ?? "target commit"}`);
console.log(line);

let failures = 0;
for (const s of scenarios) {
  const context = db.collection("live_replay_leaderboards")
    .doc(`live_climb__${s.climb}`);
  const finisher = (await context.collection("finishers").doc(s.uid).get())
    .data();
  const contextDoc = (await context.get()).data();
  const holdsFirstAscent = contextDoc?.firstAscentUserId === s.uid;
  const claimed = s.doc.participations[0]?.leaderboardEligible;

  const ok = !!finisher === s.expect.published &&
    holdsFirstAscent === !!s.expect.firstAscent;
  if (!ok) failures += 1;

  console.log(`\n${s.title}`);
  console.log(`  climb                        : ${s.climb}`);
  console.log("  client claim leaderboardEligible : " +
    `${claimed === undefined ? "(no climb_attempt participation)" : claimed}`);
  console.log("  server-derived evidence          : " +
    `stopReason=${JSON.parse(s.doc.sourceMetadata).stopReason} ` +
    `steps=${s.doc.steps} target=` +
    `${JSON.parse(s.doc.sourceMetadata).targetStepCount} ` +
    `baseline=` +
    `${JSON.parse(s.doc.sourceMetadata).attemptBaselineSteps ?? 0}`);
  console.log("  -> public leaderboard row        : " +
    (finisher ?
      `PUBLISHED  (${finisher.displayName}, ` +
        `${finisher.bestCompletionDurationSeconds}s, ` +
        `finisher #${finisher.globalCompletionOrder})` :
      "NONE"));
  console.log("  -> holds this climb's First Ascent: " +
    `${holdsFirstAscent}`);
  console.log(`  -> expected                      : ` +
    `${s.expect.published ? "published" : "no row"}, ` +
    `firstAscent=${!!s.expect.firstAscent}   [${ok ? "PASS" : "FAIL"}]`);
}

for (const climb of ["empire-state-building", "eiffel-tower"]) {
  const context = db.collection("live_replay_leaderboards")
    .doc(`live_climb__${climb}`);
  const doc = (await context.get()).data();
  const finishers = await context.collection("finishers")
    .orderBy("globalCompletionOrder").get();
  console.log(`\n--- Public leaderboard: ${climb} ---`);
  console.log(`  completedCount        : ${doc?.completedCount ?? 0}`);
  console.log("  First Ascent          : " +
    `${doc?.firstAscentDisplayName ?? "(unclaimed)"}`);
  finishers.docs.forEach((d, i) => {
    const f = d.data();
    console.log(`  ${i + 1}. ${f.displayName} - ` +
      `${f.bestCompletionDurationSeconds}s`);
  });
}

console.log("\n" + line);
console.log(failures === 0 ?
  "ALL SCENARIOS AS EXPECTED - publication is derived from the backed-up " +
    "workout;\nthe client's leaderboardEligible claim changes nothing in " +
    "either direction." :
  `${failures} SCENARIO(S) DIFFER FROM THE POST-FIX CONTRACT`);
console.log(line);
process.exit(0);
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `functions/src/liveReplayLeaderboard.ts:460` - The widened gate is not empty in honest data when a landmark&#39;s step target changes in the hosted catalog. A live session that auto-finished writes stopReason=target_reached and climbTargetStepCount=&lt;old target&gt; into sourceMetadata. If the catalog later raises referenceStepCount, ClimbService.apply computes isCompletion(steps, newTarget)=false, so it marks the attempt .failed locally and leaves leaderboardEligible=false; normalizeStopReason only upgrades user_stopped and never downgrades target_reached, so the stored metadata still says target_reached with steps &gt;= the old recorded target. That document now satisfies every re-derived condition (climb_attempt participation present, live_climb, target_reached, target recorded, finalSteps &gt;= target, baseline 0) and publishes with firstAscentEligible: true - a permanent, unreclaimable First Ascent - while the app shows the attempt as failed. The old flag check blocked exactly this. Worth confirming whether that is the intended outcome (arguably the user did reach the target as it stood), or whether the gate should also cross-check the catalog target once a server-readable catalog exists.
- ℹ️ `functions/src/liveReplayLeaderboard.ts:436` - Noting the tradeoff explicitly acknowledged in the new comment: finalSteps &gt;= targetStepCount still compares two client-written numbers (steps and climbTargetStepCount), so a modified client can still mint a First Ascent by writing a low climbTargetStepCount with matching steps, trackingMode live_climb, stopReason target_reached, and a climb_attempt participation. The change is a strict improvement over reading the boolean, and the gap is documented at the gate rather than hidden, but the trust boundary is not actually closed by this PR - it is relocated from one client field to two.

🔧 Fix: document deliberate grandfathering in live climb publication gate
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd functions &amp;&amp; npm test` (node --test over the compiled suite, 145/145 pass, incl. the 3 new gate tests)</code>
- <code>Started the Firebase Firestore emulator (`firebase emulators:start --only firestore --project ascend-f2e4f`)</code>
- <code>E2E: `BUILD_LABEL=&#34;TARGET commit 33146f8&#34; node e2e-eligibility.mjs` - invokes the real compiled `onWorkoutReplaySplitsWritten` trigger on client-shaped workout backups and reads back persisted `live_replay_leaderboards` finisher rows / First Ascent holder</code>
- <code>E2E comparison: compiled base commit 9be9b23&#39;s `liveReplayLeaderboard.ts` and ran the same scenarios via `TRIGGER_MODULE=... node e2e-eligibility.mjs` to confirm the behaviour delta</code>
- <code>Scenarios exercised: forged `leaderboardEligible:true` on a quit attempt; forged flag on a resumed attempt with 2004 baseline steps; honest completion with `leaderboardEligible:false`; honest completion with the flag true; legacy backup with no climb_attempt participation</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

