### PR TITLE
fix(telemetry): tag Mixpanel events with build environment

### DIFF
--- a/.claude/skills/ascend-analytics/SKILL.md
+++ b/.claude/skills/ascend-analytics/SKILL.md
@@ -21,12 +21,24 @@ If an event wouldn't change a decision, don't log it. Volume of events != value 
 Multiple analytics destinations are sanctioned - each is best at a different job. Route events to the right destination through a single facade; never call providers directly from feature code.
 
 - **Firebase Analytics** - broad funnel, cohort, retention analysis. Most product events go here.
-- **Mixpanel** - product funnel, retention, and behavior analytics. Implemented as `MixpanelTelemetrySink`, configured from the `AscendMixpanelToken` Info.plist key; the sink is inert when no token is present.
+- **Mixpanel** - product funnel, retention, and behavior analytics. Implemented as `MixpanelTelemetrySink`, configured from the `AscendMixpanelToken` Info.plist key; the sink is inert when no token is present. Dev, staging, and production all report into one project and are separated by super-properties - see "Mixpanel environment tagging" below.
 - **SuperWall** - onboarding-flow step-level conversion + paywall presentation analytics (its specialty).
 - **Crashlytics** - crashes, fatal errors, stability metrics.
 - **Sentry** - error/crash diagnostics mirror alongside Crashlytics (non-fatal errors, app hangs, symbolicated traces). When reading, triaging, or updating Sentry issues/events, use the `sentry` skill.
 
 When evaluating new providers, justify them by what they uniquely measure that the existing set doesn't.
+
+## Mixpanel environment tagging
+
+Dev, staging, and production share a single Mixpanel project (`4032860`).
+There are no per-environment projects or tokens; environments are told apart by the `app_environment`, `build_config`, `app_version`, and `build_number` super-properties on every event.
+Those values come from `TelemetryBuildMetadata`, the same source Sentry tags its events with, so the two providers always agree for a given build.
+
+The invariant: the super-properties are registered before any event can be tracked, and re-registered after anything that clears Mixpanel SDK state - `reset()` on sign-out, opting back in to collection, or a user property whose name collides with one of those reserved keys.
+`AscendAppTests/MixpanelTelemetrySinkTests.swift` enforces it.
+
+Events recorded before this tagging shipped carry none of these properties, and that history cannot be separated retroactively.
+Filter on `app_environment` when analyzing, and treat untagged events as unattributable rather than as clean production data.
 
 ## Implementation principles
 - One analytics facade. Feature code never imports a provider directly; it logs through the facade, which routes to the right destination. Sinks conform to `TelemetrySink` under `AscendApp/Shared/Services/Telemetry/`.

--- a/AscendApp/Shared/Managers/TelemetryManager.swift
+++ b/AscendApp/Shared/Managers/TelemetryManager.swift
@@ -141,16 +141,6 @@ final class TelemetryManager: @unchecked Sendable {
     }
     #endif
 
