### PR TITLE
build(scripts): stop link-firebase-plists from clobbering tracked Firebase plists

### DIFF
--- a/.claude/skills/ascend-deploy/SKILL.md
+++ b/.claude/skills/ascend-deploy/SKILL.md
@@ -138,7 +138,7 @@ Do not introduce a *new* long-lived JSON service-account key for deploy auth; th
 
 ## CI Firebase plists
 
-`GoogleService-Info*.plist` files are gitignored. CI decodes them from base64 secrets into `AscendApp/App/Firebase/` before building:
+The Staging and Production plists are gitignored; the Dev plist is committed (see `AscendApp/App/Firebase/README.md`). CI decodes all three from base64 secrets into `AscendApp/App/Firebase/` before building:
 `GOOGLE_SERVICE_INFO_DEV_BASE64`, `GOOGLE_SERVICE_INFO_STAGING_BASE64`, `GOOGLE_SERVICE_INFO_PRODUCTION_BASE64`.
 
 ## Related

--- a/AscendApp/App/Firebase/README.md
+++ b/AscendApp/App/Firebase/README.md
@@ -1,10 +1,17 @@
-# Firebase Local Config (Not Committed)
+# Firebase Config Plists
 
-This folder stores local symlinks to `GoogleService-Info-*.plist` files.
+This folder holds the `GoogleService-Info-*.plist` for each environment.
+`GoogleService-Info-Dev.plist` is committed.
+The Staging and Production plists are gitignored and live outside git, symlinked in locally.
 
-The actual plist files should live outside git and are linked by:
+`scripts/link-firebase-plists.sh` runs from the Xcode build phase and creates those symlinks.
+It never writes over a path git tracks, so the committed Dev plist is left exactly as checked out - including when `CONFIGURATION` is unset or unrecognized.
+It also leaves any existing real file alone, which is how CI keeps the plists it decodes from base64 secrets into this folder.
+If a tracked plist is missing from the working tree the script refuses to link over it; restore it instead:
 
-- `scripts/link-firebase-plists.sh`
+```sh
+git restore -- AscendApp/App/Firebase/GoogleService-Info-Dev.plist
+```
 
 You can set a custom secrets folder with:
 
