### PR TITLE
ci: order production backend rollout into gated, verified deploy stages

### DIFF
--- a/.claude/skills/ascend-deploy/SKILL.md
+++ b/.claude/skills/ascend-deploy/SKILL.md
@@ -43,7 +43,7 @@ A trigger pointing at a branch that no longer exists silently disables the workf
 
 `develop` is what makes the staging trigger safe: staging cannot run on pushes to `main`, because `deploy-production.yml` already does and one push would deploy both. Keep the two deploy workflows on disjoint branches - pointing either at the other's branch reintroduces the double-deploy.
 
-`.github/workflows/deploy-production.yml` runs on pushes to `main` and manual dispatch. It is **stricter** than staging, not a mirror of it: every job is gated behind `PRODUCTION_READY=true` plus GitHub `production` environment protection, and `deploy-firebase` keeps `needs: [production-gate, build-ios]`, so a failed build stops the deploy. Same combined `--only` deploy command, Release configuration.
+`.github/workflows/deploy-production.yml` runs on pushes to `main` and manual dispatch. It is **stricter** than staging, not a mirror of it: every job is gated behind `PRODUCTION_READY=true` plus GitHub `production` environment protection, and `deploy-firebase` keeps `needs: [production-gate, build-ios]`, so a failed build stops the deploy. The Firebase job is an ordered rollout rather than one combined deploy: indexes deploy and every declaration must report `READY`, then Functions deploy and the gate-critical exports must report `ACTIVE`, then Firestore rules, Storage rules, and Hosting deploy. The TestFlight upload still depends on the whole Firebase job, so the backend is ahead of the binary. `docs/production-backend-rollout-runbook.md` is the production operator contract and rollback guide.
 
 ## Deploy Authentication
 

--- a/.claude/skills/ascend-deploy/SKILL.md
+++ b/.claude/skills/ascend-deploy/SKILL.md
@@ -47,7 +47,7 @@ A trigger pointing at a branch that no longer exists silently disables the workf
 
 ## Deploy Authentication
 
-**Today (what the workflows actually do):** both pipelines authenticate to Firebase with a single long-lived `FIREBASE_TOKEN` repository secret, passed as `--token "$FIREBASE_TOKEN"` on the `firebase-tools` deploy step (`deploy-staging.yml`, `deploy-production.yml`). Both deploy jobs declare only `permissions: contents: read`. Commit a3c4021 moved deploys to this token and removed the `google-github-actions/auth@v2` steps. If you are editing a deploy step now, this is the mechanism you are working with.
+**Today (what the workflows actually do):** both pipelines authenticate to Firebase with a single long-lived `FIREBASE_TOKEN` repository secret, passed as `--token "$FIREBASE_TOKEN"` on every `firebase-tools` deploy step (`deploy-staging.yml`, and each step of the production ordered rollout in `deploy-production.yml`). Both deploy jobs declare only `permissions: contents: read`. Commit a3c4021 moved deploys to this token and removed the `google-github-actions/auth@v2` steps. If you are editing a deploy step now, this is the mechanism you are working with.
 
 **Target (not yet implemented):** move deploys to OIDC + GCP Workload Identity Federation and retire the standing long-lived credential. This is a real open security gap, not a settled decision - `FIREBASE_TOKEN` is a broad, non-expiring credential that OIDC's short-lived tokens would replace.
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -194,7 +194,7 @@ jobs:
       - production-gate
       - build-ios
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     environment: production
     permissions:
       contents: read
@@ -216,10 +216,79 @@ jobs:
       - name: Build web app
         run: npm --prefix web run build
 
-      - name: Deploy Functions, Rules, Indexes, Storage, and Hosting
+      # Indexes go first because onWorkoutWritten immediately queries workouts
+      # by source + climbId. Functions go before Hosting because both Hosting
+      # rewrites target functions deployed by this job. The binary uploads only
+      # after this entire job succeeds, so its backend is already compatible.
+      - name: Deploy Firestore indexes
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-        run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions,firestore:rules,firestore:indexes,storage,hosting --non-interactive --force --token "$FIREBASE_TOKEN"
+        run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only firestore:indexes --non-interactive --token "$FIREBASE_TOKEN"
+
+      - name: Wait for every declared Firestore index
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 180); do
+            deployed_indexes="$(npx -y firebase-tools@15.22.1 firestore:indexes --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --pretty --token "$FIREBASE_TOKEN")"
+            printf "%s\n" "$deployed_indexes"
+
+            if printf "%s\n" "$deployed_indexes" | node scripts/ci/assert-firestore-indexes-ready.mjs firestore.indexes.json; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 180 ]; then
+              sleep 20
+            fi
+          done
+
+          echo "::error::Firestore indexes did not become READY within 60 minutes."
+          exit 1
+
+      - name: Deploy Functions
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only functions --non-interactive --force --token "$FIREBASE_TOKEN"
+
+      - name: Verify critical Functions are active
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          npx -y firebase-tools@15.22.1 --json functions:list --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --token "$FIREBASE_TOKEN" \
+            | node scripts/ci/assert-firebase-functions-active.mjs \
+                cleanupDeletedUserData \
+                onWorkoutWritten \
+                onWorkoutReplaySplitsWritten \
+                unsubscribeFromEmails
+
+      - name: Deploy Firestore rules
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only firestore:rules --non-interactive --token "$FIREBASE_TOKEN"
+
+      - name: Deploy Storage rules
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only storage --non-interactive --token "$FIREBASE_TOKEN"
+
+      - name: Deploy Hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only hosting --non-interactive --token "$FIREBASE_TOKEN"
+
+      - name: Verify Hosting serves the climb manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl --fail --location --retry 5 --retry-all-errors \
+            "https://${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}.web.app/climbs/manifest.json" \
+            --output /dev/null
 
   upload-testflight:
     name: Upload to TestFlight (Production)

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -233,11 +233,25 @@ jobs:
           set -euo pipefail
 
           for attempt in $(seq 1 180); do
-            deployed_indexes="$(npx -y firebase-tools@15.22.1 firestore:indexes --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --pretty --token "$FIREBASE_TOKEN")"
+            if ! deployed_indexes="$(npx -y firebase-tools@15.22.1 firestore:indexes --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --pretty --token "$FIREBASE_TOKEN")"; then
+              echo "::warning::firestore:indexes poll attempt ${attempt} of 180 failed; retrying."
+              if [ "$attempt" -lt 180 ]; then
+                sleep 20
+              fi
+              continue
+            fi
             printf "%s\n" "$deployed_indexes"
 
-            if printf "%s\n" "$deployed_indexes" | node scripts/ci/assert-firestore-indexes-ready.mjs firestore.indexes.json; then
+            readiness_status=0
+            printf "%s\n" "$deployed_indexes" | node scripts/ci/assert-firestore-indexes-ready.mjs firestore.indexes.json || readiness_status=$?
+
+            if [ "$readiness_status" -eq 0 ]; then
               exit 0
+            fi
+
+            if [ "$readiness_status" -eq 2 ]; then
+              echo "::error::Index readiness check failed on a structural config or parser error; fix it instead of retrying."
+              exit 2
             fi
 
             if [ "$attempt" -lt 180 ]; then