-    private static var appEnvironmentName: String {
-        #if DEBUG
-        return "dev"
-        #elseif STAGING
-        return "staging"
-        #else
-        return "production"
-        #endif
-    }
-
     // MARK: - User Identity
 
     func setUserId(_ userId: String) {
@@ -198,7 +188,7 @@ final class TelemetryManager: @unchecked Sendable {
 
     private func enrich(_ record: TelemetryRecord) -> TelemetryRecord {
         var parameters = record.parameters
-        parameters["app_environment"] = .string(Self.appEnvironmentName)
+        parameters["app_environment"] = .string(TelemetryBuildMetadata.current.appEnvironment)
         return TelemetryRecord(
             name: record.name,
             parameters: parameters,
@@ -208,7 +198,7 @@ final class TelemetryManager: @unchecked Sendable {
 
     private func enrich(_ screen: TelemetryScreen) -> TelemetryScreen {
         var parameters = screen.parameters
-        parameters["app_environment"] = .string(Self.appEnvironmentName)
+        parameters["app_environment"] = .string(TelemetryBuildMetadata.current.appEnvironment)
         return TelemetryScreen(
             name: screen.name,
             screenClass: screen.screenClass,
@@ -243,16 +233,10 @@ final class TelemetryManager: @unchecked Sendable {
 
     func setAppMetadata() {
         guard isCollectionEnabled else { return }
-        let bundle = Bundle.main
-        #if DEBUG
-        set(.buildConfig, value: "debug")
-        #elseif STAGING
-        set(.buildConfig, value: "staging")
-        #else
-        set(.buildConfig, value: "release")
-        #endif
-        set(.appVersion, value: bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown")
-        set(.buildNumber, value: bundle.infoDictionary?["CFBundleVersion"] as? String ?? "unknown")
+        let metadata = TelemetryBuildMetadata.current
+        set(.buildConfig, value: metadata.buildConfig)
+        set(.appVersion, value: metadata.appVersion)
+        set(.buildNumber, value: metadata.buildNumber)
     }
 
     // MARK: - Breadcrumbs (Structured Tokens)

--- a/AscendApp/Shared/Services/Telemetry/MixpanelClient.swift
+++ b/AscendApp/Shared/Services/Telemetry/MixpanelClient.swift
@@ -1,0 +1,12 @@
+@preconcurrency import Mixpanel
+
+protocol MixpanelClient: AnyObject {
+    var loggingEnabled: Bool { get set }
+
+    func setCollectionEnabled(_ enabled: Bool)
+    func setUserID(_ userID: String?)
+    func setUserProperty(_ name: String, value: String?)
+    func registerSuperProperties(_ properties: [String: String])
+    func track(event: String, properties: Properties)
+    func flush(performFullFlush: Bool)
+}

--- a/AscendApp/Shared/Services/Telemetry/MixpanelSDKClient.swift
+++ b/AscendApp/Shared/Services/Telemetry/MixpanelSDKClient.swift
@@ -1,0 +1,56 @@
+@preconcurrency import Mixpanel
+
+final class MixpanelSDKClient: MixpanelClient {
+    var loggingEnabled: Bool {
+        get { instance.loggingEnabled }
+        set { instance.loggingEnabled = newValue }
+    }
+
+    private let instance: MixpanelInstance
+
+    init(token: String, flushInterval: Double) {
+        instance = Mixpanel.initialize(
+            token: token,
+            trackAutomaticEvents: false,
+            flushInterval: flushInterval
+        )
+    }
+
+    func setCollectionEnabled(_ enabled: Bool) {
+        if enabled {
+            instance.optInTracking()
+        } else {
+            instance.optOutTracking()
+        }
+    }
+
+    func setUserID(_ userID: String?) {
+        if let userID {
+            instance.identify(distinctId: userID, usePeople: true)
+        } else {
+            instance.reset()
+        }
+    }
+
+    func setUserProperty(_ name: String, value: String?) {
+        if let value {
+            instance.people.set(property: name, to: value)
+            instance.registerSuperProperties([name: value])
+        } else {
+            instance.people.unset(properties: [name])
+            instance.unregisterSuperProperty(name)
+        }
+    }
+
+    func registerSuperProperties(_ properties: [String: String]) {
+        instance.registerSuperProperties(properties)
+    }
+
+    func track(event: String, properties: Properties) {
+        instance.track(event: event, properties: properties)
+    }
+
+    func flush(performFullFlush: Bool) {
+        instance.flush(performFullFlush: performFullFlush)
+    }
+}

--- a/AscendApp/Shared/Services/Telemetry/MixpanelTelemetrySink.swift
+++ b/AscendApp/Shared/Services/Telemetry/MixpanelTelemetrySink.swift
@@ -5,93 +5,95 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
     let supportedDestinations: Set<TelemetryDestination> = [.analytics]
 
     private let configuration: AnalyticsConfiguration
+    private let buildMetadata: TelemetryBuildMetadata
+    private let makeClient: (String, Double) -> any MixpanelClient
     private let lock = NSLock()
-    private var instance: MixpanelInstance?
+    private var client: (any MixpanelClient)?
 
-    init(configuration: AnalyticsConfiguration = .live) {
+    init(
+        configuration: AnalyticsConfiguration = .live,
+        buildMetadata: TelemetryBuildMetadata = .current,
+        makeClient: @escaping (String, Double) -> any MixpanelClient = {
+            MixpanelSDKClient(token: $0, flushInterval: $1)
+        }
+    ) {
         self.configuration = configuration
+        self.buildMetadata = buildMetadata
+        self.makeClient = makeClient
     }
 
     func setCollectionEnabled(_ enabled: Bool) {
-        guard let instance = configuredInstance() else { return }
-
-        if enabled {
-            instance.optInTracking()
-        } else {
-            instance.optOutTracking()
+        withConfiguredClient { client, isNewClient in
+            if enabled && !isNewClient {
+                client.registerSuperProperties(buildMetadata.properties)
+            }
+            client.setCollectionEnabled(enabled)
         }
     }
 
     func setUserID(_ userID: String?) {
-        guard let instance = configuredInstance() else { return }
-
-        if let userID {
-            instance.identify(distinctId: userID, usePeople: true)
-        } else {
-            instance.reset()
+        withConfiguredClient { client, _ in
+            client.setUserID(userID)
+            if userID == nil {
+                client.registerSuperProperties(buildMetadata.properties)
+            }
         }
     }
 
     func setUserProperty(_ name: String, value: String?) {
-        guard let instance = configuredInstance() else { return }
-
-        if let value {
-            instance.people.set(property: name, to: value)
-            instance.registerSuperProperties([name: value])
-        } else {
-            instance.people.unset(properties: [name])
-            instance.unregisterSuperProperty(name)
+        withConfiguredClient { client, _ in
+            client.setUserProperty(name, value: value)
+            if buildMetadata.properties[name] != nil {
+                client.registerSuperProperties(buildMetadata.properties)
+            }
+            flushAfterDebugEvent(client)
         }
-
-        flushAfterDebugEvent(instance)
     }
 
     func record(_ record: TelemetryRecord) {
-        guard let instance = configuredInstance() else { return }
-
-        instance.track(
-            event: record.name,
-            properties: record.parameters.mixpanelProperties
-        )
-
-        flushAfterDebugEvent(instance)
+        withConfiguredClient { client, _ in
+            client.track(
+                event: record.name,
+                properties: record.parameters.mixpanelProperties
+            )
+            flushAfterDebugEvent(client)
+        }
     }
 
     func record(screen: TelemetryScreen) {
-        guard let instance = configuredInstance() else { return }
+        withConfiguredClient { client, _ in
+            var properties = screen.parameters.mixpanelProperties
+            properties["screen_name"] = screen.name
+            properties["screen_class"] = screen.screenClass
 
-        var properties = screen.parameters.mixpanelProperties
-        properties["screen_name"] = screen.name
-        properties["screen_class"] = screen.screenClass
-
-        instance.track(
-            event: "screen_view",
-            properties: properties
-        )
-
-        flushAfterDebugEvent(instance)
+            client.track(
+                event: "screen_view",
+                properties: properties
+            )
+            flushAfterDebugEvent(client)
+        }
     }
 
-    private func configuredInstance() -> MixpanelInstance? {
-        guard let token = configuration.mixpanelToken else { return nil }
+    private func withConfiguredClient(
+        _ action: (any MixpanelClient, _ isNewClient: Bool) -> Void
+    ) {
+        guard let token = configuration.mixpanelToken else { return }
 
         lock.lock()
         defer { lock.unlock() }
 
-        if let instance {
-            return instance
+        if let client {
+            action(client, false)
+            return
         }
 
-        let instance = Mixpanel.initialize(
-            token: token,
-            trackAutomaticEvents: false,
-            flushInterval: flushInterval
-        )
+        let client = makeClient(token, flushInterval)
         #if DEBUG
-        instance.loggingEnabled = true
+        client.loggingEnabled = true
         #endif
-        self.instance = instance
-        return instance
+        client.registerSuperProperties(buildMetadata.properties)
+        self.client = client
+        action(client, true)
     }
 
     private var flushInterval: Double {
@@ -102,9 +104,9 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
         #endif
     }
 
-    private func flushAfterDebugEvent(_ instance: MixpanelInstance) {
+    private func flushAfterDebugEvent(_ client: any MixpanelClient) {
         #if DEBUG
-        instance.flush(performFullFlush: true)
+        client.flush(performFullFlush: true)
         #endif
     }
 }

--- a/AscendApp/Shared/Services/Telemetry/MixpanelTelemetrySink.swift
+++ b/AscendApp/Shared/Services/Telemetry/MixpanelTelemetrySink.swift
@@ -23,8 +23,8 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
     }
 
     func setCollectionEnabled(_ enabled: Bool) {
-        withConfiguredClient { client, isNewClient in
-            if enabled && !isNewClient {
+        withConfiguredClient { client in
+            if enabled {
                 client.registerSuperProperties(buildMetadata.properties)
             }
             client.setCollectionEnabled(enabled)
@@ -32,7 +32,7 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
     }
 
     func setUserID(_ userID: String?) {
-        withConfiguredClient { client, _ in
+        withConfiguredClient { client in
             client.setUserID(userID)
             if userID == nil {
                 client.registerSuperProperties(buildMetadata.properties)
@@ -41,8 +41,10 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
     }
 
     func setUserProperty(_ name: String, value: String?) {
-        withConfiguredClient { client, _ in
+        withConfiguredClient { client in
             client.setUserProperty(name, value: value)
+            // A caller can pass any name, including one of the reserved build-metadata
+            // keys; the build's own values stay authoritative after such a collision.
             if buildMetadata.properties[name] != nil {
                 client.registerSuperProperties(buildMetadata.properties)
             }
@@ -51,7 +53,7 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
     }
 
     func record(_ record: TelemetryRecord) {
-        withConfiguredClient { client, _ in
+        withConfiguredClient { client in
             client.track(
                 event: record.name,
                 properties: record.parameters.mixpanelProperties
@@ -61,7 +63,7 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
     }
 
     func record(screen: TelemetryScreen) {
-        withConfiguredClient { client, _ in
+        withConfiguredClient { client in
             var properties = screen.parameters.mixpanelProperties
             properties["screen_name"] = screen.name
             properties["screen_class"] = screen.screenClass
@@ -74,16 +76,14 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
         }
     }
 
-    private func withConfiguredClient(
-        _ action: (any MixpanelClient, _ isNewClient: Bool) -> Void
-    ) {
+    private func withConfiguredClient(_ action: (any MixpanelClient) -> Void) {
         guard let token = configuration.mixpanelToken else { return }
 
         lock.lock()
         defer { lock.unlock() }
 
         if let client {
-            action(client, false)
+            action(client)
             return
         }
 
@@ -93,7 +93,7 @@ final class MixpanelTelemetrySink: TelemetrySink, @unchecked Sendable {
         #endif
         client.registerSuperProperties(buildMetadata.properties)
         self.client = client
-        action(client, true)
+        action(client)
     }
 
     private var flushInterval: Double {

--- a/AscendApp/Shared/Services/Telemetry/SentryDiagnosticsReporter.swift
+++ b/AscendApp/Shared/Services/Telemetry/SentryDiagnosticsReporter.swift
@@ -108,5 +108,4 @@ final class SentryDiagnosticsReporter: CrashlyticsReporting, @unchecked Sendable
         SentrySDK.close()
         didStart = false
     }
-
 }

--- a/AscendApp/Shared/Services/Telemetry/SentryDiagnosticsReporter.swift
+++ b/AscendApp/Shared/Services/Telemetry/SentryDiagnosticsReporter.swift
@@ -3,11 +3,16 @@ import Foundation
 
 final class SentryDiagnosticsReporter: CrashlyticsReporting, @unchecked Sendable {
     private let configuration: SentryConfiguration
+    private let buildMetadata: TelemetryBuildMetadata
     private let lock = NSLock()
     private var didStart = false
 
-    init(configuration: SentryConfiguration = .live) {
+    init(
+        configuration: SentryConfiguration = .live,
+        buildMetadata: TelemetryBuildMetadata = .current
+    ) {
         self.configuration = configuration
+        self.buildMetadata = buildMetadata
     }
 
     func setCollectionEnabled(_ enabled: Bool) {
@@ -23,9 +28,9 @@ final class SentryDiagnosticsReporter: CrashlyticsReporting, @unchecked Sendable
 
         let options = Options()
         options.dsn = dsn
-        options.environment = Self.appEnvironmentName
-        options.releaseName = Self.releaseName
-        options.dist = Self.buildNumber
+        options.environment = buildMetadata.appEnvironment
+        options.releaseName = buildMetadata.releaseName
+        options.dist = buildMetadata.buildNumber
         options.sendDefaultPii = false
         options.attachScreenshot = false
         options.attachViewHierarchy = false
@@ -40,10 +45,9 @@ final class SentryDiagnosticsReporter: CrashlyticsReporting, @unchecked Sendable
 
         SentrySDK.start(options: options)
         SentrySDK.configureScope { scope in
-            scope.setTag(value: Self.appEnvironmentName, key: "app_environment")
-            scope.setTag(value: Self.buildConfigName, key: "build_config")
-            scope.setTag(value: Self.appVersion, key: "app_version")
-            scope.setTag(value: Self.buildNumber, key: "build_number")
+            self.buildMetadata.properties.forEach { key, value in
+                scope.setTag(value: value, key: key)
+            }
         }
         didStart = true
     }
@@ -105,35 +109,4 @@ final class SentryDiagnosticsReporter: CrashlyticsReporting, @unchecked Sendable
         didStart = false
     }
 
-    private static var appEnvironmentName: String {
-        #if DEBUG
-        return "dev"
-        #elseif STAGING
-        return "staging"
-        #else
-        return "production"
-        #endif
-    }
-
-    private static var buildConfigName: String {
-        #if DEBUG
-        return "debug"
-        #elseif STAGING
-        return "staging"
-        #else
-        return "release"
-        #endif
-    }
-
-    private static var appVersion: String {
-        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-    }
-
-    private static var buildNumber: String {
-        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
-    }
-
-    private static var releaseName: String {
-        "\(Bundle.main.bundleIdentifier ?? "AscendApp")@\(appVersion)+\(buildNumber)"
-    }
 }

--- a/AscendApp/Shared/Services/Telemetry/TelemetryBuildMetadata.swift
+++ b/AscendApp/Shared/Services/Telemetry/TelemetryBuildMetadata.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+struct TelemetryBuildMetadata: Equatable, Sendable {
+    static let current = TelemetryBuildMetadata()
+
+    let appEnvironment: String
+    let buildConfig: String
+    let appVersion: String
+    let buildNumber: String
+    let bundleIdentifier: String
+
+    var properties: [String: String] {
+        [
+            "app_environment": appEnvironment,
+            "build_config": buildConfig,
+            "app_version": appVersion,
+            "build_number": buildNumber
+        ]
+    }
+
+    var releaseName: String {
+        "\(bundleIdentifier)@\(appVersion)+\(buildNumber)"
+    }
+
+    init(
+        infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:],
+        bundleIdentifier: String = Bundle.main.bundleIdentifier ?? "AscendApp"
+    ) {
+        #if DEBUG
+        appEnvironment = "dev"
+        buildConfig = "debug"
+        #elseif STAGING
+        appEnvironment = "staging"
+        buildConfig = "staging"
+        #else
+        appEnvironment = "production"
+        buildConfig = "release"
+        #endif
+
+        appVersion = infoDictionary["CFBundleShortVersionString"] as? String ?? "unknown"
+        buildNumber = infoDictionary["CFBundleVersion"] as? String ?? "unknown"
+        self.bundleIdentifier = bundleIdentifier
+    }
+
+    init(
+        appEnvironment: String,
+        buildConfig: String,
+        appVersion: String,
+        buildNumber: String,
+        bundleIdentifier: String
+    ) {
+        self.appEnvironment = appEnvironment
+        self.buildConfig = buildConfig
+        self.appVersion = appVersion
+        self.buildNumber = buildNumber
+        self.bundleIdentifier = bundleIdentifier
+    }
+}

--- a/AscendAppTests/MixpanelTelemetrySinkTests.swift
+++ b/AscendAppTests/MixpanelTelemetrySinkTests.swift
@@ -29,7 +29,14 @@ struct MixpanelTelemetrySinkTests {
         telemetry.configure()
         telemetry.track(TelemetryRecord(name: "first_event"))
 
-        #expect(client.calls == ["register_super_properties", "opt_in", "track"])
+        #expect(
+            client.calls == [
+                "register_super_properties",
+                "register_super_properties",
+                "opt_in",
+                "track"
+            ]
+        )
         #expect(client.registeredSuperProperties == buildMetadata.properties)
         #expect(client.trackedEvents == ["first_event"])
     }
@@ -59,6 +66,30 @@ struct MixpanelTelemetrySinkTests {
         #expect(client.registeredSuperProperties == buildMetadata.properties)
         #expect(client.trackedEvents == ["signed_out_event"])
     }
+
+    @Test
+    func restoresBuildMetadataWhenUserPropertyCollidesWithReservedKey() {
+        let client = RecordingMixpanelClient()
+        let buildMetadata = TelemetryBuildMetadata(
+            appEnvironment: "staging",
+            buildConfig: "staging",
+            appVersion: "1.2.3",
+            buildNumber: "456",
+            bundleIdentifier: "com.tylerpavay.AscendApp.staging"
+        )
+        let sink = MixpanelTelemetrySink(
+            configuration: AnalyticsConfiguration(
+                infoDictionary: [AnalyticsConfiguration.mixpanelTokenInfoKey: "token"]
+            ),
+            buildMetadata: buildMetadata,
+            makeClient: { _, _ in client }
+        )
+
+        sink.setUserProperty("app_environment", value: "spoofed")
+
+        #expect(client.calls == ["register_super_properties", "set_user_property", "register_super_properties"])
+        #expect(client.registeredSuperProperties == buildMetadata.properties)
+    }
 }
 
 private extension MixpanelTelemetrySinkTests {
@@ -76,7 +107,9 @@ private extension MixpanelTelemetrySinkTests {
             calls.append(userID == nil ? "reset" : "identify")
         }
 
-        func setUserProperty(_ name: String, value: String?) {}
+        func setUserProperty(_ name: String, value: String?) {
+            calls.append("set_user_property")
+        }
 
         func registerSuperProperties(_ properties: [String: String]) {
             calls.append("register_super_properties")

--- a/AscendAppTests/MixpanelTelemetrySinkTests.swift
+++ b/AscendAppTests/MixpanelTelemetrySinkTests.swift
@@ -101,19 +101,26 @@ private extension MixpanelTelemetrySinkTests {
 
         func setCollectionEnabled(_ enabled: Bool) {
             calls.append(enabled ? "opt_in" : "opt_out")
+            if !enabled {
+                registeredSuperProperties.removeAll()
+            }
         }
 
         func setUserID(_ userID: String?) {
             calls.append(userID == nil ? "reset" : "identify")
+            if userID == nil {
+                registeredSuperProperties.removeAll()
+            }
         }
 
         func setUserProperty(_ name: String, value: String?) {
             calls.append("set_user_property")
+            registeredSuperProperties[name] = value
         }
 
         func registerSuperProperties(_ properties: [String: String]) {
             calls.append("register_super_properties")
-            registeredSuperProperties = properties
+            registeredSuperProperties.merge(properties) { _, registered in registered }
         }
 
         func track(event: String, properties: Properties) {

--- a/AscendAppTests/MixpanelTelemetrySinkTests.swift
+++ b/AscendAppTests/MixpanelTelemetrySinkTests.swift
@@ -1,0 +1,93 @@
+import Mixpanel
+import Testing
+@testable import AscendApp
+
+struct MixpanelTelemetrySinkTests {
+    @Test
+    func registersBuildMetadataBeforeFirstEvent() {
+        let client = RecordingMixpanelClient()
+        let buildMetadata = TelemetryBuildMetadata(
+            appEnvironment: "staging",
+            buildConfig: "staging",
+            appVersion: "1.2.3",
+            buildNumber: "456",
+            bundleIdentifier: "com.tylerpavay.AscendApp.staging"
+        )
+        let sink = MixpanelTelemetrySink(
+            configuration: AnalyticsConfiguration(
+                infoDictionary: [AnalyticsConfiguration.mixpanelTokenInfoKey: "token"]
+            ),
+            buildMetadata: buildMetadata,
+            makeClient: { _, _ in client }
+        )
+        let telemetry = TelemetryManager(
+            sinks: [sink],
+            crashlyticsReporter: NoopCrashlyticsReporter(),
+            collectionEnabledOverride: true
+        )
+
+        telemetry.configure()
+        telemetry.track(TelemetryRecord(name: "first_event"))
+
+        #expect(client.calls == ["register_super_properties", "opt_in", "track"])
+        #expect(client.registeredSuperProperties == buildMetadata.properties)
+        #expect(client.trackedEvents == ["first_event"])
+    }
+
+    @Test
+    func restoresBuildMetadataAfterIdentityReset() {
+        let client = RecordingMixpanelClient()
+        let buildMetadata = TelemetryBuildMetadata(
+            appEnvironment: "production",
+            buildConfig: "release",
+            appVersion: "1.2.3",
+            buildNumber: "456",
+            bundleIdentifier: "com.tylerpavay.AscendApp"
+        )
+        let sink = MixpanelTelemetrySink(
+            configuration: AnalyticsConfiguration(
+                infoDictionary: [AnalyticsConfiguration.mixpanelTokenInfoKey: "token"]
+            ),
+            buildMetadata: buildMetadata,
+            makeClient: { _, _ in client }
+        )
+
+        sink.setUserID(nil)
+        sink.record(TelemetryRecord(name: "signed_out_event"))
+
+        #expect(client.calls == ["register_super_properties", "reset", "register_super_properties", "track"])
+        #expect(client.registeredSuperProperties == buildMetadata.properties)
+        #expect(client.trackedEvents == ["signed_out_event"])
+    }
+}
+
+private extension MixpanelTelemetrySinkTests {
+    final class RecordingMixpanelClient: MixpanelClient {
+        var loggingEnabled = false
+        private(set) var calls: [String] = []
+        private(set) var registeredSuperProperties: [String: String] = [:]
+        private(set) var trackedEvents: [String] = []
+
+        func setCollectionEnabled(_ enabled: Bool) {
+            calls.append(enabled ? "opt_in" : "opt_out")
+        }
+
+        func setUserID(_ userID: String?) {
+            calls.append(userID == nil ? "reset" : "identify")
+        }
+
+        func setUserProperty(_ name: String, value: String?) {}
+
+        func registerSuperProperties(_ properties: [String: String]) {
+            calls.append("register_super_properties")
+            registeredSuperProperties = properties
+        }
+
+        func track(event: String, properties: Properties) {
+            calls.append("track")
+            trackedEvents.append(event)
+        }
+
+        func flush(performFullFlush: Bool) {}
+    }
+}

--- a/docs/sentry-setup.md
+++ b/docs/sentry-setup.md
@@ -31,6 +31,9 @@ Events are tagged with:
 - `build_number`
 - `ascend_error_context` and `ascend_error_code` for handled errors
 
+The first four come from `TelemetryBuildMetadata`, which also supplies Sentry's release name and dist and Mixpanel's environment super-properties, so a build reports identical values to both providers.
+See `.claude/skills/ascend-analytics/SKILL.md` for the Mixpanel side.
+
 ## MCP Workflow
 
 Use Sentry MCP for agent triage:


### PR DESCRIPTION
## Summary

- Add `TelemetryBuildMetadata` as the shared derivation source for `app_environment`, `build_config`, `app_version`, and `build_number`.
- Use the shared metadata in both Sentry and Mixpanel so their values agree for the same build.
- Register all four Mixpanel super-properties before opt-in or the first tracked event.
- Restore the properties after Mixpanel state resets, including sign-out and reserved-key collisions.
- Add an injectable Mixpanel client and tests for first-event ordering and every restoration path.

## Existing Mixpanel data

Events before this change have no environment marker and cannot be separated retroactively.
Dev, staging, and production sessions are mixed together in Mixpanel project `4032860` for all data prior to this build.
Do not report pre-fix Mixpanel figures as production behavior.
New events carry `app_environment`, `build_config`, `app_version`, and `build_number`.

## Verification scope

Verified: super-property registration and ordering under Staging runtime, plus the full Staging suite.
Release configuration compiles in CI.
NOT verified: Release runtime behavior, because the production Firebase plist is supplied by CI and is deliberately absent locally.
The tagging mechanism is environment-agnostic; only the emitted values differ by configuration.

The registration-before-first-event test is configuration-agnostic.
It injects build metadata and a recording Mixpanel client, then asserts the call order is registration, opt-in, and first event tracking.

## Validation

- Full Staging Swift test suite: 508 tests passed.
- Real Debug runtime: the first Mixpanel event, `$opt_in`, carried all four metadata fields.
- Real Staging runtime: persisted Mixpanel super-properties used the same project token and carried Staging values.
- Real SDK reset path: all four fields were restored after Mixpanel regenerated its anonymous identity.
- Sentry scope tags matched Mixpanel values from the shared metadata source.
- GitHub CI: Staging and Release iOS verification passed.
