### PR TITLE
fix(workouts): clear stale heart-rate series after manual edits

### DIFF
--- a/AscendApp/Features/Workouts/Services/WorkoutHeartRateEditPolicy.swift
+++ b/AscendApp/Features/Workouts/Services/WorkoutHeartRateEditPolicy.swift
@@ -1,0 +1,20 @@
+enum WorkoutHeartRateEditPolicy {
+    static func applyManualSummary(
+        averageHeartRate: Int?,
+        maximumHeartRate: Int?,
+        to workout: Workout
+    ) {
+        let summaryChanged =
+            workout.avgHeartRate != averageHeartRate ||
+            workout.maxHeartRate != maximumHeartRate
+
+        // The samples are the source data for their original summaries. Keeping
+        // them after a manual override would leave the workout contradictory.
+        if summaryChanged {
+            workout.heartRateData = nil
+        }
+
+        workout.avgHeartRate = averageHeartRate
+        workout.maxHeartRate = maximumHeartRate
+    }
+}

--- a/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
+++ b/AscendApp/Features/Workouts/Views/EditWorkoutView.swift
@@ -720,8 +720,11 @@ struct EditWorkoutView: View {
             workout.date = workoutDate
             workout.duration = totalDuration
             workout.notes = notes
-            workout.avgHeartRate = avgHR
-            workout.maxHeartRate = maxHR
+            WorkoutHeartRateEditPolicy.applyManualSummary(
+                averageHeartRate: avgHR,
+                maximumHeartRate: maxHR,
+                to: workout
+            )
             workout.caloriesBurned = calories
             workout.effortRating = effortRating
 

--- a/AscendAppTests/WorkoutHeartRateEditPolicyTests.swift
+++ b/AscendAppTests/WorkoutHeartRateEditPolicyTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct WorkoutHeartRateEditPolicyTests {
+    @Test
+    func manualSummaryEditDiscardsIncompatibleSampleSeries() {
+        let startedAt = Date(timeIntervalSince1970: 1_753_776_000)
+        let workout = Workout(
+            duration: 1_800,
+            steps: 1_800,
+            floors: 113,
+            avgHeartRate: 140,
+            maxHeartRate: 168,
+            heartRateTimeSeries: [
+                HeartRateDataPoint(timestamp: startedAt, heartRate: 132),
+                HeartRateDataPoint(timestamp: startedAt.addingTimeInterval(600), heartRate: 148),
+                HeartRateDataPoint(timestamp: startedAt.addingTimeInterval(1_200), heartRate: 168)
+            ],
+            source: .appleHealth
+        )
+
+        WorkoutHeartRateEditPolicy.applyManualSummary(
+            averageHeartRate: 150,
+            maximumHeartRate: 168,
+            to: workout
+        )
+
+        #expect(workout.avgHeartRate == 150)
+        #expect(workout.maxHeartRate == 168)
+        #expect(
+            workout.heartRateTimeSeries.isEmpty,
+            "Manual summary values must not coexist with a sampled series that produces different values."
+        )
+    }
+
+    @Test
+    func unchangedSummaryPreservesCompatibleSampleSeries() {
+        let startedAt = Date(timeIntervalSince1970: 1_753_776_000)
+        let samples = [
+            HeartRateDataPoint(timestamp: startedAt, heartRate: 132),
+            HeartRateDataPoint(timestamp: startedAt.addingTimeInterval(600), heartRate: 148),
+            HeartRateDataPoint(timestamp: startedAt.addingTimeInterval(1_200), heartRate: 168)
+        ]
+        let workout = Workout(
+            duration: 1_800,
+            steps: 1_800,
+            floors: 113,
+            avgHeartRate: 140,
+            maxHeartRate: 168,
+            heartRateTimeSeries: samples,
+            source: .appleHealth
+        )
+
+        WorkoutHeartRateEditPolicy.applyManualSummary(
+            averageHeartRate: 140,
+            maximumHeartRate: 168,
+            to: workout
+        )
+
+        #expect(workout.heartRateTimeSeries == samples)
+    }
+}


### PR DESCRIPTION
## Summary

Editing a workout's Avg or Max heart rate by hand could leave the workout internally contradictory. The chart preferred the manually stored summaries while the stale sampled series still drove plotted points and share splits.

This change routes manual summary updates through one policy that clears the sampled heart-rate series only when Avg or Max actually changes. Unchanged summaries and unrelated workout edits preserve the original samples, while the existing sync path removes the corresponding stale remote sidecar.

## Regression coverage

- WorkoutHeartRateEditPolicyTests verifies that changing a summary clears the sample series and leaving both summaries unchanged preserves it.
- WorkoutSyncCoordinatorTests covers the existing sidecar cleanup behavior.

## Validation

Passed with exit code 0:

xcodebuild -quiet -project AscendApp.xcodeproj -scheme AscendApp-Staging -configuration Staging -destination "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.2" ENABLE_TESTABILITY=YES test -only-testing:AscendAppTests/WorkoutHeartRateEditPolicyTests -only-testing:AscendAppTests/WorkoutSyncCoordinatorTests

The captain authorized this direct PR without a public issue or no-mistakes pipeline run.