--- a/docs/production-backend-rollout-runbook.md
+++ b/docs/production-backend-rollout-runbook.md
@@ -1,0 +1,259 @@
+# Production backend rollout runbook
+
+## Purpose and safety boundary
+
+This runbook closes production-readiness gate 8 from the 2026-07-21 production audit.
+It prepares one GitHub Actions operation that builds the production binary, deploys the compatible backend in dependency order, verifies the critical backend state, and only then uploads the binary to TestFlight.
+
+Every command that names the `production` Firebase alias or the production workflow is captain-only.
+Do not run a production Firebase command while preparing or reviewing this change.
+Do not combine the deploy targets into one Firebase CLI call because that provides no index-readiness barrier before dependent Functions become active.
+
+The workflow uses the repository's protected `production` environment and requires `PRODUCTION_READY=true`.
+The captain must approve the protected environment before production work begins.
+
+## What this rollout contains
+
+The audit examined an older `develop` SHA that declared 11 composite indexes and found nine of them deployed.
+The two missing Live Replay indexes are both collection-scoped `entries` indexes:
+
+- `isBestForUser ASCENDING`, then `stepsAtBucket ASCENDING`.
+- `isBestForUser ASCENDING`, then `stepsAtBucket DESCENDING`.
+
+The current query filters per-climb and per-routine live races with `isBestForUser == true`, then reads the window ahead in ascending `stepsAtBucket` order and the window behind in descending order.
+Both matching definitions already exist exactly once in `firestore.indexes.json` after rebasing onto current `develop`, so this preparation does not add duplicates.
+
+Current `develop` declares 13 indexes because later work also added the `workouts(source, climbId)` projection index and the routine completion `entries(finalSteps DESCENDING, __name__ ASCENDING)` index.
+The production workflow waits until every index currently declared in `firestore.indexes.json` reports `READY`, not only the two the older audit identified.
+
+The `cleanupDeletedUserData` function is implemented in `functions/src/accountCleanup.ts` and exported from `functions/src/index.ts`.
+It is retry-enabled, discovers all `users/{uid}` subcollections, continues independent cleanup steps after a partial failure, and throws when any cleanup step fails so Cloud Functions retries it.
+It also handles user-keyed data outside the user subtree, including notification devices, leaderboard rows, replay finisher state, First Ascent identity fields, feedback, lifecycle email jobs, and rate limits.
+The implementation is covered by `functions/test/accountCleanup.test.ts`.
+No source correction is required for the function, so the forward-looking production gap is deployment only.
+
+The delete trigger is not retroactive.
+If a production user document was deleted before `cleanupDeletedUserData` became active, deploying it will not sweep that historical deletion.
+The captain must confirm whether any production account deletion occurred during the gap and open a separate, reviewed reconciliation task if one did.
+
+## Captain preflight
+
+Complete every item before starting the production workflow.
+
+1. Confirm this rollout PR has merged through `develop` and the chosen release commit is on `main`.
+2. Confirm CI is green for the exact release SHA.
+3. Confirm the audit's `profile_stats` compatibility gate has been resolved by checking whether any distributed production-bundle build still writes the legacy `top_*_weeks` fields.
+4. Confirm the repository-level `FIREBASE_TOKEN`, `GOOGLE_SERVICE_INFO_PRODUCTION_BASE64`, signing secrets, and App Store Connect secrets exist.
+5. Confirm the `production` environment still requires the intended human approval and `PRODUCTION_READY` is `true` only for the approved release window.
+6. Confirm no other Deploy Production run is queued or in progress.
+7. Rerun the production replay backfill in read-only mode and require zero planned writes, or prepare and separately approve the migration before continuing.
+
+Use these read-only GitHub checks:
+
+```sh
+gh-axi run list --workflow deploy-production.yml --branch main --limit 10
+gh-axi secret list
+gh-axi variable list --env production
+```
+
+The captain-only replay check is:
+
+```sh
+node scripts/backfill-live-replay-best-per-user.mjs --project prod --dry-run
+```
+
+Do not use `--confirm-production` for this preflight.
+If the dry-run reports writes, stop and prepare a separate migration review before deploying the binary.
+
+## One-command launch
+
+A merge to `main` that changes a watched path automatically creates a Deploy Production run.
+Use that run and do not manually dispatch a duplicate.
+
+If `main` is already at the approved release SHA and no push-triggered run exists, launch exactly one run with:
+
+```sh
+gh-axi workflow run 240226254 --ref main
+```
+
+Workflow `240226254` is `Deploy Production` at `.github/workflows/deploy-production.yml`.
+Approve the protected `production` environment only after confirming the run's SHA is the approved release SHA.
+
+The workflow performs the following order automatically:
+
+1. Pass the production readiness gate.
+2. Build and retain the signed production IPA.
+3. Build the Functions and Hosting artifacts.
+4. Deploy Firestore indexes.
+5. Poll until all 13 indexes declared by the release SHA report `READY`.
+6. Deploy Functions.
+7. Verify `cleanupDeletedUserData`, `onWorkoutWritten`, `onWorkoutReplaySplitsWritten`, and `unsubscribeFromEmails` report `ACTIVE`.
+8. Deploy Firestore rules.
+9. Deploy Storage rules.
+10. Deploy Hosting.
+11. Verify Hosting serves `/climbs/manifest.json` successfully.
+12. Upload the already-built IPA to TestFlight only after every backend step succeeds.
+
+This ordering makes indexes available before `onWorkoutWritten` can execute its `source + climbId` query.
+It makes Functions available before Hosting publishes rewrites to `joinWaitlist` and `unsubscribeFromEmails`.
+It keeps the backend ahead of the binary because `upload-testflight` depends on the complete `deploy-firebase` job.
+
+## Exact deployment commands
+
+The workflow is the authoritative deployment path and supplies the repository secret as `FIREBASE_TOKEN` plus the protected environment variable as `FIREBASE_PROJECT_ID_PRODUCTION`.
+These are the exact Firebase operations it runs, shown for review and captain-only recovery.
+
+### 1. Firestore indexes
+
+```sh
+npx -y firebase-tools@15.22.1 deploy --project production \
+  --only firestore:indexes --non-interactive
+```
+
+Verify the deployment does not request deletion of an unexpected index.
+Then wait for every declared index, including both `isBestForUser + stepsAtBucket` directions, to report `READY`:
+
+```sh
+npx -y firebase-tools@15.22.1 firestore:indexes \
+  --project production --pretty \
+  | node scripts/ci/assert-firestore-indexes-ready.mjs firestore.indexes.json
+```
+
+Do not proceed while this command exits nonzero.
+
+Rollback: do not delete a newly created additive index during an incident.
+An unused composite index does not change query results, and deleting it adds risk while providing no immediate recovery benefit.
+Revert the declaration in a reviewed follow-up only after confirming no released query needs it.
+
+### 2. Functions
+
+```sh
+npx -y firebase-tools@15.22.1 deploy --project production \
+  --only functions --non-interactive --force
+```
+
+`--force` is intentionally scoped to Functions so the deployed set matches `functions/src/index.ts` without making rules, indexes, Storage, or Hosting destructive.
+
+Verify the four gate-critical functions are active:
+
+```sh
+npx -y firebase-tools@15.22.1 --json functions:list \
+  --project production \
+  | node scripts/ci/assert-firebase-functions-active.mjs \
+      cleanupDeletedUserData \
+      onWorkoutWritten \
+      onWorkoutReplaySplitsWritten \
+      unsubscribeFromEmails
+```
+
+Rollback: stop before the Firestore rules and TestFlight steps, inspect the failed Function logs, and redeploy the Functions from the last known good production SHA using the rollback worktree described below.
+Do not remove a healthy `cleanupDeletedUserData` merely because an unrelated Function failed.
+If the failure can be isolated, redeploy only the affected function with `--only functions:<functionId>`.
+
+### 3. Firestore rules
+
+```sh
+npx -y firebase-tools@15.22.1 deploy --project production \
+  --only firestore:rules --non-interactive
+```
+
+Verify the command reports a successful rules release.
+Then use the production-signed smoke account to read and write its allowed private documents and confirm an unauthenticated client cannot read them.
+Also confirm the current `profile_stats` write succeeds before uploading the binary.
+
+Rollback: redeploy only `firestore:rules` from the last known good production SHA.
+Do not roll rules back after distributing a binary that requires the new schema unless the rollback rules remain compatible with both schemas.
+
+### 4. Storage rules
+
+```sh
+npx -y firebase-tools@15.22.1 deploy --project production \
+  --only storage --non-interactive
+```
+
+Verify the command reports a successful rules release.
+Using the production-signed smoke account, upload and delete one file beneath that account's `users/{uid}/...` prefix and confirm a second account cannot read or write it.
+
+Rollback: redeploy only `storage` from the last known good production SHA.
+
+### 5. Hosting
+
+```sh
+npm --prefix web ci
+npm --prefix web run build
+npx -y firebase-tools@15.22.1 deploy --project production \
+  --only hosting --non-interactive
+```
+
+Verify the climb manifest is served from the environment-derived Hosting site:
+
+```sh
+PRODUCTION_PROJECT_ID="$(node -p 'require("./.firebaserc").projects.production')"
+curl --fail --location --retry 5 --retry-all-errors \
+  "https://${PRODUCTION_PROJECT_ID}.web.app/climbs/manifest.json" \
+  --output /dev/null
+```
+
+Verify `/api/join-waitlist` and `/api/unsubscribe` route to their deployed Functions with safe test requests.
+Do not submit a real email address as a routing probe.
+
+Rollback: rebuild and redeploy only Hosting from the last known good production SHA.
+
+## Rollback worktree
+
+Prepare a clean rollback worktree from the SHA recorded by the last successful production deployment.
+The captain must replace the placeholder before running these commands.
+
+```sh
+LAST_KNOWN_GOOD_SHA='<last-successful-production-sha>'
+ROLLBACK_ROOT="$(mktemp -d)"
+git worktree add "$ROLLBACK_ROOT/repo" "$LAST_KNOWN_GOOD_SHA"
+cd "$ROLLBACK_ROOT/repo"
+npm --prefix functions ci
+npm --prefix web ci
+npm --prefix web run build
+```
+
+Run only the rollback target required by the failed step:
+
+```sh
+npx -y firebase-tools@15.22.1 deploy --project production \
+  --only functions --non-interactive --force
+npx -y firebase-tools@15.22.1 deploy --project production \
+  --only firestore:rules --non-interactive
+npx -y firebase-tools@15.22.1 deploy --project production \
+  --only storage --non-interactive
+npx -y firebase-tools@15.22.1 deploy --project production \
+  --only hosting --non-interactive
+```
+
+These are alternatives, not a batch.
+Do not run all four unless the incident requires a full backend rollback and compatibility with every already-distributed binary has been checked.
+
+After the incident is closed, remove the temporary worktree from the original repository:
+
+```sh
+git worktree remove "$ROLLBACK_ROOT/repo"
+rmdir "$ROLLBACK_ROOT"
+```
+
+## Post-deploy production verification
+
+The workflow must reach green before selecting or distributing the TestFlight build.
+Then complete these captain-only checks against production.
+
+1. Confirm all declared Firestore indexes still report `READY` with the index assertion command above.
+2. Confirm the four critical Functions still report `ACTIVE` with the function assertion command above.
+3. Inspect recent cleanup logs with `npx -y firebase-tools@15.22.1 functions:log --project production --only cleanupDeletedUserData --lines 50`.
+4. Create one Google smoke account and one Apple smoke account in a production-signed physical-device build.
+5. For each account, create a workout, replay presence, profile data, a push token, feedback, and user-scoped Storage data that exercise the cleanup paths.
+6. Delete each account in the app and wait for the `Swept deleted user data` success log with no retry failure.
+7. Confirm the Auth user, `users/{uid}` document and subcollections, top-level `notification_devices`, `leaderboard_stats`, replay finisher record, feedback, uid-keyed lifecycle email job, rate-limit record, and user Storage prefixes are gone.
+8. Confirm a held First Ascent remains claimed and dated but renders as `Anonymous Climber` with no photo or avatar token.
+9. Confirm the app returns to signed-out state and RevenueCat and Superwall no longer identify the deleted user.
+10. Confirm the Apple credential is revoked and both providers can create a fresh account again.
+11. Confirm a new production workout creates or updates `users/{uid}/landmarkResults` through `onWorkoutWritten`.
+12. Confirm a modified client cannot publish an ineligible replay entry because `onWorkoutReplaySplitsWritten` derives eligibility from server-visible workout evidence.
+
+If any check fails, do not select the TestFlight build for App Review.
+Capture the failing release SHA, Function execution ID, affected uid, and exact verification step before deciding whether to repair forward or use the scoped rollback.