@@ -12,8 +19,10 @@ You can set a custom secrets folder with:
 export ASCEND_FIREBASE_PLISTS_DIR="$HOME/.config/ascend/firebase"
 ```
 
-Expected files in the source folder:
+Files the script looks for in that source folder, linking only the ones missing here:
 
 - `GoogleService-Info-Dev.plist`
 - `GoogleService-Info-Staging.plist`
 - `GoogleService-Info-Production.plist`
+
+Regression coverage lives in `scripts/test/link-firebase-plists.test.mjs` (`node --test scripts/test/*.test.mjs`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ web/                    # Website source
 
 ## Build, Test, Run
 
-`GoogleService-Info*.plist` files are gitignored. `AscendApp/App/Firebase/` needs the plist for the environment you're building; see the README there. CI decodes them from base64 secrets.
+`AscendApp/App/Firebase/` needs the plist for the environment you're building - the Dev plist is committed, Staging and Production are gitignored and linked in locally; see the README there. CI decodes them from base64 secrets.
 
 ```bash
 # iOS tests (mirrors CI - .github/workflows/ci.yml)

--- a/scripts/link-firebase-plists.sh
+++ b/scripts/link-firebase-plists.sh
@@ -61,14 +61,39 @@ MSG
   fi
 fi
 
+is_tracked() {
+  git -C "$PROJECT_ROOT" ls-files --error-unmatch -- "$1" >/dev/null 2>&1
+}
+
+linked_any=0
+
 link_plist() {
   file_name="$1"
   source_file="$source_dir/$file_name"
   target_file="$TARGET_DIR/$file_name"
   required="${2:-0}"
 
-  if git -C "$PROJECT_ROOT" ls-files --error-unmatch -- "$target_file" >/dev/null 2>&1; then
-    echo "Firebase plist is tracked at $target_file - leaving it unchanged."
+  if is_tracked "$target_file"; then
+    if [ -e "$target_file" ]; then
+      echo "Firebase plist is tracked at $target_file - leaving it unchanged."
+      return 0
+    fi
+
+    if [ "$required" = "1" ]; then
+      cat <<MSG
+error: Tracked $file_name is missing from the working tree: $target_file
+Restore it instead of linking over a tracked path:
+  git -C "$PROJECT_ROOT" restore -- "$target_file"
+MSG
+      exit 1
+    fi
+
+    echo "warning: Tracked $file_name is missing from the working tree - restore it with git restore; not linking over a tracked path."
+    return 0
+  fi
+
+  if [ -e "$target_file" ] && [ ! -L "$target_file" ]; then
+    echo "Firebase plist at $target_file is a real file - leaving it unchanged."
     return 0
   fi
 
@@ -82,6 +107,7 @@ link_plist() {
   fi
 
   ln -sfn "$source_file" "$target_file"
+  linked_any=1
 }
 
 required_dev=0
@@ -105,7 +131,11 @@ if [ "$skip_linking" != "1" ]; then
   link_plist "GoogleService-Info-Staging.plist" "$required_staging"
   link_plist "GoogleService-Info-Production.plist" "$required_production"
 
-  echo "Linked Firebase plists from: $source_dir"
+  if [ "$linked_any" = "1" ]; then
+    echo "Linked Firebase plists from: $source_dir"
+  else
+    echo "No Firebase plists linked - existing files left unchanged."
+  fi
 fi
 
 copy_selected_plist_into_bundle() {

--- a/scripts/link-firebase-plists.sh
+++ b/scripts/link-firebase-plists.sh
@@ -22,7 +22,7 @@ esac
 
 skip_linking=0
 if [ -n "$required_plist" ] && [ -f "$TARGET_DIR/$required_plist" ]; then
-  echo "Firebase plist already present at $TARGET_DIR/$required_plist — skipping link."
+  echo "Firebase plist already present at $TARGET_DIR/$required_plist - skipping link."
   skip_linking=1
 fi
 
@@ -66,6 +66,11 @@ link_plist() {
   source_file="$source_dir/$file_name"
   target_file="$TARGET_DIR/$file_name"
   required="${2:-0}"
+
+  if git -C "$PROJECT_ROOT" ls-files --error-unmatch -- "$target_file" >/dev/null 2>&1; then
+    echo "Firebase plist is tracked at $target_file - leaving it unchanged."
+    return 0
+  fi
 
   if [ ! -f "$source_file" ]; then
     if [ "$required" = "1" ]; then

--- a/scripts/test/link-firebase-plists.test.mjs
+++ b/scripts/test/link-firebase-plists.test.mjs
@@ -1,0 +1,193 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import {spawnSync} from "node:child_process";
+import {tmpdir} from "node:os";
+import {dirname, join, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scriptPath = resolve(here, "../link-firebase-plists.sh");
+const devPlist = "GoogleService-Info-Dev.plist";
+const stagingPlist = "GoogleService-Info-Staging.plist";
+const productionPlist = "GoogleService-Info-Production.plist";
+const plistNames = [devPlist, stagingPlist, productionPlist];
+
+test("unset CONFIGURATION never replaces a tracked plist", (t) => {
+  const fixture = makeFixture(t);
+  const result = runScript(fixture);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.ok(
+    lstatSync(fixture.devTarget).isFile(),
+    "tracked Dev plist must remain a regular file"
+  );
+  assert.equal(
+    readFileSync(fixture.devTarget, "utf8"),
+    trackedContents(devPlist)
+  );
+  assert.equal(trackedStatus(fixture.projectRoot), "");
+
+  for (const fileName of [stagingPlist, productionPlist]) {
+    const target = join(fixture.targetDirectory, fileName);
+    assert.ok(lstatSync(target).isSymbolicLink());
+    assert.equal(readlinkSync(target), join(fixture.sourceDirectory, fileName));
+  }
+});
+
+test("every tracked plist target is left untouched", (t) => {
+  const fixture = makeFixture(t, {trackedFileNames: plistNames});
+  const result = runScript(fixture);
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  for (const fileName of plistNames) {
+    const target = join(fixture.targetDirectory, fileName);
+    assert.ok(lstatSync(target).isFile(), `${fileName} must remain a file`);
+    assert.equal(readFileSync(target, "utf8"), trackedContents(fileName));
+  }
+  assert.equal(trackedStatus(fixture.projectRoot), "");
+});
+
+test("tracked plist stays clean for every configuration and source state", (t) => {
+  const configurations = [
+    undefined,
+    "Debug",
+    "Staging",
+    "Release",
+    "Profile",
+  ];
+  const sourceStates = ["complete", "empty", "absent"];
+
+  for (const configuration of configurations) {
+    for (const sourceState of sourceStates) {
+      const fixture = makeFixture(t, {sourceState});
+      runScript(fixture, configuration);
+      const context = `CONFIGURATION=${configuration ?? "unset"}, source=${sourceState}`;
+
+      assert.ok(
+        lstatSync(fixture.devTarget).isFile(),
+        `tracked Dev plist must remain a file for ${context}`
+      );
+      assert.equal(
+        readFileSync(fixture.devTarget, "utf8"),
+        trackedContents(devPlist),
+        `tracked Dev plist contents changed for ${context}`
+      );
+      assert.equal(
+        trackedStatus(fixture.projectRoot),
+        "",
+        `tracked status changed for ${context}`
+      );
+    }
+  }
+});
+
+test("CI can use a decoded plist without a local source directory", (t) => {
+  const fixture = makeFixture(t, {sourceState: "absent"});
+  const stagingTarget = join(fixture.targetDirectory, stagingPlist);
+  writeFileSync(stagingTarget, "decoded-staging\n");
+
+  const result = runScript(fixture, "Staging");
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.ok(lstatSync(stagingTarget).isFile());
+  assert.equal(readFileSync(stagingTarget, "utf8"), "decoded-staging\n");
+  assert.equal(trackedStatus(fixture.projectRoot), "");
+});
+
+function makeFixture(
+  t,
+  {sourceState = "complete", trackedFileNames = [devPlist]} = {}
+) {
+  const projectRoot = mkdtempSync(join(tmpdir(), "ascend-link-plists-"));
+  t.after(() => rmSync(projectRoot, {recursive: true, force: true}));
+
+  const targetDirectory = join(projectRoot, "AscendApp/App/Firebase");
+  const sourceDirectory = join(projectRoot, "plist-source");
+  mkdirSync(targetDirectory, {recursive: true});
+
+  if (sourceState !== "absent") {
+    mkdirSync(sourceDirectory);
+  }
+
+  if (sourceState === "complete") {
+    for (const fileName of plistNames) {
+      writeFileSync(join(sourceDirectory, fileName), `source-${fileName}\n`);
+    }
+  }
+
+  for (const fileName of trackedFileNames) {
+    writeFileSync(
+      join(targetDirectory, fileName),
+      trackedContents(fileName)
+    );
+  }
+
+  runGit(projectRoot, ["init", "--quiet"]);
+  runGit(projectRoot, [
+    "add",
+    ...trackedFileNames.map(
+      (fileName) => `AscendApp/App/Firebase/${fileName}`
+    ),
+  ]);
+  runGit(projectRoot, [
+    "-c",
+    "user.name=Ascend Tests",
+    "-c",
+    "user.email=tests@example.com",
+    "commit",
+    "--quiet",
+    "-m",
+    "Add tracked plist fixture",
+  ]);
+
+  return {
+    devTarget: join(targetDirectory, devPlist),
+    projectRoot,
+    sourceDirectory,
+    targetDirectory,
+  };
+}
+
+function runScript(fixture, configuration) {
+  const environment = {
+    ...process.env,
+    ASCEND_FIREBASE_PLISTS_DIR: fixture.sourceDirectory,
+    HOME: join(fixture.projectRoot, "home"),
+    SRCROOT: fixture.projectRoot,
+  };
+  delete environment.CONFIGURATION;
+
+  if (configuration !== undefined) {
+    environment.CONFIGURATION = configuration;
+  }
+
+  return spawnSync(scriptPath, {
+    encoding: "utf8",
+    env: environment,
+  });
+}
+
+function trackedStatus(projectRoot) {
+  return runGit(projectRoot, ["status", "--porcelain", "--untracked-files=no"]);
+}
+
+function trackedContents(fileName) {
+  return `tracked-${fileName}\n`;
+}
+
+function runGit(projectRoot, arguments_) {
+  const result = spawnSync("git", ["-C", projectRoot, ...arguments_], {
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+}

--- a/scripts/test/link-firebase-plists.test.mjs
+++ b/scripts/test/link-firebase-plists.test.mjs
@@ -56,6 +56,44 @@ test("every tracked plist target is left untouched", (t) => {
   assert.equal(trackedStatus(fixture.projectRoot), "");
 });
 
+test("a tracked plist missing from the working tree fails loudly", (t) => {
+  const fixture = makeFixture(t, {deletedFileNames: [devPlist]});
+  const result = runScript(fixture, "Debug");
+  const output = `${result.stdout}${result.stderr}`;
+
+  assert.equal(result.status, 1, output);
+  assert.ok(
+    output.includes("missing from the working tree"),
+    `expected a missing-tracked-plist error, got: ${output}`
+  );
+  assert.ok(
+    output.includes("restore -- "),
+    `expected a git restore hint, got: ${output}`
+  );
+  assert.throws(
+    () => lstatSync(fixture.devTarget),
+    "tracked Dev plist must not be recreated as a symlink"
+  );
+});
+
+test("a real plist survives when git cannot report tracking", (t) => {
+  const fixture = makeFixture(t, {initializeGit: false});
+  const result = runScript(fixture, "Staging");
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  assert.ok(
+    lstatSync(fixture.devTarget).isFile(),
+    "existing Dev plist must remain a regular file"
+  );
+  assert.equal(
+    readFileSync(fixture.devTarget, "utf8"),
+    trackedContents(devPlist)
+  );
+
+  const stagingTarget = join(fixture.targetDirectory, stagingPlist);
+  assert.ok(lstatSync(stagingTarget).isSymbolicLink());
+});
+
 test("tracked plist stays clean for every configuration and source state", (t) => {
   const configurations = [
     undefined,
@@ -69,8 +107,21 @@ test("tracked plist stays clean for every configuration and source state", (t) =
   for (const configuration of configurations) {
     for (const sourceState of sourceStates) {
       const fixture = makeFixture(t, {sourceState});
-      runScript(fixture, configuration);
+      const result = runScript(fixture, configuration);
       const context = `CONFIGURATION=${configuration ?? "unset"}, source=${sourceState}`;
+      const expected = expectedOutcome(configuration, sourceState);
+
+      assert.equal(
+        result.status,
+        expected.status,
+        `unexpected exit status for ${context}: ${result.stderr || result.stdout}`
+      );
+      if (expected.message !== undefined) {
+        assert.ok(
+          `${result.stdout}${result.stderr}`.includes(expected.message),
+          `expected "${expected.message}" for ${context}, got: ${result.stdout}${result.stderr}`
+        );
+      }
 
       assert.ok(
         lstatSync(fixture.devTarget).isFile(),
@@ -103,9 +154,38 @@ test("CI can use a decoded plist without a local source directory", (t) => {
   assert.equal(trackedStatus(fixture.projectRoot), "");
 });
 
+function expectedOutcome(configuration, sourceState) {
+  if (configuration === "Debug") {
+    return {status: 0};
+  }
+
+  if (sourceState === "absent") {
+    return {
+      status: 1,
+      message: "Could not locate Firebase plist source directory",
+    };
+  }
+
+  const requiredPlist = {
+    Staging: stagingPlist,
+    Release: productionPlist,
+  }[configuration];
+
+  if (sourceState === "empty" && requiredPlist !== undefined) {
+    return {status: 1, message: `Missing required ${requiredPlist}`};
+  }
+
+  return {status: 0};
+}
+
 function makeFixture(
   t,
-  {sourceState = "complete", trackedFileNames = [devPlist]} = {}
+  {
+    sourceState = "complete",
+    trackedFileNames = [devPlist],
+    deletedFileNames = [],
+    initializeGit = true,
+  } = {}
 ) {
   const projectRoot = mkdtempSync(join(tmpdir(), "ascend-link-plists-"));
   t.after(() => rmSync(projectRoot, {recursive: true, force: true}));
@@ -131,23 +211,29 @@ function makeFixture(
     );
   }
 
-  runGit(projectRoot, ["init", "--quiet"]);
-  runGit(projectRoot, [
-    "add",
-    ...trackedFileNames.map(
-      (fileName) => `AscendApp/App/Firebase/${fileName}`
-    ),
-  ]);
-  runGit(projectRoot, [
-    "-c",
-    "user.name=Ascend Tests",
-    "-c",
-    "user.email=tests@example.com",
-    "commit",
-    "--quiet",
-    "-m",
-    "Add tracked plist fixture",
-  ]);
+  if (initializeGit) {
+    runGit(projectRoot, ["init", "--quiet"]);
+    runGit(projectRoot, [
+      "add",
+      ...trackedFileNames.map(
+        (fileName) => `AscendApp/App/Firebase/${fileName}`
+      ),
+    ]);
+    runGit(projectRoot, [
+      "-c",
+      "user.name=Ascend Tests",
+      "-c",
+      "user.email=tests@example.com",
+      "commit",
+      "--quiet",
+      "-m",
+      "Add tracked plist fixture",
+    ]);
+  }
+
+  for (const fileName of deletedFileNames) {
+    rmSync(join(targetDirectory, fileName));
+  }
 
   return {
     devTarget: join(targetDirectory, devPlist),
@@ -157,14 +243,36 @@ function makeFixture(
   };
 }
 
+const leakedVariableNames = [
+  "ASCEND_FIREBASE_PLISTS_DIR",
+  "CONFIGURATION",
+  "INFOPLIST_FILE",
+  "PRODUCT_BUNDLE_IDENTIFIER",
+  "SRCROOT",
+  "TARGET_BUILD_DIR",
+  "UNLOCALIZED_RESOURCES_FOLDER_PATH",
+];
+
+function hermeticEnvironment() {
+  const environment = {...process.env};
+  for (const name of Object.keys(environment)) {
+    if (name.startsWith("GIT_")) {
+      delete environment[name];
+    }
+  }
+  for (const name of leakedVariableNames) {
+    delete environment[name];
+  }
+  return environment;
+}
+
 function runScript(fixture, configuration) {
   const environment = {
-    ...process.env,
+    ...hermeticEnvironment(),
     ASCEND_FIREBASE_PLISTS_DIR: fixture.sourceDirectory,
     HOME: join(fixture.projectRoot, "home"),
     SRCROOT: fixture.projectRoot,
   };
-  delete environment.CONFIGURATION;
 
   if (configuration !== undefined) {
     environment.CONFIGURATION = configuration;
@@ -187,6 +295,7 @@ function trackedContents(fileName) {
 function runGit(projectRoot, arguments_) {
   const result = spawnSync("git", ["-C", projectRoot, ...arguments_], {
     encoding: "utf8",
+    env: hermeticEnvironment(),
   });
   assert.equal(result.status, 0, result.stderr || result.stdout);
   return result.stdout.trim();


### PR DESCRIPTION
## Intent

Prevent scripts/link-firebase-plists.sh from ever replacing a Git-tracked Firebase plist with a machine-specific absolute-path symlink, regardless of CONFIGURATION being unset, recognized, or arbitrary and regardless of source plist availability. Preserve CI behavior where decoded plists already exist in the target directory and preserve local symlink convenience for untracked Staging and Production plists. Add repository-native regression coverage that specifically proves the unset-CONFIGURATION failure, verify that test failed against the pre-fix script and passes after the fix, exercise configuration and source-state combinations, and restore the tracked Dev plist only if its HEAD tree mode is corrupt. The branch is based on origin/develop and the PR must target develop.

## What Changed

- `scripts/link-firebase-plists.sh` now checks each plist target against the git index before linking: a tracked path is left exactly as checked out, a tracked-but-missing path errors out with the `git restore` command (or warns when not required for the selected configuration), and an existing non-symlink real file is preserved. This closes the path where an unset or unrecognized `CONFIGURATION` replaced the committed Dev plist with a machine-specific absolute-path symlink, while still linking absent targets and refreshing existing symlinks for the untracked Staging and Production plists, and leaving CI's base64-decoded plists in place. The final summary line now distinguishes "linked" from "nothing linked - existing files left unchanged".
- Added `scripts/test/link-firebase-plists.test.mjs`: six regression tests over temp-repo fixtures covering the unset-`CONFIGURATION` case, all tracked targets, tracked-but-missing failure, git-unavailable fallback, a configuration x source-state matrix, and CI's decoded-plist path. It runs in the existing `node --test scripts/test/*.test.mjs` suite and uses a hermetic environment that strips `GIT_*` and Xcode build variables.
- Corrected the docs that claimed all three plists are gitignored: `AscendApp/App/Firebase/README.md` now describes the committed Dev plist, the guard's behavior, and the recovery command; `CLAUDE.md` and `.claude/skills/ascend-deploy/SKILL.md` were updated to match.

Verification per the pipeline: the new test file fails 5/6 against the base-commit script (including `unset CONFIGURATION never replaces a tracked plist`) and passes 6/6 after the fix; the full 180-test scripts suite passes. Shell lint has no coverage in this repo - only `sh -n` syntax validation was possible, so adding shellcheck for `scripts/*.sh` is a reasonable follow-up.

## Risk Assessment

✅ Low: The follow-up commit resolved both prior warnings with a fail-closed filesystem backstop and an explicit tracked-but-missing error, the matrix test now pins exit status and message for all fifteen combinations, and the only remaining findings are a missing recovery hint in one diagnostic message and a residual global-git-config dependency in the test fixture.

## Testing

I reproduced the actual failure end-to-end on real clones of this repo: at the base commit, running the build-phase script with CONFIGURATION unset turned the tracked GoogleService-Info-Dev.plist into a symlink to a machine-specific absolute path and dirtied git; at the fix commit the same invocation leaves it untouched with a clean tree while Staging and Production still get their local symlinks. I swept all 15 CONFIGURATION x source-state combinations on real checkouts (tracked plist stays a regular file and the tree stays clean everywhere, with the pre-existing missing-source and missing-required-plist errors intact), confirmed the CI decoded-plist path behaves identically before and after, and ran a full Xcode-style Debug build phase where bundle-ID and Google URL-scheme validation still pass and the plist lands in the app bundle. The new repository-native test fails 5 of 6 cases against the pre-fix script (including the named unset-CONFIGURATION case) and passes 6 of 6 after; the whole scripts suite is 180/180 and CI already globs that directory. HEAD's tree mode for the Dev plist is 100644 with real plist XML, so the conditional restore correctly did not apply, and the branch is based on origin/develop. No visual artifacts: the change is a shell build-phase script with no rendered UI, so CLI transcripts are the end-user surface. Everything passed and the worktree is clean.

<details>
<summary>Evidence: Before/after repro of the tracked-plist clobber on a real repo clone</summary>

<code>======&#10;BEFORE the fix (a9cb24d)&#10;(developer runs the Xcode build phase script with CONFIGURATION unset)&#10;======&#10;$ env -u CONFIGURATION SRCROOT=&lt;repo&gt; HOME=&lt;sandbox&gt; \&#10;ASCEND_FIREBASE_PLISTS_DIR=&lt;local secrets&gt; ./scripts/link-firebase-plists.sh&#10;Linked Firebase plists from: &lt;evidence&gt;/fake-secrets&#10;&#10;$ ls -l AscendApp/App/Firebase/&#10;lrwxr-xr-x GoogleService-Info-Dev.plist -&gt; &lt;evidence&gt;/fake-secrets/GoogleService-Info-Dev.plist&#10;lrwxr-xr-x GoogleService-Info-Production.plist -&gt; &lt;evidence&gt;/fake-secrets/GoogleService-Info-Production.plist&#10;lrwxr-xr-x GoogleService-Info-Staging.plist -&gt; &lt;evidence&gt;/fake-secrets/GoogleService-Info-Staging.plist&#10;-rw-r--r-- README.md&#10;&#10;$ git status --short&#10;T AscendApp/App/Firebase/GoogleService-Info-Dev.plist&#10;&#10;$ git diff --stat -- AscendApp/App/Firebase/GoogleService-Info-Dev.plist&#10;.../App/Firebase/GoogleService-Info-Dev.plist | 35 +---------------------&#10;1 file changed, 1 insertion(+), 34 deletions(-)&#10;&#10;======&#10;AFTER the fix (cc490d2)&#10;(developer runs the Xcode build phase script with CONFIGURATION unset)&#10;======&#10;$ env -u CONFIGURATION SRCROOT=&lt;repo&gt; HOME=&lt;sandbox&gt; \&#10;ASCEND_FIREBASE_PLISTS_DIR=&lt;local secrets&gt; ./scripts/link-firebase-plists.sh&#10;Firebase plist is tracked at &lt;evidence&gt;/after/AscendApp/App/Firebase/GoogleService-Info-Dev.plist - leaving it unchanged.&#10;Linked Firebase plists from: &lt;evidence&gt;/fake-secrets&#10;&#10;$ ls -l AscendApp/App/Firebase/&#10;-rw-r--r-- GoogleService-Info-Dev.plist&#10;lrwxr-xr-x GoogleService-Info-Production.plist -&gt; &lt;evidence&gt;/fake-secrets/GoogleService-Info-Production.plist&#10;lrwxr-xr-x GoogleService-Info-Staging.plist -&gt; &lt;evidence&gt;/fake-secrets/GoogleService-Info-Staging.plist&#10;-rw-r--r-- README.md&#10;&#10;$ git status --short&#10;(clean)&#10;&#10;$ git diff --stat -- AscendApp/App/Firebase/GoogleService-Info-Dev.plist&#10;(no change to tracked Dev plist)</code>

```text
==============================================================
  BEFORE the fix (a9cb24d)
  (developer runs the Xcode build phase script with CONFIGURATION unset)
==============================================================
$ env -u CONFIGURATION SRCROOT=<repo> HOME=<sandbox> \
      ASCEND_FIREBASE_PLISTS_DIR=<local secrets> ./scripts/link-firebase-plists.sh
Linked Firebase plists from: /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/repro/fake-secrets

$ ls -l AscendApp/App/Firebase/
total 8
lrwxr-xr-x@ 1 tylerpavay  staff  144 Jul 29 12:18 GoogleService-Info-Dev.plist -> <evidence>/fake-secrets/GoogleService-Info-Dev.plist
lrwxr-xr-x@ 1 tylerpavay  staff  151 Jul 29 12:18 GoogleService-Info-Production.plist -> <evidence>/fake-secrets/GoogleService-Info-Production.plist
lrwxr-xr-x@ 1 tylerpavay  staff  148 Jul 29 12:18 GoogleService-Info-Staging.plist -> <evidence>/fake-secrets/GoogleService-Info-Staging.plist
-rw-r--r--@ 1 tylerpavay  staff  487 Jul 29 12:17 README.md

$ git status --short
 T AscendApp/App/Firebase/GoogleService-Info-Dev.plist

$ git diff --stat -- AscendApp/App/Firebase/GoogleService-Info-Dev.plist
 .../App/Firebase/GoogleService-Info-Dev.plist      | 35 +---------------------
 1 file changed, 1 insertion(+), 34 deletions(-)

==============================================================
  AFTER the fix (cc490d2)
  (developer runs the Xcode build phase script with CONFIGURATION unset)
==============================================================
$ env -u CONFIGURATION SRCROOT=<repo> HOME=<sandbox> \
      ASCEND_FIREBASE_PLISTS_DIR=<local secrets> ./scripts/link-firebase-plists.sh
Firebase plist is tracked at /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/repro/after/AscendApp/App/Firebase/GoogleService-Info-Dev.plist - leaving it unchanged.
Linked Firebase plists from: /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/repro/fake-secrets

$ ls -l AscendApp/App/Firebase/
total 16
-rw-r--r--@ 1 tylerpavay  staff  1119 Jul 29 12:17 GoogleService-Info-Dev.plist
lrwxr-xr-x@ 1 tylerpavay  staff   151 Jul 29 12:18 GoogleService-Info-Production.plist -> <evidence>/fake-secrets/GoogleService-Info-Production.plist
lrwxr-xr-x@ 1 tylerpavay  staff   148 Jul 29 12:18 GoogleService-Info-Staging.plist -> <evidence>/fake-secrets/GoogleService-Info-Staging.plist
-rw-r--r--@ 1 tylerpavay  staff   487 Jul 29 12:17 README.md

$ git status --short
(clean)

$ git diff --stat -- AscendApp/App/Firebase/GoogleService-Info-Dev.plist
(no change to tracked Dev plist)
```
</details>
<details>
<summary>Evidence: Configuration x source-state sweep on real checkouts (fixed script)</summary>

<code>Real-repo sweep on the fixed script (cc490d2): tracked Dev plist must stay a regular file in every case.&#10;CONFIGURATION SOURCE EXIT DEV_TYPE GIT_STATUS NOTE&#10;unset complete 0 file clean is tracked at&#10;unset empty 0 file clean is tracked at&#10;unset absent 1 file clean Could not locate Firebase plist source directory&#10;Debug complete 0 file clean&#10;Debug empty 0 file clean&#10;Debug absent 0 file clean&#10;Staging complete 0 file clean is tracked at&#10;Staging empty 1 file clean is tracked at&#10;Staging absent 1 file clean Could not locate Firebase plist source directory&#10;Release complete 0 file clean is tracked at&#10;Release empty 1 file clean is tracked at&#10;Release absent 1 file clean Could not locate Firebase plist source directory&#10;Profile complete 0 file clean is tracked at&#10;Profile empty 0 file clean is tracked at&#10;Profile absent 1 file clean Could not locate Firebase plist source directory</code>

```text
Real-repo sweep on the fixed script (cc490d2): tracked Dev plist must stay a regular file in every case.
CONFIGURATION  SOURCE    EXIT DEV_TYPE  GIT_STATUS NOTE
unset          complete  0    file      clean     is tracked at
unset          empty     0    file      clean     is tracked at
unset          absent    1    file      clean     Could not locate Firebase plist source directory
Debug          complete  0    file      clean     
Debug          empty     0    file      clean     
Debug          absent    0    file      clean     
Staging        complete  0    file      clean     is tracked at
Staging        empty     1    file      clean     is tracked at
Staging        absent    1    file      clean     Could not locate Firebase plist source directory
Release        complete  0    file      clean     is tracked at
Release        empty     1    file      clean     is tracked at
Release        absent    1    file      clean     Could not locate Firebase plist source directory
Profile        complete  0    file      clean     is tracked at
Profile        empty     0    file      clean     is tracked at
Profile        absent    1    file      clean     Could not locate Firebase plist source directory
```
</details>
<details>
<summary>Evidence: CI decoded-plist path unchanged before and after the fix</summary>

<code>CI simulation: decoded plist already in AscendApp/App/Firebase, no local source dir, CONFIGURATION=Staging&#10;&#10;--- BEFORE fix (a9cb24d) ---&#10;Firebase plist already present at &lt;evidence&gt;/ci/AscendApp/App/Firebase/GoogleService-Info-Staging.plist - skipping link.&#10;Copied GoogleService-Info-Staging.plist to &lt;evidence&gt;/ci/build/Ascend.app/GoogleService-Info.plist&#10;exit=0&#10;bundled plist present: yes&#10;staging target type: file&#10;git status: 0 tracked changes&#10;&#10;--- AFTER fix (cc490d2) ---&#10;Firebase plist already present at &lt;evidence&gt;/ci/AscendApp/App/Firebase/GoogleService-Info-Staging.plist - skipping link.&#10;Copied GoogleService-Info-Staging.plist to &lt;evidence&gt;/ci/build/Ascend.app/GoogleService-Info.plist&#10;exit=0&#10;bundled plist present: yes&#10;staging target type: file&#10;git status: 0 tracked changes</code>

```text
CI simulation: decoded plist already in AscendApp/App/Firebase, no local source dir, CONFIGURATION=Staging

--- BEFORE fix (a9cb24d) ---
Firebase plist already present at <evidence>/ci/AscendApp/App/Firebase/GoogleService-Info-Staging.plist — skipping link.
Copied GoogleService-Info-Staging.plist to <evidence>/ci/build/Ascend.app/GoogleService-Info.plist
exit=0
bundled plist present: yes
staging target type: file
git status: 0 tracked changes

--- AFTER fix (cc490d2) ---
Firebase plist already present at <evidence>/ci/AscendApp/App/Firebase/GoogleService-Info-Staging.plist - skipping link.
Copied GoogleService-Info-Staging.plist to <evidence>/ci/build/Ascend.app/GoogleService-Info.plist
exit=0
bundled plist present: yes
staging target type: file
git status: 0 tracked changes
```
</details>
<details>
<summary>Evidence: Full Xcode-style Debug build phase on a clean checkout</summary>

<code>Full Xcode-style Debug build-phase invocation on a clean checkout (fixed script).&#10;$ CONFIGURATION=Debug PRODUCT_BUNDLE_IDENTIFIER=com.TylerPavay.AscendApp.dev ... ./scripts/link-firebase-plists.sh&#10;Firebase plist already present at &lt;evidence&gt;/debugbuild/AscendApp/App/Firebase/GoogleService-Info-Dev.plist - skipping link.&#10;Copied GoogleService-Info-Dev.plist to &lt;evidence&gt;/debugbuild/build/Ascend.app/GoogleService-Info.plist&#10;exit=0&#10;&#10;$ git status --short -&gt; 0 tracked changes&#10;$ ls -l build/Ascend.app/GoogleService-Info.plist&#10;-rw-r--r-- 1119 &lt;evidence&gt;/debugbuild/build/Ascend.app/GoogleService-Info.plist&#10;bundled BUNDLE_ID: com.TylerPavay.AscendApp.dev</code>

```text
Full Xcode-style Debug build-phase invocation on a clean checkout (fixed script).
$ CONFIGURATION=Debug PRODUCT_BUNDLE_IDENTIFIER=com.TylerPavay.AscendApp.dev ... ./scripts/link-firebase-plists.sh
Firebase plist already present at <evidence>/debugbuild/AscendApp/App/Firebase/GoogleService-Info-Dev.plist - skipping link.
Copied GoogleService-Info-Dev.plist to <evidence>/debugbuild/build/Ascend.app/GoogleService-Info.plist
exit=0

$ git status --short  -> 0 tracked changes
$ ls -l build/Ascend.app/GoogleService-Info.plist
-rw-r--r--@ 1 tylerpavay  staff  1119 Jul 29 12:20 <evidence>/debugbuild/build/Ascend.app/GoogleService-Info.plist
bundled BUNDLE_ID: com.TylerPavay.AscendApp.dev
```
</details>
<details>
<summary>Evidence: New regression test run against the pre-fix script (5 of 6 fail)</summary>

<code>not ok 1 - unset CONFIGURATION never replaces a tracked plist&#10;error: &#39;tracked Dev plist must remain a regular file&#39;&#10;not ok 2 - every tracked plist target is left untouched&#10;error: &#39;GoogleService-Info-Dev.plist must remain a file&#39;&#10;not ok 4 - a real plist survives when git cannot report tracking&#10;not ok 5 - tracked plist stays clean for every configuration and source state&#10;error: &#39;tracked Dev plist must remain a file for CONFIGURATION=unset, source=complete&#39;&#10;ok 6 - CI can use a decoded plist without a local source directory&#10;# tests 6&#10;# pass 1&#10;# fail 5&#10;&#10;(same file against the fixed script: # tests 6 / # pass 6 / # fail 0)</code>

```text
TAP version 13
# Subtest: unset CONFIGURATION never replaces a tracked plist
not ok 1 - unset CONFIGURATION never replaces a tracked plist
  ---
  duration_ms: 401.765584
  type: 'test'
  location: '/private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:24:1'
  failureType: 'testCodeFailure'
  error: 'tracked Dev plist must remain a regular file'
  code: 'ERR_ASSERTION'
  name: 'AssertionError'
  expected: true
  actual: false
  operator: '=='
  stack: |-
    TestContext.<anonymous> (file:///private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:29:10)
    Test.runInAsyncScope (node:async_hooks:214:14)
    Test.run (node:internal/test_runner/test:1047:25)
    Test.start (node:internal/test_runner/test:944:17)
    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
  ...
# Subtest: every tracked plist target is left untouched
not ok 2 - every tracked plist target is left untouched
  ---
  duration_ms: 177.914667
  type: 'test'
  location: '/private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:46:1'
  failureType: 'testCodeFailure'
  error: 'GoogleService-Info-Dev.plist must remain a file'
  code: 'ERR_ASSERTION'
  name: 'AssertionError'
  expected: true
  actual: false
  operator: '=='
  stack: |-
    TestContext.<anonymous> (file:///private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:53:12)
    Test.runInAsyncScope (node:async_hooks:214:14)
    Test.run (node:internal/test_runner/test:1047:25)
    Test.processPendingSubtests (node:internal/test_runner/test:744:18)
    Test.postRun (node:internal/test_runner/test:1173:19)
    Test.run (node:internal/test_runner/test:1101:12)
    async startSubtestAfterBootstrap (node:internal/test_runner/harness:296:3)
  ...
# Subtest: a tracked plist missing from the working tree fails loudly
not ok 3 - a tracked plist missing from the working tree fails loudly
  ---
  duration_ms: 174.660375
  type: 'test'
  location: '/private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:59:1'
  failureType: 'testCodeFailure'
  error: |-
    Linked Firebase plists from: /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/ascend-link-plists-2Ai3Fq/plist-source
    
    
    0 !== 1
    
  code: 'ERR_ASSERTION'
  name: 'AssertionError'
  expected: 1
  actual: 0
  operator: 'strictEqual'
  stack: |-
    TestContext.<anonymous> (file:///private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:64:10)
    Test.runInAsyncScope (node:async_hooks:214:14)
    Test.run (node:internal/test_runner/test:1047:25)
    Test.processPendingSubtests (node:internal/test_runner/test:744:18)
    Test.postRun (node:internal/test_runner/test:1173:19)
    Test.run (node:internal/test_runner/test:1101:12)
    async Test.processPendingSubtests (node:internal/test_runner/test:744:7)
  ...
# Subtest: a real plist survives when git cannot report tracking
not ok 4 - a real plist survives when git cannot report tracking
  ---
  duration_ms: 15.8955
  type: 'test'
  location: '/private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:79:1'
  failureType: 'testCodeFailure'
  error: 'existing Dev plist must remain a regular file'
  code: 'ERR_ASSERTION'
  name: 'AssertionError'
  expected: true
  actual: false
  operator: '=='
  stack: |-
    TestContext.<anonymous> (file:///private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:84:10)
    Test.runInAsyncScope (node:async_hooks:214:14)
    Test.run (node:internal/test_runner/test:1047:25)
    Test.processPendingSubtests (node:internal/test_runner/test:744:18)
    Test.postRun (node:internal/test_runner/test:1173:19)
    Test.run (node:internal/test_runner/test:1101:12)
    async Test.processPendingSubtests (node:internal/test_runner/test:744:7)
  ...
# Subtest: tracked plist stays clean for every configuration and source state
not ok 5 - tracked plist stays clean for every configuration and source state
  ---
  duration_ms: 178.099
  type: 'test'
  location: '/private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:97:1'
  failureType: 'testCodeFailure'
  error: 'tracked Dev plist must remain a file for CONFIGURATION=unset, source=complete'
  code: 'ERR_ASSERTION'
  name: 'AssertionError'
  expected: true
  actual: false
  operator: '=='
  stack: |-
    TestContext.<anonymous> (file:///private/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYQBGH0ZDYZMQZ6NWJX52M1W/prefix-harness/scripts/test/link-firebase-plists.test.mjs:126:14)
    Test.runInAsyncScope (node:async_hooks:214:14)
    Test.run (node:internal/test_runner/test:1047:25)
    Test.processPendingSubtests (node:internal/test_runner/test:744:18)
    Test.postRun (node:internal/test_runner/test:1173:19)
    Test.run (node:internal/test_runner/test:1101:12)
    async Test.processPendingSubtests (node:internal/test_runner/test:744:7)
  ...
# Subtest: CI can use a decoded plist without a local source directory
ok 6 - CI can use a decoded plist without a local source directory
  ---
  duration_ms: 208.668375
  type: 'test'
  ...
1..6
# tests 6
# suites 0
# pass 1
# fail 5
# cancelled 0
# skipped 0
# todo 0
# duration_ms 1202.906042
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ⚠️ `scripts/link-firebase-plists.sh:70` - The new guard keys purely on the Git index, not the filesystem, so it returns success for a plist that is tracked but absent from the working tree. This swallows the `required=1` error path below it: with CONFIGURATION=Debug and a deleted `AscendApp/App/Firebase/GoogleService-Info-Dev.plist`, the script prints &#34;Firebase plist is tracked at ... - leaving it unchanged&#34; and exits 0 having produced nothing, instead of the old &#34;error: Missing required GoogleService-Info-Dev.plist&#34;. Outside Xcode nothing else catches it; inside Xcode it surfaces much later as the unrelated-looking &#34;error: Selected Firebase plist not found&#34;. Fix by taking the tracked branch only when the target actually exists on disk, and when it is tracked-but-missing emit an explicit error telling the developer to `git restore` it (still never symlinking over a tracked path).
- ⚠️ `scripts/link-firebase-plists.sh:70` - The protection depends entirely on `git` being on PATH and PROJECT_ROOT being a readable checkout; `&gt;/dev/null 2&gt;&amp;1` swallows every failure mode and treats it as &#34;untracked&#34;, after which `ln -sfn` overwrites the tracked plist exactly as before. This matters here because the invoking run-script phase (AscendApp.xcodeproj/project.pbxproj:383) is on the AscendApp target, which inherits project-level `ENABLE_USER_SCRIPT_SANDBOXING = YES` - a sandbox that denies reading `$SRCROOT/.git` silently disarms the guard. Same for a source export or any build image without git. Consider a filesystem-level backstop that also refuses to replace an existing regular (non-symlink) file at the target, which would satisfy the intent unconditionally; note this would also change today&#39;s behavior of replacing an untracked real file with a symlink, so it needs a decision.
- ℹ️ `scripts/link-firebase-plists.sh:70` - Safety now rests on a repo state that contradicts the repo&#39;s own rules: `.gitignore:49` ignores `GoogleService-Info*.plist`, yet `AscendApp/App/Firebase/GoogleService-Info-Dev.plist` is tracked (mode 100644, committed in 51458dc) with real CLIENT_ID/API_KEY/GOOGLE_APP_ID values, and CLAUDE.md states these plists are gitignored. If anyone later untracks the Dev plist to match the ignore rule, this guard silently stops firing and the clobbering returns with no test failure to warn them. Worth deciding explicitly whether the Dev plist stays tracked, and recording that decision next to the guard.
- ℹ️ `scripts/test/link-firebase-plists.test.mjs:72` - The configuration × source-state matrix test discards the script&#39;s exit status and only asserts the tracked Dev plist is unchanged. A script that died on line 1 for an unrelated reason would pass every assertion in this test, since a crashed script also clobbers nothing - so the matrix cannot distinguish &#34;the guard held&#34; from &#34;the script never ran&#34;. Assert the expected status per combination (0 when a source dir exists or the CI skip applies; 1 with the documented &#34;Could not locate Firebase plist source directory&#34; message when the source is absent and no decoded plist is present).
- ℹ️ `scripts/test/link-firebase-plists.test.mjs:162` - `runScript` spreads all of `process.env` and only deletes `CONFIGURATION`, so ambient Xcode variables leak into the script under test: with `PRODUCT_BUNDLE_IDENTIFIER` or `INFOPLIST_FILE` set (e.g. tests invoked from a build phase) the `validate_selected_plist_*` paths run against fake fixture contents and exit 1, failing the &#34;CI can use a decoded plist&#34; assertion of status 0. Likewise `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` (set inside any git hook that runs the suite) would redirect the fixture&#39;s `git init`/`add`/`commit` away from the temp repo. Explicitly delete `TARGET_BUILD_DIR`, `UNLOCALIZED_RESOURCES_FOLDER_PATH`, `PRODUCT_BUNDLE_IDENTIFIER`, `INFOPLIST_FILE`, and the `GIT_*` set alongside `CONFIGURATION`.
- ℹ️ `scripts/link-firebase-plists.sh:108` - When every plist target is tracked, all three `link_plist` calls return early yet the script still prints &#34;Linked Firebase plists from: $source_dir&#34;, claiming work it did not do. Cosmetic, but it is the line a developer reads when diagnosing why their plists did not update.

🔧 Fix: Harden Firebase plist guard against missing files and absent git
3 infos still open:
- ℹ️ `scripts/link-firebase-plists.sh:96` - The new non-symlink backstop leaves an untracked real file in place permanently and exits 0, but the message gives no way out. A developer who once copied a real `GoogleService-Info-Staging.plist` into `AscendApp/App/Firebase/` and later updates `~/.config/ascend/firebase/GoogleService-Info-Staging.plist` will silently keep building against the stale copy - the script reports &#34;is a real file - leaving it unchanged&#34; and then &#34;No Firebase plists linked&#34;, neither of which hints that deleting the target re-enables linking. Every sibling branch in this function names the remedy (the tracked-missing branch even prints the exact `git restore` command); this one should too, e.g. append &#34;delete it to re-link from $source_dir&#34;.
- ℹ️ `scripts/test/link-firebase-plists.test.mjs:298` - `hermeticEnvironment()` strips `GIT_*` and the Xcode variables but keeps the real `HOME`, so the fixture&#39;s `git init`/`add`/`commit` still read the developer&#39;s global git config. A global `commit.gpgsign=true` (commit fails), `core.hooksPath` pointing at a hooks dir, or a `core.excludesFile` matching `GoogleService-Info*.plist` (the repo&#39;s own `.gitignore:49` uses exactly that pattern, and some developers mirror it globally) makes `runGit` trip its `assert.equal(result.status, 0, ...)` and fails the whole suite for reasons unrelated to the script under test. Since the isolation helper already exists, finish the job by adding `GIT_CONFIG_GLOBAL: &#34;/dev/null&#34;` and `GIT_CONFIG_SYSTEM: &#34;/dev/null&#34;` to the env passed here (they must be set after the `GIT_*` strip).
- ℹ️ `scripts/link-firebase-plists.sh:95` - Recording the accepted tradeoff for the reviewer of record: closing the git-unavailable fail-open hole also narrows the intent&#39;s &#34;preserve local symlink convenience for untracked Staging and Production plists&#34; - an untracked regular file at the target is no longer replaced by a symlink. The core convenience is intact (absent target links, existing symlink is refreshed by `ln -sfn`), and this exact consequence was flagged and chosen in the previous review round, so no action is needed here.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test scripts/test/link-firebase-plists.test.mjs` (6/6 pass against the fixed script)</code>
- <code>Same test file run against the base-commit script in an isolated harness: 5/6 fail, including `unset CONFIGURATION never replaces a tracked plist`</code>
- <code>`node --test scripts/test/*.test.mjs` (full repo-native scripts suite, 180/180 pass; matches `.github/workflows/ci.yml:190`)</code>
- <code>Real-repo end-to-end repro: cloned this repo at a9cb24d and cc490d2, ran `./scripts/link-firebase-plists.sh` with CONFIGURATION unset and a local secrets dir, then compared `ls -l AscendApp/App/Firebase/` and `git status --short`</code>
- <code>Configuration x source-state sweep on real clones: CONFIGURATION in {unset, Debug, Staging, Release, Profile} x source dir in {complete, empty, absent}, asserting tracked Dev plist type and `git status` for all 15 cases</code>
- `CI simulation on both commits: decoded Staging plist placed directly in AscendApp/App/Firebase with no local source dir, CONFIGURATION=Staging, TARGET_BUILD_DIR/UNLOCALIZED_RESOURCES_FOLDER_PATH set`
- `Full Xcode-style Debug build phase with PRODUCT_BUNDLE_IDENTIFIER and INFOPLIST_FILE set, verifying bundle-ID/URL-scheme validation and the copied bundle plist`
- <code>`git ls-tree HEAD -- AscendApp/App/Firebase/GoogleService-Info-Dev.plist` and `git log --oneline -1 origin/develop` to confirm file mode 100644 and the develop base</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `scripts/link-firebase-plists.sh` - The changed shell script scripts/link-firebase-plists.sh has no static-analysis coverage: the repo configures no shell linter, and shellcheck is not installed on this machine (installing system packages is outside the worktree boundary). Only `sh -n` syntax validation was possible. Consider adding shellcheck to CI for scripts/*.sh as a follow-up.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
