### PR TITLE
ci: harden deploy workflow triggers, gate, and build-number derivation

### DIFF
--- a/.claude/skills/ascend-deploy/SKILL.md
+++ b/.claude/skills/ascend-deploy/SKILL.md
@@ -72,6 +72,12 @@ Do not introduce a *new* long-lived JSON service-account key for deploy auth; th
   - `MATCH_PASSWORD`
   - `MATCH_GIT_PRIVATE_KEY`
 - Also required by both build jobs: `SENTRY_AUTH_TOKEN`.
+
+### Build numbers (CFBundleVersion allocator)
+- `BUILD_NUMBER` is derived by `scripts/ci/derive-build-number.sh <slot>` in a pre-archive "Derive build number" step, not from `github.run_id`/`run_number`. The step assigns the result to a variable first so a non-zero exit propagates under `set -e` before anything is written to `$GITHUB_ENV`; a failed derivation stops the deploy instead of exporting an empty build number.
+- Value: `(UTC epoch seconds - 2026-01-01T00:00:00Z) * 2 + slot`. Staging passes slot `0`, production slot `1`. Two slots consume two integers per second, giving `4294967296 / 2 = 2147483648` seconds of range - exhausting around 2094-01-19 UTC, where the script hard-fails rather than emitting a value above the 32-bit App Store ceiling.
+- Uniqueness depends on two invariants, both enforced by `scripts/test/ci-workflow-contracts.test.mjs`: every uploadable workflow (one that runs a signed `build_*` lane or `upload_testflight`) declares a **fixed, non-ref-scoped** concurrency group (`deploy-staging`, `deploy-production`) so all of its runs - including manual `workflow_dispatch` from any ref - serialize; and each such workflow passes a **distinct** allocator slot. A new uploadable workflow, a duplicate slot, or a group that regains a `${{ github.ref }}` component fails that contract test.
+- The script also refuses any value at or below the recorded `PREVIOUS_BUILD_NUMBER_FLOOR`. Do not raise `BUILD_NUMBER_EPOCH_SECONDS`: a larger epoch emits build numbers below already-uploaded builds, which TestFlight rejects irreversibly. If the range is ever exhausted, ship a new marketing version with a reset build-number scheme instead.
 - Legacy manual-signing CI secrets are deprecated:
   - `BUILD_CERTIFICATE_BASE64`
   - `BUILD_PROVISION_PROFILE_BASE64`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,10 @@ on:
     paths:
       - "AscendApp/**"
       - "AscendAppTests/**"
+      - "AscendLiveActivityWidgets/**"
       - "AscendApp.xcodeproj/**"
       - "functions/**"
+      - "firestore.indexes.json"
       - "scripts/**"
       - "web/**"
       - "package.json"
@@ -47,10 +49,12 @@ jobs:
             ios:
               - "AscendApp/**"
               - "AscendAppTests/**"
+              - "AscendLiveActivityWidgets/**"
               - "AscendApp.xcodeproj/**"
               - ".github/workflows/**"
             functions:
               - "functions/**"
+              - "firestore.indexes.json"
               - "SharedTestVectors/**"
               - ".github/workflows/**"
             scripts:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -22,7 +22,7 @@ on:
       - ".github/workflows/deploy-production.yml"
 
 concurrency:
-  group: deploy-production-${{ github.ref }}
+  group: deploy-production
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -161,7 +161,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "BUILD_NUMBER=$(scripts/ci/derive-build-number.sh)" >> "$GITHUB_ENV"
+          build_number="$(scripts/ci/derive-build-number.sh 1)"
+          echo "BUILD_NUMBER=${build_number}" >> "$GITHUB_ENV"
 
       - name: Build production IPA via Fastlane
         env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,15 +6,17 @@ on:
     branches: [main]
     paths:
       - "AscendApp/**"
+      - "AscendLiveActivityWidgets/**"
       - "AscendApp.xcodeproj/**"
       - "fastlane/**"
-      - "scripts/upload-sentry-dsyms.sh"
+      - "scripts/**"
       - "Gemfile"
       - "Gemfile.lock"
       - "functions/**"
       - "web/**"
       - "firebase.json"
       - "firestore.rules"
+      - "firestore.indexes.json"
       - "storage.rules"
       - ".firebaserc"
       - ".github/workflows/deploy-production.yml"
@@ -36,7 +38,8 @@ jobs:
           if [ "${{ vars.PRODUCTION_READY }}" != "true" ]; then
             echo "Production deploy is disabled."
             echo "Set repository variable PRODUCTION_READY=true after provisioning production Firebase + secrets."
-            echo "Workflow will exit without deploy jobs."
+            echo "Workflow will fail before deploy jobs."
+            exit 1
           else
             echo "Production deploy is enabled."
           fi
@@ -168,7 +171,7 @@ jobs:
           IOS_PRODUCTION_WIDGET_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.LiveClimbWidgets
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
-          BUILD_NUMBER: ${{ github.run_number }}
+          BUILD_NUMBER: ${{ github.run_id }}
         run: bundle exec fastlane build_production
 
       - name: Upload production IPA artifact

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -157,6 +157,12 @@ jobs:
             exit 1
           fi
 
+      - name: Derive build number
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "BUILD_NUMBER=$(scripts/ci/derive-build-number.sh)" >> "$GITHUB_ENV"
+
       - name: Build production IPA via Fastlane
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
@@ -171,7 +177,6 @@ jobs:
           IOS_PRODUCTION_WIDGET_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.LiveClimbWidgets
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
-          BUILD_NUMBER: ${{ github.run_id }}
         run: bundle exec fastlane build_production
 
       - name: Upload production IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -146,6 +146,12 @@ jobs:
             exit 1
           fi
 
+      - name: Derive build number
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "BUILD_NUMBER=$(scripts/ci/derive-build-number.sh)" >> "$GITHUB_ENV"
+
       - name: Build staging IPA via Fastlane
         env:
           MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
@@ -160,7 +166,6 @@ jobs:
           IOS_STAGING_WIDGET_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.staging.LiveClimbWidgets
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
-          BUILD_NUMBER: ${{ github.run_id }}
         run: bundle exec fastlane build_staging
 
       - name: Upload staging IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -6,15 +6,17 @@ on:
     branches: [develop]
     paths:
       - "AscendApp/**"
+      - "AscendLiveActivityWidgets/**"
       - "AscendApp.xcodeproj/**"
       - "fastlane/**"
-      - "scripts/upload-sentry-dsyms.sh"
+      - "scripts/**"
       - "Gemfile"
       - "Gemfile.lock"
       - "functions/**"
       - "web/**"
       - "firebase.json"
       - "firestore.rules"
+      - "firestore.indexes.json"
       - "storage.rules"
       - ".firebaserc"
       - ".github/workflows/deploy-staging.yml"
@@ -158,7 +160,7 @@ jobs:
           IOS_STAGING_WIDGET_PROVISIONING_PROFILE_SPECIFIER: match AppStore com.TylerPavay.AscendApp.staging.LiveClimbWidgets
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: "120"
-          BUILD_NUMBER: ${{ github.run_number }}
+          BUILD_NUMBER: ${{ github.run_id }}
         run: bundle exec fastlane build_staging
 
       - name: Upload staging IPA artifact

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -150,7 +150,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          echo "BUILD_NUMBER=$(scripts/ci/derive-build-number.sh)" >> "$GITHUB_ENV"
+          build_number="$(scripts/ci/derive-build-number.sh 0)"
+          echo "BUILD_NUMBER=${build_number}" >> "$GITHUB_ENV"
 
       - name: Build staging IPA via Fastlane
         env:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,7 +26,7 @@ on:
 # deploy or the TestFlight upload and leave staging half-deployed. Overlapping
 # runs queue behind the running one instead.
 concurrency:
