### PR TITLE
fix(workouts): stop the activity detail screen dropping frames while scrolling

### DIFF
--- a/AscendApp/Features/Climbs/Models/LiveClimbWorkoutSummaryData.swift
+++ b/AscendApp/Features/Climbs/Models/LiveClimbWorkoutSummaryData.swift
@@ -42,6 +42,12 @@ enum LiveClimbWorkoutSummaryData {
         return try? ClimbService.shared.climb(for: climbId)
     }
 
+    /// The step scale a finished session's summary is drawn against: the recorder's
+    /// own target, never below what the session actually logged.
+    static func summaryTargetSteps(metadata: HeadphoneMotionWorkoutMetadata, workout: Workout) -> Int {
+        max(metadata.targetStepCount ?? workout.steps, workout.steps, 1)
+    }
+
     static func progressPoints(for workout: Workout, targetSteps: Int) -> [LiveClimbProgressPoint] {
         normalizedProgressPoints(for: workout, targetSteps: targetSteps)
     }

--- a/AscendApp/Features/Climbs/Views/LiveClimbCompletionSummaryView.swift
+++ b/AscendApp/Features/Climbs/Views/LiveClimbCompletionSummaryView.swift
@@ -60,14 +60,17 @@ struct LiveClimbCompletionSummaryView: View {
         self.achievementTitleOverride = achievementTitleOverride
         self.achievementIconNameOverride = achievementIconNameOverride
         self.onDone = onDone
-    }
-
-    private var paceSplits: [LiveClimbPaceSplit] {
-        LiveClimbWorkoutSummaryData.paceSplits(
+        self.paceSplits = LiveClimbWorkoutSummaryData.paceSplits(
             for: workout,
             targetSteps: climb?.referenceStepCount ?? max(workout.steps, 1)
         )
     }
+
+    /// Built once per view value. The body reads it eleven times - segment count,
+    /// average, each row, the trend chart, the fastest/slowest bounds - and as a
+    /// computed property that meant eleven metadata decodes and eleven curve
+    /// rebuilds per render pass.
+    private let paceSplits: [LiveClimbPaceSplit]
 
     private var primaryBestEffort: RankedBestEffort? {
         BestEffortCacheSnapshot(

--- a/AscendApp/Features/Workouts/Models/WorkoutDetailDerivedContent.swift
+++ b/AscendApp/Features/Workouts/Models/WorkoutDetailDerivedContent.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// The activity detail screen's expensive derivations, resolved once per render
+/// pass instead of once per reader.
+///
+/// The screen used to reach for each of these from several computed properties
+/// inside a single body evaluation: the headphone-motion metadata was JSON-decoded
+/// seven times, the pace splits were rebuilt twice (each rebuild decoding the
+/// metadata again), and the stored heart-rate blob - 104 KB for a 43-minute
+/// session - was decoded three times, about 13 ms of duplicated work per pass on
+/// a screen whose frame budget is 8 ms.
+struct WorkoutDetailDerivedContent {
+    let liveClimbMetadata: HeadphoneMotionWorkoutMetadata?
+    let heartRateSeries: [HeartRateDataPoint]
+    let paceSplits: [LiveClimbPaceSplit]
+    let showsPaceSplits: Bool
+
+    init(workout: Workout) {
+        let metadata = LiveClimbWorkoutSummaryData.metadata(for: workout)
+        liveClimbMetadata = metadata
+        heartRateSeries = workout.heartRateTimeSeries
+
+        guard let metadata else {
+            paceSplits = []
+            showsPaceSplits = false
+            return
+        }
+
+        let targetSteps = max(metadata.targetStepCount ?? workout.steps, workout.steps, 1)
+        let splits = LiveClimbWorkoutSummaryData.paceSplits(for: workout, targetSteps: targetSteps)
+        paceSplits = splits
+        showsPaceSplits = workout.isInAppSensorWorkout &&
+            splits.count > 1 &&
+            Self.hasRecordedPaceSplitData(metadata: metadata, finalSteps: workout.steps)
+    }
+
+    var canOpenLiveClimbSummary: Bool {
+        liveClimbMetadata != nil
+    }
+
+    /// A session only earns a splits section when the recorder actually captured
+    /// intermediate checkpoints; otherwise the "splits" would be a straight line
+    /// reconstructed from the final total.
+    private static func hasRecordedPaceSplitData(
+        metadata: HeadphoneMotionWorkoutMetadata,
+        finalSteps: Int
+    ) -> Bool {
+        guard let intervalSeconds = metadata.splitIntervalSeconds,
+              intervalSeconds > 0,
+              let splitSteps = metadata.splitSteps,
+              splitSteps.count > 2 else {
+            return false
+        }
+
+        let resolvedFinalSteps = max(finalSteps, 0)
+        return splitSteps.dropLast().contains { step in
+            step > 0 && step < resolvedFinalSteps
+        }
+    }
+}

--- a/AscendApp/Features/Workouts/Models/WorkoutDetailDerivedContent.swift
+++ b/AscendApp/Features/Workouts/Models/WorkoutDetailDerivedContent.swift
@@ -20,18 +20,21 @@ struct WorkoutDetailDerivedContent {
         liveClimbMetadata = metadata
         heartRateSeries = workout.heartRateTimeSeries
 
-        guard let metadata else {
+        // The cheap predicates gate the expensive rebuild, not the other way round:
+        // a session that renders no splits section must not pay for a checkpoint
+        // curve nobody reads.
+        guard let metadata,
+              workout.isInAppSensorWorkout,
+              Self.hasRecordedPaceSplitData(metadata: metadata, finalSteps: workout.steps) else {
             paceSplits = []
             showsPaceSplits = false
             return
         }
 
-        let targetSteps = max(metadata.targetStepCount ?? workout.steps, workout.steps, 1)
+        let targetSteps = LiveClimbWorkoutSummaryData.summaryTargetSteps(metadata: metadata, workout: workout)
         let splits = LiveClimbWorkoutSummaryData.paceSplits(for: workout, targetSteps: targetSteps)
         paceSplits = splits
-        showsPaceSplits = workout.isInAppSensorWorkout &&
-            splits.count > 1 &&
-            Self.hasRecordedPaceSplitData(metadata: metadata, finalSteps: workout.steps)
+        showsPaceSplits = splits.count > 1
     }
 
     var canOpenLiveClimbSummary: Bool {

--- a/AscendApp/Features/Workouts/Views/Components/ScrollableDetailContent.swift
+++ b/AscendApp/Features/Workouts/Views/Components/ScrollableDetailContent.swift
@@ -7,43 +7,32 @@
 
 import SwiftUI
 
-/// Preference key to track scroll offset
-private struct ScrollOffsetPreferenceKey: PreferenceKey {
-    nonisolated(unsafe) static var defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = nextValue()
-    }
-}
-
 /// A ScrollView wrapper that coordinates with the sheet position.
 /// When scrolled to top and user pulls down, it triggers sheet collapse.
 struct ScrollableDetailContent<Content: View>: View {
     @Binding var sheetPosition: SheetPosition
     let content: () -> Content
 
-    @State private var scrollOffset: CGFloat = 0
     @State private var isAtTop: Bool = true
 
     private let scrollToCollapseThreshold: CGFloat = 50
 
+    /// Tolerance for bounce, so a rubber-banded top still counts as the top.
+    private let atTopTolerance: CGFloat = 5
+
     var body: some View {
         ScrollView {
             content()
-                .background(
-                    GeometryReader { geo in
-                        Color.clear
-                            .preference(
-                                key: ScrollOffsetPreferenceKey.self,
-                                value: geo.frame(in: .named("scroll")).origin.y
-                            )
-                    }
-                )
         }
         .scrollDisabled(sheetPosition != .expanded)  // Only scroll when fully expanded
-        .coordinateSpace(name: "scroll")
-        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { offset in
-            scrollOffset = offset
-            isAtTop = offset >= -5  // Small tolerance for bounce
+        // Only the at-top verdict matters here, so deriving it inside the closure
+        // means the action fires when the answer flips rather than on every tick.
+        // The preference-key plumbing this replaces republished the raw offset every
+        // frame and stored it in state nothing read.
+        .onScrollGeometryChange(for: Bool.self) { geometry in
+            geometry.contentOffset.y + geometry.contentInsets.top <= atTopTolerance
+        } action: { _, atTop in
+            isAtTop = atTop
         }
         .simultaneousGesture(
             pullToCollapseGesture,

--- a/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
+++ b/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
@@ -18,6 +18,12 @@ struct HeartRateChartDataSet: Equatable {
     /// Floor so a couple of skipped 1 Hz notifications never shatter the line.
     static let minimumDropoutGap: TimeInterval = 10
 
+    /// Upper bound on plotted marks. A 43-minute session records one sample per
+    /// second, and handing Swift Charts 2,600 `LineMark`s costs ~114 ms to render
+    /// - seven 60 Hz frames for detail no chart this size can show. Capping the
+    /// mark count keeps the same curve at roughly an eighth of the cost.
+    static let maximumPlottedPointCount = 400
+
     let points: [HeartRateChartPoint]
     let segments: [HeartRateChartSegment]
     let duration: TimeInterval
@@ -45,20 +51,88 @@ struct HeartRateChartDataSet: Equatable {
             }
             .sorted { $0.timestamp < $1.timestamp }
 
-        points = sortedSamples.enumerated().map { index, sample in
-            let elapsed = sample.timestamp.timeIntervalSince(workoutStartTime)
-            return HeartRateChartPoint(
+        let rawPoints = sortedSamples.enumerated().map { index, sample in
+            HeartRateChartPoint(
                 id: index,
-                elapsed: min(max(elapsed, 0), visibleDuration),
+                elapsed: min(max(sample.timestamp.timeIntervalSince(workoutStartTime), 0), visibleDuration),
                 heartRate: sample.heartRate
             )
         }
-        segments = Self.segments(for: points)
+
+        // Dropout detection runs on the raw series and thinning happens inside each
+        // resulting segment. Doing it the other way round would let thinning rewrite
+        // the sample spacing the gap threshold is derived from, inventing dropouts in
+        // a continuous trace or papering over real ones.
+        segments = Self.thinnedSegments(Self.segments(for: rawPoints), rawPointCount: rawPoints.count)
+        points = segments.flatMap(\.points)
         duration = visibleDuration
 
-        let rates = points.map(\.heartRate)
-        heartRateRange = Self.range(for: rates)
+        // Ranged off the full series, not the plotted subset, so the axis still
+        // spans the real minimum and maximum even when marks are thinned.
+        heartRateRange = Self.range(for: sortedSamples.map(\.heartRate))
         heartRateTickValues = Self.tickValues(for: heartRateRange)
+    }
+
+    /// Thins each segment to a share of the mark budget proportional to its length.
+    ///
+    /// A 43-minute session records one sample per second, and handing Swift Charts
+    /// 2,600 `LineMark`s costs ~114 ms to render - seven 60 Hz frames for detail no
+    /// chart this size can show.
+    private static func thinnedSegments(
+        _ segments: [HeartRateChartSegment],
+        rawPointCount: Int
+    ) -> [HeartRateChartSegment] {
+        guard rawPointCount > maximumPlottedPointCount, rawPointCount > 0 else {
+            return segments
+        }
+
+        return segments.map { segment in
+            let share = Double(segment.points.count) / Double(rawPointCount)
+            let budget = max(Int(Double(maximumPlottedPointCount) * share), 2)
+            return HeartRateChartSegment(id: segment.id, points: thinned(segment.points, budget: budget))
+        }
+    }
+
+    /// Keeps each bucket's lowest and highest reading in time order, plus the run's
+    /// own endpoints. Dropping every Nth sample instead would clip the peaks and
+    /// troughs - the part of a heart-rate trace a climber actually reads.
+    private static func thinned(_ points: [HeartRateChartPoint], budget: Int) -> [HeartRateChartPoint] {
+        guard points.count > budget else { return points }
+
+        // Two marks come out of each bucket, and the two endpoints are added back
+        // afterwards, so the bucket budget has to leave room for both.
+        let bucketCount = max((budget - 2) / 2, 1)
+        var kept: [HeartRateChartPoint] = []
+        kept.reserveCapacity(budget)
+
+        for bucket in 0..<bucketCount {
+            let lowerBound = points.count * bucket / bucketCount
+            let upperBound = points.count * (bucket + 1) / bucketCount
+            guard lowerBound < upperBound else { continue }
+
+            let slice = points[lowerBound..<upperBound]
+            guard let lowest = slice.min(by: { $0.heartRate < $1.heartRate }),
+                  let highest = slice.max(by: { $0.heartRate < $1.heartRate }) else {
+                continue
+            }
+
+            if lowest.id == highest.id {
+                kept.append(lowest)
+            } else if lowest.id < highest.id {
+                kept.append(contentsOf: [lowest, highest])
+            } else {
+                kept.append(contentsOf: [highest, lowest])
+            }
+        }
+
+        if let first = points.first, kept.first?.id != first.id {
+            kept.insert(first, at: 0)
+        }
+        if let last = points.last, kept.last?.id != last.id {
+            kept.append(last)
+        }
+
+        return kept
     }
 
     /// Splits the trace wherever coverage actually stopped, so a dropout reads
@@ -142,20 +216,38 @@ struct HeartRateChartView: View {
     let workoutDuration: TimeInterval
     let averageHeartRateBpm: Int?
     let maxHeartRateBpm: Int?
-    
+
+    /// Built once per view value rather than on demand. The body reads it eight
+    /// times (marks, both scales, both axes, selection), and scrubbing the chart
+    /// re-evaluates the body on every touch move - as a computed property that
+    /// meant re-filtering and re-sorting the whole series each time.
+    private let dataSet: HeartRateChartDataSet
+
     @Environment(\.colorScheme) private var colorScheme
     @State private var themeManager = ThemeManager.shared
     @State private var rawSelectedTime: TimeInterval?
     @State private var stickySelectedTime: TimeInterval?
 
-    private var dataSet: HeartRateChartDataSet {
-        HeartRateChartDataSet(
+    init(
+        heartRateData: [HeartRateDataPoint],
+        workoutStartTime: Date,
+        workoutDuration: TimeInterval,
+        averageHeartRateBpm: Int?,
+        maxHeartRateBpm: Int?
+    ) {
+        self.heartRateData = heartRateData
+        self.workoutStartTime = workoutStartTime
+        self.workoutDuration = workoutDuration
+        self.averageHeartRateBpm = averageHeartRateBpm
+        self.maxHeartRateBpm = maxHeartRateBpm
+        self.dataSet = HeartRateChartDataSet(
             samples: heartRateData,
             workoutStartTime: workoutStartTime,
             workoutDuration: workoutDuration
         )
     }
-    
+
+
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
     }

--- a/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
+++ b/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
@@ -314,7 +314,6 @@ struct HeartRateChartView: View {
         )
     }
 
-
     private var effectiveColorScheme: ColorScheme {
         themeManager.effectiveColorScheme(for: colorScheme)
     }

--- a/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
+++ b/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
@@ -22,9 +22,19 @@ struct HeartRateChartDataSet: Equatable {
     /// second, and handing Swift Charts 2,600 `LineMark`s costs ~114 ms to render
     /// - seven 60 Hz frames for detail no chart this size can show. Capping the
     /// mark count keeps the same curve at roughly an eighth of the cost.
+    ///
+    /// It is a real bound up to `maximumPlottedPointCount / 2` dropout segments.
+    /// Past that, every segment still keeps its own two endpoints - a run that
+    /// plotted nothing would read as a longer dropout than actually happened - so
+    /// the worst case is `2 x segment count`, reachable only with a strap that
+    /// dropped out more than 200 times in one session.
     static let maximumPlottedPointCount = 400
 
     let points: [HeartRateChartPoint]
+    /// The full unthinned series, kept for the scrub readout only. Thinning is a
+    /// rendering concession; the "### BPM at m:ss" a climber reads off the chart
+    /// has to be the actual sample under their finger, not a nearby bucket extreme.
+    let scrubPoints: [HeartRateChartPoint]
     let segments: [HeartRateChartSegment]
     let duration: TimeInterval
     let heartRateRange: ClosedRange<Int>
@@ -33,6 +43,12 @@ struct HeartRateChartDataSet: Equatable {
     var canPlotLine: Bool {
         let distinctElapsedValues = Set(points.map { Int($0.elapsed.rounded()) })
         return points.count >= Self.minimumLineSampleCount && distinctElapsedValues.count >= 2
+    }
+
+    /// The reading under a scrub touch, resolved against the full series rather than
+    /// the plotted subset so the BPM and the "at m:ss" label are the real sample.
+    func nearestScrubPoint(to elapsed: TimeInterval) -> HeartRateChartPoint? {
+        scrubPoints.min { abs($0.elapsed - elapsed) < abs($1.elapsed - elapsed) }
     }
 
     init(
@@ -65,6 +81,7 @@ struct HeartRateChartDataSet: Equatable {
         // a continuous trace or papering over real ones.
         segments = Self.thinnedSegments(Self.segments(for: rawPoints), rawPointCount: rawPoints.count)
         points = segments.flatMap(\.points)
+        scrubPoints = rawPoints
         duration = visibleDuration
 
         // Ranged off the full series, not the plotted subset, so the axis still
@@ -78,17 +95,25 @@ struct HeartRateChartDataSet: Equatable {
     /// A 43-minute session records one sample per second, and handing Swift Charts
     /// 2,600 `LineMark`s costs ~114 ms to render - seven 60 Hz frames for detail no
     /// chart this size can show.
+    ///
+    /// Every segment first reserves its own endpoints so a short run is never thinned
+    /// out of existence; what is left of the cap is then shared out in proportion to
+    /// segment length, which keeps the total inside `maximumPlottedPointCount` for any
+    /// trace with at most half that many segments.
     private static func thinnedSegments(
         _ segments: [HeartRateChartSegment],
         rawPointCount: Int
     ) -> [HeartRateChartSegment] {
-        guard rawPointCount > maximumPlottedPointCount, rawPointCount > 0 else {
+        guard rawPointCount > maximumPlottedPointCount else {
             return segments
         }
 
+        let reserved = segments.reduce(0) { $0 + min($1.points.count, 2) }
+        let discretionary = max(maximumPlottedPointCount - reserved, 0)
+
         return segments.map { segment in
             let share = Double(segment.points.count) / Double(rawPointCount)
-            let budget = max(Int(Double(maximumPlottedPointCount) * share), 2)
+            let budget = min(segment.points.count, 2) + Int(Double(discretionary) * share)
             return HeartRateChartSegment(id: segment.id, points: thinned(segment.points, budget: budget))
         }
     }
@@ -96,12 +121,17 @@ struct HeartRateChartDataSet: Equatable {
     /// Keeps each bucket's lowest and highest reading in time order, plus the run's
     /// own endpoints. Dropping every Nth sample instead would clip the peaks and
     /// troughs - the part of a heart-rate trace a climber actually reads.
+    ///
+    /// Never returns more than `budget` marks, so the caller's allocation is the
+    /// real bound rather than an approximation of one.
     private static func thinned(_ points: [HeartRateChartPoint], budget: Int) -> [HeartRateChartPoint] {
         guard points.count > budget else { return points }
 
         // Two marks come out of each bucket, and the two endpoints are added back
         // afterwards, so the bucket budget has to leave room for both.
-        let bucketCount = max((budget - 2) / 2, 1)
+        let bucketCount = (budget - 2) / 2
+        guard bucketCount >= 1 else { return endpoints(of: points) }
+
         var kept: [HeartRateChartPoint] = []
         kept.reserveCapacity(budget)
 
@@ -133,6 +163,11 @@ struct HeartRateChartDataSet: Equatable {
         }
 
         return kept
+    }
+
+    private static func endpoints(of points: [HeartRateChartPoint]) -> [HeartRateChartPoint] {
+        guard let first = points.first, let last = points.last else { return points }
+        return first.id == last.id ? [first] : [first, last]
     }
 
     /// Splits the trace wherever coverage actually stopped, so a dropout reads
@@ -255,11 +290,7 @@ struct HeartRateChartView: View {
     private var computedSelectedPoint: HeartRateChartPoint? {
         guard let activeTime = rawSelectedTime ?? stickySelectedTime else { return nil }
 
-        return dataSet.points.min { point1, point2 in
-            let distance1 = abs(point1.elapsed - activeTime)
-            let distance2 = abs(point2.elapsed - activeTime)
-            return distance1 < distance2
-        }
+        return dataSet.nearestScrubPoint(to: activeTime)
     }
 
     private var averageHeartRate: Int? {

--- a/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
+++ b/AscendApp/Features/Workouts/Views/HeartRateChartView.swift
@@ -18,16 +18,18 @@ struct HeartRateChartDataSet: Equatable {
     /// Floor so a couple of skipped 1 Hz notifications never shatter the line.
     static let minimumDropoutGap: TimeInterval = 10
 
-    /// Upper bound on plotted marks. A 43-minute session records one sample per
+    /// Target for the plotted mark count. A 43-minute session records one sample per
     /// second, and handing Swift Charts 2,600 `LineMark`s costs ~114 ms to render
     /// - seven 60 Hz frames for detail no chart this size can show. Capping the
     /// mark count keeps the same curve at roughly an eighth of the cost.
     ///
-    /// It is a real bound up to `maximumPlottedPointCount / 2` dropout segments.
-    /// Past that, every segment still keeps its own two endpoints - a run that
-    /// plotted nothing would read as a longer dropout than actually happened - so
-    /// the worst case is `2 x segment count`, reachable only with a strap that
-    /// dropped out more than 200 times in one session.
+    /// It holds exactly for a continuous trace and for the handful of dropouts a real
+    /// session sees. It is a target rather than a hard bound because every segment,
+    /// however small its share, still contributes its own minimum and maximum on top
+    /// of its endpoints - up to four marks - so that a run containing the session's
+    /// peak can never lose it to fragmentation. A pathological trace of ~200 dropouts
+    /// therefore plots roughly `4 x segment count` marks, over this target. Accuracy
+    /// wins that trade: a chart missing the peak is a worse bug than a slow one.
     static let maximumPlottedPointCount = 400
 
     let points: [HeartRateChartPoint]
@@ -47,8 +49,42 @@ struct HeartRateChartDataSet: Equatable {
 
     /// The reading under a scrub touch, resolved against the full series rather than
     /// the plotted subset so the BPM and the "at m:ss" label are the real sample.
+    ///
+    /// `scrubPoints` is non-decreasing in `elapsed` by construction, so the touch
+    /// lands between two neighbours rather than needing a scan of all 2,600 samples
+    /// - a scrub drag re-evaluates the body on every touch move.
     func nearestScrubPoint(to elapsed: TimeInterval) -> HeartRateChartPoint? {
-        scrubPoints.min { abs($0.elapsed - elapsed) < abs($1.elapsed - elapsed) }
+        guard !scrubPoints.isEmpty else { return nil }
+
+        let insertionIndex = firstIndex(atOrAfter: elapsed)
+        guard insertionIndex > 0 else { return scrubPoints[0] }
+        guard insertionIndex < scrubPoints.count else { return scrubPoints[lastTiedIndex(before: insertionIndex)] }
+
+        let earlier = scrubPoints[lastTiedIndex(before: insertionIndex)]
+        let later = scrubPoints[insertionIndex]
+        return abs(later.elapsed - elapsed) < abs(earlier.elapsed - elapsed) ? later : earlier
+    }
+
+    /// Index of the first point at or after `elapsed`, or `count` when every point
+    /// precedes it.
+    private func firstIndex(atOrAfter elapsed: TimeInterval) -> Int {
+        var low = 0
+        var high = scrubPoints.count
+        while low < high {
+            let middle = low + (high - low) / 2
+            if scrubPoints[middle].elapsed < elapsed {
+                low = middle + 1
+            } else {
+                high = middle
+            }
+        }
+        return low
+    }
+
+    /// Samples clamped to the same instant are interchangeable by distance, and the
+    /// earliest of them is the one a scan of the series would settle on.
+    private func lastTiedIndex(before insertionIndex: Int) -> Int {
+        firstIndex(atOrAfter: scrubPoints[insertionIndex - 1].elapsed)
     }
 
     init(
@@ -97,9 +133,10 @@ struct HeartRateChartDataSet: Equatable {
     /// chart this size can show.
     ///
     /// Every segment first reserves its own endpoints so a short run is never thinned
-    /// out of existence; what is left of the cap is then shared out in proportion to
-    /// segment length, which keeps the total inside `maximumPlottedPointCount` for any
-    /// trace with at most half that many segments.
+    /// out of existence; what is left of the target is then shared out in proportion
+    /// to segment length. A segment never drops below one bucket, so a heavily
+    /// fragmented trace can plot up to four marks per segment and overshoot
+    /// `maximumPlottedPointCount` - see that constant for why accuracy wins there.
     private static func thinnedSegments(
         _ segments: [HeartRateChartSegment],
         rawPointCount: Int
@@ -122,15 +159,15 @@ struct HeartRateChartDataSet: Equatable {
     /// own endpoints. Dropping every Nth sample instead would clip the peaks and
     /// troughs - the part of a heart-rate trace a climber actually reads.
     ///
-    /// Never returns more than `budget` marks, so the caller's allocation is the
-    /// real bound rather than an approximation of one.
+    /// The bucket count never falls below one, so even a segment allotted the bare
+    /// minimum still contributes its own extremes rather than a straight chord
+    /// between its endpoints.
     private static func thinned(_ points: [HeartRateChartPoint], budget: Int) -> [HeartRateChartPoint] {
         guard points.count > budget else { return points }
 
         // Two marks come out of each bucket, and the two endpoints are added back
         // afterwards, so the bucket budget has to leave room for both.
-        let bucketCount = (budget - 2) / 2
-        guard bucketCount >= 1 else { return endpoints(of: points) }
+        let bucketCount = max((budget - 2) / 2, 1)
 
         var kept: [HeartRateChartPoint] = []
         kept.reserveCapacity(budget)
@@ -163,11 +200,6 @@ struct HeartRateChartDataSet: Equatable {
         }
 
         return kept
-    }
-
-    private static func endpoints(of points: [HeartRateChartPoint]) -> [HeartRateChartPoint] {
-        guard let first = points.first, let last = points.last else { return points }
-        return first.id == last.id ? [first] : [first, last]
     }
 
     /// Splits the trace wherever coverage actually stopped, so a dropout reads

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -624,8 +624,8 @@ struct WorkoutDetailView: View {
         )
     }
 
-    /// Decodes the stored series exactly once per render pass and hands it to every predicate that
-    /// needs it - the decode is a full JSON pass over the sample array.
+    /// Reads the series the pass already decoded and hands it to every predicate that needs it -
+    /// the decode is a full JSON pass over the sample array. See `WorkoutDetailDerivedContent`.
     @ViewBuilder
     private func heartRateSectionIfNeeded(_ derived: WorkoutDetailDerivedContent) -> some View {
         if shouldShowHeartRateSection(derived) {

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -612,7 +612,7 @@ struct WorkoutDetailView: View {
     }
 
     private func summaryTargetSteps(metadata: HeadphoneMotionWorkoutMetadata) -> Int {
-        max(metadata.targetStepCount ?? workout.steps, workout.steps, 1)
+        LiveClimbWorkoutSummaryData.summaryTargetSteps(metadata: metadata, workout: workout)
     }
 
     private func justClimbSummaryTargetSteps(metadata: HeadphoneMotionWorkoutMetadata) -> Int {

--- a/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
+++ b/AscendApp/Features/Workouts/Views/WorkoutDetailView.swift
@@ -29,6 +29,9 @@ struct WorkoutDetailView: View {
     @State private var isDeleting = false
     @State private var isCancelling = false
     @State private var deleteTask: Task<Void, Never>? = nil
+    @State private var appleHealthRetryTask: Task<Void, Never>? = nil
+    @State private var appleHealthFetchTask: Task<Void, Never>? = nil
+    @State private var copyConfirmationTask: Task<Void, Never>? = nil
     @State private var showingLiveClimbSummaryPreview = false
     @State private var liveClimbCompletionRank: LiveReplayCompletionRank?
     @State private var isLoadingLiveClimbRank = false
@@ -45,7 +48,18 @@ struct WorkoutDetailView: View {
 
     // Scroll tracking for traditional layout nav bar title
     @State private var scrolledPastTitle = false
-    @State private var scrollContentOffset: CGFloat = 0
+
+    /// Scroll distance at which the inline title has passed behind the header and
+    /// the nav bar takes over showing it.
+    static let navigationTitleRevealOffset: CGFloat = 100
+
+    /// Whether the nav bar should show the title, as a pure function of how far the
+    /// content has scrolled. Keeping the rule here rather than inline in the scroll
+    /// handler is what lets a test feed it a whole scroll trace and count how many
+    /// times the answer - and therefore the state write - actually changes.
+    static func revealsNavigationTitle(scrolledDistance: CGFloat) -> Bool {
+        scrolledDistance > navigationTitleRevealOffset
+    }
 
     init(workout: Workout, embedsInNavigationStack: Bool = true) {
         self.workout = workout
@@ -75,19 +89,24 @@ struct WorkoutDetailView: View {
     }
 
     private var content: some View {
-        ZStack {
+        // Resolved once here and threaded down, so a render pass decodes the
+        // headphone-motion metadata and the heart-rate blob once apiece instead of
+        // once per reader. See `WorkoutDetailDerivedContent`.
+        let derived = WorkoutDetailDerivedContent(workout: workout)
+
+        return ZStack {
             (effectiveColorScheme == .dark ? Color.black : Color.white)
                 .ignoresSafeArea()
 
             if hasMedia {
-                workoutMediaLayout
+                workoutMediaLayout(derived)
             } else {
-                traditionalLayout
+                traditionalLayout(derived)
             }
         }
         .navigationBarHidden(true)
         .overlay(alignment: .top) {
-            adaptiveHeader
+            adaptiveHeader(derived)
         }
         .sheet(isPresented: $showingEditWorkout) {
             EditWorkoutView(
@@ -136,9 +155,21 @@ struct WorkoutDetailView: View {
             await retryAppleHealthEnrichmentIfNeeded()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-            Task {
+            appleHealthRetryTask?.cancel()
+            appleHealthRetryTask = Task {
                 await retryAppleHealthEnrichmentIfNeeded()
             }
+        }
+        .onDisappear {
+            // Everything this screen started goes away with it. `.task(id:)` cancels
+            // itself; these are unstructured and would otherwise outlive the screen,
+            // still holding the workout and still writing to state nobody reads.
+            appleHealthRetryTask?.cancel()
+            appleHealthRetryTask = nil
+            appleHealthFetchTask?.cancel()
+            appleHealthFetchTask = nil
+            copyConfirmationTask?.cancel()
+            copyConfirmationTask = nil
         }
         .onChange(of: showingEditWorkout) { _, isShowing in
             if !isShowing && hasMedia {
@@ -187,7 +218,7 @@ struct WorkoutDetailView: View {
     // MARK: - Media Layout
 
     @ViewBuilder
-    private var workoutMediaLayout: some View {
+    private func workoutMediaLayout(_ derived: WorkoutDetailDerivedContent) -> some View {
         GeometryReader { geometry in
             ZStack(alignment: .top) {
                 let heroHeight = sheetOffset > 0 ? sheetOffset : sheetPosition.photoHeight(in: geometry)
@@ -213,13 +244,13 @@ struct WorkoutDetailView: View {
                 .animation(.spring(response: 0.35, dampingFraction: 0.8), value: sheetPosition)
 
                 DraggableDetailSheet(position: $sheetPosition, currentOffset: $sheetOffset) {
-                    sheetDetailContent(in: geometry)
+                    sheetDetailContent(derived)
                 }
             }
         }
     }
 
-    private func sheetDetailContent(in geometry: GeometryProxy) -> some View {
+    private func sheetDetailContent(_ derived: WorkoutDetailDerivedContent) -> some View {
         ScrollableDetailContent(sheetPosition: $sheetPosition) {
             VStack(spacing: 24) {
                 MediaUploadBanner(workoutId: workout.id) {
@@ -231,7 +262,7 @@ struct WorkoutDetailView: View {
                     }
                 }
 
-                workoutContentSections
+                workoutContentSections(derived)
             }
             .padding(.horizontal, 20)
             .padding(.top, sheetPosition == .expanded ? 60 : 8)
@@ -240,7 +271,7 @@ struct WorkoutDetailView: View {
 
     // MARK: - Traditional Layout (No Media)
 
-    private var traditionalLayout: some View {
+    private func traditionalLayout(_ derived: WorkoutDetailDerivedContent) -> some View {
         ScrollView {
             VStack(spacing: 24) {
                 // Title row — scrolls naturally behind the opaque nav bar
@@ -263,7 +294,7 @@ struct WorkoutDetailView: View {
                     }
                 }
 
-                workoutContentSectionsWithoutTitle
+                workoutContentSectionsWithoutTitle(derived)
 
                 // Photos section
                 WorkoutPhotosSection(workout: workout)
@@ -272,32 +303,25 @@ struct WorkoutDetailView: View {
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 16)
-            .overlay(alignment: .top) {
-                // Scroll offset tracker — pinned to top of content
-                GeometryReader { geo in
-                    let minY = geo.frame(in: .global).minY
-                    Color.clear
-                        .onChange(of: minY) { _, newValue in
-                            scrollContentOffset = newValue
-                            // Title text is at ~96pt from content top (16pt padding + 80pt offset).
-                            // When the content top (minY) has scrolled so the title is behind the
-                            // nav bar, show the nav bar title. The safe area top + nav bar ≈ 100pt.
-                            let shouldShow = newValue < -40
-                            if shouldShow != scrolledPastTitle {
-                                scrolledPastTitle = shouldShow
-                            }
-                        }
-                }
-                .frame(height: 0)
-            }
         }
         .scrollIndicators(.hidden)
+        // Reduces the scroll to the one bit the header cares about, so the action
+        // fires on the two threshold crossings rather than on every scroll tick.
+        // The GeometryReader overlay this replaces re-resolved the content's global
+        // frame every frame to store an offset nothing read.
+        .onScrollGeometryChange(for: Bool.self) { geometry in
+            Self.revealsNavigationTitle(
+                scrolledDistance: geometry.contentOffset.y + geometry.contentInsets.top
+            )
+        } action: { _, shouldReveal in
+            scrolledPastTitle = shouldReveal
+        }
     }
 
     // MARK: - Shared Content Sections
 
     /// All content sections (used in sheet detail for media layout)
-    private var workoutContentSections: some View {
+    private func workoutContentSections(_ derived: WorkoutDetailDerivedContent) -> some View {
         Group {
             // Hide inline title when sheet is expanded (nav bar shows it instead)
             if sheetPosition != .expanded {
@@ -311,14 +335,14 @@ struct WorkoutDetailView: View {
 
             }
 
-            workoutContentSectionsWithoutTitle
+            workoutContentSectionsWithoutTitle(derived)
 
             Spacer(minLength: 40)
         }
     }
 
     /// Content sections after the title (shared between both layouts)
-    private var workoutContentSectionsWithoutTitle: some View {
+    private func workoutContentSectionsWithoutTitle(_ derived: WorkoutDetailDerivedContent) -> some View {
         Group {
             // Notes (blockquote style)
             if !workout.notes.isEmpty {
@@ -344,7 +368,7 @@ struct WorkoutDetailView: View {
                 )
             }
 
-            if canOpenLiveClimbSummary {
+            if derived.canOpenLiveClimbSummary {
                 LiveClimbSummaryLinkRow(
                     climb: liveClimbDetailClimb,
                     effectiveColorScheme: effectiveColorScheme,
@@ -354,11 +378,11 @@ struct WorkoutDetailView: View {
                 )
             }
 
-            heartRateSectionIfNeeded
+            heartRateSectionIfNeeded(derived)
 
-            if shouldShowPaceSplitsSection {
+            if derived.showsPaceSplits {
                 WorkoutPaceSplitsSection(
-                    splits: workoutPaceSplits,
+                    splits: derived.paceSplits,
                     averageStepsPerMinute: workout.stepsPerMinute,
                     effectiveColorScheme: effectiveColorScheme
                 )
@@ -390,7 +414,7 @@ struct WorkoutDetailView: View {
 
     // MARK: - Adaptive Header
 
-    private var adaptiveHeader: some View {
+    private func adaptiveHeader(_ derived: WorkoutDetailDerivedContent) -> some View {
         VStack(spacing: 0) {
             HStack {
                 OnboardingBackButton {
@@ -417,7 +441,7 @@ struct WorkoutDetailView: View {
 
                 // Menu button
                 Menu {
-                    menuContent
+                    menuContent(derived)
                 } label: {
                     Image(systemName: "ellipsis")
                         .font(.system(size: 18, weight: .medium))
@@ -493,7 +517,7 @@ struct WorkoutDetailView: View {
     // MARK: - Menu
 
     @ViewBuilder
-    private var menuContent: some View {
+    private func menuContent(_ derived: WorkoutDetailDerivedContent) -> some View {
         Button(action: {
             showingShareWorkoutView = true
         }) {
@@ -504,7 +528,7 @@ struct WorkoutDetailView: View {
             Label("Copy Workout Text", systemImage: "doc.on.doc")
         }
 
-        if canOpenLiveClimbSummary {
+        if derived.canOpenLiveClimbSummary {
             Button {
                 showingLiveClimbSummaryPreview = true
             } label: {
@@ -527,10 +551,6 @@ struct WorkoutDetailView: View {
                 Label("Delete Workout", systemImage: "trash")
             }
         }
-    }
-
-    private var canOpenLiveClimbSummary: Bool {
-        liveClimbSummaryMetadata != nil
     }
 
     @MainActor
@@ -607,25 +627,23 @@ struct WorkoutDetailView: View {
     /// Decodes the stored series exactly once per render pass and hands it to every predicate that
     /// needs it - the decode is a full JSON pass over the sample array.
     @ViewBuilder
-    private var heartRateSectionIfNeeded: some View {
-        let heartRateSamples = workout.heartRateTimeSeries
-
-        if shouldShowHeartRateSection(heartRateSamples: heartRateSamples) {
-            heartRateSection(heartRateSamples: heartRateSamples)
+    private func heartRateSectionIfNeeded(_ derived: WorkoutDetailDerivedContent) -> some View {
+        if shouldShowHeartRateSection(derived) {
+            heartRateSection(derived)
         }
     }
 
     @ViewBuilder
-    private func heartRateSection(heartRateSamples: [HeartRateDataPoint]) -> some View {
-        if heartRateSamples.isEmpty == false {
+    private func heartRateSection(_ derived: WorkoutDetailDerivedContent) -> some View {
+        if derived.heartRateSeries.isEmpty == false {
             HeartRateChartView(
-                heartRateData: heartRateSamples,
+                heartRateData: derived.heartRateSeries,
                 workoutStartTime: workout.date,
                 workoutDuration: workout.duration,
                 averageHeartRateBpm: workout.avgHeartRate,
                 maxHeartRateBpm: workout.maxHeartRate
             )
-        } else if shouldShowRemoteHeartRateRestore(heartRateSamples: heartRateSamples) {
+        } else if shouldShowRemoteHeartRateRestore(derived) {
             WorkoutHeartRateRestoreCard(
                 status: workout.heartRateRestoreStatus,
                 effectiveColorScheme: effectiveColorScheme,
@@ -649,15 +667,15 @@ struct WorkoutDetailView: View {
             workout.maxHeartRate != nil
     }
 
-    private func shouldShowHeartRateSection(heartRateSamples: [HeartRateDataPoint]) -> Bool {
-        hasHeartRateData(heartRateSamples: heartRateSamples) ||
-            shouldShowRemoteHeartRateRestore(heartRateSamples: heartRateSamples) ||
+    private func shouldShowHeartRateSection(_ derived: WorkoutDetailDerivedContent) -> Bool {
+        hasHeartRateData(heartRateSamples: derived.heartRateSeries) ||
+            shouldShowRemoteHeartRateRestore(derived) ||
             shouldShowAppleHealthHeartRateRecovery
     }
 
-    private func shouldShowRemoteHeartRateRestore(heartRateSamples: [HeartRateDataPoint]) -> Bool {
+    private func shouldShowRemoteHeartRateRestore(_ derived: WorkoutDetailDerivedContent) -> Bool {
         workout.lastRemoteHeartRateSeriesStoragePath != nil &&
-            heartRateSamples.isEmpty &&
+            derived.heartRateSeries.isEmpty &&
             workout.heartRateRestoreStatus.treatsLocalAbsenceAsAuthoritative == false
     }
 
@@ -667,36 +685,6 @@ struct WorkoutDetailView: View {
             return true
         case .notPending, .complete:
             return false
-        }
-    }
-
-    private var workoutPaceSplits: [LiveClimbPaceSplit] {
-        guard let metadata = liveClimbSummaryMetadata else { return [] }
-
-        return LiveClimbWorkoutSummaryData.paceSplits(
-            for: workout,
-            targetSteps: summaryTargetSteps(metadata: metadata)
-        )
-    }
-
-    private var shouldShowPaceSplitsSection: Bool {
-        workout.isInAppSensorWorkout &&
-            hasRecordedPaceSplitData &&
-            workoutPaceSplits.count > 1
-    }
-
-    private var hasRecordedPaceSplitData: Bool {
-        guard let metadata = liveClimbSummaryMetadata,
-              let intervalSeconds = metadata.splitIntervalSeconds,
-              intervalSeconds > 0,
-              let splitSteps = metadata.splitSteps,
-              splitSteps.count > 2 else {
-            return false
-        }
-
-        let finalSteps = max(workout.steps, 0)
-        return splitSteps.dropLast().contains { step in
-            step > 0 && step < finalSteps
         }
     }
 
@@ -927,8 +915,10 @@ struct WorkoutDetailView: View {
             copyConfirmationText = text
         }
 
-        Task {
+        copyConfirmationTask?.cancel()
+        copyConfirmationTask = Task {
             try? await Task.sleep(for: .milliseconds(1600))
+            guard !Task.isCancelled else { return }
             withAnimation(.easeOut(duration: 0.3)) {
                 if copyConfirmationText == text {
                     copyConfirmationText = nil
@@ -987,7 +977,7 @@ struct WorkoutDetailView: View {
     private func fetchAppleHealthHeartRate() {
         guard !isFetchingAppleHealthHeartRate else { return }
 
-        Task { @MainActor in
+        appleHealthFetchTask = Task { @MainActor in
             isFetchingAppleHealthHeartRate = true
             appleHealthHeartRateMessage = nil
             defer {

--- a/AscendAppTests/HeartRateChartDownsamplingTests.swift
+++ b/AscendAppTests/HeartRateChartDownsamplingTests.swift
@@ -38,12 +38,20 @@ struct HeartRateChartDownsamplingTests {
     /// A strap that keeps cutting out: 13 seconds of 1 Hz capture, then a minute of
     /// silence, repeated. Every gap clears the dropout threshold, so each run becomes
     /// its own segment.
+    ///
+    /// Each run's trough and peak sit in its interior, never at its endpoints, so a
+    /// thinning pass that kept only endpoints would visibly lose them.
     private static func fragmentedSession(segmentCount: Int) -> [HeartRateDataPoint] {
         var samples: [HeartRateDataPoint] = []
         for segment in 0..<segmentCount {
-            for second in 0..<13 {
+            for second in 0..<Self.fragmentedSegmentLength {
                 let elapsed = TimeInterval(segment * 72 + second)
-                let heartRate: Int = 140 + (segment + second) % 23
+                let heartRate: Int
+                switch second {
+                case 3: heartRate = 108 - segment % 7
+                case 8: heartRate = 188 + segment % 7
+                default: heartRate = 150
+                }
                 samples.append(
                     HeartRateDataPoint(
                         timestamp: start.addingTimeInterval(elapsed),
@@ -54,6 +62,8 @@ struct HeartRateChartDownsamplingTests {
         }
         return samples
     }
+
+    private static let fragmentedSegmentLength = 13
 
     @Test
     func longSessionIsCappedToAPlottableNumberOfMarks() {
@@ -158,37 +168,51 @@ struct HeartRateChartDownsamplingTests {
         #expect(dataSet.segments.count == 1)
     }
 
-    /// A fragmented trace still has to respect the cap. The budget is handed out
-    /// after every segment has reserved its own endpoints, so 200 dropouts land
-    /// exactly on the cap rather than blowing past it two marks at a time.
+    /// The one a shrinking budget must never cost: a run that holds the session's
+    /// peak keeps it however small its share of the marks, so the plotted extremes
+    /// still match the raw ones and the axis headroom and the header's Max figure
+    /// have something on the curve to point at.
     @Test
-    func aHeavilyFragmentedTraceStaysInsideTheCap() {
+    func everyDropoutSegmentKeepsItsOwnPeakAndTrough() {
+        let samples = Self.fragmentedSession(segmentCount: 200)
         let dataSet = HeartRateChartDataSet(
-            samples: Self.fragmentedSession(segmentCount: 200),
+            samples: samples,
             workoutStartTime: Self.start,
             workoutDuration: 14_400
         )
 
         #expect(dataSet.segments.count == 200)
-        #expect(dataSet.points.count <= HeartRateChartDataSet.maximumPlottedPointCount)
-        // No run is thinned out of existence - a segment that plotted nothing would
-        // read as a longer dropout than actually happened.
-        #expect(dataSet.segments.allSatisfy { $0.points.count == 2 })
+
+        let rawSegments = stride(from: 0, to: samples.count, by: Self.fragmentedSegmentLength).map { lowerBound in
+            samples[lowerBound..<(lowerBound + Self.fragmentedSegmentLength)].map(\.heartRate)
+        }
+        let everySegmentKeepsItsExtremes = zip(rawSegments, dataSet.segments).allSatisfy { rawRates, segment in
+            let plottedRates = segment.points.map(\.heartRate)
+            guard let lowest = rawRates.min(), let highest = rawRates.max() else { return false }
+            return plottedRates.contains(lowest) && plottedRates.contains(highest)
+        }
+        #expect(everySegmentKeepsItsExtremes)
+
+        #expect(dataSet.points.map(\.heartRate).min() == samples.map(\.heartRate).min())
+        #expect(dataSet.points.map(\.heartRate).max() == samples.map(\.heartRate).max())
     }
 
-    /// Past `maximumPlottedPointCount / 2` segments the endpoints alone exceed the
-    /// cap. This pins the documented worst case: two marks per segment, no more.
+    /// The honest worst case of preferring extremes over the target: four marks per
+    /// segment - endpoints plus the one bucket's low and high - so a pathological
+    /// 200-dropout trace overshoots `maximumPlottedPointCount` while still plotting a
+    /// small fraction of the raw series.
     @Test
-    func aTraceWithMoreSegmentsThanBudgetKeepsOnlyEndpoints() {
+    func aPathologicallyFragmentedTraceOvershootsTheTargetButStaysBounded() {
+        let samples = Self.fragmentedSession(segmentCount: 200)
         let dataSet = HeartRateChartDataSet(
-            samples: Self.fragmentedSession(segmentCount: 250),
+            samples: samples,
             workoutStartTime: Self.start,
-            workoutDuration: 18_000
+            workoutDuration: 14_400
         )
 
-        #expect(dataSet.segments.count == 250)
-        #expect(dataSet.points.count == 500)
-        #expect(dataSet.segments.allSatisfy { $0.points.count == 2 })
+        #expect(dataSet.points.count > HeartRateChartDataSet.maximumPlottedPointCount)
+        #expect(dataSet.points.count <= dataSet.segments.count * 4)
+        #expect(dataSet.points.count < samples.count / 3)
     }
 
     /// Thinning is a rendering concession, not a licence to misreport. The scrub
@@ -226,6 +250,58 @@ struct HeartRateChartDownsamplingTests {
 
         let resolved = try #require(dataSet.nearestScrubPoint(to: 1_234.4))
         #expect(resolved.elapsed == 1_234)
+    }
+
+    /// The lookup is a binary search over the raw series; it has to agree with a
+    /// scan of every sample, tie-breaking included, or the readout depends on how
+    /// the search happened to land.
+    @Test
+    func theScrubLookupMatchesAScanOfTheWholeSeries() {
+        let dataSet = HeartRateChartDataSet(
+            samples: Self.longSession(),
+            workoutStartTime: Self.start,
+            workoutDuration: 2_603
+        )
+        let probes: [TimeInterval] = [
+            -400, -0.4, 0, 0.4, 0.5, 0.6,
+            1_234, 1_234.4, 1_234.5, 1_234.6,
+            2_601.5, 2_602, 2_700
+        ]
+
+        let agrees = probes.allSatisfy { probe in
+            dataSet.nearestScrubPoint(to: probe) == Self.nearestByScan(in: dataSet.scrubPoints, to: probe)
+        }
+        #expect(agrees)
+    }
+
+    /// Samples recorded just before the workout start clamp to the same elapsed
+    /// value, so the lookup has to settle on the same one of them a scan would.
+    @Test
+    func theScrubLookupMatchesAScanWhenSamplesShareAnInstant() {
+        let samples = [-30, -20, -10, 0, 5, 6, 7].map { offset in
+            HeartRateDataPoint(
+                timestamp: Self.start.addingTimeInterval(TimeInterval(offset)),
+                heartRate: 140 + offset
+            )
+        }
+        let dataSet = HeartRateChartDataSet(
+            samples: samples,
+            workoutStartTime: Self.start,
+            workoutDuration: 60
+        )
+        let probes: [TimeInterval] = [-10, 0, 1, 2, 2.5, 5, 6.5, 40, 120]
+
+        let agrees = probes.allSatisfy { probe in
+            dataSet.nearestScrubPoint(to: probe) == Self.nearestByScan(in: dataSet.scrubPoints, to: probe)
+        }
+        #expect(agrees)
+    }
+
+    private static func nearestByScan(
+        in points: [HeartRateChartPoint],
+        to elapsed: TimeInterval
+    ) -> HeartRateChartPoint? {
+        points.min { abs($0.elapsed - elapsed) < abs($1.elapsed - elapsed) }
     }
 
     @Test

--- a/AscendAppTests/HeartRateChartDownsamplingTests.swift
+++ b/AscendAppTests/HeartRateChartDownsamplingTests.swift
@@ -35,6 +35,26 @@ struct HeartRateChartDownsamplingTests {
         }
     }
 
+    /// A strap that keeps cutting out: 13 seconds of 1 Hz capture, then a minute of
+    /// silence, repeated. Every gap clears the dropout threshold, so each run becomes
+    /// its own segment.
+    private static func fragmentedSession(segmentCount: Int) -> [HeartRateDataPoint] {
+        var samples: [HeartRateDataPoint] = []
+        for segment in 0..<segmentCount {
+            for second in 0..<13 {
+                let elapsed = TimeInterval(segment * 72 + second)
+                let heartRate: Int = 140 + (segment + second) % 23
+                samples.append(
+                    HeartRateDataPoint(
+                        timestamp: start.addingTimeInterval(elapsed),
+                        heartRate: heartRate
+                    )
+                )
+            }
+        }
+        return samples
+    }
+
     @Test
     func longSessionIsCappedToAPlottableNumberOfMarks() {
         let samples = Self.longSession()
@@ -136,6 +156,76 @@ struct HeartRateChartDownsamplingTests {
         )
 
         #expect(dataSet.segments.count == 1)
+    }
+
+    /// A fragmented trace still has to respect the cap. The budget is handed out
+    /// after every segment has reserved its own endpoints, so 200 dropouts land
+    /// exactly on the cap rather than blowing past it two marks at a time.
+    @Test
+    func aHeavilyFragmentedTraceStaysInsideTheCap() {
+        let dataSet = HeartRateChartDataSet(
+            samples: Self.fragmentedSession(segmentCount: 200),
+            workoutStartTime: Self.start,
+            workoutDuration: 14_400
+        )
+
+        #expect(dataSet.segments.count == 200)
+        #expect(dataSet.points.count <= HeartRateChartDataSet.maximumPlottedPointCount)
+        // No run is thinned out of existence - a segment that plotted nothing would
+        // read as a longer dropout than actually happened.
+        #expect(dataSet.segments.allSatisfy { $0.points.count == 2 })
+    }
+
+    /// Past `maximumPlottedPointCount / 2` segments the endpoints alone exceed the
+    /// cap. This pins the documented worst case: two marks per segment, no more.
+    @Test
+    func aTraceWithMoreSegmentsThanBudgetKeepsOnlyEndpoints() {
+        let dataSet = HeartRateChartDataSet(
+            samples: Self.fragmentedSession(segmentCount: 250),
+            workoutStartTime: Self.start,
+            workoutDuration: 18_000
+        )
+
+        #expect(dataSet.segments.count == 250)
+        #expect(dataSet.points.count == 500)
+        #expect(dataSet.segments.allSatisfy { $0.points.count == 2 })
+    }
+
+    /// Thinning is a rendering concession, not a licence to misreport. The scrub
+    /// readout resolves against the full series, so a sample the chart never plots
+    /// is still the value shown when the climber's finger is over it.
+    @Test
+    func scrubbingResolvesASampleThatThinningRemovedFromTheChart() throws {
+        let samples = Self.longSession()
+        let dataSet = HeartRateChartDataSet(
+            samples: samples,
+            workoutStartTime: Self.start,
+            workoutDuration: 2_603
+        )
+
+        #expect(dataSet.scrubPoints.count == samples.count)
+        #expect(dataSet.points.count < dataSet.scrubPoints.count)
+
+        let plottedIds = Set(dataSet.points.map(\.id))
+        let thinnedAway = try #require(dataSet.scrubPoints.first { plottedIds.contains($0.id) == false })
+        let resolved = try #require(dataSet.nearestScrubPoint(to: thinnedAway.elapsed))
+
+        #expect(resolved == thinnedAway)
+        #expect(resolved.heartRate == samples[thinnedAway.id].heartRate)
+    }
+
+    /// The "at m:ss" label has to name the touched moment, not the nearest surviving
+    /// mark several seconds away.
+    @Test
+    func scrubbingResolvesTheSampleClosestToTheTouchedTime() throws {
+        let dataSet = HeartRateChartDataSet(
+            samples: Self.longSession(),
+            workoutStartTime: Self.start,
+            workoutDuration: 2_603
+        )
+
+        let resolved = try #require(dataSet.nearestScrubPoint(to: 1_234.4))
+        #expect(resolved.elapsed == 1_234)
     }
 
     @Test

--- a/AscendAppTests/HeartRateChartDownsamplingTests.swift
+++ b/AscendAppTests/HeartRateChartDownsamplingTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+/// Regression cover for the activity detail screen's scroll stutter.
+///
+/// A 43-minute session stores one heart-rate sample per second, and the chart used
+/// to emit one `LineMark` per sample - 2,603 marks, ~114 ms to render, seven 60 Hz
+/// frames for a curve 362 points wide. These pin the cap and, just as importantly,
+/// pin the fidelity: a cheaper chart that loses the climber's peak would be a worse
+/// bug than the one being fixed.
+struct HeartRateChartDownsamplingTests {
+    private static let start = Date(timeIntervalSince1970: 1_750_300_000)
+
+    /// A full-length session shaped like the recording: hard ramp, plateau, a dip,
+    /// then interval spikes.
+    private static func longSession() -> [HeartRateDataPoint] {
+        var rate = 62.0
+        return (0..<2_603).map { second in
+            let elapsed = Double(second)
+            let target: Double
+            switch elapsed {
+            case ..<90: target = 62 + elapsed * 1.05
+            case ..<900: target = 150 + sin(elapsed / 70) * 6
+            case ..<1_000: target = 128
+            case ..<1_500: target = 165 + sin(elapsed / 50) * 5
+            case ..<2_400: target = 170 + sin(elapsed / 45) * 6
+            default: target = 150
+            }
+            rate += (target - rate) * 0.25
+            return HeartRateDataPoint(
+                timestamp: start.addingTimeInterval(elapsed),
+                heartRate: Int(rate.rounded())
+            )
+        }
+    }
+
+    @Test
+    func longSessionIsCappedToAPlottableNumberOfMarks() {
+        let samples = Self.longSession()
+        let dataSet = HeartRateChartDataSet(
+            samples: samples,
+            workoutStartTime: Self.start,
+            workoutDuration: 2_603
+        )
+
+        #expect(samples.count == 2_603)
+        #expect(dataSet.points.count <= HeartRateChartDataSet.maximumPlottedPointCount)
+        #expect(dataSet.canPlotLine)
+    }
+
+    @Test
+    func thinningKeepsTheRealPeakAndTrough() {
+        let samples = Self.longSession()
+        let dataSet = HeartRateChartDataSet(
+            samples: samples,
+            workoutStartTime: Self.start,
+            workoutDuration: 2_603
+        )
+
+        let rawRates = samples.map(\.heartRate)
+        let plottedRates = dataSet.points.map(\.heartRate)
+
+        #expect(plottedRates.max() == rawRates.max())
+        #expect(plottedRates.min() == rawRates.min())
+    }
+
+    @Test
+    func thinningKeepsTheCurveAnchoredToBothEndsOfTheSession() {
+        let samples = Self.longSession()
+        let dataSet = HeartRateChartDataSet(
+            samples: samples,
+            workoutStartTime: Self.start,
+            workoutDuration: 2_603
+        )
+
+        #expect(dataSet.points.first?.heartRate == samples.first?.heartRate)
+        #expect(dataSet.points.last?.heartRate == samples.last?.heartRate)
+        #expect(dataSet.points.first?.elapsed == 0)
+        #expect(dataSet.points.last?.elapsed == 2_602)
+    }
+
+    @Test
+    func plottedPointsStayInTimeOrder() {
+        let dataSet = HeartRateChartDataSet(
+            samples: Self.longSession(),
+            workoutStartTime: Self.start,
+            workoutDuration: 2_603
+        )
+
+        let elapsedValues = dataSet.points.map(\.elapsed)
+        #expect(elapsedValues == elapsedValues.sorted())
+    }
+
+    /// Thinning runs inside each dropout segment, never across the series, because
+    /// the gap threshold is derived from the samples' own median spacing - thinning
+    /// first would rewrite that spacing and invent or hide dropouts.
+    @Test
+    func aDropoutSurvivesThinningAsASeparateSegment() {
+        // Two 20-minute runs of 1 Hz capture with the strap silent in between.
+        let firstRun = (0..<1_200).map { second in
+            HeartRateDataPoint(
+                timestamp: Self.start.addingTimeInterval(TimeInterval(second)),
+                heartRate: 150 + second % 11
+            )
+        }
+        let secondRun = (0..<1_200).map { second in
+            HeartRateDataPoint(
+                timestamp: Self.start.addingTimeInterval(TimeInterval(1_500 + second)),
+                heartRate: 160 + second % 9
+            )
+        }
+
+        let dataSet = HeartRateChartDataSet(
+            samples: firstRun + secondRun,
+            workoutStartTime: Self.start,
+            workoutDuration: 2_700
+        )
+
+        #expect(dataSet.segments.count == 2)
+        #expect(dataSet.points.count <= HeartRateChartDataSet.maximumPlottedPointCount)
+        // Both runs still get marks - neither is thinned out of existence.
+        #expect(dataSet.segments.allSatisfy { $0.points.count >= 2 })
+        // The gap is still a gap: no plotted mark lands inside the silent window.
+        let gapPoints = dataSet.points.filter { $0.elapsed > 1_210 && $0.elapsed < 1_490 }
+        #expect(gapPoints.isEmpty)
+    }
+
+    /// A contiguous trace must not be split just because thinning spaced its marks out.
+    @Test
+    func aContinuousTraceStaysOneSegmentAfterThinning() {
+        let dataSet = HeartRateChartDataSet(
+            samples: Self.longSession(),
+            workoutStartTime: Self.start,
+            workoutDuration: 2_603
+        )
+
+        #expect(dataSet.segments.count == 1)
+    }
+
+    @Test
+    func shortSessionsArePlottedSampleForSample() {
+        let samples = (0..<120).map { second in
+            HeartRateDataPoint(
+                timestamp: Self.start.addingTimeInterval(TimeInterval(second)),
+                heartRate: 140 + second % 7
+            )
+        }
+        let dataSet = HeartRateChartDataSet(
+            samples: samples,
+            workoutStartTime: Self.start,
+            workoutDuration: 120
+        )
+
+        #expect(dataSet.points.count == samples.count)
+        #expect(dataSet.points.map(\.heartRate) == samples.map(\.heartRate))
+    }
+}

--- a/AscendAppTests/HeartRateChartRenderCostEvidenceTests.swift
+++ b/AscendAppTests/HeartRateChartRenderCostEvidenceTests.swift
@@ -1,0 +1,358 @@
+import Charts
+import Foundation
+import SwiftData
+import SwiftUI
+import Testing
+import UIKit
+@testable import AscendApp
+
+/// Renders the shipping heart-rate chart against the pre-fix mark set and writes the
+/// proof to disk.
+///
+/// The plotted marks are the whole cost: before the fix the chart handed Swift Charts
+/// one `LineMark` per raw sample, so this renders the same curve twice - once from the
+/// raw series (`scrubPoints`, which is exactly what used to be plotted) and once from
+/// the thinned series the view now plots - and compares both the wall-clock render
+/// cost and the resulting pixels.
+///
+/// Images land in the test host's temporary directory; the paths are printed so a run
+/// can lift them out for review.
+@MainActor
+struct HeartRateChartRenderCostEvidenceTests {
+    private static let start = Date(timeIntervalSince1970: 1_750_300_000)
+    private static let sessionSeconds = 2_603
+    private static let chartSize = CGSize(width: 362, height: 200)
+    private static let renderIterations = 5
+
+    @Test
+    func theThinnedChartDrawsTheSameCurveForAFractionOfTheRenderCost() throws {
+        let samples = Self.session()
+        let dataSet = HeartRateChartDataSet(
+            samples: samples,
+            workoutStartTime: Self.start,
+            workoutDuration: TimeInterval(Self.sessionSeconds)
+        )
+
+        // What the view plotted before the fix: every raw sample, segmented the same way.
+        let rawSegments = HeartRateChartDataSet.segments(for: dataSet.scrubPoints)
+        let rawMarkCount = rawSegments.reduce(0) { $0 + $1.points.count }
+        let thinnedMarkCount = dataSet.points.count
+
+        let before = Self.curve(segments: rawSegments, dataSet: dataSet)
+        let after = Self.curve(segments: dataSet.segments, dataSet: dataSet)
+
+        let beforeDuration = Self.medianRenderDuration(of: before)
+        let afterDuration = Self.medianRenderDuration(of: after)
+
+        let beforeImage = try #require(Self.render(before), "before image")
+        let afterImage = try #require(Self.render(after), "after image")
+        let difference = try Self.differingPixelFraction(beforeImage, afterImage)
+
+        let overlay = try #require(
+            Self.render(
+                ZStack {
+                    Color.black
+                    Self.curve(segments: rawSegments, dataSet: dataSet, color: .white, lineWidth: 7)
+                    Self.curve(segments: dataSet.segments, dataSet: dataSet, color: .red, lineWidth: 2)
+                }
+                .frame(width: Self.chartSize.width, height: Self.chartSize.height)
+            ),
+            "overlay image"
+        )
+
+        let full = try #require(
+            Self.render(
+                HeartRateChartView(
+                    heartRateData: samples,
+                    workoutStartTime: Self.start,
+                    workoutDuration: TimeInterval(Self.sessionSeconds),
+                    averageHeartRateBpm: 154,
+                    maxHeartRateBpm: samples.map(\.heartRate).max()
+                )
+                .padding(20)
+                .frame(width: 402)
+                .background(Color.black)
+                .environment(\.colorScheme, .dark)
+            ),
+            "full chart image"
+        )
+
+        let directory = try Self.evidenceDirectory()
+        try Self.write(beforeImage, to: directory, named: "heart-rate-chart-before.png")
+        try Self.write(afterImage, to: directory, named: "heart-rate-chart-after.png")
+        try Self.write(overlay, to: directory, named: "heart-rate-chart-overlay.png")
+        try Self.write(full, to: directory, named: "heart-rate-chart-full.png")
+
+        let rawRates = samples.map(\.heartRate)
+        let plottedRates = dataSet.points.map(\.heartRate)
+        let report = """
+        heart-rate chart render cost, \(Self.sessionSeconds / 60)m\(Self.sessionSeconds % 60)s session at 1 Hz
+          plotted marks   before \(rawMarkCount)   after \(thinnedMarkCount)
+          render (median of \(Self.renderIterations))   before \(Self.milliseconds(beforeDuration)) ms   after \(Self.milliseconds(afterDuration)) ms
+          differing pixels  \(String(format: "%.2f", difference * 100))%
+          peak BPM        raw \(rawRates.max() ?? 0)   plotted \(plottedRates.max() ?? 0)
+          trough BPM      raw \(rawRates.min() ?? 0)   plotted \(plottedRates.min() ?? 0)
+          axis range      \(dataSet.heartRateRange.lowerBound)...\(dataSet.heartRateRange.upperBound)
+          images          \(directory.path())
+        """
+        print(report)
+        try Data(report.utf8).write(to: directory.appending(path: "heart-rate-chart-render-cost.txt"))
+
+        #expect(rawMarkCount == Self.sessionSeconds)
+        #expect(thinnedMarkCount <= HeartRateChartDataSet.maximumPlottedPointCount)
+        #expect(plottedRates.max() == rawRates.max())
+        #expect(plottedRates.min() == rawRates.min())
+        #expect(
+            difference < 0.10,
+            "the thinned curve should trace the raw one, but \(String(format: "%.2f", difference * 100))% of pixels differ"
+        )
+    }
+
+    /// Screenshots the real activity detail screen for the session that stuttered, at
+    /// the top and mid-scroll, so the fix can be reviewed as the screen a climber sees.
+    @Test
+    func theActivityDetailScreenRendersTheSessionThatStuttered() throws {
+        let container = try ModelContainer(
+            for: Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            BestEffortCacheEntry.self,
+            BestEffortCacheMetadata.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+
+        let workout = Self.stutteringWorkout()
+        container.mainContext.insert(workout)
+
+        let host = UIHostingController(
+            rootView: WorkoutDetailView(workout: workout, embedsInNavigationStack: false)
+                .environment(AuthenticationViewModel())
+                .environment(MediaUploadManager.shared)
+                .modelContainer(container)
+        )
+
+        let scene = try #require(
+            UIApplication.shared.connectedScenes.first as? UIWindowScene,
+            "test host app should expose a live UIWindowScene"
+        )
+        let window = UIWindow(windowScene: scene)
+        window.frame = CGRect(x: 0, y: 0, width: 402, height: 874)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        defer {
+            window.rootViewController = nil
+            window.isHidden = true
+        }
+        Self.flush(window)
+
+        let scrollView = try #require(Self.firstScrollView(in: window), "detail ScrollView")
+        Self.flush(window)
+
+        let directory = try Self.evidenceDirectory()
+        Self.settle(window)
+        try Self.write(Self.snapshot(window), to: directory, named: "activity-detail-top.png")
+
+        // Just past the reveal threshold: the header takes the title over from the
+        // inline row.
+        scrollView.contentOffset = CGPoint(x: 0, y: WorkoutDetailView.navigationTitleRevealOffset + 40)
+        Self.settle(window)
+        try Self.write(Self.snapshot(window), to: directory, named: "activity-detail-title-revealed.png")
+
+        // Far enough down that the heart-rate chart - the expensive section - clears
+        // the header and sits fully on screen.
+        scrollView.contentOffset = CGPoint(x: 0, y: 330)
+        Self.settle(window)
+        try Self.write(Self.snapshot(window), to: directory, named: "activity-detail-heart-rate.png")
+
+        print("activity detail screenshots: \(directory.path())")
+        #expect(scrollView.contentSize.height > 1_400)
+    }
+
+    // MARK: - Fixtures
+
+    /// Hard ramp, plateau, a dip, then interval spikes - the shape of the recording.
+    private static func session() -> [HeartRateDataPoint] {
+        var rate = 62.0
+        return (0..<sessionSeconds).map { second in
+            let elapsed = Double(second)
+            let target: Double
+            switch elapsed {
+            case ..<90: target = 62 + elapsed * 1.05
+            case ..<900: target = 150 + sin(elapsed / 70) * 6
+            case ..<1_000: target = 128
+            case ..<1_500: target = 165 + sin(elapsed / 50) * 5
+            case ..<2_400: target = 170 + sin(elapsed / 45) * 6
+            default: target = 150
+            }
+            rate += (target - rate) * 0.25
+            return HeartRateDataPoint(
+                timestamp: start.addingTimeInterval(elapsed),
+                heartRate: Int(rate.rounded())
+            )
+        }
+    }
+
+    private static func stutteringWorkout() -> Workout {
+        let metadata = HeadphoneMotionWorkoutMetadata(
+            sampleCount: sessionSeconds * 50,
+            trackingMode: .routine,
+            climbId: nil,
+            targetStepCount: 4_134,
+            stopReason: .userStopped,
+            splitCurve: LiveReplaySplitCurve(
+                intervalSeconds: 300,
+                steps: [370, 876, 1_383, 1_840, 2_375, 2_835, 3_361, 3_895, 4_134]
+            )
+        )
+        let samples = session()
+
+        return Workout(
+            name: "Threshold Intervals",
+            date: start,
+            duration: TimeInterval(sessionSeconds),
+            steps: 4_134,
+            floors: 258,
+            avgHeartRate: 154,
+            maxHeartRate: samples.map(\.heartRate).max() ?? 177,
+            caloriesBurned: 669,
+            heartRateTimeSeries: samples,
+            averageMETs: 11.4,
+            source: .headphoneMotion,
+            sourceMetadata: metadata.jsonString
+        )
+    }
+
+    // MARK: - Rendering
+
+    private static func curve(
+        segments: [HeartRateChartSegment],
+        dataSet: HeartRateChartDataSet,
+        color: Color = .red,
+        lineWidth: CGFloat = 3
+    ) -> some View {
+        Chart {
+            ForEach(segments) { segment in
+                ForEach(segment.points) { point in
+                    LineMark(
+                        x: .value("Time", point.elapsed),
+                        y: .value("Heart Rate", point.heartRate),
+                        series: .value("Segment", segment.id)
+                    )
+                    .foregroundStyle(color)
+                    .lineStyle(StrokeStyle(lineWidth: lineWidth, lineCap: .round, lineJoin: .round))
+                }
+            }
+        }
+        .chartXScale(domain: 0...dataSet.duration)
+        .chartYScale(domain: dataSet.heartRateRange)
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+        .frame(width: chartSize.width, height: chartSize.height)
+    }
+
+    private static func render(_ view: some View) -> UIImage? {
+        let renderer = ImageRenderer(content: view)
+        renderer.scale = 2
+        return renderer.uiImage
+    }
+
+    /// Median rather than mean so a single scheduling hiccup on a loaded machine does
+    /// not decide the number.
+    private static func medianRenderDuration(of view: some View) -> Duration {
+        _ = render(view) // warm the font and chart machinery
+        let samples = (0..<renderIterations)
+            .map { _ in ContinuousClock().measure { _ = render(view) } }
+            .sorted()
+        return samples[samples.count / 2]
+    }
+
+    private static func snapshot(_ window: UIWindow) -> UIImage {
+        UIGraphicsImageRenderer(bounds: window.bounds).image { _ in
+            window.drawHierarchy(in: window.bounds, afterScreenUpdates: true)
+        }
+    }
+
+    private static func milliseconds(_ duration: Duration) -> String {
+        let value = Double(duration.components.seconds) * 1_000
+            + Double(duration.components.attoseconds) / 1e15
+        return String(format: "%.1f", value)
+    }
+
+    // MARK: - Pixel comparison
+
+    /// Share of pixels whose colour differs by more than an antialiasing wobble.
+    private static func differingPixelFraction(_ lhs: UIImage, _ rhs: UIImage) throws -> Double {
+        let left = try pixels(of: lhs)
+        let right = try pixels(of: rhs)
+        #expect(left.count == right.count, "images should share a size")
+
+        var differing = 0
+        for index in stride(from: 0, to: min(left.count, right.count), by: 4) {
+            let delta = (0..<4).reduce(0) { running, channel in
+                max(running, abs(Int(left[index + channel]) - Int(right[index + channel])))
+            }
+            if delta > 32 { differing += 1 }
+        }
+        return Double(differing) / Double(left.count / 4)
+    }
+
+    private static func pixels(of image: UIImage) throws -> [UInt8] {
+        let cgImage = try #require(image.cgImage, "image should be CG backed")
+        let width = cgImage.width
+        let height = cgImage.height
+        var buffer = [UInt8](repeating: 0, count: width * height * 4)
+        let context = try #require(
+            CGContext(
+                data: &buffer,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ),
+            "bitmap context"
+        )
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return buffer
+    }
+
+    // MARK: - Files
+
+    private static func evidenceDirectory() throws -> URL {
+        let directory = URL(filePath: NSTemporaryDirectory())
+            .appending(path: "heart-rate-chart-evidence")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private static func write(_ image: UIImage, to directory: URL, named name: String) throws {
+        let png = try #require(image.pngData(), "\(name) should encode to PNG")
+        try png.write(to: directory.appending(path: name))
+    }
+
+    // MARK: - Hosting helpers
+
+    private static func flush(_ window: UIWindow) {
+        window.layoutIfNeeded()
+        CATransaction.flush()
+        RunLoop.current.run(until: Date())
+    }
+
+    /// A screenshot taken the instant after a scroll catches Swift Charts mid-draw, so
+    /// let the render loop run itself out before capturing.
+    private static func settle(_ window: UIWindow) {
+        for _ in 0..<5 {
+            flush(window)
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+    }
+
+    private static func firstScrollView(in view: UIView) -> UIScrollView? {
+        if let scrollView = view as? UIScrollView { return scrollView }
+        for subview in view.subviews {
+            if let found = firstScrollView(in: subview) { return found }
+        }
+        return nil
+    }
+}

--- a/AscendAppTests/HeartRateChartRenderCostEvidenceTests.swift
+++ b/AscendAppTests/HeartRateChartRenderCostEvidenceTests.swift
@@ -15,8 +15,12 @@ import UIKit
 /// the thinned series the view now plots - and compares both the wall-clock render
 /// cost and the resulting pixels.
 ///
-/// Images land in the test host's temporary directory; the paths are printed so a run
-/// can lift them out for review.
+/// Images land in `ASCEND_EVIDENCE_DIR` when it is set, and in the test host's temporary
+/// directory otherwise; the paths are printed so a run can lift them out for review.
+///
+/// The render timings are printed for the record and never asserted - a wall-clock
+/// threshold would flake on a loaded runner. Only the mark counts, the preserved
+/// min/max envelope, and the pixel-difference bound are assertions.
 @MainActor
 struct HeartRateChartRenderCostEvidenceTests {
     private static let start = Date(timeIntervalSince1970: 1_750_300_000)
@@ -319,9 +323,13 @@ struct HeartRateChartRenderCostEvidenceTests {
 
     // MARK: - Files
 
+    /// The harness-provided override when present, otherwise the always-writable temp
+    /// dir. Never a hardcoded machine path - that exists only on one Mac and fails on
+    /// CI runners.
     private static func evidenceDirectory() throws -> URL {
-        let directory = URL(filePath: NSTemporaryDirectory())
-            .appending(path: "heart-rate-chart-evidence")
+        let base = ProcessInfo.processInfo.environment["ASCEND_EVIDENCE_DIR"]
+            ?? NSTemporaryDirectory()
+        let directory = URL(filePath: base).appending(path: "heart-rate-chart-evidence")
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
     }

--- a/AscendAppTests/WorkoutDetailScrollHostingTests.swift
+++ b/AscendAppTests/WorkoutDetailScrollHostingTests.swift
@@ -58,6 +58,10 @@ struct WorkoutDetailScrollHostingTests {
         window.frame = CGRect(x: 0, y: 0, width: 402, height: 874)
         window.rootViewController = host
         window.makeKeyAndVisible()
+        defer {
+            window.rootViewController = nil
+            window.isHidden = true
+        }
         Self.flush(window)
 
         let scrollView = try #require(

--- a/AscendAppTests/WorkoutDetailScrollHostingTests.swift
+++ b/AscendAppTests/WorkoutDetailScrollHostingTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import SwiftData
+import SwiftUI
+import Testing
+import UIKit
+@testable import AscendApp
+
+/// Drives a real scroll on the real activity detail screen.
+///
+/// The screen is hosted in a `UIHostingController` on the test host app's live
+/// window scene - a detached window has no display link, so SwiftUI never runs its
+/// update loop in one and every measurement taken there reads as free - and the
+/// `UIScrollView` SwiftUI created is driven a display frame's worth at a time.
+///
+/// What this covers: the screen still builds and scrolls for the shape of activity
+/// that stuttered (43 minutes, nine pace splits, a per-second heart-rate trace), and
+/// a whole drag stays far inside a loose wall-clock bound.
+///
+/// What it cannot cover: the frame drops the captain saw are rasterization cost on
+/// device, and neither this harness nor any other test in this target observes the
+/// render server. `HeartRateChartDownsamplingTests` pins the mark count that drives
+/// that cost instead.
+@MainActor
+struct WorkoutDetailScrollHostingTests {
+    /// Two seconds of 60 Hz scrolling - the length of the drag in the recording.
+    private static let scrollTickCount = 120
+
+    /// Loose on purpose: it guards the order of magnitude, not a machine's speed, so
+    /// it cannot flake on a loaded CI runner. Measured well under 100 ms locally.
+    private static let scrollBudget: Duration = .milliseconds(1_500)
+
+    @Test
+    func theScreenScrollsWithoutPerTickWork() throws {
+        let container = try ModelContainer(
+            for: Workout.self,
+            WorkoutSourceLink.self,
+            WorkoutParticipation.self,
+            BestEffortCacheEntry.self,
+            BestEffortCacheMetadata.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+
+        let workout = Self.thresholdIntervalsWorkout()
+        container.mainContext.insert(workout)
+
+        let host = UIHostingController(
+            rootView: WorkoutDetailView(workout: workout, embedsInNavigationStack: false)
+                .environment(AuthenticationViewModel())
+                .environment(MediaUploadManager.shared)
+                .modelContainer(container)
+        )
+
+        let scene = try #require(
+            UIApplication.shared.connectedScenes.first as? UIWindowScene,
+            "test host app should expose a live UIWindowScene"
+        )
+        let window = UIWindow(windowScene: scene)
+        window.frame = CGRect(x: 0, y: 0, width: 402, height: 874)
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        Self.flush(window)
+
+        let scrollView = try #require(
+            Self.firstScrollView(in: window),
+            "the no-photo layout should render a ScrollView"
+        )
+        Self.flush(window)
+
+        // Every section of the recording's screen has to be laid out for this to be
+        // a fair drive; a blank or truncated hierarchy would scroll for free.
+        #expect(
+            scrollView.contentSize.height > 1_400,
+            "expected the full detail content, got \(scrollView.contentSize)"
+        )
+
+        let pointsPerTick: CGFloat = 6
+        let elapsed = ContinuousClock().measure {
+            for tick in 1...Self.scrollTickCount {
+                scrollView.contentOffset = CGPoint(x: 0, y: CGFloat(tick) * pointsPerTick)
+                Self.flush(window)
+            }
+        }
+
+        #expect(
+            elapsed < Self.scrollBudget,
+            """
+            \(Self.scrollTickCount) scroll ticks took \(elapsed), over the \
+            \(Self.scrollBudget) budget - the screen is doing per-tick work again. \
+            Check for scroll position written into view state on every tick, and for \
+            derived values (pace splits, heart-rate series, chart data set) rebuilt \
+            inside the view body rather than resolved once per pass.
+            """
+        )
+    }
+
+    // MARK: - Fixtures
+
+    /// The activity from the recording: a 43:23 headphone-motion session with nine
+    /// pace splits and a full per-second heart-rate trace.
+    ///
+    /// `.routine` with no template id renders every section the recording shows while
+    /// resolving to a nil leaderboard context, so `.task` never reaches for the
+    /// network and the drive stays deterministic.
+    private static func thresholdIntervalsWorkout() -> Workout {
+        let start = Date(timeIntervalSince1970: 1_750_300_000)
+        let durationSeconds = 2_603
+        let metadata = HeadphoneMotionWorkoutMetadata(
+            sampleCount: durationSeconds * 50,
+            trackingMode: .routine,
+            climbId: nil,
+            targetStepCount: 4_134,
+            stopReason: .userStopped,
+            splitCurve: LiveReplaySplitCurve(
+                intervalSeconds: 300,
+                steps: [370, 876, 1_383, 1_840, 2_375, 2_835, 3_361, 3_895, 4_134]
+            )
+        )
+
+        return Workout(
+            name: "Threshold Intervals",
+            date: start,
+            duration: TimeInterval(durationSeconds),
+            steps: 4_134,
+            floors: 258,
+            avgHeartRate: 154,
+            maxHeartRate: 177,
+            caloriesBurned: 669,
+            heartRateTimeSeries: (0..<durationSeconds).map { second in
+                HeartRateDataPoint(
+                    timestamp: start.addingTimeInterval(TimeInterval(second)),
+                    heartRate: 150 + Int((sin(Double(second) / 90) * 20).rounded())
+                )
+            },
+            averageMETs: 11.4,
+            source: .headphoneMotion,
+            sourceMetadata: metadata.jsonString
+        )
+    }
+
+    // MARK: - Hosting helpers
+
+    /// Runs the render loop far enough that SwiftUI has applied the invalidations the
+    /// tick produced, so the loop measures the work rather than the queuing of it.
+    private static func flush(_ window: UIWindow) {
+        window.layoutIfNeeded()
+        CATransaction.flush()
+        RunLoop.current.run(until: Date())
+    }
+
+    private static func firstScrollView(in view: UIView) -> UIScrollView? {
+        if let scrollView = view as? UIScrollView {
+            return scrollView
+        }
+        for subview in view.subviews {
+            if let found = firstScrollView(in: subview) {
+                return found
+            }
+        }
+        return nil
+    }
+}

--- a/AscendAppTests/WorkoutDetailScrollWorkTests.swift
+++ b/AscendAppTests/WorkoutDetailScrollWorkTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import SwiftUI
+import Testing
+@testable import AscendApp
+
+/// The activity detail screen's per-scroll and per-render work contracts.
+struct WorkoutDetailScrollWorkTests {
+    /// The nav-bar title reveal is the only thing the detail screen derives from the
+    /// scroll position. Fed a whole drag, the value it keys on must change once per
+    /// threshold crossing - not once per tick, which is what the replaced
+    /// `GeometryReader` + `onChange(of: minY)` overlay produced.
+    @Test
+    func aFullScrollFlipsTheNavigationTitleOnlyAtTheCrossings() {
+        // Scroll down past the threshold, then back up: 200 ticks, two crossings.
+        let downwards = stride(from: CGFloat(0), through: 600, by: 6)
+        let upwards = stride(from: CGFloat(600), through: 0, by: -6)
+        let trace = Array(downwards) + Array(upwards)
+
+        let reveals = trace.map { WorkoutDetailView.revealsNavigationTitle(scrolledDistance: $0) }
+        let changes = zip(reveals, reveals.dropFirst()).count { $0 != $1 }
+
+        #expect(trace.count == 202)
+        #expect(changes == 2)
+    }
+
+    @Test
+    func theTitleStaysHiddenWhileTheInlineTitleIsStillOnScreen() {
+        #expect(WorkoutDetailView.revealsNavigationTitle(scrolledDistance: 0) == false)
+        #expect(WorkoutDetailView.revealsNavigationTitle(scrolledDistance: -40) == false)
+        #expect(
+            WorkoutDetailView.revealsNavigationTitle(
+                scrolledDistance: WorkoutDetailView.navigationTitleRevealOffset
+            ) == false
+        )
+        #expect(
+            WorkoutDetailView.revealsNavigationTitle(
+                scrolledDistance: WorkoutDetailView.navigationTitleRevealOffset + 1
+            )
+        )
+    }
+
+    // MARK: - Derived content
+
+    /// `WorkoutDetailDerivedContent` exists so one render pass decodes the
+    /// headphone-motion metadata and the heart-rate blob once each. That "once" is
+    /// carried by the initialiser's shape rather than by a counter, so what is
+    /// asserted here is that it answers everything the body needs - if any of these
+    /// were missing, the body would have to re-derive it per reader again.
+    @Test
+    func derivedContentAnswersEverythingTheBodyNeedsForALiveSession() throws {
+        let workout = Self.thresholdIntervalsWorkout()
+        let derived = WorkoutDetailDerivedContent(workout: workout)
+
+        #expect(derived.liveClimbMetadata != nil)
+        #expect(derived.canOpenLiveClimbSummary)
+        #expect(derived.heartRateSeries.isEmpty == false)
+        #expect(derived.heartRateSeries.count == 2_603)
+        #expect(derived.showsPaceSplits)
+        #expect(derived.paceSplits.count == 9)
+    }
+
+    @Test
+    func derivedContentIsEmptyForAManualEntry() {
+        let workout = Workout(
+            name: "Manual Session",
+            duration: 1_800,
+            steps: 2_000,
+            floors: 125
+        )
+        let derived = WorkoutDetailDerivedContent(workout: workout)
+
+        #expect(derived.liveClimbMetadata == nil)
+        #expect(derived.canOpenLiveClimbSummary == false)
+        #expect(derived.heartRateSeries.isEmpty)
+        #expect(derived.showsPaceSplits == false)
+        #expect(derived.paceSplits.isEmpty)
+    }
+
+    /// A session whose recorder never captured intermediate checkpoints must not get
+    /// a splits section - those "splits" would be a straight line reconstructed from
+    /// the final total. This is the rule the view used to own inline.
+    @Test
+    func derivedContentHidesSplitsWhenNoIntermediateCheckpointsWereRecorded() {
+        let workout = Self.thresholdIntervalsWorkout(splitSteps: [0, 0, 4_134])
+        let derived = WorkoutDetailDerivedContent(workout: workout)
+
+        #expect(derived.canOpenLiveClimbSummary)
+        #expect(derived.showsPaceSplits == false)
+    }
+
+    // MARK: - Fixtures
+
+    private static func thresholdIntervalsWorkout(
+        splitSteps: [Int] = [370, 876, 1_383, 1_840, 2_375, 2_835, 3_361, 3_895, 4_134]
+    ) -> Workout {
+        let start = Date(timeIntervalSince1970: 1_750_300_000)
+        let durationSeconds = 2_603
+        let metadata = HeadphoneMotionWorkoutMetadata(
+            sampleCount: durationSeconds * 50,
+            trackingMode: .routine,
+            climbId: nil,
+            targetStepCount: 4_134,
+            stopReason: .userStopped,
+            splitCurve: LiveReplaySplitCurve(intervalSeconds: 300, steps: splitSteps)
+        )
+
+        return Workout(
+            name: "Threshold Intervals",
+            date: start,
+            duration: TimeInterval(durationSeconds),
+            steps: 4_134,
+            floors: 258,
+            avgHeartRate: 154,
+            maxHeartRate: 177,
+            caloriesBurned: 669,
+            heartRateTimeSeries: (0..<durationSeconds).map { second in
+                HeartRateDataPoint(
+                    timestamp: start.addingTimeInterval(TimeInterval(second)),
+                    heartRate: 150 + Int((sin(Double(second) / 90) * 20).rounded())
+                )
+            },
+            averageMETs: 11.4,
+            source: .headphoneMotion,
+            sourceMetadata: metadata.jsonString
+        )
+    }
+}


### PR DESCRIPTION
## Before / after measurements

The defect, measured rather than asserted. Frame-differencing the captain's screen recording of the ~6 s drag, against Strava scrolled on the same device seconds later in the same recording:

| | activity detail (Ascend) | Strava (control) |
|---|---|---|
| Frames identical to their predecessor | 71 | 0 of 121 |
| Hitches (static run that then resumes at full scroll velocity) | 24 | 0 |
| Scroll time rendering nothing | ~1.19 s | 0 |

Static frames were separated from benign finger-pauses by checking whether motion resumed at velocity (hitch) or ramped from rest (pause): 24 hitches vs 5 pauses.

The cost, and what the fix does to it:

| | before | after |
|---|---|---|
| Plotted `LineMark`s, 43-minute session | 2,603 | 335 (target 400) |
| Full chart view render (`ImageRenderer` @3x) | **114 ms** | **11 ms** |
| Curve render, median of 5 (committed evidence test) | **29.6 ms** | **4.2 ms** |
| Curve pixels differing before vs after | — | 0.58 % |
| Peak / trough BPM preserved | — | raw 176/62, plotted 176/62 |
| Duplicated derivation per render pass | ~13 ms | ~4 ms |
| Metadata decodes · pace-split rebuilds · HR blob decodes · chart data-set builds, per pass | 7 · 2 · 3 · 8 | 1 · 1 · 1 · 1 |

The two render rows measure different scopes - the full chart view including header and axes, versus the curve alone - which is why the absolute numbers differ. Both show the same ~8-10x reduction, and the mark count is the cause in both.

At 114 ms, a single chart render is seven 60 Hz frames. That is the hitch.

## Scrub accuracy

Capping the plotted marks initially thinned the array the scrub lookup searched, which would have made the "### BPM at m:ss" readout snap to each ~13 s bucket's min/max - a local extreme rather than the reading under the finger. The review caught it and the product owner ruled on it directly: **minimising overhead is not a licence to cut accuracy**.

So the data set now keeps the full raw series purely for the scrub lookup, resolved by binary search, while the plotted marks stay capped. The BPM shown while scrubbing and its time label are exact against the raw series, at no rendering cost.

The same rule then decided a second-order regression: a hard numeric mark cap was dropping short segments' interior peaks. The cap is now an honest soft target - every segment keeps its own extremes, the real worst case is documented on the constant, and a pathologically fragmented trace is pinned by a test. Accuracy over the round number.

One acknowledged visual consequence: the selection dot is drawn at a raw sample's BPM while the line under it is the thinned polyline, so it can sit 2-5 pt off the drawn curve. Horizontal position and the time label are exact.

## Audit: does this pattern exist elsewhere?

The captain asked for an audit of the class, not just a fix of the instance.

**Fixed - trivially the same one-line change:**
- `LiveClimbCompletionSummaryView` derived `paceSplits` **11x** per body pass, each a metadata decode plus a full curve rebuild. It already had an `init`, so hoisting to a stored `let` was the same edit. This is the screen in the captain's second recording.

**Checked and clean:**
- `ProgressLineChartView`, `ProfileWeeklyStepsChart`, `AscendTrendChart` - all plot bounded data (workouts, weekly buckets, pace splits), never raw sensor samples, so no per-sample mark explosion.
- `AppSheet`, `RoutineDetailView` - preference-key writes are guarded or size-based, not per-scroll-tick.
- `WorkoutListHeaderView` - `GeometryReader` used for slider layout only; writes no state.
- No polling timers on this screen; the app's timers belong to live sessions and are cancelled with them.

**Found, filed, not fixed (out of scope per the task):**
- `DraggableDetailSheet` writes `sheetOffset` into `WorkoutDetailView`'s state on **every drag frame**, and unlike the two dead writes removed here, that one **is** read - it drives hero height and opacity - so it genuinely invalidates the whole screen per drag frame on workouts with photos. Still a strict improvement over `develop` on that path (1x per pass instead of 8x), but the real fix scopes the hero's offset to a child view rather than routing it through root state. Not the same line of code, so not folded in here.
- `WorkoutPaceSplitsSection` draws a blurred `.shadow` per split bar (9 per screen) - a known GPU cost in a scrolling list, but changing it changes the visual design, so it belongs to a design decision rather than this fix.

## Honest limits

- The hosting test would **not** have caught this bug, and its doc comment says so. The frame drops are device rasterization cost, and nothing in this test target observes the render server. The mark-count tests pin the cause instead.
- The "before" side of the evidence test is reconstructed in-process from the raw series - exactly what the old code plotted - rather than by building the base commit, so both sides run on identical data in one binary.
- The Release compile check could not run locally: `GoogleService-Info-Production.plist` has never existed on this machine (pre-existing, unrelated to this change). CI covers it.

---

## Intent

Fix the bug the captain reproduced on device: the activity (workout) detail screen feels laggy while scrolling - "the screen seems like it's updating over and over and over again". He has ruled this class of problem a correctness defect, not polish: the app "should be 100% correct, and should not drain battery or consume processing any more than it needs", so "recomputes on every render", "builds N views eagerly", and "never cancels" count as defects, and closing it by calling it acceptable was explicitly not allowed.

Required approach, which explains several choices in the diff: reproduce end-to-end before theorising, prove the cause with a counterfactual rather than fixing the first plausible candidate, state what would disprove the explanation and go looking for it, and include a before/after measurement rather than an assertion.

What was actually found. The obvious suspect - a dead scrollContentOffset @State written on every scroll tick - was DISPROVED by a control experiment: SwiftUI only invalidates views that read a @State, so 120 scroll ticks produced 0 body evaluations. Frame-differencing the captain's screen recording instead showed dropped frames: 24 hitches / 71 frames identical to their predecessor then resuming at full scroll velocity (~1.19s of a ~6s drag rendering nothing), against Strava on the same device in the same recording dropping 0 of 121. The measured cause is the heart-rate chart emitting one Swift Charts LineMark per raw sample - 2,603 marks for a 43-minute session - costing 114ms per render, seven 60Hz frames.

Deliberate decisions a reviewer would not infer from the diff:
- The chart is capped at 400 plotted marks using a min/max-preserving bucket downsample rather than every-Nth sampling, specifically so peaks and troughs (the part a climber reads, and the Max BPM figure) survive. Verified plotted min/max equal raw min/max exactly, and the axis range is computed over the FULL series, not the thinned subset. One render: 114ms -> 11ms.
- develop already had dropout segmentation whose gap threshold derives from the samples' own median spacing. Thinning therefore runs INSIDE each segment, after segmentation on the raw series - doing it the other way round would rewrite the spacing the threshold is derived from and invent or hide dropouts. Two tests cover exactly that interaction, and develop's existing segmentation tests still pass.
- WorkoutDetailDerivedContent resolves per-pass derivations once (metadata decode 7x->1, pace-split rebuild 2x->1, chart data set 8x->1; ~13ms -> ~4ms per pass). develop had independently fixed the heart-rate decode half of this; the merge keeps develop's heartRateSectionIfNeeded shape and its remote heart-rate restore card, sourcing the samples from the single per-pass decode.
- I deliberately did NOT add a @State cache for that derived content, even though it would remove per-frame cost during a photo-sheet drag. Workout is a SwiftData @Model that sync can mutate at any time, and a manually-invalidated cache is a correctness risk not worth ~4ms. Intentional tradeoff, not an oversight.
- Two per-tick scroll state writes (the GeometryReader overlay here, the preference key in ScrollableDetailContent) were replaced with onScrollGeometryChange deriving only the boolean each needs. These were wasted work, NOT the cause of the hitching - the commit message says so rather than overclaiming.
- The nav-title reveal threshold moved from "global minY < -40" (device-dependent, ~99pt on the captain's device) to "contentOffset+inset > 100" (device-independent). Behaviour is intentionally equivalent, not identical.
- Three unstructured Tasks the screen started are now owned and cancelled on disappear (required by the task's acceptance criteria).
- LiveClimbCompletionSummaryView had the identical defect (paceSplits derived 11x per pass) and was fixed because it is trivially the same one-line change; the task scoped other instances to findings-only, so the remaining one (DraggableDetailSheet writing per drag frame into root state that IS read) is reported in the PR body rather than fixed.

Tests: HeartRateChartDownsamplingTests pins the cap, the fidelity and the segment interaction, and the cap test was verified to FAIL on the previous behaviour (2603 <= 400). WorkoutDetailScrollWorkTests covers the nav-title reveal collapsing a 202-tick trace to exactly 2 transitions plus the derived-content contract. WorkoutDetailScrollHostingTests drives a real scroll on the real screen hosted on the test host's live window scene; its doc comment deliberately states it would NOT have caught this bug, because the frame drops are device rasterization cost no test in this target can observe - that honesty is intended, not a gap to close.

Full iOS suite on the develop base: 533 tests in 100 suites pass. The Release compile check cannot run in this worktree because GoogleService-Info-Production.plist has never existed on this machine (pre-existing environment limitation, unrelated to this change); CI covers it.

Branch note: the worktree was handed over based on main's tip, but this project's PRs target develop. The branch was rebased onto origin/develop so it carries only this one commit; the PR must target develop, never main.

## What Changed

- `HeartRateChartView` now downsamples the plotted series to a target of 400 marks instead of emitting one Swift Charts `LineMark` per raw sample (2,603 for a 43-minute session). Thinning is min/max-preserving and runs inside each dropout segment, after develop's existing median-spacing segmentation, so peaks, troughs and gap detection are unchanged; the axis range is still computed over the full series. One render measured 114 ms -> 11 ms. The scrub readout resolves against the raw samples via binary search, so the "### BPM at m:ss" value stays exact. The 400 target holds for continuous traces and normal dropout counts; a pathologically fragmented trace can overshoot it by design, since each segment keeps its own extremes - documented on the constant and pinned by a test.
- New `WorkoutDetailDerivedContent` resolves the screen's per-pass derivations once and threads them down (headphone-motion metadata decode 7x -> 1, pace-split rebuild 2x -> 1, heart-rate chart data set 8x -> 1, ~13 ms -> ~4 ms per pass). `LiveClimbCompletionSummaryView` had the same defect (pace splits derived 11x per pass) and got the same fix. No `@State` cache was added: `Workout` is a SwiftData `@Model` that sync can mutate, and manual invalidation is a correctness risk not worth ~4 ms.
- Two per-tick scroll state writes - the detail screen's `GeometryReader` overlay and `ScrollableDetailContent`'s preference key - now derive only the boolean each needs via `onScrollGeometryChange`, and the nav-title reveal threshold moved from a device-dependent global `minY` to a device-independent `contentOffset + inset`. These were wasted work, not the cause of the hitching. The screen's three unstructured `Task`s are now owned and cancelled on disappear. New `HeartRateChartDownsamplingTests`, `WorkoutDetailScrollWorkTests`, `WorkoutDetailScrollHostingTests` and `HeartRateChartRenderCostEvidenceTests` cover the cap, fidelity, segmentation interaction, and before/after render cost.

Known and deliberately not fixed here: `DraggableDetailSheet` writes `sheetOffset` per drag frame into root state that the layout reads, so a workout with photos re-runs the derived content on each drag frame - still 1x per pass instead of develop's 8x, but worth its own change.

## Risk Assessment

✅ Low: Both round-2 findings are fixed correctly and are now pinned by tests I verified by hand - the binary search matches a full scan on every branch including tie-breaking, and per-segment extremes are restored - leaving only a misleading helper name and an informational note about an explicitly authorised, well-documented deviation.

## Testing

Ran the targeted chart/scroll/pace-split suites and then the full iOS suite on the iPhone 17 Pro simulator - 543 tests, 0 failures - after fixing two local setup blockers (the sandbox-blocked staging Firebase plist symlink, and the missing iPhone 16 Pro runtime). Because passing tests alone do not show the intent, I added an evidence test that renders the shipped chart against the pre-fix mark set for the same 2,603-sample 43-minute session: marks fall 2,603 to 335 and median render 29.6 ms to 4.2 ms, the two curves differ by 0.58% of pixels, and plotted peak/trough match the raw series exactly, with an overlay PNG showing the thinned curve tracing the raw one spike for spike. A second evidence test hosts the real WorkoutDetailView on a live window scene and screenshots the actual end-user screen at the top, at the nav-title reveal crossing (header correctly takes over title and date past 100pt), and with the heart-rate chart fully on screen. The "before" side is reconstructed in-process from the raw series - exactly what the old code plotted - rather than by building the base commit, so both sides run on identical data in one binary; frame-level device hitching itself remains unobservable from this target, as the author's own doc comment states. The Release compile check was not attempted because GoogleService-Info-Production.plist does not exist on this machine, a pre-existing limitation CI covers.

- Evidence: Pre-fix vs shipped chart curve overlay (white = all 2,603 raw marks, red = 335 thinned marks) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYWG85NM98W3ANC44X9F4W8F/heart-rate-chart-overlay.png</code>)
<details>
<summary>Evidence: Render cost + fidelity report</summary>

<code>heart-rate chart render cost, 43m23s session at 1 Hz&#10;plotted marks before 2603 after 335&#10;render (median of 5) before 29.6 ms after 4.2 ms&#10;differing pixels 0.58%&#10;peak BPM raw 176 plotted 176&#10;trough BPM raw 62 plotted 62&#10;axis range 50...188</code>

```text
heart-rate chart render cost, 43m23s session at 1 Hz
  plotted marks   before 2603   after 335
  render (median of 5)   before 30.0 ms   after 4.2 ms
  differing pixels  0.58%
  peak BPM        raw 176   plotted 176
  trough BPM      raw 62   plotted 62
  axis range      50...188
  images          /Users/tylerpavay/Library/Developer/CoreSimulator/Devices/DC178358-9383-496A-A885-050EC9F6FD0D/data/Containers/Data/Application/DAF33E4B-00E7-4C3D-9A93-C983DF2210DD/tmp/heart-rate-chart-evidence
```
</details>
- Evidence: Activity detail screen, top of scroll (real WorkoutDetailView on a live window scene) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYWG85NM98W3ANC44X9F4W8F/activity-detail-top.png</code>)
- Evidence: Activity detail screen past the 100pt nav-title reveal threshold - header shows title and date (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYWG85NM98W3ANC44X9F4W8F/activity-detail-title-revealed.png</code>)
- Evidence: Activity detail screen scrolled to the heart-rate chart - full 43:23 trace, Max 176 intact (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYWG85NM98W3ANC44X9F4W8F/activity-detail-heart-rate.png</code>)
- Evidence: Shipped heart-rate chart section rendered standalone (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYWG85NM98W3ANC44X9F4W8F/heart-rate-chart-full.png</code>)
- Evidence: Curve rendered from all 2,603 raw marks (pre-fix) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYWG85NM98W3ANC44X9F4W8F/heart-rate-chart-before.png</code>)
- Evidence: Curve rendered from the 335 thinned marks (shipped) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KYWG85NM98W3ANC44X9F4W8F/heart-rate-chart-after.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `AscendApp/Features/Workouts/Views/HeartRateChartView.swift:67` - `points` is now the thinned mark set, and `computedSelectedPoint` (line 258) resolves the scrub selection against it. For a 43-minute session only each ~13s bucket&#39;s min and max remain selectable, so the &#34;### BPM&#34; readout is systematically a local extreme rather than the reading at the touched time, and the &#34;at m:ss&#34; label can be off by several seconds. The intent&#39;s fidelity argument covers the drawn curve and Max BPM but not the scrub readout. The raw points are already built in the initializer, so keeping them (or a parallel raw array) for the nearest-point lookup would restore exact scrub values at no rendering cost.
- ⚠️ `AscendAppTests/WorkoutDetailScrollHostingTests.swift:60` - The test creates a `UIWindow` on the host app&#39;s scene, calls `makeKeyAndVisible()`, and never tears it down. A live `WorkoutDetailView` - with its `.task`, its `UIApplication.willEnterForegroundNotification` subscription, and an in-memory `ModelContainer` - stays mounted as the key window for the rest of the 533-test process, which is exactly the kind of cross-test state that produces flakiness. Add a `defer { window.isHidden = true; window.rootViewController = nil }` immediately after `makeKeyAndVisible()` so the teardown survives the `#require` throws below it.
- ⚠️ `AscendApp/Features/Workouts/Models/WorkoutDetailDerivedContent.swift:63` - `paceSplits` is built for every workout whose metadata decodes, and only afterwards gated by `isInAppSensorWorkout` and `hasRecordedPaceSplitData`. develop evaluated those two predicates first and skipped `LiveClimbWorkoutSummaryData.paceSplits` entirely when either failed. Since `paceSplits` -&gt; `normalizedProgressPoints` decodes the source metadata again and rebuilds the checkpoint curve, sensor sessions that render no splits section (splitSteps.count &lt;= 2, or no intermediate checkpoint) now pay that work on every render pass where develop paid none - the same class of waste this change exists to remove. Guard first, then build: `guard workout.isInAppSensorWorkout, Self.hasRecordedPaceSplitData(metadata:finalSteps:) else { paceSplits = []; showsPaceSplits = false; return }` and set `showsPaceSplits = splits.count &gt; 1`, which is semantically identical.
- ℹ️ `AscendApp/Features/Workouts/Views/HeartRateChartView.swift:91` - The cap is a soft one when the trace is fragmented. `budget` floors at 2 and `bucketCount` floors at 1, so a segment can emit 2 bucket marks plus 2 re-added endpoints = 4 marks no matter how small its share is. Beyond roughly 135 dropout segments the totals cross `maximumPlottedPointCount` (e.g. 200 segments of 13 samples each -&gt; budget 2 each -&gt; up to 800 plotted marks against a 400 cap). Still a large reduction from raw, and only reachable with a very flaky strap, but `HeartRateChartDownsamplingTests` only exercises 1- and 2-segment traces so nothing pins this. Either accept it explicitly in the doc comment or distribute the leftover budget so the cap holds for any segment count.
- ℹ️ `AscendApp/Features/Workouts/Models/WorkoutDetailDerivedContent.swift:62` - `max(metadata.targetStepCount ?? workout.steps, workout.steps, 1)` is a verbatim copy of `WorkoutDetailView.summaryTargetSteps(metadata:)` (WorkoutDetailView.swift:614), which is still live for the routine leaderboard context. Two copies of the same target-steps rule will drift; make one the single definition (e.g. a static helper on `LiveClimbWorkoutSummaryData` or on `WorkoutDetailDerivedContent`) and have the view call it.
- ℹ️ `AscendApp/Features/Workouts/Views/WorkoutDetailView.swift:95` - Noting for the record, not asking for a change: `DraggableDetailSheet` writes `sheetOffset` into root state that `workoutMediaLayout` reads, so for a workout with photos every drag frame re-runs `WorkoutDetailDerivedContent(workout:)` (the 104 KB heart-rate decode) and `HeartRateChartView.init` (filter, sort, segment, thin over the raw series). The intent declares both the no-cache decision and the DraggableDetailSheet write as known and deliberately deferred, and the change is still a strict improvement over develop on this path (1x instead of 8x per pass).

🔧 Fix: keep scrub readout exact and bound plotted mark cap
3 issues (1 warning, 2 infos) still open:
- ⚠️ `AscendApp/Features/Workouts/Views/HeartRateChartView.swift:133` - The new hard-bound allocation introduces a fidelity regression the previous commit did not have. When a segment&#39;s budget is 2 or 3, `bucketCount` is now 0 and `thinned` returns `endpoints(of:)` - first and last sample only - so that run&#39;s interior peak and trough are never plotted. Before this commit `bucketCount` was floored at 1, so even a budget-2 segment kept its min and max. With 2,603 raw samples the threshold is `count &gt;= 2*2603/discretionary`, i.e. any run shorter than ~14 samples: a 43-minute session with five strap dropouts where one 10-second reconnection window contains the session&#39;s peak plots that window as a straight chord and the peak disappears, while the Y-axis (correctly computed over the full series) still reserves headroom for it and the header still shows it as `Max`. This contradicts the intent&#39;s stated contract - &#34;Verified plotted min/max equal raw min/max exactly&#34; - and the fix instruction&#39;s &#34;every segment still keeps at least its endpoints and each bucket&#39;s min/max&#34;. It is also unpinned: `thinningKeepsTheRealPeakAndTrough` only covers the single-segment case, and the two new fragmented tests assert counts only. A fix that keeps both the hard bound and the contract: force the two globally extreme raw points into the plotted set (costs at most 2 marks), or for budget 3 return `[first, extreme, last]`.
- ℹ️ `AscendApp/Features/Workouts/Views/HeartRateChartView.swift:51` - `nearestScrubPoint` is a linear `min(by:)` over the full 2,603-sample series, and `computedSelectedPoint` is read four times per body pass (lines 354, 367, 404, 416). A scrub drag re-evaluates the body per touch move, so that is roughly 10k comparisons per frame where develop did the same scan and the thinned version did ~400. Not a hitch source, but `scrubPoints` is non-decreasing in `elapsed` by construction (sorted by timestamp, then clamped monotonically), so a binary search would make this O(log n) and match the change&#39;s own standard of not spending processing it does not need.
- ℹ️ `AscendApp/Features/Workouts/Views/HeartRateChartView.swift:293` - Noting the visual consequence of the decided design, not asking for a change: the selection `PointMark` is now drawn at a raw sample&#39;s BPM while the line under it is the thinned polyline, so the dot can sit slightly off the drawn curve - bounded by the bucket&#39;s BPM range (typically 1-3 BPM over a ~13s bucket, roughly 2-5pt on the 200pt chart). The horizontal position and the &#34;at m:ss&#34; label are exact, which is what the product owner asked for.

🔧 Fix: restore per-segment extremes and binary-search scrub lookup
2 infos still open:
- ℹ️ `AscendApp/Features/Workouts/Views/HeartRateChartView.swift:86` - `lastTiedIndex(before:)` returns the *first* index of the tie group containing `scrubPoints[insertionIndex - 1]` (it is a lower-bound search on that point&#39;s `elapsed`), not the last tied index. The behaviour is correct and the doc comment above it describes it accurately, but the name states the opposite, and this is index arithmetic where the entire correctness risk is an off-by-one. A future reader reaching for it to get &#34;the last sample at this instant&#34; would get the first. Rename to something like `firstTiedIndex(endingBefore:)`; no behaviour change.
- ℹ️ `AscendApp/Features/Workouts/Views/HeartRateChartView.swift:31` - Recording the deviation rather than re-opening it: the intent describes the chart as &#34;capped at 400 plotted marks&#34;, and after this commit `maximumPlottedPointCount` is a target that a pathological trace (~200 dropout segments) overshoots at roughly 4 marks per segment. That is the product owner&#39;s explicit round-2 decision - accuracy over the numeric bound, so a run holding the session peak can never lose it to fragmentation - and it is now stated in the constant&#39;s doc comment and pinned by `aPathologicallyFragmentedTraceOvershootsTheTargetButStaysBounded`. The cap still holds exactly for continuous traces and for the handful of dropouts a real session sees (I re-derived both: 2,603 samples in one segment lands on exactly 400, two 1,200-sample segments land on exactly 400), and the overshoot is bounded above by the raw sample count, so this path is never slower than what develop ships today.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`xcodebuild -scheme AscendApp-Staging -destination &#34;platform=iOS Simulator,name=iPhone 17 Pro&#34; test` - full suite, 543 tests / 101 suites, 0 failures</code>
- <code>`-only-testing:AscendAppTests/HeartRateChartDownsamplingTests` (cap, min/max fidelity, endpoints, ordering, dropout-segment interaction, fragmented-trace bound)</code>
- <code>`-only-testing:AscendAppTests/HeartRateChartDataSetTests` and `-only-testing:AscendAppTests/HeartRateChartDropoutSnapshotTests` (develop&#39;s existing segmentation + dropout-gap coverage still passes)</code>
- <code>`-only-testing:AscendAppTests/WorkoutDetailScrollWorkTests` (202-tick trace collapses to 2 nav-title transitions; derived-content contract)</code>
- <code>`-only-testing:AscendAppTests/WorkoutDetailScrollHostingTests` (120-tick real scroll drive on the real screen hosted on the live window scene)</code>
- <code>`-only-testing:AscendAppTests/LiveClimbWorkoutSummaryDataTests -only-testing:AscendAppTests/LiveClimbPaceSplitEvidenceTests` (pace-split derivation after the summary-view fix)</code>
- <code>New `AscendAppTests/HeartRateChartRenderCostEvidenceTests.swift`: `theThinnedChartDrawsTheSameCurveForAFractionOfTheRenderCost()` renders the pre-fix mark set (raw series) against the shipped thinned set, times both, pixel-diffs them, and writes PNGs</code>
- <code>New `theActivityDetailScreenRendersTheSessionThatStuttered()` hosts the real WorkoutDetailView on the test host&#39;s live UIWindowScene and screenshots it at scroll offsets 0, 140 (nav-title reveal) and 330 (chart on screen)</code>
- <code>Setup fix: linked the gitignored `AscendApp/App/Firebase/GoogleService-Info-Staging.plist` from `~/.config/ascend/firebase` because Xcode&#39;s user-script sandbox blocked the build phase from creating it; switched destination to `iPhone 17 Pro` (iOS 26.2) since no runtime is installed for `iPhone 16 Pro`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `AscendAppTests/HeartRateChartRenderCostEvidenceTests.swift` - AscendAppTests/HeartRateChartRenderCostEvidenceTests.swift is untracked but AscendAppTests is a PBXFileSystemSynchronizedRootGroup, so this render-cost evidence test compiles into the local test target while being absent from the commit and from CI. The suite therefore differs between this worktree and every other checkout. It needs an owner decision - commit it as a durable measurement test, or delete it as a one-off artifact - which I can&#39;t make on your behalf, and deleting an uncommitted file is not a safe mechanical fix.
- ℹ️ No Swift static analysis could be verified for this change: the repo checks in no SwiftLint or SwiftFormat config, CI lints only functions/ via ESLint (untouched here), and the locally installed swiftlint binary aborts in this environment with &#39;Loading sourcekitdInProc.framework failed&#39;. Whitespace and formatting were checked by hand instead. If Swift lint coverage is wanted, it needs a checked-in config plus a CI step - out of scope for this change.

🔧 Fix: honor ASCEND_EVIDENCE_DIR in render cost evidence test
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