--- a/docs/production-backend-rollout-runbook.md
+++ b/docs/production-backend-rollout-runbook.md
@@ -73,10 +73,10 @@ Use that run and do not manually dispatch a duplicate.
 If `main` is already at the approved release SHA and no push-triggered run exists, launch exactly one run with:
 
 ```sh
-gh-axi workflow run 240226254 --ref main
+gh-axi workflow run deploy-production.yml --ref main
 ```
 
-Workflow `240226254` is `Deploy Production` at `.github/workflows/deploy-production.yml`.
+`deploy-production.yml` is the `Deploy Production` workflow at `.github/workflows/deploy-production.yml`.
 Approve the protected `production` environment only after confirming the run's SHA is the approved release SHA.
 
 The workflow performs the following order automatically:

--- a/scripts/ci/assert-firebase-functions-active.mjs
+++ b/scripts/ci/assert-firebase-functions-active.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+const expectedFunctionIds = process.argv.slice(2);
+const payload = JSON.parse(await readStandardInput());
+
+if (expectedFunctionIds.length === 0) {
+  throw new Error("Pass at least one expected Firebase Function id");
+}
+
+if (payload.status !== "success" || !Array.isArray(payload.result)) {
+  throw new Error("Firebase functions:list did not return a successful result array");
+}
+
+const deployedFunctions = new Map(
+  payload.result.map((deployedFunction) => [deployedFunction.id, deployedFunction])
+);
+const inactive = expectedFunctionIds.filter((functionId) => {
+  const deployedFunction = deployedFunctions.get(functionId);
+  return deployedFunction?.state !== "ACTIVE";
+});
+
+if (inactive.length > 0) {
+  console.error(`Missing or inactive Firebase Functions: ${inactive.join(", ")}`);
+  process.exitCode = 1;
+} else {
+  console.log(`Verified ACTIVE Firebase Functions: ${expectedFunctionIds.join(", ")}`);
+}
+
+async function readStandardInput() {
+  const chunks = [];
+
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/scripts/ci/assert-firestore-indexes-ready.mjs
+++ b/scripts/ci/assert-firestore-indexes-ready.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+import {readFile} from "node:fs/promises";
+
+const configPath = process.argv[2] ?? "firestore.indexes.json";
+const output = await readStandardInput();
+const config = JSON.parse(await readFile(configPath, "utf8"));
+const lines = stripAnsi(output).split("\n");
+
+if (!Array.isArray(config.indexes)) {
+  throw new Error(`${configPath} does not contain an indexes array`);
+}
+
+const unsupportedScopes = config.indexes.filter(
+  (index) => index.queryScope !== "COLLECTION"
+);
+
+if (unsupportedScopes.length > 0) {
+  throw new Error(
+    "The Firebase CLI readiness output does not expose query scope, so only " +
+      "COLLECTION indexes can be verified by this script"
+  );
+}
+
+const missing = config.indexes.filter((index) => {
+  const prefix = `[READY] (${index.collectionGroup}) -- `;
+  // firebase firestore:indexes --pretty omits the __name__ tiebreak field,
+  // including when its direction is explicitly declared in the config.
+  const fields = index.fields
+    .filter((field) => field.fieldPath !== "__name__")
+    .map(fieldToken)
+    .join(" ");
+
+  return !lines.some((line) => line.startsWith(prefix) && line.includes(fields));
+});
+
+if (missing.length > 0) {
+  console.error(
+    `${missing.length} of ${config.indexes.length} declared Firestore indexes ` +
+      "are not READY:"
+  );
+
+  for (const index of missing) {
+    console.error(`- ${indexSignature(index)}`);
+  }
+
+  process.exitCode = 1;
+} else {
+  console.log(`All ${config.indexes.length} declared Firestore indexes are READY.`);
+}
+
+function fieldToken(field) {
+  const mode = field.order ?? field.arrayConfig;
+
+  if (typeof field.fieldPath !== "string" || typeof mode !== "string") {
+    throw new Error(`Unsupported Firestore index field: ${JSON.stringify(field)}`);
+  }
+
+  return `(${field.fieldPath},${mode})`;
+}
+
+function indexSignature(index) {
+  return `(${index.collectionGroup}) -- ${index.fields.map(fieldToken).join(" ")}`;
+}
+
+function stripAnsi(value) {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+async function readStandardInput() {
+  const chunks = [];
+
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
+}

--- a/scripts/ci/assert-firestore-indexes-ready.mjs
+++ b/scripts/ci/assert-firestore-indexes-ready.mjs
@@ -2,37 +2,55 @@
 
 import {readFile} from "node:fs/promises";
 
+const STRUCTURAL_ERROR_EXIT_CODE = 2;
+
 const configPath = process.argv[2] ?? "firestore.indexes.json";
 const output = await readStandardInput();
-const config = JSON.parse(await readFile(configPath, "utf8"));
-const lines = stripAnsi(output).split("\n");
 
-if (!Array.isArray(config.indexes)) {
-  throw new Error(`${configPath} does not contain an indexes array`);
-}
+let config;
+let missing;
 
-const unsupportedScopes = config.indexes.filter(
-  (index) => index.queryScope !== "COLLECTION"
-);
+try {
+  config = JSON.parse(await readFile(configPath, "utf8"));
+  const lines = stripAnsi(output).split("\n");
 
-if (unsupportedScopes.length > 0) {
-  throw new Error(
-    "The Firebase CLI readiness output does not expose query scope, so only " +
-      "COLLECTION indexes can be verified by this script"
+  if (!Array.isArray(config.indexes)) {
+    throw new Error(`${configPath} does not contain an indexes array`);
+  }
+
+  const unsupportedScopes = config.indexes.filter(
+    (index) => index.queryScope !== "COLLECTION"
   );
+
+  if (unsupportedScopes.length > 0) {
+    throw new Error(
+      "The Firebase CLI readiness output does not expose query scope, so only " +
+        "COLLECTION indexes can be verified by this script"
+    );
+  }
+
+  missing = config.indexes.filter((index) => {
+    const prefix = `[READY] (${index.collectionGroup}) -- `;
+    // firebase firestore:indexes --pretty omits the __name__ tiebreak field,
+    // including when its direction is explicitly declared in the config.
+    const fields = index.fields
+      .filter((field) => field.fieldPath !== "__name__")
+      .map(fieldToken)
+      .join(" ");
+
+    return !lines.some((line) => {
+      if (!line.startsWith(prefix + fields)) {
+        return false;
+      }
+
+      const rest = line.slice(prefix.length + fields.length);
+      return rest === "" || rest.startsWith(" ");
+    });
+  });
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(STRUCTURAL_ERROR_EXIT_CODE);
 }
-
-const missing = config.indexes.filter((index) => {
-  const prefix = `[READY] (${index.collectionGroup}) -- `;
-  // firebase firestore:indexes --pretty omits the __name__ tiebreak field,
-  // including when its direction is explicitly declared in the config.
-  const fields = index.fields
-    .filter((field) => field.fieldPath !== "__name__")
-    .map(fieldToken)
-    .join(" ");
-
-  return !lines.some((line) => line.startsWith(prefix) && line.includes(fields));
-});
 
 if (missing.length > 0) {
   console.error(

--- a/scripts/test/production-backend-rollout.test.mjs
+++ b/scripts/test/production-backend-rollout.test.mjs
@@ -94,8 +94,20 @@ test("index readiness requires every declared index to report READY", () => {
       "(stepsAtBucket,ASCENDING) (ignored,ASCENDING)\n" +
       "[CREATING] (entries) -- (finalSteps,DESCENDING)\n"
   );
-  assert.notEqual(building.status, 0);
+  assert.equal(building.status, 1);
   assert.match(building.stderr, /finalSteps/);
+
+  const leadingSuperset = runNode(
+    indexReadinessScript,
+    [configPath],
+    "[READY] (entries) -- (other,ASCENDING) (isBestForUser,ASCENDING) " +
+      "(stepsAtBucket,ASCENDING)\n" +
+      "[CREATING] (entries) -- (isBestForUser,ASCENDING) " +
+      "(stepsAtBucket,ASCENDING)\n" +
+      "[READY] (entries) -- (finalSteps,DESCENDING)\n"
+  );
+  assert.equal(leadingSuperset.status, 1);
+  assert.match(leadingSuperset.stderr, /isBestForUser/);
 
   const ready = runNode(
     indexReadinessScript,
@@ -106,6 +118,28 @@ test("index readiness requires every declared index to report READY", () => {
   );
   assert.equal(ready.status, 0, ready.stderr);
   assert.match(ready.stdout, /All 2 declared Firestore indexes are READY/);
+
+  const unsupportedScopePath = join(directory, "collection-group.indexes.json");
+  writeFileSync(
+    unsupportedScopePath,
+    JSON.stringify({
+      indexes: [
+        {
+          collectionGroup: "entries",
+          queryScope: "COLLECTION_GROUP",
+          fields: [{fieldPath: "finalSteps", order: "DESCENDING"}],
+        },
+      ],
+      fieldOverrides: [],
+    })
+  );
+  const structural = runNode(
+    indexReadinessScript,
+    [unsupportedScopePath],
+    "[READY] (entries) -- (finalSteps,DESCENDING)\n"
+  );
+  assert.equal(structural.status, 2);
+  assert.match(structural.stderr, /COLLECTION indexes/);
 });
 
 test("function readiness rejects missing and inactive critical functions", () => {

--- a/scripts/test/production-backend-rollout.test.mjs
+++ b/scripts/test/production-backend-rollout.test.mjs
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import {spawnSync} from "node:child_process";
+import {mkdtempSync, readFileSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import test from "node:test";
+import {fileURLToPath} from "node:url";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+const indexReadinessScript = join(
+  repositoryRoot,
+  "scripts/ci/assert-firestore-indexes-ready.mjs"
+);
+const functionReadinessScript = join(
+  repositoryRoot,
+  "scripts/ci/assert-firebase-functions-active.mjs"
+);
+
+function hasIndex(indexes, collectionGroup, fields) {
+  return indexes.some((index) =>
+    index.collectionGroup === collectionGroup &&
+    index.queryScope === "COLLECTION" &&
+    JSON.stringify(index.fields) === JSON.stringify(fields)
+  );
+}
+
+test("declares both filtered Live Replay window indexes", () => {
+  const config = JSON.parse(
+    readFileSync(join(repositoryRoot, "firestore.indexes.json"), "utf8")
+  );
+  const ascendingFields = [
+    {fieldPath: "isBestForUser", order: "ASCENDING"},
+    {fieldPath: "stepsAtBucket", order: "ASCENDING"},
+  ];
+  const descendingFields = [
+    {fieldPath: "isBestForUser", order: "ASCENDING"},
+    {fieldPath: "stepsAtBucket", order: "DESCENDING"},
+  ];
+
+  assert.ok(hasIndex(config.indexes, "entries", ascendingFields));
+  assert.ok(hasIndex(config.indexes, "entries", descendingFields));
+
+  const repository = readFileSync(
+    join(
+      repositoryRoot,
+      "AscendApp/Shared/Repositories/Firebase/" +
+        "FirestoreLiveReplayLeaderboardRepository.swift"
+    ),
+    "utf8"
+  );
+  assert.match(repository, /whereField\("isBestForUser", isEqualTo: true\)/);
+  assert.match(
+    repository,
+    /whereField\("stepsAtBucket", isGreaterThanOrEqualTo: currentSteps\)[\s\S]*?order\(by: "stepsAtBucket", descending: false\)/
+  );
+  assert.match(
+    repository,
+    /whereField\("stepsAtBucket", isLessThan: currentSteps\)[\s\S]*?order\(by: "stepsAtBucket", descending: true\)/
+  );
+});
+
+test("index readiness requires every declared index to report READY", () => {
+  const directory = mkdtempSync(join(tmpdir(), "ascend-index-readiness-"));
+  const configPath = join(directory, "firestore.indexes.json");
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      indexes: [
+        {
+          collectionGroup: "entries",
+          queryScope: "COLLECTION",
+          fields: [
+            {fieldPath: "isBestForUser", order: "ASCENDING"},
+            {fieldPath: "stepsAtBucket", order: "ASCENDING"},
+          ],
+        },
+        {
+          collectionGroup: "entries",
+          queryScope: "COLLECTION",
+          fields: [
+            {fieldPath: "finalSteps", order: "DESCENDING"},
+            {fieldPath: "__name__", order: "ASCENDING"},
+          ],
+        },
+      ],
+      fieldOverrides: [],
+    })
+  );
+
+  const building = runNode(
+    indexReadinessScript,
+    [configPath],
+    "[READY] (entries) -- (isBestForUser,ASCENDING) " +
+      "(stepsAtBucket,ASCENDING) (ignored,ASCENDING)\n" +
+      "[CREATING] (entries) -- (finalSteps,DESCENDING)\n"
+  );
+  assert.notEqual(building.status, 0);
+  assert.match(building.stderr, /finalSteps/);
+
+  const ready = runNode(
+    indexReadinessScript,
+    [configPath],
+    "[READY] (entries) -- (isBestForUser,ASCENDING) " +
+      "(stepsAtBucket,ASCENDING)\n" +
+      "[READY] (entries) -- (finalSteps,DESCENDING)\n"
+  );
+  assert.equal(ready.status, 0, ready.stderr);
+  assert.match(ready.stdout, /All 2 declared Firestore indexes are READY/);
+});
+
+test("function readiness rejects missing and inactive critical functions", () => {
+  const expected = [
+    "cleanupDeletedUserData",
+    "onWorkoutWritten",
+    "onWorkoutReplaySplitsWritten",
+    "unsubscribeFromEmails",
+  ];
+  const payload = JSON.stringify({
+    status: "success",
+    result: [
+      {id: "cleanupDeletedUserData", state: "ACTIVE"},
+      {id: "onWorkoutWritten", state: "ACTIVE"},
+      {id: "onWorkoutReplaySplitsWritten", state: "FAILED"},
+    ],
+  });
+  const incomplete = runNode(functionReadinessScript, expected, payload);
+
+  assert.notEqual(incomplete.status, 0);
+  assert.match(
+    incomplete.stderr,
+    /onWorkoutReplaySplitsWritten, unsubscribeFromEmails/
+  );
+
+  const completePayload = JSON.stringify({
+    status: "success",
+    result: expected.map((id) => ({id, state: "ACTIVE"})),
+  });
+  const complete = runNode(functionReadinessScript, expected, completePayload);
+
+  assert.equal(complete.status, 0, complete.stderr);
+  assert.match(complete.stdout, /Verified ACTIVE Firebase Functions/);
+});
+
+test("production deploy waits for indexes and rolls the backend out in dependency order", () => {
+  const workflow = readFileSync(
+    join(repositoryRoot, ".github/workflows/deploy-production.yml"),
+    "utf8"
+  );
+  const orderedSteps = [
+    "      - name: Deploy Firestore indexes\n",
+    "      - name: Wait for every declared Firestore index\n",
+    "      - name: Deploy Functions\n",
+    "      - name: Verify critical Functions are active\n",
+    "      - name: Deploy Firestore rules\n",
+    "      - name: Deploy Storage rules\n",
+    "      - name: Deploy Hosting\n",
+    "      - name: Verify Hosting serves the climb manifest\n",
+  ];
+  const positions = orderedSteps.map((step) => workflow.indexOf(step));
+
+  for (const [index, position] of positions.entries()) {
+    assert.notEqual(position, -1, `Missing production rollout step: ${orderedSteps[index]}`);
+  }
+
+  assert.deepEqual(positions, [...positions].sort((left, right) => left - right));
+  assert.match(
+    workflow,
+    /upload-testflight:[\s\S]*?needs:[\s\S]*?- deploy-firebase/
+  );
+  assert.doesNotMatch(
+    workflow,
+    /--only functions,firestore:rules,firestore:indexes,storage,hosting/
+  );
+});
+
+function runNode(script, argumentsList, input) {
+  return spawnSync(process.execPath, [script, ...argumentsList], {
+    encoding: "utf8",
+    input,
+  });
+}


### PR DESCRIPTION
## Intent

Prepare, but do not execute, AscendApp's coordinated production backend rollout for production-readiness audit gate 8. Rebase onto current develop, verify the Live Replay query code requires the two isBestForUser plus stepsAtBucket ascending and descending composite indexes, and avoid duplicating them if current develop already contains them. Verify cleanupDeletedUserData exists, is exported, retry-safe, idempotent, and complete for account deletion; if correct, treat the production gap as deployment-only while documenting that delete triggers are not retroactive. Make the production release one correctly ordered, captain-approved operation: build the binary, deploy and wait for every declared Firestore index before activating dependent Functions, verify critical Functions are ACTIVE, then deploy Firestore rules, Storage rules, and Hosting, and upload TestFlight only after the backend succeeds. Provide an exact captain-only runbook with preflight, verification after every stage, scoped rollback procedures, and an explicit ban on preparation-time production Firebase commands. Ship the committed work as a PR against develop without deploying or merging anything.

## What Changed

- Split the production deploy job's single `firebase deploy --only functions,firestore:rules,firestore:indexes,storage,hosting` step into ordered stages: deploy Firestore indexes, poll until every declared index is READY (up to 60 min, resilient to transient CLI failures, failing fast on structural errors), deploy Functions, verify the four critical Functions (`cleanupDeletedUserData`, `onWorkoutWritten`, `onWorkoutReplaySplitsWritten`, `unsubscribeFromEmails`) are ACTIVE, then deploy Firestore rules, Storage rules, and Hosting, finishing with a live check that Hosting serves `climbs/manifest.json`; TestFlight upload still runs only after the whole backend job succeeds.
- Added `scripts/ci/assert-firestore-indexes-ready.mjs` (parses `firestore:indexes --pretty` output and requires an exact-prefix READY match for each index declared in `firestore.indexes.json`, exit code 2 for structural/parse errors) and `scripts/ci/assert-firebase-functions-active.mjs` (asserts named functions report ACTIVE in `functions:list --json`), with 4 new tests in `scripts/test/production-backend-rollout.test.mjs` covering index declarations vs. the Live Replay query shape, readiness semantics, the ACTIVE gate, and workflow step ordering.
- Added `docs/production-backend-rollout-runbook.md` - a captain-only runbook with preflight checks, per-stage verification, scoped rollback procedures, a note that delete triggers are not retroactive, and an explicit ban on preparation-time production Firebase commands - and pointed the `ascend-deploy` skill at it.

## Risk Assessment

✅ Low: The fix round cleanly implements all four approved corrections (retry-tolerant poll loop with preserved timeout, distinct structural exit code with fail-fast, boundary-anchored index matching with trailing tolerance, stable workflow reference) with matching test coverage, stays deploy-preparation-only, and introduces no new issues.</risk_rationale>
<parameter name="tested">[]

## Testing

Ran the full scripts test suite (110 pass, including the 4 new rollout tests), the full Cloud Functions suite (169 pass, after a routine npm ci in the fresh worktree), and the 24-test accountCleanup suite proving cleanupDeletedUserData is exported, retry-enabled, and idempotent; then demonstrated the rollout ordering end-to-end by executing the actual workflow index-wait step script against a stubbed Firebase CLI (blocked at 2/13 CREATING, released only at 13/13 READY) and the Functions-ACTIVE gate in both failing and passing states, while confirming the branch sits exactly on current develop, the two Live Replay indexes are declared once with no duplicates, TestFlight upload is gated on the complete backend job, and no real Firebase project was touched during validation.

<details>
<summary>Evidence: Index-wait barrier simulation (real workflow step, stubbed CLI: CREATING → retry → READY → exit 0)</summary>

```text
=== Simulation: workflow 'Wait for every declared Firestore index' step, real script, stubbed firebase CLI ===
Polls 1-2 report 2 of 13 indexes CREATING; poll 3 reports all 13 READY.

poll #1: firebase -y firebase-tools@15.22.1 firestore:indexes --project ascend-prod-SIMULATED --pretty --token simulated
[CREATING] (workouts) -- (source,ASCENDING) (climbId,ASCENDING)
[CREATING] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalSteps,DESCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalWorkouts,DESCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalDuration,DESCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (stepsPerMinute,DESCENDING)
[READY] (email_jobs) -- (status,ASCENDING) (readyAt,ASCENDING)
[READY] (email_jobs) -- (status,ASCENDING) (processingStartedAt,ASCENDING)
[READY] (notification_devices) -- (active,ASCENDING) (climbDropPushEnabled,ASCENDING) (platform,ASCENDING)
[READY] (notification_devices) -- (uid,ASCENDING) (active,ASCENDING)
[READY] (notification_devices) -- (uid,ASCENDING) (active,ASCENDING) (climbDropPushEnabled,ASCENDING) (platform,ASCENDING)
[READY] (entries) -- (isBestForUser,ASCENDING) (stepsAtBucket,ASCENDING)
[READY] (entries) -- (isBestForUser,ASCENDING) (stepsAtBucket,DESCENDING)
[READY] (entries) -- (finalSteps,DESCENDING)
2 of 13 declared Firestore indexes are not READY:
- (workouts) -- (source,ASCENDING) (climbId,ASCENDING)
- (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalSteps,DESCENDING)
(sleep 20 skipped in simulation)
poll #2: firebase -y firebase-tools@15.22.1 firestore:indexes --project ascend-prod-SIMULATED --pretty --token simulated
[CREATING] (workouts) -- (source,ASCENDING) (climbId,ASCENDING)
[CREATING] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalSteps,DESCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalWorkouts,DESCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalDuration,DESCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (stepsPerMinute,DESCENDING)
[READY] (email_jobs) -- (status,ASCENDING) (readyAt,ASCENDING)
[READY] (email_jobs) -- (status,ASCENDING) (processingStartedAt,ASCENDING)
[READY] (notification_devices) -- (active,ASCENDING) (climbDropPushEnabled,ASCENDING) (platform,ASCENDING)
[READY] (notification_devices) -- (uid,ASCENDING) (active,ASCENDING)
[READY] (notification_devices) -- (uid,ASCENDING) (active,ASCENDING) (climbDropPushEnabled,ASCENDING) (platform,ASCENDING)
[READY] (entries) -- (isBestForUser,ASCENDING) (stepsAtBucket,ASCENDING)
[READY] (entries) -- (isBestForUser,ASCENDING) (stepsAtBucket,DESCENDING)
[READY] (entries) -- (finalSteps,DESCENDING)
2 of 13 declared Firestore indexes are not READY:
- (workouts) -- (source,ASCENDING) (climbId,ASCENDING)
- (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalSteps,DESCENDING)
(sleep 20 skipped in simulation)
poll #3: firebase -y firebase-tools@15.22.1 firestore:indexes --project ascend-prod-SIMULATED --pretty --token simulated
[READY] (workouts) -- (source,ASCENDING) (climbId,ASCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalSteps,DESCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalWorkouts,DESCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (totalDuration,DESCENDING)
[READY] (leaderboard_stats) -- (timeFrame,ASCENDING) (periodStartAt,ASCENDING) (stepsPerMinute,DESCENDING)
[READY] (email_jobs) -- (status,ASCENDING) (readyAt,ASCENDING)
[READY] (email_jobs) -- (status,ASCENDING) (processingStartedAt,ASCENDING)
[READY] (notification_devices) -- (active,ASCENDING) (climbDropPushEnabled,ASCENDING) (platform,ASCENDING)
[READY] (notification_devices) -- (uid,ASCENDING) (active,ASCENDING)
[READY] (notification_devices) -- (uid,ASCENDING) (active,ASCENDING) (climbDropPushEnabled,ASCENDING) (platform,ASCENDING)
[READY] (entries) -- (isBestForUser,ASCENDING) (stepsAtBucket,ASCENDING)
[READY] (entries) -- (isBestForUser,ASCENDING) (stepsAtBucket,DESCENDING)
[READY] (entries) -- (finalSteps,DESCENDING)
All 13 declared Firestore indexes are READY.

=== exit status: 0 ===
```
</details>
<details>
<summary>Evidence: Functions-ACTIVE gate simulation (fails on FAILED function, passes when all four ACTIVE)</summary>

<code>=== Simulate &#34;Verify critical Functions are active&#34; (one function FAILED) ===&#10;Missing or inactive Firebase Functions: onWorkoutReplaySplitsWritten&#10;exit: 1&#10;&#10;=== Same gate, all four ACTIVE ===&#10;Verified ACTIVE Firebase Functions: cleanupDeletedUserData, onWorkoutWritten, onWorkoutReplaySplitsWritten, unsubscribeFromEmails&#10;exit: 0</code>

```text
=== Simulate "Verify critical Functions are active" (one function FAILED) ===
Missing or inactive Firebase Functions: onWorkoutReplaySplitsWritten
exit: 1

=== Same gate, all four ACTIVE ===
Verified ACTIVE Firebase Functions: cleanupDeletedUserData, onWorkoutWritten, onWorkoutReplaySplitsWritten, unsubscribeFromEmails
exit: 0
```
</details>
<details>
<summary>Evidence: Production-backend-rollout test transcript (4/4 pass)</summary>

```text
TAP version 13
# Subtest: declares both filtered Live Replay window indexes
ok 1 - declares both filtered Live Replay window indexes
  ---
  duration_ms: 0.810042
  type: 'test'
  ...
# Subtest: index readiness requires every declared index to report READY
ok 2 - index readiness requires every declared index to report READY
  ---
  duration_ms: 74.189375
  type: 'test'
  ...
# Subtest: function readiness rejects missing and inactive critical functions
ok 3 - function readiness rejects missing and inactive critical functions
  ---
  duration_ms: 35.553333
  type: 'test'
  ...
# Subtest: production deploy waits for indexes and rolls the backend out in dependency order
ok 4 - production deploy waits for indexes and rolls the backend out in dependency order
  ---
  duration_ms: 0.392625
  type: 'test'
  ...
1..4
# tests 4
# suites 0
# pass 4
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 142.850583
```
</details>
<details>
<summary>Evidence: accountCleanup retry/idempotency test transcript (24/24 pass)</summary>

```text
TAP version 13
# Subtest: sweeps server-owned subcollections a client cannot delete
ok 1 - sweeps server-owned subcollections a client cannot delete
  ---
  duration_ms: 0.828916
  type: 'test'
  ...
# Subtest: sweeps mirrors left behind by an interrupted client
ok 2 - sweeps mirrors left behind by an interrupted client
  ---
  duration_ms: 0.083958
  type: 'test'
  ...
# Subtest: discovers subcollections rather than assuming a fixed list
ok 3 - discovers subcollections rather than assuming a fixed list
  ---
  duration_ms: 0.111333
  type: 'test'
  ...
# Subtest: removes leaderboard entries so deleted users stop ranking
ok 4 - removes leaderboard entries so deleted users stop ranking
  ---
  duration_ms: 0.071667
  type: 'test'
  ...
# Subtest: deletes every device record the top-level uid field owns
ok 5 - deletes every device record the top-level uid field owns
  ---
  duration_ms: 0.184666
  type: 'test'
  ...
# Subtest: removes top-level notification delivery records
ok 6 - removes top-level notification delivery records
  ---
  duration_ms: 0.470542
  type: 'test'
  ...
# Subtest: a failing notification device sweep is reported for retry
ok 7 - a failing notification device sweep is reported for retry
  ---
  duration_ms: 0.160958
  type: 'test'
  ...
# Subtest: removes replay finishers living outside users/{uid}
ok 8 - removes replay finishers living outside users/{uid}
  ---
  duration_ms: 0.101292
  type: 'test'
  ...
# Subtest: de-identifies a First Ascent the deleted user holds
ok 9 - de-identifies a First Ascent the deleted user holds
  ---
  duration_ms: 0.275375
  type: 'test'
  ...
# Subtest: a de-identified First Ascent keeps its slot and date
ok 10 - a de-identified First Ascent keeps its slot and date
  ---
  duration_ms: 0.282
  type: 'test'
  ...
# Subtest: leaves First Ascents held by other climbers untouched
ok 11 - leaves First Ascents held by other climbers untouched
  ---
  duration_ms: 0.098
  type: 'test'
  ...
# Subtest: finds First Ascents without needing a new Firestore index
ok 12 - finds First Ascents without needing a new Firestore index
  ---
  duration_ms: 0.045167
  type: 'test'
  ...
# Subtest: a failing First Ascent sweep is reported for retry
ok 13 - a failing First Ascent sweep is reported for retry
  ---
  duration_ms: 0.069875
  type: 'test'
  ...
# Subtest: removes feedback carrying the user's email and message
ok 14 - removes feedback carrying the user's email and message
  ---
  duration_ms: 0.042041
  type: 'test'
  ...
# Subtest: removes queued lifecycle email jobs holding a raw email
ok 15 - removes queued lifecycle email jobs holding a raw email
  ---
  duration_ms: 0.073875
  type: 'test'
  ...
# Subtest: one failing subcollection does not abandon other PII
ok 16 - one failing subcollection does not abandon other PII
  ---
  duration_ms: 0.112
  type: 'test'
  ...
# Subtest: a failing feedback sweep is reported for retry
ok 17 - a failing feedback sweep is reported for retry
  ---
  duration_ms: 0.0555
  type: 'test'
  ...
# Subtest: a failing leaderboard sweep is reported for retry
ok 18 - a failing leaderboard sweep is reported for retry
  ---
  duration_ms: 0.0585
  type: 'test'
  ...
# Subtest: a permanently failed leaderboard delete is not a success
ok 19 - a permanently failed leaderboard delete is not a success
  ---
  duration_ms: 0.246625
  type: 'test'
  ...
# Subtest: a permanently failed leaderboard delete lands in failures
ok 20 - a permanently failed leaderboard delete lands in failures
  ---
  duration_ms: 0.08425
  type: 'test'
  ...
# Subtest: a leaderboard sweep counts only writes that succeeded
ok 21 - a leaderboard sweep counts only writes that succeeded
  ---
  duration_ms: 0.042958
  type: 'test'
  ...
# Subtest: a failing finisher sweep is reported for retry
ok 22 - a failing finisher sweep is reported for retry
  ---
  duration_ms: 0.082125
  type: 'test'
  ...
# Subtest: a failed listing still clears the top-level user records
ok 23 - a failed listing still clears the top-level user records
  ---
  duration_ms: 0.066542
  type: 'test'
  ...
# Subtest: failures are reported so the trigger can retry
ok 24 - failures are reported so the trigger can retry
  ---
  duration_ms: 0.058625
  type: 'test'
  ...
1..24
# tests 24
# suites 0
# pass 24
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 79.557
```
</details>
<details>
<summary>Evidence: Rendered index-wait step script as executed (vars substituted like Actions)</summary>

```text
set -euo pipefail

for attempt in $(seq 1 180); do
  if ! deployed_indexes="$(npx -y firebase-tools@15.22.1 firestore:indexes --project "ascend-prod-SIMULATED" --pretty --token "$FIREBASE_TOKEN")"; then
    echo "::warning::firestore:indexes poll attempt ${attempt} of 180 failed; retrying."
    if [ "$attempt" -lt 180 ]; then
      sleep 20
    fi
    continue
  fi
  printf "%s\n" "$deployed_indexes"

  readiness_status=0
  printf "%s\n" "$deployed_indexes" | node scripts/ci/assert-firestore-indexes-ready.mjs firestore.indexes.json || readiness_status=$?

  if [ "$readiness_status" -eq 0 ]; then
    exit 0
  fi

  if [ "$readiness_status" -eq 2 ]; then
    echo "::error::Index readiness check failed on a structural config or parser error; fix it instead of retrying."
    exit 2
  fi

  if [ "$attempt" -lt 180 ]; then
    sleep 20
  fi
done

echo "::error::Firestore indexes did not become READY within 60 minutes."
exit 1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed ✅</summary>

- ⚠️ `.github/workflows/deploy-production.yml:236` - The index-readiness poll loop is not resilient to transient CLI failures: under `set -euo pipefail`, the top-level command substitution `deployed_indexes=&#34;$(npx ... firestore:indexes ...)&#34;` aborts the whole step if a single poll invocation exits nonzero (network blip, transient 503, npx registry hiccup) during a wait that can legitimately run up to 60 minutes and ~180 invocations. That fails the entire production deploy mid-rollout (after indexes, before functions/rules/hosting) and forces a full workflow rerun including the ~60-minute IPA rebuild. Guard the capture (e.g. `if ! deployed_indexes=$(npx ...); then sleep 20; continue; fi`) so a transient poll failure counts as a retryable attempt.
- ⚠️ `scripts/ci/assert-firestore-indexes-ready.mjs:18` - assert-firestore-indexes-ready.mjs conflates structural errors with &#34;not ready&#34;: a thrown error (e.g. someone later adds a COLLECTION_GROUP index to firestore.indexes.json, or firebase-tools pretty-output drift) exits nonzero exactly like a not-yet-READY result, so the workflow loop retries it for the full 60 minutes and then fails with the misleading &#34;indexes did not become READY&#34; message instead of failing fast on a config/parse problem. Exit with a distinct code (e.g. 2) for structural errors and have the workflow loop abort immediately when it sees that code.
- ⚠️ `scripts/ci/assert-firestore-indexes-ready.mjs:34` - `line.includes(fields)` matches the declared field tokens anywhere in a READY line, so a READY index with extra LEADING fields (e.g. a leftover manually created `(other, isBestForUser, stepsAtBucket)` index) satisfies a declared index that is itself still CREATING - a false-positive pass in exactly the readiness barrier this script implements, and a leading-superset index does not serve the prefix query. Trailing-superset tolerance (which the test intentionally encodes) is fine; require the fields to appear immediately after the prefix instead: `line.startsWith(prefix + fields)`.
- ℹ️ `scripts/ci/assert-firestore-indexes-ready.mjs:26` - Both assertion scripts&#39; expectations about firebase-tools@15.22.1 output (`[READY] (group) -- (field,ORDER)` pretty format with no leading indentation, `--json functions:list` returning `{status, result: [{id, state}]}` with camelCase ids) are validated only against synthetic fixtures in production-backend-rollout.test.mjs, never against real CLI output, and the production workflow is the first place they run for real. The version pin bounds the drift risk; the captain should watch the first &#34;Wait for every declared Firestore index&#34; attempt&#39;s log to confirm the parser matches real output before letting it poll.
- ℹ️ `docs/production-backend-rollout-runbook.md:76` - The runbook&#39;s launch command hardcodes the numeric workflow ID (`gh-axi workflow run 240226254 --ref main`); that ID changes if the workflow file is ever deleted and recreated, while `deploy-production.yml` as the workflow reference is stable and equally unambiguous.

🔧 Fix: harden index-readiness poll loop, matching, and runbook reference
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test scripts/test/*.test.mjs` (110/110 pass, includes the 4 new production-backend-rollout tests)</code>
- <code>`node --test scripts/test/production-backend-rollout.test.mjs` (index declarations + Swift query shape, readiness script semantics, ACTIVE gate semantics, workflow step ordering)</code>
- <code>`cd functions &amp;&amp; npm ci &amp;&amp; npm test` (169/169 pass after fresh-worktree dependency install)</code>
- <code>`node --test lib/test/accountCleanup.test.js` (24/24 pass: retry-safety, partial-failure continuation, subcollection discovery, First Ascent de-identification)</code>
- <code>End-to-end simulation of the workflow&#39;s `Wait for every declared Firestore index` step: extracted the real run script from deploy-production.yml, stubbed npx/firebase CLI to report 2 of 13 indexes CREATING for two polls then all READY - loop retried and exited 0 only after full readiness</code>
- <code>Simulated the `Verify critical Functions are active` gate with the exact workflow command: exit 1 when onWorkoutReplaySplitsWritten reports FAILED, exit 0 when all four critical functions are ACTIVE</code>
- `Manual verification: firestore.indexes.json has 13 indexes, zero duplicates, both isBestForUser+stepsAtBucket directions declared exactly once; cleanupDeletedUserData exported at functions/src/index.ts:12 with retry:true; workflow YAML parses and upload-testflight needs deploy-firebase; merge-base with origin/develop equals origin/develop head; runbook bans preparation-time production Firebase commands and no real Firebase command was executed during validation`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