-  group: deploy-staging-${{ github.ref }}
+  group: deploy-staging
   cancel-in-progress: false
 
 permissions:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,7 +112,8 @@ platform :ios do
     staging_widget_bundle_identifier = ENV.fetch("IOS_STAGING_WIDGET_BUNDLE_ID", "com.TylerPavay.AscendApp.staging.LiveClimbWidgets")
     staging_widget_profile_specifier = ENV.fetch("IOS_STAGING_WIDGET_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp.staging.LiveClimbWidgets")
 
-    # Auto-increment build number on CI using the workflow run number
+    # BUILD_NUMBER is derived pre-archive by scripts/ci/derive-build-number.sh
+    # from epoch seconds and the workflow slot, not github.run_number.
     build_number = ENV["BUILD_NUMBER"]
     if build_number
       increment_build_number(
@@ -196,7 +197,8 @@ platform :ios do
     production_widget_bundle_identifier = ENV.fetch("IOS_PRODUCTION_WIDGET_BUNDLE_ID", "com.TylerPavay.AscendApp.LiveClimbWidgets")
     production_widget_profile_specifier = ENV.fetch("IOS_PRODUCTION_WIDGET_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp.LiveClimbWidgets")
 
-    # Auto-increment build number on CI using the workflow run number
+    # BUILD_NUMBER is derived pre-archive by scripts/ci/derive-build-number.sh
+    # from epoch seconds and the workflow slot, not github.run_number.
     build_number = ENV["BUILD_NUMBER"]
     if build_number
       increment_build_number(

--- a/scripts/ci/derive-build-number.sh
+++ b/scripts/ci/derive-build-number.sh
@@ -5,11 +5,14 @@ set -euo pipefail
 # across staging and production, and raw run IDs are ~11 digits - far past the
 # 32-bit ceiling App Store Connect enforces on every CFBundleVersion component.
 # Coarse UTC epoch seconds carry the ordering instead: one integer per second,
-# doubled so each workflow owns a slot. Every workflow serializes its own runs
-# through its concurrency group, so two staging (or two production) builds
-# cannot derive in the same second, and the distinct slot keeps staging and
-# production apart when they derive in the same second. Across adjacent seconds
-# even the later tick's slot 0 outranks the earlier tick's slot 1.
+# doubled so each workflow owns a slot. Each uploadable workflow declares a
+# fixed, non-ref-scoped concurrency group (deploy-staging, deploy-production),
+# so every run of that workflow - push or manual dispatch from any ref -
+# serializes and two staging (or two production) builds cannot derive in the
+# same second. The distinct slot keeps staging and production apart when they
+# derive in the same second. Across adjacent seconds even the later tick's
+# slot 0 outranks the earlier tick's slot 1. The ci-workflow-contracts test
+# enforces the fixed group + unique slot for every uploadable workflow.
 #
 # 2026-01-01 00:00:00 UTC. Two slots consume two integers per second, so
 # 4294967296 / 2 = 2147483648 seconds of range, exhausting around 2094-01-19 UTC.

--- a/scripts/ci/derive-build-number.sh
+++ b/scripts/ci/derive-build-number.sh
@@ -1,14 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# GitHub run IDs are repository-wide and strictly increasing, so they are the
-# only counter both deploy workflows share - each workflow's github.run_number
-# is its own sequence and collides across workflows. Raw run IDs are ~11 digits
-# though, far past the 32-bit ceiling App Store Connect enforces on every
-# CFBundleVersion component, so a fixed epoch is subtracted. Subtraction keeps
-# the mapping order-preserving and collision-free; a modulo would wrap and let a
-# later run emit a smaller build number than an earlier one.
-RUN_ID_EPOCH=29800000000
+# Each workflow's github.run_number is its own sequence, so it is not shared
+# across staging and production, and raw run IDs are ~11 digits - far past the
+# 32-bit ceiling App Store Connect enforces on every CFBundleVersion component.
+# Coarse UTC epoch seconds carry the ordering instead: one integer per second,
+# doubled so each workflow owns a slot. Every workflow serializes its own runs
+# through its concurrency group, so two staging (or two production) builds
+# cannot derive in the same second, and the distinct slot keeps staging and
+# production apart when they derive in the same second. Across adjacent seconds
+# even the later tick's slot 0 outranks the earlier tick's slot 1.
+#
+# 2026-01-01 00:00:00 UTC. Two slots consume two integers per second, so
+# 4294967296 / 2 = 2147483648 seconds of range, exhausting around 2094-01-19 UTC.
+BUILD_NUMBER_EPOCH_SECONDS=1767225600
+
+WORKFLOW_SLOT_COUNT=2
 
 # App Store Connect rejects any CFBundleVersion component above 2^32 - 1.
 MAX_BUILD_NUMBER=4294967295
@@ -18,19 +25,25 @@ MAX_BUILD_NUMBER=4294967295
 # number must stay strictly above it or TestFlight rejects the upload.
 PREVIOUS_BUILD_NUMBER_FLOOR=147
 
-run_id="${1:-${GITHUB_RUN_ID:-}}"
+slot="${1:-}"
+timestamp="${2:-$(date -u +%s)}"
 
-if [[ ! "${run_id}" =~ ^[0-9]+$ ]]; then
-  echo "::error::GITHUB_RUN_ID must be a positive integer, got '${run_id}'." >&2
+if [[ ! "${slot}" =~ ^[0-9]+$ ]] || (( slot >= WORKFLOW_SLOT_COUNT )); then
+  echo "::error::Workflow slot must be 0 (staging) or 1 (production), got '${slot}'." >&2
   exit 1
 fi
 
-build_number=$((run_id - RUN_ID_EPOCH))
-
-if (( build_number <= 0 )); then
-  echo "::error::Run ID ${run_id} is at or below the build-number epoch ${RUN_ID_EPOCH}." >&2
+if [[ ! "${timestamp}" =~ ^[0-9]+$ ]]; then
+  echo "::error::UTC timestamp must be a non-negative integer, got '${timestamp}'." >&2
   exit 1
 fi
+
+if (( timestamp < BUILD_NUMBER_EPOCH_SECONDS )); then
+  echo "::error::Timestamp ${timestamp} predates the build-number epoch ${BUILD_NUMBER_EPOCH_SECONDS}." >&2
+  exit 1
+fi
+
+build_number=$(((timestamp - BUILD_NUMBER_EPOCH_SECONDS) * WORKFLOW_SLOT_COUNT + slot))
 
 if (( build_number <= PREVIOUS_BUILD_NUMBER_FLOOR )); then
   echo "::error::Derived build number ${build_number} is not above the last uploaded build number ${PREVIOUS_BUILD_NUMBER_FLOOR}." >&2
@@ -39,7 +52,7 @@ fi
 
 if (( build_number > MAX_BUILD_NUMBER )); then
   echo "::error::Derived build number ${build_number} exceeds the App Store limit ${MAX_BUILD_NUMBER}." >&2
-  echo "::error::Raising RUN_ID_EPOCH would emit build numbers below already-uploaded builds; ship a new marketing version with a reset build-number scheme instead." >&2
+  echo "::error::The 32-bit range from the epoch is exhausted; ship a new marketing version with a reset build-number scheme." >&2
   exit 1
 fi
 

--- a/scripts/ci/derive-build-number.sh
+++ b/scripts/ci/derive-build-number.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub run IDs are repository-wide and strictly increasing, so they are the
+# only counter both deploy workflows share - each workflow's github.run_number
+# is its own sequence and collides across workflows. Raw run IDs are ~11 digits
+# though, far past the 32-bit ceiling App Store Connect enforces on every
+# CFBundleVersion component, so a fixed epoch is subtracted. Subtraction keeps
+# the mapping order-preserving and collision-free; a modulo would wrap and let a
+# later run emit a smaller build number than an earlier one.
+RUN_ID_EPOCH=29800000000
+
+# App Store Connect rejects any CFBundleVersion component above 2^32 - 1.
+MAX_BUILD_NUMBER=4294967295
+
+# Highest build number uploaded while the workflows still used
+# github.run_number (Deploy Staging run 147, 2026-07-21). Every derived build
+# number must stay strictly above it or TestFlight rejects the upload.
+PREVIOUS_BUILD_NUMBER_FLOOR=147
+
+run_id="${1:-${GITHUB_RUN_ID:-}}"
+
+if [[ ! "${run_id}" =~ ^[0-9]+$ ]]; then
+  echo "::error::GITHUB_RUN_ID must be a positive integer, got '${run_id}'." >&2
+  exit 1
+fi
+
+build_number=$((run_id - RUN_ID_EPOCH))
+
+if (( build_number <= 0 )); then
+  echo "::error::Run ID ${run_id} is at or below the build-number epoch ${RUN_ID_EPOCH}." >&2
+  exit 1
+fi
+
+if (( build_number <= PREVIOUS_BUILD_NUMBER_FLOOR )); then
+  echo "::error::Derived build number ${build_number} is not above the last uploaded build number ${PREVIOUS_BUILD_NUMBER_FLOOR}." >&2
+  exit 1
+fi
+
+if (( build_number > MAX_BUILD_NUMBER )); then
+  echo "::error::Derived build number ${build_number} exceeds the App Store limit ${MAX_BUILD_NUMBER}." >&2
+  echo "::error::Raising RUN_ID_EPOCH would emit build numbers below already-uploaded builds; ship a new marketing version with a reset build-number scheme instead." >&2
+  exit 1
+fi
+
+printf '%s\n' "${build_number}"

--- a/scripts/test/ci-workflow-contracts.test.mjs
+++ b/scripts/test/ci-workflow-contracts.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -54,11 +55,83 @@ test("production readiness failure is visible to GitHub Actions", async () => {
   assert.match(disabledBranch, /^\s+exit 1$/m);
 });
 
-test("deploy build numbers use the repository-wide run identifier", async () => {
+test("deploy build numbers come from the shared run-id derivation, before the archive", async () => {
   for (const name of ["deploy-staging.yml", "deploy-production.yml"]) {
     const workflow = await readWorkflow(name);
+    const deriveIndex = workflow.indexOf("scripts/ci/derive-build-number.sh");
+    const buildIndex = workflow.indexOf("bundle exec fastlane build_");
 
-    assert.match(workflow, /BUILD_NUMBER: \$\{\{ github\.run_id \}\}/, name);
+    assert.notEqual(deriveIndex, -1, name);
+    assert.ok(deriveIndex < buildIndex, `${name} must derive the build number before archiving`);
     assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_number \}\}/, name);
+    assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_id \}\}/, name);
   }
+});
+
+const deriveScript = `${repositoryRoot}scripts/ci/derive-build-number.sh`;
+
+function deriveBuildNumber(runId) {
+  return spawnSync(deriveScript, [], {encoding: "utf8", env: {PATH: "/usr/bin:/bin", GITHUB_RUN_ID: String(runId)}});
+}
+
+async function scriptConstant(name) {
+  const source = await readFile(deriveScript, "utf8");
+  const value = source.match(new RegExp(`^${name}=(\\d+)$`, "m"))?.[1];
+
+  assert.ok(value, `Missing constant ${name}`);
+  return Number(value);
+}
+
+test("derived build numbers clear the last build number uploaded from run_number", async () => {
+  const epoch = await scriptConstant("RUN_ID_EPOCH");
+  const floor = await scriptConstant("PREVIOUS_BUILD_NUMBER_FLOOR");
+  // The run ID of the last deploy before this change; every future run ID is larger.
+  const result = deriveBuildNumber(29_863_763_672);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.ok(Number(result.stdout.trim()) > floor);
+  assert.ok(epoch < 29_863_763_672, "epoch must sit below observed run IDs");
+});
+
+test("derivation is monotonic and collision-free for increasing run IDs", async () => {
+  const epoch = await scriptConstant("RUN_ID_EPOCH");
+  const runIds = [epoch + 1_000, epoch + 1_001, epoch + 500_000, epoch + 4_000_000_000];
+  const derived = runIds.map((runId) => {
+    const result = deriveBuildNumber(runId);
+    assert.equal(result.status, 0, result.stderr);
+    return Number(result.stdout.trim());
+  });
+
+  assert.equal(new Set(derived).size, derived.length);
+  for (let index = 1; index < derived.length; index += 1) {
+    assert.ok(derived[index] > derived[index - 1], `${runIds[index]} must derive above ${runIds[index - 1]}`);
+  }
+});
+
+test("out-of-range run IDs fail the build instead of wrapping", async () => {
+  const epoch = await scriptConstant("RUN_ID_EPOCH");
+  const max = await scriptConstant("MAX_BUILD_NUMBER");
+  const floor = await scriptConstant("PREVIOUS_BUILD_NUMBER_FLOOR");
+
+  assert.equal(max, 4_294_967_295);
+
+  const atLimit = deriveBuildNumber(epoch + max);
+  assert.equal(atLimit.status, 0, atLimit.stderr);
+  assert.equal(Number(atLimit.stdout.trim()), max);
+
+  const overLimit = deriveBuildNumber(epoch + max + 1);
+  assert.notEqual(overLimit.status, 0);
+  assert.match(overLimit.stderr, /exceeds the App Store limit/);
+
+  const atEpoch = deriveBuildNumber(epoch);
+  assert.notEqual(atEpoch.status, 0);
+  assert.match(atEpoch.stderr, /at or below the build-number epoch/);
+
+  const belowFloor = deriveBuildNumber(epoch + floor);
+  assert.notEqual(belowFloor.status, 0);
+  assert.match(belowFloor.stderr, /not above the last uploaded build number/);
+
+  const notANumber = deriveBuildNumber("29863763672abc");
+  assert.notEqual(notANumber.status, 0);
+  assert.match(notANumber.stderr, /must be a positive integer/);
 });

--- a/scripts/test/ci-workflow-contracts.test.mjs
+++ b/scripts/test/ci-workflow-contracts.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+async function readWorkflow(name) {
+  return readFile(`${repositoryRoot}/.github/workflows/${name}`, "utf8");
+}
+
+function sectionBetween(source, start, end) {
+  const startIndex = source.indexOf(start);
+  assert.notEqual(startIndex, -1, `Missing section start: ${start}`);
+
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  assert.notEqual(endIndex, -1, `Missing section end: ${end}`);
+
+  return source.slice(startIndex, endIndex);
+}
+
+test("CI watches every iOS source and Firebase index definition", async () => {
+  const workflow = await readWorkflow("ci.yml");
+  const trigger = sectionBetween(workflow, "on:\n", "\nconcurrency:");
+  const iosFilter = sectionBetween(workflow, "            ios:\n", "            functions:\n");
+  const functionsFilter = sectionBetween(workflow, "            functions:\n", "            scripts:\n");
+
+  assert.match(trigger, /- "AscendLiveActivityWidgets\/\*\*"/);
+  assert.match(trigger, /- "scripts\/\*\*"/);
+  assert.match(trigger, /- "firestore\.indexes\.json"/);
+  assert.match(iosFilter, /- "AscendLiveActivityWidgets\/\*\*"/);
+  assert.match(functionsFilter, /- "firestore\.indexes\.json"/);
+});
+
+test("deploy workflows watch every artifact and Firebase deployment input", async () => {
+  for (const name of ["deploy-staging.yml", "deploy-production.yml"]) {
+    const workflow = await readWorkflow(name);
+    const trigger = sectionBetween(workflow, "on:\n", "\nconcurrency:");
+
+    assert.match(trigger, /- "AscendLiveActivityWidgets\/\*\*"/, name);
+    assert.match(trigger, /- "scripts\/\*\*"/, name);
+    assert.match(trigger, /- "firestore\.indexes\.json"/, name);
+  }
+});
+
+test("production readiness failure is visible to GitHub Actions", async () => {
+  const workflow = await readWorkflow("deploy-production.yml");
+  const disabledBranch = sectionBetween(
+    workflow,
+    '          if [ "${{ vars.PRODUCTION_READY }}" != "true" ]; then\n',
+    "          else\n"
+  );
+
+  assert.match(disabledBranch, /^\s+exit 1$/m);
+});
+
+test("deploy build numbers use the repository-wide run identifier", async () => {
+  for (const name of ["deploy-staging.yml", "deploy-production.yml"]) {
+    const workflow = await readWorkflow(name);
+
+    assert.match(workflow, /BUILD_NUMBER: \$\{\{ github\.run_id \}\}/, name);
+    assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_number \}\}/, name);
+  }
+});

--- a/scripts/test/ci-workflow-contracts.test.mjs
+++ b/scripts/test/ci-workflow-contracts.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -55,23 +58,20 @@ test("production readiness failure is visible to GitHub Actions", async () => {
   assert.match(disabledBranch, /^\s+exit 1$/m);
 });
 
-test("deploy build numbers come from the shared run-id derivation, before the archive", async () => {
-  for (const name of ["deploy-staging.yml", "deploy-production.yml"]) {
-    const workflow = await readWorkflow(name);
-    const deriveIndex = workflow.indexOf("scripts/ci/derive-build-number.sh");
-    const buildIndex = workflow.indexOf("bundle exec fastlane build_");
-
-    assert.notEqual(deriveIndex, -1, name);
-    assert.ok(deriveIndex < buildIndex, `${name} must derive the build number before archiving`);
-    assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_number \}\}/, name);
-    assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_id \}\}/, name);
-  }
-});
-
 const deriveScript = `${repositoryRoot}scripts/ci/derive-build-number.sh`;
+const workflowSlots = {"deploy-staging.yml": "0", "deploy-production.yml": "1"};
 
-function deriveBuildNumber(runId) {
-  return spawnSync(deriveScript, [], {encoding: "utf8", env: {PATH: "/usr/bin:/bin", GITHUB_RUN_ID: String(runId)}});
+function deriveBuildNumber(slot, timestamp) {
+  const argumentList = timestamp === undefined ? [String(slot)] : [String(slot), String(timestamp)];
+
+  return spawnSync(deriveScript, argumentList, {encoding: "utf8", env: {PATH: "/usr/bin:/bin"}});
+}
+
+function derivedValue(slot, timestamp) {
+  const result = deriveBuildNumber(slot, timestamp);
+
+  assert.equal(result.status, 0, result.stderr);
+  return Number(result.stdout.trim());
 }
 
 async function scriptConstant(name) {
@@ -82,56 +82,117 @@ async function scriptConstant(name) {
   return Number(value);
 }
 
-test("derived build numbers clear the last build number uploaded from run_number", async () => {
-  const epoch = await scriptConstant("RUN_ID_EPOCH");
-  const floor = await scriptConstant("PREVIOUS_BUILD_NUMBER_FLOOR");
-  // The run ID of the last deploy before this change; every future run ID is larger.
-  const result = deriveBuildNumber(29_863_763_672);
+function deriveStepScript(workflow) {
+  const step = sectionBetween(workflow, "      - name: Derive build number\n", "\n      - name: ");
+  const body = step.slice(step.indexOf("        run: |\n") + "        run: |\n".length);
 
-  assert.equal(result.status, 0, result.stderr);
-  assert.ok(Number(result.stdout.trim()) > floor);
-  assert.ok(epoch < 29_863_763_672, "epoch must sit below observed run IDs");
-});
+  return body.replace(/^ {10}/gm, "");
+}
 
-test("derivation is monotonic and collision-free for increasing run IDs", async () => {
-  const epoch = await scriptConstant("RUN_ID_EPOCH");
-  const runIds = [epoch + 1_000, epoch + 1_001, epoch + 500_000, epoch + 4_000_000_000];
-  const derived = runIds.map((runId) => {
-    const result = deriveBuildNumber(runId);
-    assert.equal(result.status, 0, result.stderr);
-    return Number(result.stdout.trim());
-  });
+test("deploy build numbers come from the shared derivation, before the archive", async () => {
+  for (const [name, slot] of Object.entries(workflowSlots)) {
+    const workflow = await readWorkflow(name);
+    const deriveIndex = workflow.indexOf("scripts/ci/derive-build-number.sh");
+    const buildIndex = workflow.indexOf("bundle exec fastlane build_");
 
-  assert.equal(new Set(derived).size, derived.length);
-  for (let index = 1; index < derived.length; index += 1) {
-    assert.ok(derived[index] > derived[index - 1], `${runIds[index]} must derive above ${runIds[index - 1]}`);
+    assert.notEqual(deriveIndex, -1, name);
+    assert.ok(deriveIndex < buildIndex, `${name} must derive the build number before archiving`);
+    assert.match(deriveStepScript(workflow), new RegExp(`derive-build-number\\.sh ${slot}\\b`), name);
+    assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_number \}\}/, name);
+    assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_id \}\}/, name);
   }
 });
 
-test("out-of-range run IDs fail the build instead of wrapping", async () => {
-  const epoch = await scriptConstant("RUN_ID_EPOCH");
-  const max = await scriptConstant("MAX_BUILD_NUMBER");
+test("a failed derivation stops the deploy instead of exporting an empty build number", async () => {
+  for (const name of Object.keys(workflowSlots)) {
+    const stepScript = deriveStepScript(await readWorkflow(name));
+    const root = mkdtempSync(join(tmpdir(), "ascend-build-number-"));
+    const stubPath = join(root, "scripts/ci/derive-build-number.sh");
+    const environmentFile = join(root, "github-env");
+    mkdirSync(dirname(stubPath), {recursive: true});
+    writeFileSync(environmentFile, "");
+
+    writeFileSync(stubPath, "#!/bin/sh\necho '::error::boom' >&2\nexit 1\n");
+    chmodSync(stubPath, 0o755);
+    const failed = spawnSync("bash", ["-c", stepScript], {
+      cwd: root,
+      encoding: "utf8",
+      env: {PATH: "/usr/bin:/bin", GITHUB_ENV: environmentFile},
+    });
+
+    assert.notEqual(failed.status, 0, `${name} must fail when derivation fails`);
+    assert.doesNotMatch(readFileSync(environmentFile, "utf8"), /BUILD_NUMBER=/, name);
+
+    writeFileSync(stubPath, "#!/bin/sh\necho 4321\n");
+    chmodSync(stubPath, 0o755);
+    const succeeded = spawnSync("bash", ["-c", stepScript], {
+      cwd: root,
+      encoding: "utf8",
+      env: {PATH: "/usr/bin:/bin", GITHUB_ENV: environmentFile},
+    });
+
+    assert.equal(succeeded.status, 0, succeeded.stderr);
+    assert.match(readFileSync(environmentFile, "utf8"), /^BUILD_NUMBER=4321$/m, name);
+  }
+});
+
+test("staging and production never collide, even deriving in the same second", async () => {
+  const epoch = await scriptConstant("BUILD_NUMBER_EPOCH_SECONDS");
+  const sameSecond = epoch + 20_000_000;
+  const staging = derivedValue(0, sameSecond);
+  const production = derivedValue(1, sameSecond);
+
+  assert.notEqual(staging, production);
+  assert.equal(production, staging + 1);
+});
+
+test("later seconds outrank earlier ones regardless of workflow slot", async () => {
+  const epoch = await scriptConstant("BUILD_NUMBER_EPOCH_SECONDS");
+  const second = epoch + 20_000_000;
+
+  assert.ok(derivedValue(0, second + 1) > derivedValue(1, second));
+  assert.ok(derivedValue(0, second + 2) > derivedValue(1, second + 1));
+});
+
+test("derived build numbers clear the last build number uploaded from run_number", async () => {
   const floor = await scriptConstant("PREVIOUS_BUILD_NUMBER_FLOOR");
+  const epoch = await scriptConstant("BUILD_NUMBER_EPOCH_SECONDS");
+
+  assert.equal(epoch, Date.parse("2026-01-01T00:00:00Z") / 1000);
+
+  for (const slot of [0, 1]) {
+    assert.ok(derivedValue(slot) > floor, `slot ${slot} must clear the previous build number floor`);
+  }
+
+  const atFloor = deriveBuildNumber(0, epoch + Math.floor(floor / 2));
+  assert.notEqual(atFloor.status, 0);
+  assert.match(atFloor.stderr, /not above the last uploaded build number/);
+});
+
+test("invalid and out-of-range inputs fail the build instead of wrapping", async () => {
+  const epoch = await scriptConstant("BUILD_NUMBER_EPOCH_SECONDS");
+  const max = await scriptConstant("MAX_BUILD_NUMBER");
 
   assert.equal(max, 4_294_967_295);
+  assert.equal(derivedValue(1, epoch + (max - 1) / 2), max);
 
-  const atLimit = deriveBuildNumber(epoch + max);
-  assert.equal(atLimit.status, 0, atLimit.stderr);
-  assert.equal(Number(atLimit.stdout.trim()), max);
-
-  const overLimit = deriveBuildNumber(epoch + max + 1);
+  const overLimit = deriveBuildNumber(0, epoch + (max + 1) / 2);
   assert.notEqual(overLimit.status, 0);
   assert.match(overLimit.stderr, /exceeds the App Store limit/);
 
-  const atEpoch = deriveBuildNumber(epoch);
-  assert.notEqual(atEpoch.status, 0);
-  assert.match(atEpoch.stderr, /at or below the build-number epoch/);
+  const beforeEpoch = deriveBuildNumber(0, epoch - 1);
+  assert.notEqual(beforeEpoch.status, 0);
+  assert.match(beforeEpoch.stderr, /predates the build-number epoch/);
 
-  const belowFloor = deriveBuildNumber(epoch + floor);
-  assert.notEqual(belowFloor.status, 0);
-  assert.match(belowFloor.stderr, /not above the last uploaded build number/);
+  for (const slot of ["", "2", "-1", "0x1"]) {
+    const badSlot = deriveBuildNumber(slot, epoch + 20_000_000);
+    assert.notEqual(badSlot.status, 0, `slot '${slot}' must be rejected`);
+    assert.match(badSlot.stderr, /Workflow slot must be 0 \(staging\) or 1 \(production\)/);
+  }
 
-  const notANumber = deriveBuildNumber("29863763672abc");
-  assert.notEqual(notANumber.status, 0);
-  assert.match(notANumber.stderr, /must be a positive integer/);
+  for (const timestamp of ["not-a-number", "1767225600.5"]) {
+    const badTimestamp = deriveBuildNumber(0, timestamp);
+    assert.notEqual(badTimestamp.status, 0, `timestamp '${timestamp}' must be rejected`);
+    assert.match(badTimestamp.stderr, /UTC timestamp must be a non-negative integer/);
+  }
 });

--- a/scripts/test/ci-workflow-contracts.test.mjs
+++ b/scripts/test/ci-workflow-contracts.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import test from "node:test";
@@ -59,7 +59,66 @@ test("production readiness failure is visible to GitHub Actions", async () => {
 });
 
 const deriveScript = `${repositoryRoot}scripts/ci/derive-build-number.sh`;
-const workflowSlots = {"deploy-staging.yml": "0", "deploy-production.yml": "1"};
+const workflowsDirectory = `${repositoryRoot}.github/workflows`;
+
+// A workflow can put a build on TestFlight if it drives a signed archive lane
+// or the upload lane. Every such workflow shares the one TestFlight app and so
+// must serialize on a fixed concurrency group and own a distinct allocator slot.
+function isUploadableWorkflow(workflow) {
+  return /bundle exec fastlane build_(staging|production)\b/.test(workflow)
+    || /\bupload_to_testflight\b/.test(workflow)
+    || /\bupload_testflight\b/.test(workflow);
+}
+
+function concurrencyGroup(workflow) {
+  return workflow.match(/\nconcurrency:\n[ \t]+group:[ \t]*(.+)/)?.[1]?.trim() ?? null;
+}
+
+function buildNumberSlot(workflow) {
+  const slot = workflow.match(/derive-build-number\.sh[ \t]+(\d+)\b/)?.[1];
+  return slot === undefined ? null : Number(slot);
+}
+
+async function uploadableWorkflows() {
+  const names = (await readdir(workflowsDirectory)).filter((name) => /\.ya?ml$/.test(name)).sort();
+  const uploadable = [];
+
+  for (const name of names) {
+    const workflow = await readWorkflow(name);
+    if (!isUploadableWorkflow(workflow)) continue;
+
+    uploadable.push({name, workflow, group: concurrencyGroup(workflow), slot: buildNumberSlot(workflow)});
+  }
+
+  return uploadable;
+}
+
+test("every uploadable workflow serializes on a fixed group and owns a unique build-number slot", async () => {
+  const slotCount = await scriptConstant("WORKFLOW_SLOT_COUNT");
+  const uploadable = await uploadableWorkflows();
+  const names = uploadable.map(({name}) => name);
+
+  assert.deepEqual(names, ["deploy-production.yml", "deploy-staging.yml"], `unexpected uploadable workflow set: ${names}`);
+
+  const slots = [];
+  for (const {name, workflow, group, slot} of uploadable) {
+    assert.ok(group, `${name} must declare a concurrency group so its runs serialize`);
+    assert.doesNotMatch(group, /\$\{\{/, `${name} concurrency group must be fixed, not ref-scoped: "${group}"`);
+
+    const deriveIndex = workflow.indexOf("scripts/ci/derive-build-number.sh");
+    assert.notEqual(deriveIndex, -1, `${name} must derive its build number`);
+    const buildIndex = workflow.search(/bundle exec fastlane build_/);
+    if (buildIndex !== -1) {
+      assert.ok(deriveIndex < buildIndex, `${name} must derive the build number before archiving`);
+    }
+
+    assert.ok(Number.isInteger(slot) && slot >= 0, `${name} must pass a numeric allocator slot`);
+    assert.ok(slot < slotCount, `${name} slot ${slot} is outside the allocator range [0, ${slotCount})`);
+    slots.push(slot);
+  }
+
+  assert.equal(new Set(slots).size, slots.length, `uploadable workflows must use unique slots, got ${slots}`);
+});
 
 function deriveBuildNumber(slot, timestamp) {
   const argumentList = timestamp === undefined ? [String(slot)] : [String(slot), String(timestamp)];
@@ -90,8 +149,7 @@ function deriveStepScript(workflow) {
 }
 
 test("deploy build numbers come from the shared derivation, before the archive", async () => {
-  for (const [name, slot] of Object.entries(workflowSlots)) {
-    const workflow = await readWorkflow(name);
+  for (const {name, workflow, slot} of await uploadableWorkflows()) {
     const deriveIndex = workflow.indexOf("scripts/ci/derive-build-number.sh");
     const buildIndex = workflow.indexOf("bundle exec fastlane build_");
 
@@ -104,8 +162,8 @@ test("deploy build numbers come from the shared derivation, before the archive",
 });
 
 test("a failed derivation stops the deploy instead of exporting an empty build number", async () => {
-  for (const name of Object.keys(workflowSlots)) {
-    const stepScript = deriveStepScript(await readWorkflow(name));
+  for (const {name, workflow} of await uploadableWorkflows()) {
+    const stepScript = deriveStepScript(workflow);
     const root = mkdtempSync(join(tmpdir(), "ascend-build-number-"));
     const stubPath = join(root, "scripts/ci/derive-build-number.sh");
     const environmentFile = join(root, "github-env");

--- a/scripts/test/sentry-dsym-upload.test.mjs
+++ b/scripts/test/sentry-dsym-upload.test.mjs
@@ -157,6 +157,6 @@ for (const workflowName of ["deploy-staging.yml", "deploy-production.yml"]) {
 
     assert.notEqual(installIndex, -1);
     assert.ok(installIndex < buildIndex);
-    assert.match(workflow, /scripts\/upload-sentry-dsyms\.sh/);
+    assert.match(workflow, /- "scripts\/\*\*"/);
   });
 }

--- a/scripts/test/sentry-dsym-upload.test.mjs
+++ b/scripts/test/sentry-dsym-upload.test.mjs
@@ -157,6 +157,5 @@ for (const workflowName of ["deploy-staging.yml", "deploy-production.yml"]) {
 
     assert.notEqual(installIndex, -1);
     assert.ok(installIndex < buildIndex);
-    assert.match(workflow, /- "scripts\/\*\*"/);
   });
 }


### PR DESCRIPTION
## Intent

Ensure Ascend's CI and deploy workflows trigger for widget sources, all scripts, and firestore.indexes.json changes. Make the production readiness gate fail with exit status 1 when production is disabled so GitHub reports the blocked deploy clearly. Source staging and production build numbers from the repository-wide GitHub Actions run identifier instead of each workflow's local run counter, while preserving the existing staging and production job ordering. Add regression coverage that fails if any of these workflow contracts regress, without refactoring unrelated CI behavior.

## What Changed

- Widened CI and deploy-staging/deploy-production trigger paths to include `AscendLiveActivityWidgets/**`, `scripts/**`, and `firestore.indexes.json`, and made the production-readiness gate hard-fail with `exit 1` when `PRODUCTION_READY` is unset so GitHub surfaces a blocked deploy as a failed run.
- Added `scripts/ci/derive-build-number.sh` to allocate staging and production `BUILD_NUMBER` values as `(UTC epoch seconds - fixed epoch) * 2 + workflow slot` (staging 0, production 1) in a pre-archive step, replacing each workflow's local `github.run_number`, with overflow, floor, and epoch-drift guards; both deploy workflows and `fastlane/Fastfile` comments were updated to match.
- Added `scripts/test/ci-workflow-contracts.test.mjs` regression coverage for trigger paths, the gate exit code, fixed concurrency groups, unique per-workflow build-number slots, derive-before-archive ordering, and the collision/overflow/floor guards, and trimmed the stale assertion in `scripts/test/sentry-dsym-upload.test.mjs`.

## Risk Assessment

✅ Low: The only new change is a two-line comment correction that accurately reflects the already-reviewed, well-tested build-number allocator; the sole open item is reconciling the written intent text (run_id) with the deliberately-superseded epoch-seconds scheme the user confirmed multiple times.

## Testing

Baseline suite ran clean (65/65 scripts tests). I exercised each intent constraint against the real end-user surface: grepped the three workflow YAMLs to confirm widget/scripts/firestore.indexes.json trigger coverage; executed the production-readiness gate shell to prove exit status 1 when disabled (visible failure in GitHub Actions) and exit 0 when enabled; and ran derive-build-number.sh directly to show staging (slot 0) and production (slot 1) build numbers never collide, later seconds always outrank earlier slots, and invalid/out-of-range inputs fail the build - matching the run_number replacement while keeping derive-before-archive job ordering. The new ci-workflow-contracts.test.mjs (10 tests) locks all these contracts and passes. The removed sentry-dsym assertion is not a regression: it matched the old narrow scripts/upload-sentry-dsyms.sh trigger path now subsumed by scripts/**, and the dSYM upload still runs from the Fastfile. This is CI/tooling config with no rendered UI surface, so evidence is CLI transcripts rather than screenshots.

<details>
<summary>Evidence: CI/deploy workflow contract evidence log</summary>

```text
### CI/Deploy workflow contract evidence (target 3ada1a3)

## 1. Trigger paths added (ci + both deploy workflows)
-- ci.yml --
      - "AscendLiveActivityWidgets/**"
      - "firestore.indexes.json"
      - "scripts/**"
              - "AscendLiveActivityWidgets/**"
              - "firestore.indexes.json"
              - "scripts/**"
-- deploy-staging.yml --
      - "AscendLiveActivityWidgets/**"
      - "scripts/**"
      - "firestore.indexes.json"
-- deploy-production.yml --
      - "AscendLiveActivityWidgets/**"
      - "scripts/**"
      - "firestore.indexes.json"

## 2. Production readiness gate exits 1 when disabled
PRODUCTION_READY=false -> printed 'Workflow will fail before deploy jobs.' + exit status 1 (verified)
PRODUCTION_READY=true  -> 'Production deploy is enabled.' + exit 0 (verified)

## 3. Build numbers from shared derivation (not github.run_number)
staging slot0 @epoch+20M: 40000000
prod    slot1 @epoch+20M: 40000001  (never collides, +1)
next-second slot0:        40000002  (outranks prior second's slot1)
invalid slot 2:           ::error::Workflow slot must be 0 (staging) or 1 (production), got '2'.
rejected exit 1

## 4. Regression coverage
scripts/test/ci-workflow-contracts.test.mjs: 10/10 pass
full scripts suite: 65/65 pass
```
</details>
<details>
<summary>Evidence: derive-build-number staging vs production (real output)</summary>

```text
staging slot0 @epoch+20M: 40000000
prod slot1 @epoch+20M: 40000001 (+1, no collision)
next-second slot0: 40000002 (outranks prior second slot1)
invalid slot 2: ::error::Workflow slot must be 0 (staging) or 1 (production), got '2'. -> exit 1
```
</details>
<details>
<summary>Evidence: production readiness gate exit behavior</summary>

```text
PRODUCTION_READY=false -> 'Workflow will fail before deploy jobs.' + exit 1
PRODUCTION_READY=true -> 'Production deploy is enabled.' + exit 0
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `.github/workflows/deploy-production.yml:174` - BUILD_NUMBER now uses ${{ github.run_id }} (also deploy-staging.yml:163). GitHub run IDs are currently ~11-digit values (~1.2-2e10), which exceeds 2^32-1. App Store Connect validates each CFBundleVersion component as a non-negative integer within a 32-bit range and rejects larger values, so `upload_testflight` can fail at the last and hardest-to-reverse step of both pipelines. It is also irreversible: CURRENT_PROJECT_VERSION is currently 2, and once a ~2e10 build number ships, every future build must exceed it forever. The intent requires &#34;Source staging and production build numbers from the repository-wide GitHub Actions run identifier&#34;, so confirm the intended encoding - e.g. `${{ github.run_id }}` truncated (mod 1000000000) or `github.run_number` plus a fixed repository-wide offset - rather than the raw ID.
- ⚠️ `scripts/test/sentry-dsym-upload.test.mjs:160` - The assertion inside the &#34;installs Sentry CLI before building&#34; test was changed from matching `scripts/upload-sentry-dsyms.sh` to matching the generic `- &#34;scripts/**&#34;` glob. That glob proves nothing about the dSYM upload script, is unrelated to this test&#39;s stated subject (install-before-build ordering), and duplicates the new coverage in ci-workflow-contracts.test.mjs. Either drop the line from this test or assert the workflow/Fastfile still references upload-sentry-dsyms.sh.
- ℹ️ `.github/workflows/deploy-production.yml:42` - Now that the gate hard-fails with `exit 1`, the per-job `if: ${{ vars.PRODUCTION_READY == &#39;true&#39; }}` guards on build-ios (line 49), deploy-firebase (186), and upload-testflight (220) are redundant - `needs: production-gate` alone already skips them. Also note the intended side effect: every push to main now reports a failed workflow run until PRODUCTION_READY=true is set.
- ℹ️ `.github/workflows/deploy-production.yml:12` - Replacing `scripts/upload-sentry-dsyms.sh` with `scripts/**` means edits to unrelated dev tooling (seeding, dev-DB, icon scripts) now trigger a full production Firebase deploy plus TestFlight upload. This matches the stated intent (&#34;all scripts&#34;); flagged only so the widened blast radius is a conscious tradeoff.
- ℹ️ `scripts/test/ci-workflow-contracts.test.mjs:41` - sectionBetween slices the paths-filter block using literal 12-space-indented `ios:`/`functions:`/`scripts:` keys, so it depends on both exact indentation and the current ordering of the filters. A harmless reorder or reindent of ci.yml fails with &#34;Missing section end&#34; rather than a real contract violation.

🔧 Fix: derive CI build numbers from run_id with overflow guards
3 issues (1 error, 1 warning, 1 info) still open:
- 🚨 `.github/workflows/deploy-staging.yml:153` - `echo &#34;BUILD_NUMBER=$(scripts/ci/derive-build-number.sh)&#34; &gt;&gt; &#34;$GITHUB_ENV&#34;` (same at deploy-production.yml:164) does not propagate the script&#39;s exit status. Under `set -e`, a command substitution&#39;s failure only aborts when the substitution is the entire command (`x=$(cmd)`); here the pipeline is `echo`, which returns 0. So when derive-build-number.sh exits 1 (epoch mismatch, over the 32-bit limit, non-numeric run ID) the step stays GREEN and writes `BUILD_NUMBER=` (empty) to $GITHUB_ENV. fastlane/Fastfile:116 and :200 then do `build_number = ENV[&#34;BUILD_NUMBER&#34;]`, and &#34;&#34; is truthy in Ruby, so `increment_build_number(build_number: &#34;&#34;)` still runs. Every guard the new script was added to provide fails open, turning a clear pre-archive stop into a confusing mid-archive/agvtool failure. Fix by assigning first: `build_number=&#34;$(scripts/ci/derive-build-number.sh)&#34;` then `echo &#34;BUILD_NUMBER=$build_number&#34; &gt;&gt; &#34;$GITHUB_ENV&#34;`. No test covers this propagation path - the contracts test only asserts step ordering.
- ⚠️ `scripts/ci/derive-build-number.sh:11` - RUN_ID_EPOCH=29800000000 leaves only ~2 months of runway before the MAX_BUILD_NUMBER guard (line 40) hard-fails every staging and production deploy. Measured from this repo&#39;s actual runs, GitHub&#39;s global run-id counter advances ~70M/day (29655296349 three days ago -&gt; 29863763672 thirty-four minutes ago). Today&#39;s derived value is ~63.7M, so the remaining headroom of ~4.23e9 is exhausted in roughly 60 days, after which line 42&#39;s only stated remedy is a manual &#34;ship a new marketing version with a reset build-number scheme&#34;. The epoch itself is chosen correctly (it sits just below current run IDs, maximizing headroom); the structural issue is that a fast-moving global counter cannot stay under a 32-bit CFBundleVersion ceiling for long, so the intent&#39;s &#34;source build numbers from the repository-wide run identifier&#34; needs a decision about what happens at the ceiling - e.g. a version-scoped epoch bumped alongside the marketing version, or a derived-and-recorded per-app counter.
- ℹ️ `scripts/ci/derive-build-number.sh:19` - PREVIOUS_BUILD_NUMBER_FLOOR=147 is a Deploy Staging github.run_number, but staging (com.TylerPavay.AscendApp.staging) and production (com.TylerPavay.AscendApp) have independent CFBundleVersion histories on App Store Connect. A single shared floor is only correct because production has never completed an upload - its one Deploy Production run is still blocked pending PRODUCTION_READY. Worth re-deriving the floor per app if production ever uploads under a different scheme.

🔧 Fix: derive build numbers from epoch seconds and workflow slot
3 issues (2 warnings, 1 info) still open:
- ⚠️ `scripts/ci/derive-build-number.sh:29` - The intent requires: &#34;Source staging and production build numbers from the repository-wide GitHub Actions run identifier instead of each workflow&#39;s local run counter.&#34; The derivation now uses wall-clock UTC seconds instead - `timestamp=&#34;${2:-$(date -u +%s)}&#34;` - and `github.run_id`/`GITHUB_RUN_ID` no longer appears in either workflow or the script. The contract test at ci-workflow-contracts.test.mjs:74 now asserts its absence (`assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_id \}\}/)`). This is the round-2 correction you directed and is technically the sounder scheme (run_id&#39;s global counter advances ~70M/day and exhausts 32 bits in ~2 months), but it contradicts the intent as written. Confirm and restate the intent as the epoch-seconds + workflow-slot contract.
- ⚠️ `scripts/ci/derive-build-number.sh:8` - The script&#39;s uniqueness argument rests on &#34;Every workflow serializes its own runs through its concurrency group, so two staging (or two production) builds cannot derive in the same second.&#34; That invariant does not hold: the group is ref-scoped (`group: deploy-staging-${{ github.ref }}` at deploy-staging.yml:29, and `deploy-production-${{ github.ref }}`), while `workflow_dispatch:` (deploy-staging.yml:4, deploy-production.yml:4) has no branch restriction. A manual dispatch from any other branch forms a separate concurrency group and runs concurrently with the develop/main push run. Both produce the same bundle ID for the same TestFlight app, so if the two derive steps land in the same second they emit an identical build number and the second upload is rejected after a full ~40-minute build. Either scope the concurrency group to the workflow (drop `${{ github.ref }}` so all runs of a workflow serialize) or correct the comment to state the real guarantee.
- ℹ️ `.claude/skills/ascend-deploy/SKILL.md:63` - The ascend-deploy skill documents the deploy job graph, Fastlane lanes, and required secrets but says nothing about build numbers - grep for BUILD_NUMBER/run_number/run_id returns no hits. The new contract has non-obvious invariants a future agent needs before editing these workflows: build numbers come from scripts/ci/derive-build-number.sh in a pre-archive step, uniqueness depends on each workflow&#39;s concurrency group plus the per-workflow slot argument (staging 0, production 1), and raising BUILD_NUMBER_EPOCH_SECONDS would emit values below already-uploaded builds. Add a short paragraph under Fastlane pointing at the script.

🔧 Fix: blocked: disk full, no fixes applied
3 issues (2 warnings, 1 info) still open:
- ⚠️ `.github/workflows/deploy-staging.yml:29` - NOT YET APPLIED - accepted in round 3 but the worktree is unchanged. The build-number scheme&#39;s uniqueness rests on the comment at scripts/ci/derive-build-number.sh:8 (&#34;Every workflow serializes its own runs through its concurrency group, so two staging (or two production) builds cannot derive in the same second&#34;). That does not hold: the groups are ref-scoped (`deploy-staging-${{ github.ref }}` here, `deploy-production-${{ github.ref }}` at deploy-production.yml:25) while `workflow_dispatch:` (deploy-staging.yml:4, deploy-production.yml:4) carries no branch restriction, so a manual dispatch from any other ref forms a separate group and runs concurrently with the push run. Both build the same bundle ID for the same TestFlight app, so a same-second derivation emits a duplicate build number rejected after a full ~40-minute build. Drop the `${{ github.ref }}` component (keeping cancel-in-progress: false) so every run of an uploadable workflow serializes. Additionally, the requested drift guard is absent: ci-workflow-contracts.test.mjs:62 still hard-codes `workflowSlots = {&#34;deploy-staging.yml&#34;: &#34;0&#34;, &#34;deploy-production.yml&#34;: &#34;1&#34;}`, so a new uploadable workflow, a missing slot, or a group regaining ref scoping would not fail the contract test.
- ⚠️ `scripts/ci/derive-build-number.sh:29` - NOT YET APPLIED - accepted in round 3 but the worktree is unchanged. The intent requires: &#34;Source staging and production build numbers from the repository-wide GitHub Actions run identifier instead of each workflow&#39;s local run counter.&#34; The derivation uses wall-clock UTC seconds - `timestamp=&#34;${2:-$(date -u +%s)}&#34;` - and `github.run_id`/`GITHUB_RUN_ID` appears nowhere in either workflow or the script; ci-workflow-contracts.test.mjs:102 actively asserts its absence. You confirmed the epoch-seconds + workflow-slot scheme supersedes the original run_id wording, so the remaining action is to restate the intent and PR body around that contract rather than the run identifier.
- ℹ️ `.claude/skills/ascend-deploy/SKILL.md:63` - NOT YET APPLIED - accepted in round 3 but the worktree is unchanged. The Fastlane section still documents lanes, match signing, and the dSYM contract with no mention of build numbers. Record the allocator invariants a future agent needs before editing these workflows: BUILD_NUMBER comes from scripts/ci/derive-build-number.sh in a pre-archive step that must propagate failure, the value is (UTC epoch seconds - 2026-01-01) * 2 + workflow slot (staging 0, production 1), uniqueness depends on each uploadable workflow having a fixed non-ref-scoped concurrency group plus a distinct slot, and changing BUILD_NUMBER_EPOCH_SECONDS can emit values below already-uploaded builds.

🔧 Fix: fix deploy concurrency scope and add build-number drift guard
2 infos still open:
- ℹ️ `scripts/ci/derive-build-number.sh:29` - The authoritative --intent states: &#34;Source staging and production build numbers from the repository-wide GitHub Actions run identifier instead of each workflow&#39;s local run counter.&#34; The implemented scheme does NOT use the run identifier - `timestamp=&#34;${2:-$(date -u +%s)}&#34;` derives from wall-clock UTC epoch seconds, and `github.run_id`/`GITHUB_RUN_ID` appears nowhere (ci-workflow-contracts.test.mjs:135 actively asserts its absence). This is a deliberate supersession you directed across rounds 2-4 (raw run_id is ~11 digits, over the 32-bit CFBundleVersion ceiling, and its global counter advances ~70M/day, exhausting 32 bits in ~2 months). Flagging only because the written intent text still says run_id: confirm the epoch-seconds + workflow-slot contract is the accepted intent and ensure the PR body records that it supersedes the original run_id wording.
- ℹ️ `fastlane/Fastfile:115` - The comment &#34;# Auto-increment build number on CI using the workflow run number&#34; (also at Fastfile:199) is now inaccurate - BUILD_NUMBER no longer comes from github.run_number but from scripts/ci/derive-build-number.sh (epoch seconds * 2 + slot). It&#39;s outside this diff&#39;s changed lines, but this change is what made it wrong, and a future reader editing build numbers would be misled. Update it to point at the derive script.

🔧 Fix: correct stale Fastfile build-number comments
1 info still open:
- ℹ️ `scripts/ci/derive-build-number.sh:29` - The authoritative --intent states: &#34;Source staging and production build numbers from the repository-wide GitHub Actions run identifier instead of each workflow&#39;s local run counter.&#34; The implemented scheme does NOT use the run identifier - `timestamp=&#34;${2:-$(date -u +%s)}&#34;` derives from wall-clock UTC epoch seconds and `github.run_id`/`GITHUB_RUN_ID` appears nowhere (ci-workflow-contracts.test.mjs actively asserts its absence). This is a deliberate supersession you confirmed across rounds 2-5 (raw run_id is ~11 digits, over the 32-bit CFBundleVersion ceiling, and its global counter exhausts 32 bits in ~2 months). Re-surfaced only because the written intent text still says run_id: confirm the epoch-seconds + workflow-slot contract is the accepted intent and that the PR body records the supersession. No code change needed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test scripts/test/ci-workflow-contracts.test.mjs` (10/10 pass) - the new regression suite covering trigger paths, gate exit-1, fixed concurrency groups, unique build-number slots, derive-before-archive ordering, and collision/overflow/floor guards</code>
- <code>`node --test scripts/test/*.test.mjs` (65/65 pass) - full scripts suite including the trimmed sentry-dsym assertion</code>
- <code>Ran `scripts/ci/derive-build-number.sh` for staging (slot 0) and production (slot 1) at a fixed timestamp: 40000000 vs 40000001 (no collision, +1), next-second slot 0 = 40000002 outranks prior second&#39;s slot 1; invalid slot 2 and pre-epoch inputs rejected with exit 1</code>
- `Executed the production-readiness gate shell logic: PRODUCTION_READY=false exits 1 with 'Workflow will fail before deploy jobs.'; PRODUCTION_READY=true exits 0`
- `Grepped all three workflows to confirm AscendLiveActivityWidgets/**, scripts/**, and firestore.indexes.json trigger paths are present`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
