### PR TITLE
fix(storage): close the legacy root media prefixes any signed-in climber could read or delete

### DIFF
--- a/.claude/skills/ascend-firebase-data/SKILL.md
+++ b/.claude/skills/ascend-firebase-data/SKILL.md
@@ -52,7 +52,7 @@ User-generated media must be stored under user-scoped prefixes:
 - `users/{uid}/workout_heart_rate/...`
 
 Rules:
-- Never write user media to shared root paths (`photos/`, `videos/`, `profile_pictures/`) in production.
+- Never write user media to shared root paths. `photos/`, `videos/`, and `profile_pictures/` at the bucket root are closed to every client (`read, write: if false`) and must stay that way: a flat path carries no owner segment, so any rule permissive enough to admit the owner admits every signed-in account. Objects predating the user-scoped migration still sit there, unattributable and reachable only by the backend.
 - Server-owned synthetic Live Replay avatar fixtures may live under `live-replay-avatars/{seedPackId}/...`; they are not user media, should be read-only to clients, and must be written only by admin/server tooling.
 - Legacy share card template assets may still live under `share-card-templates/...`, but workout share cards in v1 must not fetch their backgrounds or layout config from Firebase.
 - Account deletion and cleanup should target only the authenticated user's scoped prefixes, including durable workout heart-rate sidecars and private workout backup documents.

--- a/AscendApp/Features/Account/Services/AccountDeletionGateway.swift
+++ b/AscendApp/Features/Account/Services/AccountDeletionGateway.swift
@@ -24,9 +24,6 @@ protocol AccountDeletionGateway {
 
     func deleteAllUserStorage(userId: String) async throws
 
-    /// Best-effort deletion of legacy flat-path media identified by download URL.
-    func deleteLegacyMedia(at urls: [URL]) async
-
     func deleteLeaderboardStats(userId: String) async throws
     func deleteWorkoutBackups(userId: String) async throws
     func deleteBlockedClimbers(userId: String) async throws
@@ -127,17 +124,13 @@ struct FirebaseAccountDeletionGateway: AccountDeletionGateway {
     // MARK: - Storage
 
     // StorageReference is not Sendable, so every reference is created and
-    // consumed inside these nonisolated helpers. Only Sendable values (the uid,
-    // the legacy URLs) cross the actor boundary.
+    // consumed inside these nonisolated helpers. Only Sendable values (the uid)
+    // cross the actor boundary.
 
     /// Sweeps all user-scoped Storage prefixes and deletes every file.
     /// This is independent of SwiftData — it catches orphaned files too.
     func deleteAllUserStorage(userId: String) async throws {
         try await Self.sweepUserStorage(userId: userId)
-    }
-
-    func deleteLegacyMedia(at urls: [URL]) async {
-        await Self.sweepLegacyMedia(at: urls)
     }
 
     private nonisolated static func sweepUserStorage(userId: String) async throws {
@@ -154,22 +147,6 @@ struct FirebaseAccountDeletionGateway: AccountDeletionGateway {
 
         for prefix in prefixes {
             try await deleteAllFiles(under: prefix)
-        }
-    }
-
-    private nonisolated static func sweepLegacyMedia(at urls: [URL]) async {
-        let storage = Storage.storage()
-
-        for url in urls {
-            if Task.isCancelled { return }
-            do {
-                let ref = try storage.reference(for: url)
-                try await ref.delete()
-            } catch {
-                // Best-effort: these predate user-scoped paths and may already
-                // be gone via the prefix sweep. Never block deletion on them.
-                continue
-            }
         }
     }
 

--- a/AscendApp/Features/Account/Services/AccountDeletionService.swift
+++ b/AscendApp/Features/Account/Services/AccountDeletionService.swift
@@ -77,7 +77,7 @@ final class AccountDeletionService {
             throw DeletionError.notAuthenticated
         }
 
-        let totalSteps = 12
+        let totalSteps = 11
         var completedSteps = 0
         var hasStagedLocalDeletion = false
         var hasCommittedLocalDeletion = false
@@ -125,33 +125,27 @@ final class AccountDeletionService {
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 3: Delete any legacy flat-path files referenced by local records
-        updateProgress("Cleaning up legacy media...")
-        try await deleteLegacyFlatPathMedia(modelContext: modelContext)
-        completedSteps += 1
-        try Task.checkCancellation()
-
-        // Step 4: Delete Firestore leaderboard stats
+        // Step 3: Delete Firestore leaderboard stats
         updateProgress("Deleting leaderboard data...")
         try await deleteLeaderboardStats(userId: userId)
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 5: Delete Firestore workout backup documents
+        // Step 4: Delete Firestore workout backup documents
         updateProgress("Deleting workout backups...")
         try await deleteWorkoutBackups(userId: userId)
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 6: Delete the user's personal block list.
+        // Step 5: Delete the user's personal block list.
         updateProgress("Deleting blocked climbers...")
         try await deleteBlockedClimbers(userId: userId)
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 7: Delete the publicly readable profile mirrors.
+        // Step 6: Delete the publicly readable profile mirrors.
         //
-        // This MUST happen before the auth account goes away (step 11):
+        // This MUST happen before the auth account goes away (step 10):
         // firestore.rules gates these deletes on isOwner(userId), so once the
         // auth user is deleted no client can ever authenticate as this uid
         // again and the documents become orphaned PII that keeps the deleted
@@ -161,7 +155,7 @@ final class AccountDeletionService {
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 8: Deactivate push delivery while the callable can still
+        // Step 7: Deactivate push delivery while the callable can still
         // authenticate and while users/{uid} still exists. The Cloud Function
         // sweep remains authoritative if this best-effort request fails.
         updateProgress("Disabling notifications...")
@@ -169,7 +163,7 @@ final class AccountDeletionService {
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 9: Delete Firestore user document.
+        // Step 8: Delete Firestore user document.
         //
         // Deleting this fires the cleanupDeletedUserData Cloud Function, which
         // sweeps every remaining subcollection, including the server-owned ones
@@ -180,21 +174,21 @@ final class AccountDeletionService {
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 10: Stage local deletion (rollback if auth deletion fails)
+        // Step 9: Stage local deletion (rollback if auth deletion fails)
         updateProgress("Preparing local data cleanup...")
         try stageLocalDataDeletion(modelContext: modelContext)
         hasStagedLocalDeletion = true
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 11: Delete the Firebase Auth account (credentials already fresh
+        // Step 10: Delete the Firebase Auth account (credentials already fresh
         // from Step 1, Apple token already revoked right after reauth).
         updateProgress("Deleting account...")
         try await deleteAuthAccount()
         completedSteps += 1
         try Task.checkCancellation()
 
-        // Step 12: Commit local deletion and clear caches
+        // Step 11: Commit local deletion and clear caches
         updateProgress("Finalizing local cleanup...")
         try commitStagedLocalDeletion(modelContext: modelContext)
         hasCommittedLocalDeletion = true
@@ -289,23 +283,6 @@ final class AccountDeletionService {
         } catch {
             throw DeletionError.storageDeletionFailed(error.localizedDescription)
         }
-    }
-
-    /// Deletes legacy flat-path files that predate the user-scoped migration.
-    /// Falls back to SwiftData records because the old paths (e.g. `photos/uuid.jpg`)
-    /// have no user ID — we can only identify them through the stored download URLs.
-    private func deleteLegacyFlatPathMedia(modelContext: ModelContext) async throws {
-        let urls: [URL]
-
-        do {
-            let workouts = try modelContext.fetch(FetchDescriptor<Workout>())
-            urls = workouts.flatMap(\.photos).map(\.url)
-        } catch {
-            throw DeletionError.storageDeletionFailed(error.localizedDescription)
-        }
-
-        guard !urls.isEmpty else { return }
-        await gateway.deleteLegacyMedia(at: urls)
     }
 
     private func deleteLeaderboardStats(userId: String) async throws {

--- a/AscendApp/Shared/Services/ClosedLegacyMediaPath.swift
+++ b/AscendApp/Shared/Services/ClosedLegacyMediaPath.swift
@@ -1,0 +1,70 @@
+//
+//  ClosedLegacyMediaPath.swift
+//  AscendApp
+//
+
+import Foundation
+
+/// Recognises workout media that still lives at a bucket-root Storage prefix.
+///
+/// Uploads have written `users/{uid}/...` since the user-scoped path migration,
+/// but media attached before it sits at the flat `photos/` and `videos/`
+/// prefixes. A flat path names no owner, so any rule permissive enough to admit
+/// the uploader admits every signed-in account; `storage.rules` therefore closes
+/// those prefixes to all client access.
+///
+/// A delete aimed at one can only fail, and workout deletion refuses to proceed
+/// while any media delete fails - so without this check, a climber holding a
+/// pre-migration workout could never delete it.
+enum ClosedLegacyMediaPath {
+
+    private static let closedRootPrefixes = ["photos/", "videos/", "profile_pictures/"]
+
+    /// Whether a Firebase Storage download URL points at a closed root prefix.
+    static func addressesClosedRootObject(_ url: URL) -> Bool {
+        guard let objectPath = storageObjectPath(in: url) else { return false }
+        return closedRootPrefixes.contains { objectPath.hasPrefix($0) }
+    }
+
+    /// The object path a Firebase Storage download URL addresses.
+    ///
+    /// A download URL is `/v0/b/{bucket}/o/{object}`, with the whole object path
+    /// percent-encoded into that last segment. The raw path is split before
+    /// decoding - decoding first would turn `photos%2Ffile.jpg` into two
+    /// segments and lose the shape. Anything not matching that layout returns
+    /// nil, so an unrelated URL is never mistaken for a closed object.
+    private static func storageObjectPath(in url: URL) -> String? {
+        guard let encodedPath = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .percentEncodedPath else {
+            return nil
+        }
+
+        let segments = encodedPath.split(separator: "/", omittingEmptySubsequences: true)
+        guard segments.count == 5,
+              segments[0] == "v0",
+              segments[1] == "b",
+              segments[3] == "o" else {
+            return nil
+        }
+
+        return String(segments[4]).removingPercentEncoding
+    }
+}
+
+extension Array where Element == Photo {
+    /// Splits media into what the client can no longer reach and what it can.
+    func partitionedByClosedLegacyPath() -> (unreachable: [Photo], deletable: [Photo]) {
+        var unreachable: [Photo] = []
+        var deletable: [Photo] = []
+
+        for photo in self {
+            if ClosedLegacyMediaPath.addressesClosedRootObject(photo.url) {
+                unreachable.append(photo)
+            } else {
+                deletable.append(photo)
+            }
+        }
+
+        return (unreachable, deletable)
+    }
+}

--- a/AscendApp/Shared/Services/ClosedLegacyMediaPath.swift
+++ b/AscendApp/Shared/Services/ClosedLegacyMediaPath.swift
@@ -20,6 +20,14 @@ enum ClosedLegacyMediaPath {
 
     private static let closedRootPrefixes = ["photos/", "videos/", "profile_pictures/"]
 
+    /// Hosts that serve Firebase Storage download URLs: the production endpoint
+    /// `StorageReference.downloadURL()` emits, plus the emulator's loopback host.
+    private static let storageHosts: Set<String> = [
+        "firebasestorage.googleapis.com",
+        "127.0.0.1",
+        "localhost"
+    ]
+
     /// Whether a Firebase Storage download URL points at a closed root prefix.
     static func addressesClosedRootObject(_ url: URL) -> Bool {
         guard let objectPath = storageObjectPath(in: url) else { return false }
@@ -28,16 +36,19 @@ enum ClosedLegacyMediaPath {
 
     /// The object path a Firebase Storage download URL addresses.
     ///
-    /// A download URL is `/v0/b/{bucket}/o/{object}`, with the whole object path
-    /// percent-encoded into that last segment. The raw path is split before
-    /// decoding - decoding first would turn `photos%2Ffile.jpg` into two
-    /// segments and lose the shape. Anything not matching that layout returns
-    /// nil, so an unrelated URL is never mistaken for a closed object.
+    /// A download URL is `/v0/b/{bucket}/o/{object}` on a Storage host, with the
+    /// whole object path percent-encoded into that last segment. The raw path is
+    /// split before decoding - decoding first would turn `photos%2Ffile.jpg`
+    /// into two segments and lose the shape. A foreign host or any other layout
+    /// returns nil, so an unrelated URL is never mistaken for a closed object.
     private static func storageObjectPath(in url: URL) -> String? {
-        guard let encodedPath = URLComponents(url: url, resolvingAgainstBaseURL: false)?
-            .percentEncodedPath else {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let host = components.host?.lowercased(),
+              storageHosts.contains(host) else {
             return nil
         }
+
+        let encodedPath = components.percentEncodedPath
 
         let segments = encodedPath.split(separator: "/", omittingEmptySubsequences: true)
         guard segments.count == 5,

--- a/AscendApp/Shared/Services/PhotoService.swift
+++ b/AscendApp/Shared/Services/PhotoService.swift
@@ -156,8 +156,13 @@ actor PhotoService {
         let repo = self.repo
         let config = self.deletionConfig
 
+        // Media at a closed root prefix is unreachable by design. Attempting it
+        // would fail every retry and block the owner from deleting their own
+        // workout, so it counts as nothing left to delete.
+        let (unreachable, deletable) = photos.partitionedByClosedLegacyPath()
+
         return await withTaskGroup(of: (Photo, (any Error)?).self) { group in
-            for photo in photos {
+            for photo in deletable {
                 group.addTask {
                     do {
                         try await self.deletePhotoWithRetry(photo, repo: repo, config: config)
@@ -168,7 +173,7 @@ actor PhotoService {
                 }
             }
 
-            var successful: [Photo] = []
+            var successful: [Photo] = unreachable
             var failed: [(Photo, any Error)] = []
 
             for await (photo, error) in group {

--- a/AscendApp/Shared/Services/PhotoService.swift
+++ b/AscendApp/Shared/Services/PhotoService.swift
@@ -14,13 +14,16 @@ import FirebaseAuth
 actor PhotoService {
     private let repo: any PhotoRepositoryProtocol
     private let deletionConfig: PhotoDeletionConfig
+    private let diagnostics: any AppDiagnosticsRecording
 
     init(
         repo: any PhotoRepositoryProtocol = FirebasePhotoRepository(),
-        deletionConfig: PhotoDeletionConfig = .default
+        deletionConfig: PhotoDeletionConfig = .default,
+        diagnostics: any AppDiagnosticsRecording = AppDiagnosticsRecorder.shared
     ) {
         self.repo = repo
         self.deletionConfig = deletionConfig
+        self.diagnostics = diagnostics
     }
 
     func uploadPhotos(_ items: [PhotosPickerItem]) async throws -> [Photo] {
@@ -160,6 +163,18 @@ actor PhotoService {
         // would fail every retry and block the owner from deleting their own
         // workout, so it counts as nothing left to delete.
         let (unreachable, deletable) = photos.partitionedByClosedLegacyPath()
+
+        if !unreachable.isEmpty {
+            diagnostics.record(
+                "media_delete_skipped_closed_legacy_path",
+                level: .warning,
+                details: [
+                    "skipped_count": String(unreachable.count),
+                    "requested_count": String(photos.count)
+                ],
+                mirrorToCrashlytics: true
+            )
+        }
 
         return await withTaskGroup(of: (Photo, (any Error)?).self) { group in
             for photo in deletable {

--- a/AscendAppTests/AccountDeletionServiceTests.swift
+++ b/AscendAppTests/AccountDeletionServiceTests.swift
@@ -25,6 +25,51 @@ struct AccountDeletionServiceTests {
     }
 
     @Test
+    func sweepsOnlyOwnerScopedStorageAndNeverTheLegacyFlatPaths() async throws {
+        let gateway = RecordingAccountDeletionGateway()
+        gateway.reauthenticationResult = .success(
+            ReauthenticationResult(appleAuthorizationCode: "apple-auth-code")
+        )
+        let service = AccountDeletionService(gateway: gateway, localCleanup: StubLocalCleanup())
+
+        try await service.deleteAccount(modelContext: try makeModelContext())
+
+        // The root photos/ and videos/ prefixes carry no owner segment, so
+        // storage.rules closes them to every client. A sweep aimed there could
+        // only ever fail, and reaching for another climber's media is exactly
+        // what the closed rules exist to prevent.
+        #expect(gateway.steps == [
+            .reauthenticate,
+            .revokeAppleToken,
+            .deleteAllUserStorage,
+            .deleteLeaderboardStats,
+            .deleteWorkoutBackups,
+            .deleteBlockedClimbers,
+            .deletePublicProfileMirrors,
+            .unregisterPushDevice,
+            .deleteUserDocument,
+            .deleteAuthAccount,
+        ])
+    }
+
+    @Test
+    func reportsFullProgressOnceEveryStepHasRun() async throws {
+        let gateway = RecordingAccountDeletionGateway()
+        let service = AccountDeletionService(gateway: gateway, localCleanup: StubLocalCleanup())
+
+        // totalSteps is hand-maintained, so a step added or removed without
+        // updating it leaves the progress bar permanently short or early.
+        var lastProgress: AccountDeletionService.DeletionProgress?
+        try await service.deleteAccount(modelContext: try makeModelContext()) { progress in
+            lastProgress = progress
+        }
+
+        let progress = try #require(lastProgress)
+        #expect(progress.completedSteps == progress.totalSteps)
+        #expect(progress.progressPercentage == 1.0)
+    }
+
+    @Test
     func deletesEveryRemoteRecordBeforeTheAuthAccount() async throws {
         let gateway = RecordingAccountDeletionGateway()
         let service = AccountDeletionService(gateway: gateway, localCleanup: StubLocalCleanup())
@@ -258,7 +303,6 @@ private final class RecordingAccountDeletionGateway: AccountDeletionGateway {
     enum Step: Equatable {
         case reauthenticate
         case deleteAllUserStorage
-        case deleteLegacyMedia
         case deleteLeaderboardStats
         case deleteWorkoutBackups
         case deleteBlockedClimbers
@@ -285,10 +329,6 @@ private final class RecordingAccountDeletionGateway: AccountDeletionGateway {
 
     func deleteAllUserStorage(userId: String) async throws {
         steps.append(.deleteAllUserStorage)
-    }
-
-    func deleteLegacyMedia(at urls: [URL]) async {
-        steps.append(.deleteLegacyMedia)
     }
 
     func deleteLeaderboardStats(userId: String) async throws {

--- a/AscendAppTests/ClosedLegacyMediaPathTests.swift
+++ b/AscendAppTests/ClosedLegacyMediaPathTests.swift
@@ -14,7 +14,7 @@ struct ClosedLegacyMediaPathTests {
     private static func downloadURL(objectPath: String) -> URL {
         let encoded = objectPath.replacing("/", with: "%2F")
         return URL(
-            string: "https://firebasestorage.googleapis.com/v0/b/\(bucket)/o/\(encoded)"
+            string: "https://firebasestorage.googleapis.com/v0/b/\(Self.bucket)/o/\(encoded)"
                 + "?alt=media&token=94f4cee6-de5e-4562-b7f8-c1cf2fbc6d44"
         )!
     }
@@ -62,6 +62,10 @@ struct ClosedLegacyMediaPathTests {
             "https://example.com/v0/b/bucket/o/photos%2Fnot-a-storage-url.jpg/extra",
             "https://firebasestorage.googleapis.com/v0/b/bucket/o",
             "https://picsum.photos/200/200",
+            // Exactly the download-URL shape, but not a Storage host: the path
+            // alone must never be enough to call an object unreachable.
+            "https://example.com/v0/b/bucket/o/photos%2Fa.jpg",
+            "https://firebasestorage.googleapis.com.attacker.test/v0/b/bucket/o/photos%2Fa.jpg",
         ]
 
         for value in strangers {
@@ -71,6 +75,34 @@ struct ClosedLegacyMediaPathTests {
                 "Expected \(value) to stay deletable."
             )
         }
+    }
+
+    @Test
+    func recognisesClosedObjectsBehindTheStorageEmulator() {
+        let emulatorURLs = [
+            "http://127.0.0.1:9199/v0/b/\(Self.bucket)/o/photos%2Flegacy.jpg",
+            "http://localhost:9199/v0/b/\(Self.bucket)/o/videos%2Flegacy.mov",
+        ]
+
+        for value in emulatorURLs {
+            let url = URL(string: value)!
+            #expect(
+                ClosedLegacyMediaPath.addressesClosedRootObject(url),
+                "Expected \(value) to be recognised as unreachable."
+            )
+        }
+    }
+
+    @Test
+    func recognisesTheExplicitPortTheStorageSDKEmits() {
+        // StorageReference.downloadURL() builds its URL with Storage.port set,
+        // so the shape the SDK actually emits carries an explicit :443.
+        let url = URL(
+            string: "https://firebasestorage.googleapis.com:443/v0/b/\(Self.bucket)/o/photos%2Flegacy.jpg"
+                + "?alt=media&token=94f4cee6-de5e-4562-b7f8-c1cf2fbc6d44"
+        )!
+
+        #expect(ClosedLegacyMediaPath.addressesClosedRootObject(url))
     }
 
     @Test

--- a/AscendAppTests/ClosedLegacyMediaPathTests.swift
+++ b/AscendAppTests/ClosedLegacyMediaPathTests.swift
@@ -1,0 +1,86 @@
+//
+//  ClosedLegacyMediaPathTests.swift
+//  AscendAppTests
+//
+
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct ClosedLegacyMediaPathTests {
+
+    private static let bucket = "ascend-staging-fa7d5.firebasestorage.app"
+
+    private static func downloadURL(objectPath: String) -> URL {
+        let encoded = objectPath.replacing("/", with: "%2F")
+        return URL(
+            string: "https://firebasestorage.googleapis.com/v0/b/\(bucket)/o/\(encoded)"
+                + "?alt=media&token=94f4cee6-de5e-4562-b7f8-c1cf2fbc6d44"
+        )!
+    }
+
+    @Test
+    func recognisesEveryClosedRootPrefix() {
+        let closedPaths = [
+            "photos/07765C1A-17D5-4F48-8BBA-F083989595F9.jpg",
+            "videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov",
+            "profile_pictures/uid_4D5E6F70-8192-4A34-B567-C8D9E0F1A2B3.jpg",
+        ]
+
+        for path in closedPaths {
+            #expect(
+                ClosedLegacyMediaPath.addressesClosedRootObject(Self.downloadURL(objectPath: path)),
+                "Expected \(path) to be recognised as unreachable."
+            )
+        }
+    }
+
+    @Test
+    func leavesOwnerScopedMediaAlone() {
+        // The uid segment is what makes these reachable, and "users/.../photos/"
+        // must never be mistaken for the closed root "photos/" prefix.
+        let ownedPaths = [
+            "users/uFFxxP2fBUf15Y9Nv8gA1EAyRUF3/photos/CF12C2B5-EEF6-424E-AD37-C793DBB429BF.jpg",
+            "users/uFFxxP2fBUf15Y9Nv8gA1EAyRUF3/videos/E2BA1D96-B0A1-475D-836F-CA86ED48601D.mov",
+            "users/uFFxxP2fBUf15Y9Nv8gA1EAyRUF3/profile_pictures/58E60C20-68D3-4A91-9E5A-3F725C845D3B.jpg",
+        ]
+
+        for path in ownedPaths {
+            #expect(
+                !ClosedLegacyMediaPath.addressesClosedRootObject(Self.downloadURL(objectPath: path)),
+                "Expected \(path) to stay deletable."
+            )
+        }
+    }
+
+    @Test
+    func treatsUnrecognisedURLsAsReachable() {
+        // Anything that is not a Storage download URL keeps its normal delete
+        // path: guessing "unreachable" would silently skip a real cleanup.
+        let strangers = [
+            "https://example.com/photos/whatever.jpg",
+            "https://example.com/v0/b/bucket/o/photos%2Fnot-a-storage-url.jpg/extra",
+            "https://firebasestorage.googleapis.com/v0/b/bucket/o",
+            "https://picsum.photos/200/200",
+        ]
+
+        for value in strangers {
+            let url = URL(string: value)!
+            #expect(
+                !ClosedLegacyMediaPath.addressesClosedRootObject(url),
+                "Expected \(value) to stay deletable."
+            )
+        }
+    }
+
+    @Test
+    func partitionsMediaByReachability() {
+        let legacy = Photo(url: Self.downloadURL(objectPath: "photos/legacy.jpg"))
+        let owned = Photo(url: Self.downloadURL(objectPath: "users/uid-1/photos/owned.jpg"))
+
+        let (unreachable, deletable) = [legacy, owned].partitionedByClosedLegacyPath()
+
+        #expect(unreachable.map(\.url) == [legacy.url])
+        #expect(deletable.map(\.url) == [owned.url])
+    }
+}

--- a/AscendAppTests/Fakes/SpyDiagnosticsRecorder.swift
+++ b/AscendAppTests/Fakes/SpyDiagnosticsRecorder.swift
@@ -1,0 +1,47 @@
+//
+//  SpyDiagnosticsRecorder.swift
+//  AscendAppTests
+//
+
+import Foundation
+@testable import AscendApp
+
+/// Captures what a caller *asked* the diagnostics layer for.
+final class SpyDiagnosticsRecorder: AppDiagnosticsRecording, @unchecked Sendable {
+    struct Recorded {
+        let name: String
+        let level: AppDiagnosticEvent.Level
+        let details: [String: String]
+        let mirrorToCrashlytics: Bool
+    }
+
+    private let lock = NSLock()
+    private var recorded: [Recorded] = []
+
+    var events: [Recorded] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+
+    @discardableResult
+    func record(
+        _ name: String,
+        level: AppDiagnosticEvent.Level,
+        details: [String: String],
+        mirrorToCrashlytics: Bool
+    ) -> AppDiagnosticEvent {
+        lock.lock()
+        recorded.append(
+            Recorded(
+                name: name,
+                level: level,
+                details: details,
+                mirrorToCrashlytics: mirrorToCrashlytics
+            )
+        )
+        lock.unlock()
+
+        return AppDiagnosticEvent(name: name, level: level, details: details)
+    }
+}

--- a/AscendAppTests/PhotoServiceDeletionTests.swift
+++ b/AscendAppTests/PhotoServiceDeletionTests.swift
@@ -1,0 +1,93 @@
+//
+//  PhotoServiceDeletionTests.swift
+//  AscendAppTests
+//
+
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct PhotoServiceDeletionTests {
+
+    private static func downloadURL(objectPath: String) -> URL {
+        let encoded = objectPath.replacing("/", with: "%2F")
+        return URL(
+            string: "https://firebasestorage.googleapis.com/v0/b/bucket.firebasestorage.app/o/"
+                + "\(encoded)?alt=media&token=94f4cee6-de5e-4562-b7f8-c1cf2fbc6d44"
+        )!
+    }
+
+    @Test
+    func deletesAWorkoutWhoseMediaSitsAtAClosedLegacyPath() async throws {
+        // storage.rules closes the flat photos/ prefix to every client, so a
+        // delete there can only fail. Workout deletion aborts on any media
+        // failure, so retrying it would leave a pre-migration workout that its
+        // owner can never delete.
+        let repo = RecordingPhotoRepository(deletionError: TestError.permissionDenied)
+        let service = PhotoService(repo: repo)
+        let legacy = Photo(url: Self.downloadURL(objectPath: "photos/legacy.jpg"))
+
+        try await service.deletePhotos([legacy])
+
+        #expect(await repo.deletedURLs.isEmpty)
+    }
+
+    @Test
+    func stillDeletesOwnerScopedMediaAlongsideUnreachableMedia() async throws {
+        let repo = RecordingPhotoRepository()
+        let service = PhotoService(repo: repo)
+        let legacy = Photo(url: Self.downloadURL(objectPath: "videos/legacy.mov"))
+        let owned = Photo(url: Self.downloadURL(objectPath: "users/uid-1/photos/owned.jpg"))
+
+        let result = await service.deletePhotosWithResult([legacy, owned])
+
+        #expect(await repo.deletedURLs == [owned.url])
+        #expect(result.failedDeletions.isEmpty)
+        #expect(Set(result.successfulDeletions.map(\.url)) == [legacy.url, owned.url])
+    }
+
+    @Test
+    func stillReportsAFailureWhenOwnerScopedMediaCannotBeDeleted() async throws {
+        // Skipping unreachable media must not soften the guarantee that a real
+        // cloud object is gone before the local workout is.
+        let repo = RecordingPhotoRepository(deletionError: TestError.permissionDenied)
+        let service = PhotoService(
+            repo: repo,
+            deletionConfig: PhotoDeletionConfig(
+                maxRetries: 1,
+                initialDelaySeconds: 0,
+                backoffMultiplier: 1,
+                timeoutSeconds: 5
+            )
+        )
+        let owned = Photo(url: Self.downloadURL(objectPath: "users/uid-1/photos/owned.jpg"))
+
+        await #expect(throws: PhotoDeletionError.self) {
+            try await service.deletePhotos([owned])
+        }
+    }
+}
+
+private enum TestError: Error {
+    case permissionDenied
+}
+
+private actor RecordingPhotoRepository: PhotoRepositoryProtocol {
+    private(set) var deletedURLs: [URL] = []
+    private let deletionError: (any Error)?
+
+    init(deletionError: (any Error)? = nil) {
+        self.deletionError = deletionError
+    }
+
+    func upload(_ data: Data, filename: String) async throws -> URL {
+        URL(string: "https://example.com/\(filename)")!
+    }
+
+    func delete(url: URL) async throws {
+        if let deletionError {
+            throw deletionError
+        }
+        deletedURLs.append(url)
+    }
+}

--- a/AscendAppTests/PhotoServiceDeletionTests.swift
+++ b/AscendAppTests/PhotoServiceDeletionTests.swift
@@ -47,6 +47,35 @@ struct PhotoServiceDeletionTests {
     }
 
     @Test
+    func reportsSkippedUnreachableMediaAsADiagnostic() async throws {
+        // Skipped media is counted as deleted, so without this signal a delete
+        // that never happened is indistinguishable from one that did.
+        let diagnostics = SpyDiagnosticsRecorder()
+        let service = PhotoService(repo: RecordingPhotoRepository(), diagnostics: diagnostics)
+        let legacy = Photo(url: Self.downloadURL(objectPath: "photos/legacy.jpg"))
+        let owned = Photo(url: Self.downloadURL(objectPath: "users/uid-1/photos/owned.jpg"))
+
+        _ = await service.deletePhotosWithResult([legacy, owned])
+
+        let events = diagnostics.events
+        #expect(events.count == 1)
+        #expect(events.first?.name == "media_delete_skipped_closed_legacy_path")
+        #expect(events.first?.details["skipped_count"] == "1")
+        #expect(events.first?.details["requested_count"] == "2")
+    }
+
+    @Test
+    func staysQuietWhenEveryPhotoIsReachable() async throws {
+        let diagnostics = SpyDiagnosticsRecorder()
+        let service = PhotoService(repo: RecordingPhotoRepository(), diagnostics: diagnostics)
+        let owned = Photo(url: Self.downloadURL(objectPath: "users/uid-1/photos/owned.jpg"))
+
+        _ = await service.deletePhotosWithResult([owned])
+
+        #expect(diagnostics.events.isEmpty)
+    }
+
+    @Test
     func stillReportsAFailureWhenOwnerScopedMediaCannotBeDeleted() async throws {
         // Skipping unreachable media must not soften the guarantee that a real
         // cloud object is gone before the local workout is.

--- a/AscendAppTests/WorkoutSourceSchemaMigrationTests.swift
+++ b/AscendAppTests/WorkoutSourceSchemaMigrationTests.swift
@@ -867,37 +867,3 @@ private enum FailingWorkoutSourceMigrationPlan: SchemaMigrationPlan {
 private enum InjectedMigrationFailure: Error {
     case didMigrateInterrupted
 }
-
-/// Captures what the migration *asked* the diagnostics layer for.
-private final class SpyDiagnosticsRecorder: AppDiagnosticsRecording, @unchecked Sendable {
-    struct Recorded {
-        let name: String
-        let details: [String: String]
-        let mirrorToCrashlytics: Bool
-    }
-
-    private let lock = NSLock()
-    private var recorded: [Recorded] = []
-
-    var events: [Recorded] {
-        lock.lock()
-        defer { lock.unlock() }
-        return recorded
-    }
-
-    @discardableResult
-    func record(
-        _ name: String,
-        level: AppDiagnosticEvent.Level,
-        details: [String: String],
-        mirrorToCrashlytics: Bool
-    ) -> AppDiagnosticEvent {
-        lock.lock()
-        recorded.append(
-            Recorded(name: name, details: details, mirrorToCrashlytics: mirrorToCrashlytics)
-        )
-        lock.unlock()
-
-        return AppDiagnosticEvent(name: name, level: level, details: details)
-    }
-}

--- a/docs/launch-readiness-audit.md
+++ b/docs/launch-readiness-audit.md
@@ -20,7 +20,7 @@ Method: four parallel read-only passes — monetization, Live Climb hero loop, a
 2. ~~**No Sign in with Apple token revocation on account deletion.**~~ **Fixed** (issue #197). The `authorizationCode` is captured during Apple re-auth and revoked before the account goes away.
 3. **Verify `PrivacyInfo.xcprivacy` lands in the Release bundle.** The manifest exists and is comprehensive - `AscendApp/PrivacyInfo.xcprivacy` owns the declared data types and required-reason codes, and `AscendAppTests/PrivacyManifestTests.swift` pins both. It carries no explicit `project.pbxproj` entry by design: `AscendApp/` is a `PBXFileSystemSynchronizedRootGroup` for the `AscendApp` target whose only membership exception is `Info.plist`, so the manifest is bundled automatically. Confirm once by building Release and `find`ing the file in the built .app.
 
-> Blockers 1-2 are resolved. The deletion ordering contract, the revocation rules, and what deliberately outlives an account are owned by **CLAUDE.md → Account Deletion (Apple 5.1.1(v))**; the ordering itself is locked in by `AscendAppTests/AccountDeletionServiceTests.swift`. Consult those rather than this dated snapshot.
+> Blockers 1-2 are resolved. The deletion ordering contract, the revocation rules, and what deliberately outlives an account are owned by **`.claude/skills/ascend-firebase-data` → Account deletion (Apple 5.1.1(v))**; the ordering itself is locked in by `AscendAppTests/AccountDeletionServiceTests.swift`. Consult those rather than this dated snapshot.
 
 ## 🟡 Commerce configuration (dashboards — not auditable from code)
 

--- a/storage.rules
+++ b/storage.rules
@@ -80,24 +80,23 @@ service firebase.storage {
       allow delete: if isOwner(userId) && validFileName(fileName);
     }
 
-    // ── Legacy flat-path rules (pre-migration) ──────────────────────
-    // Files uploaded before the user-scoped path migration live at
-    // root-level photos/ and videos/ prefixes. Profile pictures at the
-    // legacy root are closed completely: the public-identity migration
-    // moves any current owner reference and deletes the remaining objects.
-    // No new writes are allowed. Remove the remaining legacy rules once
-    // their migrations are complete.
+    // ── Legacy flat-path prefixes (pre-migration), closed ───────────
+    // Objects uploaded before the user-scoped path migration still sit at the
+    // root photos/, videos/, and profile_pictures/ prefixes. A flat path has no
+    // owner segment, so no rule here can tell one climber's media from
+    // another's: any rule permissive enough to let an owner in lets every
+    // signed-in account in. These prefixes are therefore closed to all client
+    // access. Nothing shipped depends on them - uploads have written
+    // user-scoped paths since the migration, and in-app display fetches the
+    // tokenized download URL over plain HTTPS, which never consults these
+    // rules. Whatever objects remain are reachable only by the backend.
 
     match /photos/{fileName} {
-      allow read: if isSignedIn() && validFileName(fileName);
-      allow delete: if isSignedIn() && validFileName(fileName);
-      allow create, update: if false;
+      allow read, write: if false;
     }
 
     match /videos/{fileName} {
-      allow read: if isSignedIn() && validFileName(fileName);
-      allow delete: if isSignedIn() && validFileName(fileName);
-      allow create, update: if false;
+      allow read, write: if false;
     }
 
     match /profile_pictures/{fileName} {

--- a/tests/firebase-rules/workout-media-storage-contract.test.mjs
+++ b/tests/firebase-rules/workout-media-storage-contract.test.mjs
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import { after, before, beforeEach, test } from 'node:test';
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import {
+  deleteObject,
+  getBytes,
+  getMetadata,
+  listAll,
+  ref,
+  uploadBytes,
+} from 'firebase/storage';
+
+const projectId = 'demo-ascendapp-rules-storage-media';
+const storageRules = readFileSync(new URL('../../storage.rules', import.meta.url), 'utf8');
+
+const ownerId = 'owner-123';
+const intruderId = 'intruder-456';
+
+// A one-pixel JPEG is enough: the rules only inspect size and content type.
+const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00, 0xff, 0xd9]);
+const mp4Bytes = new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]);
+
+const legacyPhotoPath = 'photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg';
+const legacyVideoPath = 'videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov';
+
+const ownedPhotoPath = `users/${ownerId}/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg`;
+const ownedVideoPath = `users/${ownerId}/videos/6F708192-A3B4-4C56-D789-E0F1A2B3C4D5.mov`;
+
+let testEnv;
+
+before(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId,
+    storage: {
+      rules: storageRules,
+      host: '127.0.0.1',
+      port: 9199,
+    },
+  });
+});
+
+beforeEach(async () => {
+  await testEnv.clearStorage();
+  await testEnv.withSecurityRulesDisabled(async (adminContext) => {
+    const storage = adminContext.storage();
+    await uploadBytes(ref(storage, legacyPhotoPath), jpegBytes, { contentType: 'image/jpeg' });
+    await uploadBytes(ref(storage, legacyVideoPath), mp4Bytes, { contentType: 'video/quicktime' });
+    await uploadBytes(ref(storage, ownedPhotoPath), jpegBytes, { contentType: 'image/jpeg' });
+    await uploadBytes(ref(storage, ownedVideoPath), mp4Bytes, { contentType: 'video/quicktime' });
+  });
+});
+
+after(async () => {
+  await testEnv.cleanup();
+});
+
+// The legacy flat prefixes carry no owner segment, so no rule over them can tell
+// one climber's media from another's. Nothing may reach them.
+
+test('another climber cannot read legacy root workout media', async () => {
+  const storage = testEnv.authenticatedContext(intruderId).storage();
+
+  await assertFails(getBytes(ref(storage, legacyPhotoPath)));
+  await assertFails(getMetadata(ref(storage, legacyPhotoPath)));
+  await assertFails(getBytes(ref(storage, legacyVideoPath)));
+  await assertFails(getMetadata(ref(storage, legacyVideoPath)));
+});
+
+test('another climber cannot delete legacy root workout media', async () => {
+  const storage = testEnv.authenticatedContext(intruderId).storage();
+
+  await assertFails(deleteObject(ref(storage, legacyPhotoPath)));
+  await assertFails(deleteObject(ref(storage, legacyVideoPath)));
+});
+
+test('no signed-in climber can enumerate the legacy root workout media prefixes', async () => {
+  const storage = testEnv.authenticatedContext(intruderId).storage();
+
+  await assertFails(listAll(ref(storage, 'photos')));
+  await assertFails(listAll(ref(storage, 'videos')));
+});
+
+// A flat path cannot name an owner, so the prefixes are closed to everyone -
+// including whoever originally uploaded the object.
+test('the original uploader cannot reach legacy root workout media either', async () => {
+  const storage = testEnv.authenticatedContext(ownerId).storage();
+
+  await assertFails(getBytes(ref(storage, legacyPhotoPath)));
+  await assertFails(deleteObject(ref(storage, legacyPhotoPath)));
+  await assertFails(getBytes(ref(storage, legacyVideoPath)));
+  await assertFails(deleteObject(ref(storage, legacyVideoPath)));
+});
+
+test('no signed-in climber can write to the legacy root workout media prefixes', async () => {
+  const storage = testEnv.authenticatedContext(intruderId).storage();
+
+  await assertFails(
+    uploadBytes(ref(storage, 'photos/7081A2B3-C4D5-4E67-F890-A1B2C3D4E5F6.jpg'), jpegBytes, {
+      contentType: 'image/jpeg',
+    })
+  );
+  await assertFails(
+    uploadBytes(ref(storage, 'videos/8192B3C4-D5E6-4F78-A901-B2C3D4E5F6A7.mov'), mp4Bytes, {
+      contentType: 'video/quicktime',
+    })
+  );
+});
+
+test('an unauthenticated visitor cannot reach the legacy root prefixes', async () => {
+  const storage = testEnv.unauthenticatedContext().storage();
+
+  await assertFails(getBytes(ref(storage, legacyPhotoPath)));
+  await assertFails(deleteObject(ref(storage, legacyPhotoPath)));
+  await assertFails(getBytes(ref(storage, legacyVideoPath)));
+  await assertFails(deleteObject(ref(storage, legacyVideoPath)));
+});
+
+// The owner-scoped paths the app actually writes today keep working, and stay
+// closed to everyone else.
+
+test('an owner can read, list, upload, and delete their own workout media', async () => {
+  const storage = testEnv.authenticatedContext(ownerId).storage();
+
+  await assertSucceeds(getBytes(ref(storage, ownedPhotoPath)));
+  await assertSucceeds(getBytes(ref(storage, ownedVideoPath)));
+  await assertSucceeds(listAll(ref(storage, `users/${ownerId}/photos`)));
+  await assertSucceeds(listAll(ref(storage, `users/${ownerId}/videos`)));
+
+  await assertSucceeds(
+    uploadBytes(
+      ref(storage, `users/${ownerId}/photos/92A3B4C5-D6E7-4089-A123-B4C5D6E7F809.jpg`),
+      jpegBytes,
+      { contentType: 'image/jpeg' }
+    )
+  );
+  await assertSucceeds(
+    uploadBytes(
+      ref(storage, `users/${ownerId}/videos/A3B4C5D6-E7F8-4190-B234-C5D6E7F8091A.mov`),
+      mp4Bytes,
+      { contentType: 'video/quicktime' }
+    )
+  );
+
+  await assertSucceeds(deleteObject(ref(storage, ownedPhotoPath)));
+  await assertSucceeds(deleteObject(ref(storage, ownedVideoPath)));
+});
+
+test('another climber cannot read, list, or delete owner-scoped workout media', async () => {
+  const storage = testEnv.authenticatedContext(intruderId).storage();
+
+  await assertFails(getBytes(ref(storage, ownedPhotoPath)));
+  await assertFails(getBytes(ref(storage, ownedVideoPath)));
+  await assertFails(listAll(ref(storage, `users/${ownerId}/photos`)));
+  await assertFails(listAll(ref(storage, `users/${ownerId}/videos`)));
+  await assertFails(deleteObject(ref(storage, ownedPhotoPath)));
+  await assertFails(deleteObject(ref(storage, ownedVideoPath)));
+});


### PR DESCRIPTION
Any signed-in climber could read and permanently delete any other climber's legacy workout photos and videos. Now nobody can.

The bucket-root `photos/` and `videos/` prefixes in `storage.rules` were gated on `isSignedIn()` alone, with no owner check. Any Ascend account - which anyone can create with Sign in with Apple - could guess a filename and destroy another climber's media, with no in-app explanation to the owner and only a seven-day soft-delete window in which to notice. Both prefixes are now closed to every client.

### The trade this makes, stated plainly

A pre-migration user who deletes their account now leaves those objects behind in the bucket.

Account deletion used to sweep them, reading download URLs out of the user's own SwiftData workouts. That sweep only worked *because* the delete rule was open to every signed-in account - the same permission that was the vulnerability. A flat path carries no owner segment, so "the sweep keeps working" and "the hole is closed" cannot both hold. Closing won, and the sweep was removed rather than left to fail every retry.

No server-side replacement is possible, because legacy objects carry no owner attribution at all. The residue and its counts across all three environments are tracked in #357, which proposes no deletion.

## What Changed

- `storage.rules`: the pre-migration flat paths `photos/{fileName}` and `videos/{fileName}` were gated only by `isSignedIn()`, so any signed-in climber could read and permanently delete any other climber's legacy photos and videos. Both are now `allow read, write: if false`, matching the already-closed `profile_pictures/`. A flat path carries no owner segment, so no rule can distinguish one climber's media from another's; closing is the only expressible fix. The owner-scoped `users/{uid}/...` rules are untouched.
- Added `ClosedLegacyMediaPath`, which classifies a Firebase Storage download URL as addressing a closed root prefix (host-checked against the Storage download hosts plus the emulator loopback). `PhotoService.deletePhotos` partitions media on it and skips the unreachable objects instead of retrying deletes that can now only fail, recording a `media_delete_skipped_closed_legacy_path` diagnostic when it does. Without this, a climber holding a pre-migration workout could never delete that workout; a failure on owner-scoped media still blocks deletion.
- Removed the account-deletion legacy sweep (`AccountDeletionService.deleteLegacyFlatPathMedia`, `AccountDeletionGateway.deleteLegacyMedia`/`sweepLegacyMedia`), which fetched every `Workout` from SwiftData to retry those now-impossible deletes; deletion steps renumbered 12 to 11. Coverage: new `tests/firebase-rules/workout-media-storage-contract.test.mjs` (verified failing against the base commit's rules), `ClosedLegacyMediaPathTests`, `PhotoServiceDeletionTests`, and `AccountDeletionServiceTests` pinning the exact remote step sequence and full progress.

## Evidence

1. **Objects behind those paths.** Counted read-only; nothing moved or deleted.

   | Environment | Project | `photos/` | `videos/` | `profile_pictures/` |
   |---|---|---|---|---|
   | Dev | `ascend-f2e4f` | 0 | 0 | 0 |
   | Staging | `ascend-staging-fa7d5` | **63** | 0 | **6** |
   | Production | `ascend-prod-9c8f2` | 0 | 0 | 0 |

   Staging's 63 photos (~97.9 MiB) were all uploaded Jan 2026, before the 2026-03-09 user-scoped path migration (68be4e6). Production holds no user media at all - its only top-level prefix is the server-owned `climb-images/`. The affected set cannot grow: writes to all three root prefixes were already denied before this PR and remain denied, so 63 is a permanent upper bound.
2. **Nothing references them.** A recursive scan of every Firestore document in dev and staging (dev 2,710 docs / 18,574 string fields; staging 3,061 docs / 21,104) found zero strings pointing at root `photos/` or `videos/`. The only root-prefix references anywhere are 18 `profile_pictures/` URLs in `photoURL` and `profilePictureURL` fields, on a prefix that was already closed before this PR.
3. **No UI breaks.** Storage rules are not consulted on tokenized download URLs. Proven empirically: an object under the already-closed `profile_pictures/` prefix still returns HTTP 200 with 210,999 bytes to an unauthenticated plain-HTTPS GET. `RemoteMediaLoader` fetches every image exactly that way, via `URLRequest` on the download URL, so closing a prefix cannot break rendering.
4. **Legacy objects carry no owner attribution.** No uid in the filename, no custom metadata beyond the download token. Contrast legacy `profile_pictures/`, whose filenames embed the uid - which is exactly why *that* migration could be written. A server-side migration of `photos/`/`videos/` is therefore impossible, and nothing needs moving.

## Deliberately Not Changed

- **The 63 orphaned staging objects were left in place.** They are unreferenced and unattributable, and deleting them is an irreversible bucket write that belongs to the repository owner. Tracked in #357.
- **Nothing in production was touched.** It was counted read-only and is empty at all three prefixes.
- **Owner-scoped `users/{uid}/...` rules are unchanged.** They were already correct.
- **No new enumeration protection was added.** `list` on these prefixes was already denied.

## Unknown, Irreducible, Residual Risk

- **UNKNOWN:** whether any physical device still holds a pre-migration workout in local SwiftData. Workout media URLs never reached Firestore, so the only surviving references are on-device and cannot be counted from the server. Such a device keeps rendering its images (tokenized URL, evidence 3) and can still delete the workout (`ClosedLegacyMediaPath`); only the cloud object is left behind.
- **IRREDUCIBLE:** a flat path cannot express ownership in Storage rules, so closing is the only fix. And a tokenized download URL bypasses rules by design, so closing `read` removes filename guessing and SDK reads but does not revoke a URL someone already holds.
- **RESIDUAL:** the 63 staging objects are now unreachable by any client and can only be removed by backend tooling.

Closes #302

## Risk Assessment

✅ Low: The follow-up commit is a small, well-tested, purely additive hardening - an observational diagnostic through the codebase's existing seam and a host allowlist that closes a real misclassification - on top of a security fix that removes access rather than granting it, with the one remaining trade-off explicitly accepted by the owner and tracked in issue #357.

## Testing

I replayed the actual issue #302 attack against the Firebase Storage emulator with the real storage.rules from each commit: on the base rules a signed-in climber with no relationship to the owner read another climber's legacy photos/ and videos/ objects and permanently deleted them (confirmed by a rules-disabled bucket listing showing both prefixes empty), and on the merged rules every one of those operations returns storage/unauthorized and both objects survive, while the owner-scoped users/{uid}/... paths still read, list, upload, and delete for their owner and stay closed to everyone else. The new rules test fails on the pre-change rules exactly where it should (intruder read, intruder delete, uploader reach) and passes on the merged rules; the whole rules suite is 86/86. I also verified empirically that closing the prefix cannot break rendering - an unauthenticated GET on the tokenized download URL, the same call RemoteMediaLoader makes, still returns HTTP 200 with the image bytes while the SDK read is denied. On iOS the targeted suites and then the full suite (811 tests, 141 suites) pass on an iPhone 17 Pro simulator, since the CI-named iPhone 16 Pro has no matching runtime on this machine; the SwiftData "couldn't be saved" lines in that log come from the deliberate migration-failure test and the suite is green. No screenshot exists because this change alters no rendered surface: it is a security-rules change plus a deletion path, and its only user-visible consequence is the absence of an error when deleting a workout whose media predates the path migration, which PhotoServiceDeletionTests covers directly - seeding a live simulator with a flat-path media URL would have required adding app source purely to stage the evidence. Worktree left clean: the two throwaway emulator harnesses and the emulator debug log were removed.

<details>
<summary>Evidence: Before/after summary of cross-climber legacy media access</summary>

```text
# Issue #302 - one climber reaching another climber's legacy media

Replayed against the Firebase Storage emulator with the real `storage.rules` file
from each commit. Alice owns three objects; Mallory is a different signed-in
account with no relationship to her.

| Operation by Mallory (signed in, not the owner) | BEFORE (base `1e9b75d`) | AFTER (`ace0423`) |
| --- | --- | --- |
| `getBytes("photos/2B3C…F1.jpg")` | **ALLOWED** - read 47 bytes of Alice's photo | DENIED `storage/unauthorized` |
| `getBytes("videos/3C4D…A2.mov")` | **ALLOWED** - read 47 bytes | DENIED `storage/unauthorized` |
| `deleteObject("photos/2B3C…F1.jpg")` | **ALLOWED** - object permanently removed | DENIED `storage/unauthorized` |
| `deleteObject("videos/3C4D…A2.mov")` | **ALLOWED** - object permanently removed | DENIED `storage/unauthorized` |
| `getBytes("users/climber-alice/photos/5E6F…C4.jpg")` | DENIED | DENIED |
| `deleteObject("users/climber-alice/photos/5E6F…C4.jpg")` | DENIED | DENIED |

Bucket ground truth after Mallory's run (read with rules disabled):

`` `
BEFORE   photos/ -> EMPTY - Alice's object is gone
         videos/ -> EMPTY - Alice's object is gone
AFTER    photos/ -> photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg
         videos/ -> videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov
`` `

Alice's own owner-scoped path is unchanged in both runs: she reads, uploads, and
deletes her own media successfully.

Full transcripts: `attack-demo-before.txt`, `attack-demo-after.txt`.

## The new rules test fails without the change

`tests/firebase-rules/workout-media-storage-contract.test.mjs` run against the
base commit's `storage.rules`:

`` `
✖ another climber cannot read legacy root workout media
✖ another climber cannot delete legacy root workout media
✖ the original uploader cannot reach legacy root workout media either
ℹ tests 8   pass 5   fail 3
`` `

Same file against the merged rules: 8/8 pass, and the whole suite is 86/86.

## Closing the prefix does not break in-app display

`RemoteMediaLoader` fetches every image with `URLSession.data(for:)` on the stored
tokenized download URL, which never consults Storage rules. Verified against the
emulator with the post-fix rules in place:

`` `
1. Storage SDK read as another climber  -> DENIED storage/unauthorized
2. Plain unauthenticated GET on the download URL -> HTTP 200 OK, image/jpeg, 47 bytes
`` `

Full transcript: `download-url-still-renders.txt`.
```
</details>
<details>
<summary>Evidence: Attack transcript - BEFORE the fix (base 1e9b75d): intruder reads and deletes another climber&#39;s media</summary>

<code>Mallory signs in as &#34;climber-mallory&#34; - a different account, no relationship to Alice.&#10;&#10;Mallory reads Alice&#39;s legacy media:&#10;getBytes(&#34;photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg&#34;)&#10;-&gt; ALLOWED read 47 bytes: &#34;alice&#39;s pre-migration stair-stepper photo bytes&#34;&#10;getBytes(&#34;videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov&#34;)&#10;-&gt; ALLOWED read 47 bytes&#10;&#10;Mallory deletes Alice&#39;s legacy media:&#10;deleteObject(&#34;photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg&#34;)&#10;-&gt; ALLOWED object permanently removed&#10;deleteObject(&#34;videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov&#34;)&#10;-&gt; ALLOWED object permanently removed&#10;&#10;Bucket state afterwards (read with rules disabled, ground truth):&#10;photos/ -&gt; EMPTY - Alice&#39;s object is gone&#10;videos/ -&gt; EMPTY - Alice&#39;s object is gone&#10;users/climber-alice/photos/ -&gt; users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg</code>

```text
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/Users/tylerpavay/.cache/firebase/emulators/cloud-storage-rules-runtime-v1.1.3.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release

==============================================================================
RULES UNDER TEST: storage.rules BEFORE the fix (base 1e9b75d)
==============================================================================
Alice's media in the bucket:
  photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg   (uploaded before the user-scoped path migration)
  videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov   (uploaded before the user-scoped path migration)
  users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg   (uploaded after)

Mallory signs in as "climber-mallory" - a different account, no relationship to Alice.

Mallory reads Alice's legacy media:
  getBytes("photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg")
    -> ALLOWED  read 47 bytes: "alice's pre-migration stair-stepper photo bytes"
  getBytes("videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov")
    -> ALLOWED  read 47 bytes

Mallory deletes Alice's legacy media:
  deleteObject("photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg")
    -> ALLOWED  object permanently removed
  deleteObject("videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov")
    -> ALLOWED  object permanently removed

Mallory tries the same against Alice's owner-scoped media:
  getBytes("users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg")
    -> DENIED   storage/unauthorized: Firebase Storage: User does not have permission to access 'users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg'. (storage/unauthorized)
  deleteObject("users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg")
    -> DENIED   storage/unauthorized: Firebase Storage: User does not have permission to access 'users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg'. (storage/unauthorized)

Alice signs back in and uses her own media as the app does today:
  getBytes("users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg")
    -> ALLOWED  read 47 bytes: "alice's pre-migration stair-stepper photo bytes"
  uploadBytes("users/climber-alice/photos/new-session.jpg")
    -> ALLOWED  upload stored
  deleteObject("users/climber-alice/photos/new-session.jpg")
    -> ALLOWED  object removed by its owner

Bucket state afterwards (read with rules disabled, ground truth):
  photos/ -> EMPTY - Alice's object is gone
  videos/ -> EMPTY - Alice's object is gone
  users/climber-alice/photos/ -> users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg
```
</details>
<details>
<summary>Evidence: Attack transcript - AFTER the fix (ace0423): every attempt denied, objects intact, owner path still works</summary>

<code>Mallory reads Alice&#39;s legacy media:&#10;getBytes(&#34;photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg&#34;)&#10;-&gt; DENIED storage/unauthorized&#10;getBytes(&#34;videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov&#34;)&#10;-&gt; DENIED storage/unauthorized&#10;&#10;Mallory deletes Alice&#39;s legacy media:&#10;deleteObject(&#34;photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg&#34;)&#10;-&gt; DENIED storage/unauthorized&#10;deleteObject(&#34;videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov&#34;)&#10;-&gt; DENIED storage/unauthorized&#10;&#10;Alice signs back in and uses her own media as the app does today:&#10;getBytes(&#34;users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg&#34;)&#10;-&gt; ALLOWED read 47 bytes&#10;uploadBytes(&#34;users/climber-alice/photos/new-session.jpg&#34;)&#10;-&gt; ALLOWED upload stored&#10;deleteObject(&#34;users/climber-alice/photos/new-session.jpg&#34;)&#10;-&gt; ALLOWED object removed by its owner&#10;&#10;Bucket state afterwards (read with rules disabled, ground truth):&#10;photos/ -&gt; photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg&#10;videos/ -&gt; videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov</code>

```text
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/Users/tylerpavay/.cache/firebase/emulators/cloud-storage-rules-runtime-v1.1.3.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release

==============================================================================
RULES UNDER TEST: storage.rules AFTER the fix (ace0423)
==============================================================================
Alice's media in the bucket:
  photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg   (uploaded before the user-scoped path migration)
  videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov   (uploaded before the user-scoped path migration)
  users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg   (uploaded after)

Mallory signs in as "climber-mallory" - a different account, no relationship to Alice.

Mallory reads Alice's legacy media:
  getBytes("photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg")
    -> DENIED   storage/unauthorized: Firebase Storage: User does not have permission to access 'photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg'. (storage/unauthorized)
  getBytes("videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov")
    -> DENIED   storage/unauthorized: Firebase Storage: User does not have permission to access 'videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov'. (storage/unauthorized)

Mallory deletes Alice's legacy media:
  deleteObject("photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg")
    -> DENIED   storage/unauthorized: Firebase Storage: User does not have permission to access 'photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg'. (storage/unauthorized)
  deleteObject("videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov")
    -> DENIED   storage/unauthorized: Firebase Storage: User does not have permission to access 'videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov'. (storage/unauthorized)

Mallory tries the same against Alice's owner-scoped media:
  getBytes("users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg")
    -> DENIED   storage/unauthorized: Firebase Storage: User does not have permission to access 'users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg'. (storage/unauthorized)
  deleteObject("users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg")
    -> DENIED   storage/unauthorized: Firebase Storage: User does not have permission to access 'users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg'. (storage/unauthorized)

Alice signs back in and uses her own media as the app does today:
  getBytes("users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg")
    -> ALLOWED  read 47 bytes: "alice's pre-migration stair-stepper photo bytes"
  uploadBytes("users/climber-alice/photos/new-session.jpg")
    -> ALLOWED  upload stored
  deleteObject("users/climber-alice/photos/new-session.jpg")
    -> ALLOWED  object removed by its owner

Bucket state afterwards (read with rules disabled, ground truth):
  photos/ -> photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg
  videos/ -> videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov
  users/climber-alice/photos/ -> users/climber-alice/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg
```
</details>
<details>
<summary>Evidence: Closing the prefix does not break in-app display (tokenized download URL still serves)</summary>

<code>1. Firebase Storage SDK read, signed in as another climber (rules are consulted):&#10;-&gt; DENIED storage/unauthorized&#10;&#10;2. Plain unauthenticated HTTPS GET on the tokenized download URL&#10;(exactly what RemoteMediaLoader does: URLRequest -&gt; URLSession.data(for:)):&#10;-&gt; HTTP 200 OK&#10;-&gt; content-type: image/jpeg&#10;-&gt; 47 bytes received</code>

```text
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/Users/tylerpavay/.cache/firebase/emulators/cloud-storage-rules-runtime-v1.1.3.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release

==============================================================================
DOES CLOSING THE PREFIX BREAK IN-APP DISPLAY? (storage.rules AFTER the fix)
==============================================================================
Object: photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg
Stored download URL (what Workout.photos holds): http://127.0.0.1:9199/v0/b/demo-ascendapp-render-demo/o/photos%2F2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg?alt=media&token=44d2b5fc-f804-49a5-9fa8-0fc3d01543e4

1. Firebase Storage SDK read, signed in as another climber (rules are consulted):
   -> DENIED   storage/unauthorized

2. Plain unauthenticated HTTPS GET on the tokenized download URL
   (exactly what RemoteMediaLoader does: URLRequest -> URLSession.data(for:)):
   -> HTTP 200 OK
   -> content-type: image/jpeg
   -> 47 bytes received: "alice's pre-migration stair-stepper photo bytes"

Storage rules are not consulted on a tokenized download URL, so every
already-rendered photo and video keeps loading in the app.
```
</details>
<details>
<summary>Evidence: New rules test run against the pre-change storage.rules (fails without the fix)</summary>

<code>✖ another climber cannot read legacy root workout media&#10;✖ another climber cannot delete legacy root workout media&#10;✔ no signed-in climber can enumerate the legacy root workout media prefixes&#10;✖ the original uploader cannot reach legacy root workout media either&#10;✔ no signed-in climber can write to the legacy root workout media prefixes&#10;✔ an unauthenticated visitor cannot reach the legacy root prefixes&#10;✔ an owner can read, list, upload, and delete their own workout media&#10;✔ another climber cannot read, list, or delete owner-scoped workout media&#10;ℹ tests 8 pass 5 fail 3</code>

```text
i  emulators: Starting emulators: storage
i  emulators: Detected demo project ID "demo-ascendapp-rules", emulated services will use a demo configuration and attempts to access non-emulated services for this project will fail.
⚠  Unexpected rules runtime error: WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/Users/tylerpavay/.cache/firebase/emulators/cloud-storage-rules-runtime-v1.1.3.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release

i  Running script: node --test tests/firebase-rules/workout-media-storage-contract.test.mjs
✖ another climber cannot read legacy root workout media (128.897041ms)
✖ another climber cannot delete legacy root workout media (25.126ms)
⚠  com.google.firebase.rules.runtime.common.EvaluationException: Error: storage.rules line [92], column [52]. Null value error.
⚠  com.google.firebase.rules.runtime.common.EvaluationException: Error: storage.rules line [98], column [52]. Null value error.
✔ no signed-in climber can enumerate the legacy root workout media prefixes (44.673125ms)
✖ the original uploader cannot reach legacy root workout media either (20.76225ms)
✔ no signed-in climber can write to the legacy root workout media prefixes (36.472791ms)
✔ an unauthenticated visitor cannot reach the legacy root prefixes (71.963834ms)
✔ an owner can read, list, upload, and delete their own workout media (140.944791ms)
✔ another climber cannot read, list, or delete owner-scoped workout media (103.993542ms)
ℹ tests 8
ℹ suites 0
ℹ pass 5
ℹ fail 3
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 667.546583

✖ failing tests:

test at tests/firebase-rules/workout-media-storage-contract.test.mjs:65:1
✖ another climber cannot read legacy root workout media (128.897041ms)
  Error: Expected request to fail, but it succeeded.
      at file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZ22WJNBZNQ6PS8AXTZMAM47/node_modules/@firebase/rules-unit-testing/dist/esm/index.esm.js:572:31
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
      at async TestContext.<anonymous> (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZ22WJNBZNQ6PS8AXTZMAM47/tests/firebase-rules/workout-media-storage-contract.test.mjs:68:3)
      at async Test.run (node:internal/test_runner/test:1389:7)
      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:387:3)

test at tests/firebase-rules/workout-media-storage-contract.test.mjs:74:1
✖ another climber cannot delete legacy root workout media (25.126ms)
  Error: Expected request to fail, but it succeeded.
      at file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZ22WJNBZNQ6PS8AXTZMAM47/node_modules/@firebase/rules-unit-testing/dist/esm/index.esm.js:572:31
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
      at async TestContext.<anonymous> (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZ22WJNBZNQ6PS8AXTZMAM47/tests/firebase-rules/workout-media-storage-contract.test.mjs:77:3)
      at async Test.run (node:internal/test_runner/test:1389:7)
      at async Test.processPendingSubtests (node:internal/test_runner/test:960:7)

test at tests/firebase-rules/workout-media-storage-contract.test.mjs:90:1
✖ the original uploader cannot reach legacy root workout media either (20.76225ms)
  Error: Expected request to fail, but it succeeded.
      at file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZ22WJNBZNQ6PS8AXTZMAM47/node_modules/@firebase/rules-unit-testing/dist/esm/index.esm.js:572:31
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
      at async TestContext.<anonymous> (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZ22WJNBZNQ6PS8AXTZMAM47/tests/firebase-rules/workout-media-storage-contract.test.mjs:93:3)
      at async Test.run (node:internal/test_runner/test:1389:7)
      at async Test.processPendingSubtests (node:internal/test_runner/test:960:7)
⚠  Script exited unsuccessfully (code 1)
i  emulators: Shutting down emulators.
i  storage: Stopping Storage Emulator
i  hub: Stopping emulator hub
i  logging: Stopping Logging Emulator

Error: Script "node --test tests/firebase-rules/workout-media-storage-contract.test.mjs" exited with code 1
```
</details>
<details>
<summary>Evidence: Firebase rules suite on the merged rules (86/86)</summary>

```text
> ascendapp@1.0.0 test:firebase-rules
> npx -y firebase-tools@15.22.1 emulators:exec --project demo-ascendapp-rules --only firestore,storage "node --test tests/firebase-rules/*.test.mjs"
i  emulators: Starting emulators: firestore, storage
i  emulators: Detected demo project ID "demo-ascendapp-rules", emulated services will use a demo configuration and attempts to access non-emulated services for this project will fail.
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
⚠  Unexpected rules runtime error: WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/Users/tylerpavay/.cache/firebase/emulators/cloud-storage-rules-runtime-v1.1.3.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release
i  Running script: node --test tests/firebase-rules/*.test.mjs
✔ a user can create, read, list, and delete only their own blocks (5618.066584ms)
✔ a user cannot read or list another users blocks (165.605458ms)
✔ a user cannot create or delete a block in another users list (209.604209ms)
evaluation error at L1404:26 for 'create' @ L1404, false for 'update' @ L1406, false for 'create' @ L1404
evaluation error at L1404:26 for 'create' @ L1404, false for 'update' @ L1406, false for 'create' @ L1404
evaluation error at L1404:26 for 'create' @ L1404, false for 'update' @ L1406, false for 'create' @ L1404
✔ block documents reject self-blocking, mismatched ids, updates, and schema pollution (160.251292ms)
✔ a signed-in user can create a complete moderation report (138.772666ms)
✔ moderation reports are unreadable and immutable to every client (170.682375ms)
✔ identity propagation checkpoints are server-only (107.074208ms)
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'create' @ L1496, false for 'create' @ L1484
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'create' @ L1496, false for 'create' @ L1484
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'create' @ L1484
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'create' @ L1496, false for 'create' @ L1484
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'create' @ L1496, false for 'create' @ L1484
✔ moderation reports reject spoofing, self-reports, invalid enums, and extra fields (151.854083ms)
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, Null value error. for 'create' @ L1484
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'create' @ L1496, false for 'create' @ L1484
✔ reports require an existing target and an atomic rate-limit update (117.526334ms)
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'update' @ L1497, false for 'create' @ L1484
✔ a reporter cannot submit a second report during the server cooldown (90.235625ms)
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'create' @ L1496, false for 'create' @ L1484, false for 'create' @ L1484
✔ one batch cannot bind a single cooldown advance to two reports (64.842625ms)
evaluation error at L1484:24 for 'create' @ L1484, false for 'update' @ L1491, evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'create' @ L1496
evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'update' @ L1497
evaluation error at L1496:24 for 'create' @ L1496, evaluation error at L1497:24 for 'update' @ L1497, false for 'update' @ L1497
✔ a reporter cannot spoof or delete moderation rate-limit timestamps (107.900125ms)
✔ anonymous clients cannot create blocks or reports (66.999625ms)
✔ display-name screening is enforced on every client-writable publication (671.073375ms)
✔ account and public identity can commit atomically (60.201625ms)
✔ public identity requires bounded nonempty names and bounded photo urls (57.715417ms)
✔ display-name screening matches the shared parity vector (280.236875ms)
✔ public photo URLs must be Firebase Storage download URLs (176.255875ms)
evaluation error at L1372:26 for 'update' @ L1372, false for 'update' @ L1372
evaluation error at L1416:24 for 'update' @ L1416, false for 'update' @ L1416
evaluation error at L1416:24 for 'update' @ L1416, false for 'update' @ L1416
evaluation error at L1416:24 for 'update' @ L1416, false for 'update' @ L1416
✔ identity policy blocks stale clients and permits modern refreshes (93.007083ms)
evaluation error at L1413:24 for 'create' @ L1413, evaluation error at L1416:24 for 'update' @ L1416, false for 'create' @ L1413
✔ leaderboard creates cannot spoof identity or create a masked lifecycle (60.363041ms)
evaluation error at L1416:24 for 'update' @ L1416, false for 'update' @ L1416
evaluation error at L1416:24 for 'update' @ L1416, false for 'update' @ L1416
✔ metrics refresh preserves server-masked pending and deleted identity (75.199708ms)
✔ incoming block cleanup has a collection-group single-field index (15.539916ms)
✔ identity propagation has collection-group user indexes (14.53325ms)
✔ owner can write the renamed profile stats contract (5252.673458ms)
✔ profile stats written under the legacy _weeks names are rejected (120.199167ms)
✔ profile stats carrying both the legacy and renamed counters are rejected (59.91075ms)
evaluation error at L1381:34 for 'create' @ L1381, evaluation error at L1381:34 for 'update' @ L1381, false for 'update' @ L1381
✔ merging the renamed counters onto a legacy document is rejected while the legacy keys remain (127.292208ms)
✔ the client payload rewrites a legacy document, preserving counts and dropping the legacy keys (212.481958ms)
✔ renamed counters must stay cumulative across bands (106.084125ms)
✔ users cannot write profile stats into another users path (99.763ms)
✔ owner can write profile demographics on their private user document (5336.933709ms)
✔ profile demographic values are bounded (177.044917ms)
✔ users cannot write demographics into another users profile (110.404625ms)
✔ owner can publish validated account-authored public identity (177.982333ms)
evaluation error at L1368:26 for 'create' @ L1368, evaluation error at L1372:26 for 'update' @ L1372, false for 'update' @ L1372
evaluation error at L1368:26 for 'create' @ L1368, evaluation error at L1372:26 for 'update' @ L1372, false for 'update' @ L1372
evaluation error at L1368:26 for 'create' @ L1368, evaluation error at L1372:26 for 'update' @ L1372, false for 'update' @ L1372
evaluation error at L1368:26 for 'create' @ L1368, evaluation error at L1372:26 for 'update' @ L1372, false for 'update' @ L1372
evaluation error at L1368:26 for 'create' @ L1368, evaluation error at L1372:26 for 'update' @ L1372, false for 'update' @ L1372
✔ public profile identity rejects empty, overlong, profane, photo, and uid spoofing (193.759708ms)
✔ owner can write daily leaderboard stats (102.062041ms)
✔ daily leaderboard stats require a daily period key (123.123417ms)
✔ leaderboard stats accept validated account-authored public identity (181.560292ms)
✔ leaderboard identity rejects empty, overlong, profane, photo, and uid spoofing (149.068417ms)
✔ signed-in users can read published routine templates (159.665958ms)
✔ clients cannot read unpublished routine templates (132.919125ms)
✔ clients cannot write routine templates (65.446958ms)
✔ owner can write a valid workout backup document (75.44ms)
✔ workout HR integrity metadata is bounded and validated (113.818041ms)
✔ workout document ids must be the uppercase canonical UUID (59.824375ms)
✔ workout document ids must match the UUID group shape (52.913125ms)
✔ the public workout mirror accepts the canonical workout document id (53.154083ms)
✔ the public workout mirror rejects a case-variant workout document id (53.054167ms)
✔ owner can write a workout with routine template participation (67.252375ms)
✔ owner can write a headphone motion workout with climb attempt participation (57.00825ms)
✔ workout climb query key is bounded and limited to headphone motion (71.581792ms)
✔ climb attempt participation requires headphone motion source (63.903333ms)
✔ highlighted media id must point to an uploaded media item (58.074541ms)
✔ invalid nested media items are rejected (44.780208ms)
✔ invalid weight entries are rejected (39.958667ms)
✔ a workout weight entry rejects an unknown key and a missing required key (43.195542ms)
✔ a workout weight configuration rejects an unknown key and a missing required key (39.81575ms)
✔ a participation metrics snapshot rejects an unknown key and a missing required key (44.967959ms)
✔ a workout participation rejects an unknown key and a missing required key (48.021667ms)
✔ users cannot write workouts into another users path (38.504875ms)
✔ a workout stored at the previous schema version stays updatable after a bump (54.915542ms)
✔ a client still emitting the previous schema version is not locked out of writing (57.497083ms)
✔ a workout schema version may not regress to an older number (71.158084ms)
✔ workout schema versions outside the supported range are rejected (83.6855ms)
✔ non-string enum values are rejected without a separate type check (86.740042ms)
✔ a heart-rate reference at a bumped object schema version stays writable (39.819042ms)
✔ heart-rate object schema versions outside the supported range are rejected (46.564042ms)
✔ leaderboard stats accept every schema version still plausibly in the field (42.850916ms)
✔ leaderboard schema versions outside the supported range are rejected (42.750708ms)
✔ owner can upload a valid heart-rate sidecar blob (26.022708ms)
✔ non-owners cannot upload heart-rate sidecars into another users scope (27.764041ms)
✔ heart-rate sidecars must be compressed uploads (38.450291ms)
✔ signed-in users can read server-published live replay leaderboard windows (51.932042ms)
✔ signed-in users can read server-owned live replay avatars (56.559ms)
✔ legacy root profile pictures are private even to signed-in users (26.169625ms)
✔ clients cannot write live replay leaderboard indexes (37.741709ms)
✔ owner can read server-owned live climb publish status (49.204375ms)
✔ clients cannot write live climb publish statuses (26.772333ms)
✔ another climber cannot read legacy root workout media (213.982541ms)
✔ another climber cannot delete legacy root workout media (65.096291ms)
✔ no signed-in climber can enumerate the legacy root workout media prefixes (65.351084ms)
✔ the original uploader cannot reach legacy root workout media either (82.0105ms)
✔ no signed-in climber can write to the legacy root workout media prefixes (54.133708ms)
✔ an unauthenticated visitor cannot reach the legacy root prefixes (93.489209ms)
✔ an owner can read, list, upload, and delete their own workout media (148.654917ms)
✔ another climber cannot read, list, or delete owner-scoped workout media (125.242ms)
ℹ tests 86
ℹ suites 0
ℹ pass 86
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 8971.289083
✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  firestore: Stopping Firestore Emulator
i  storage: Stopping Storage Emulator
i  hub: Stopping emulator hub
i  logging: Stopping Logging Emulator
```
</details>
<details>
<summary>Evidence: iOS targeted suites (ClosedLegacyMediaPath, PhotoServiceDeletion, AccountDeletionService)</summary>

<code>✔ Test deletesAWorkoutWhoseMediaSitsAtAClosedLegacyPath() passed&#10;✔ Test stillDeletesOwnerScopedMediaAlongsideUnreachableMedia() passed&#10;✔ Test reportsSkippedUnreachableMediaAsADiagnostic() passed&#10;✔ Test stillReportsAFailureWhenOwnerScopedMediaCannotBeDeleted() passed&#10;✔ Test sweepsOnlyOwnerScopedStorageAndNeverTheLegacyFlatPaths() passed&#10;✔ Test reportsFullProgressOnceEveryStepHasRun() passed&#10;✔ Test run with 27 tests in 3 suites passed</code>

```text
✔ Test treatsUnrecognisedURLsAsReachable() passed after 0.001 seconds.
✔ Test recognisesTheExplicitPortTheStorageSDKEmits() passed after 0.001 seconds.
✔ Test partitionsMediaByReachability() passed after 0.001 seconds.
✔ Test leavesOwnerScopedMediaAlone() passed after 0.001 seconds.
✔ Test recognisesClosedObjectsBehindTheStorageEmulator() passed after 0.001 seconds.
✔ Test recognisesEveryClosedRootPrefix() passed after 0.001 seconds.
✔ Suite ClosedLegacyMediaPathTests passed after 0.002 seconds.
✔ Test deletesAWorkoutWhoseMediaSitsAtAClosedLegacyPath() passed after 0.001 seconds.
✔ Test staysQuietWhenEveryPhotoIsReachable() passed after 0.001 seconds.
✔ Test reportsSkippedUnreachableMediaAsADiagnostic() passed after 0.001 seconds.
✔ Test stillDeletesOwnerScopedMediaAlongsideUnreachableMedia() passed after 0.001 seconds.
✔ Test deletesTheUserDocumentLastSoTheServerSweepSeesTheRestGone() passed after 0.006 seconds.
✔ Test sweepsOnlyOwnerScopedStorageAndNeverTheLegacyFlatPaths() passed after 0.011 seconds.
✔ Test reportsFullProgressOnceEveryStepHasRun() passed after 0.015 seconds.
✔ Test deletesPublicProfileMirrorsBeforeTheAuthAccount() passed after 0.019 seconds.
✔ Test deletesEveryRemoteRecordBeforeTheAuthAccount() passed after 0.024 seconds.
✔ Test completesDeletionWhenAppleTokenRevocationFails() passed after 0.028 seconds.
✔ Test revokesTheAppleTokenBeforeTheStorageSweepAndAuthDeletion() passed after 0.032 seconds.
✔ Test skipsRevocationForProvidersWithoutAnAppleAuthorizationCode() passed after 0.036 seconds.
✔ Test reauthenticatesWithAppleWhenBothProvidersAreLinked() passed after 0.045 seconds.
✔ Test hasNoProviderToReauthenticateWithWhenNoneIsSupported() passed after 0.070 seconds.
✔ Test reauthenticatesWithApplePreferringItOverEveryOtherProvider() passed after 0.070 seconds.
✔ Test reauthenticatesWithGoogleWhenAppleIsNotLinked() passed after 0.075 seconds.
✔ Test "Unregisters push delivery before deleting the user" passed after 0.075 seconds.
✔ Test reauthenticatesBeforeAnythingIsDeleted() passed after 0.080 seconds.
✔ Test cancellingReauthenticationDeletesNothing() passed after 0.079 seconds.
✔ Test keepsLocalDataWhenTheAuthDeletionFails() passed after 0.080 seconds.
✔ Suite AccountDeletionServiceTests passed after 0.082 seconds.
✔ Test stillReportsAFailureWhenOwnerScopedMediaCannotBeDeleted() passed after 0.126 seconds.
✔ Suite PhotoServiceDeletionTests passed after 0.126 seconds.
✔ Test run with 27 tests in 3 suites passed after 0.127 seconds.
```
</details>
<details>
<summary>Evidence: Full iOS suite summary</summary>

`✔ Test run with 811 tests in 141 suites passed after 260.651 seconds.`

```text
✔ Suite ClosedLegacyMediaPathTests passed after 0.478 seconds.
✔ Suite PhotoServiceDeletionTests passed after 0.817 seconds.
✔ Suite AccountDeletionServiceTests passed after 7.078 seconds.
✔ Suite WorkoutSourceSchemaMigrationTests passed after 25.214 seconds.
✔ Test run with 811 tests in 141 suites passed after 260.651 seconds.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `AscendApp/Features/Account/Services/AccountDeletionService.swift:122` - Removing deleteLegacyFlatPathMedia leaves pre-migration root media permanently undeletable. The removed step was the only path that could attribute a root-prefix object to an owner (it read the download URLs out of the user&#39;s own SwiftData Workouts); the server has no equivalent, since the intent&#39;s own evidence says zero Firestore documents reference root photos/ or videos/ and the objects carry no uid in the filename or metadata. So for any user who still holds a pre-migration workout, deleting their account now leaves their photos/videos in the bucket forever, where previously the best-effort client sweep removed them. That is correct given the closed rules (the sweep could only fail now), but it means account deletion is no longer complete for those users - a 5.1.1(v) / data-deletion consideration, and production&#39;s legacy object count is explicitly UNKNOWN. Since nothing references these objects and none are attributable, the clean resolution is a one-time backend purge of the entire root photos/ and videos/ prefixes; that is a destructive write the captain should authorize, so flagging rather than fixing.
- ℹ️ `AscendApp/Shared/Services/PhotoService.swift:176` - Media at a closed prefix is placed directly into successfulDeletions with no log, breadcrumb, or analytics event, so a delete that never happened is indistinguishable from one that did. Because the production legacy object count was not inspected, there is currently no way to learn whether any real user hits this branch, or how much orphaned media closing the prefixes stranded. A single Sentry breadcrumb or analytics counter on a non-empty `unreachable` partition would provide that signal at no behavioral cost.
- ℹ️ `AscendApp/Shared/Services/ClosedLegacyMediaPath.swift:45` - storageObjectPath matches purely on path shape (/v0/b/{bucket}/o/{object}) and never checks the host, so a non-Firebase URL such as https://example.com/v0/b/bucket/o/photos%2Fa.jpg would be classified as an unreachable closed-root object and silently skipped. ClosedLegacyMediaPathTests.treatsUnrecognisedURLsAsReachable reads as if it covers this, but its example passes only because it has six path segments, not because the host was rejected. Impact is nil today - Photo.url always comes from StorageReference.downloadURL() - so this is a note on the gap between the stated guarantee and the implementation, not a live defect.

🔧 Fix: Report skipped legacy media and host-check Storage URLs
1 info still open:
- ℹ️ `AscendApp/Shared/Services/ClosedLegacyMediaPath.swift:26` - The host allowlist is a fixed literal set, so classification is now coupled to the Firebase Storage SDK continuing to emit firebasestorage.googleapis.com. If that download host ever changes, or someone points Storage at a non-loopback emulator host (e.g. a LAN address for on-device testing), a legacy root object stops being recognised, the delete is attempted, it fails against the closed rules, and the pre-migration workout becomes undeletable again - exactly the failure this file exists to prevent. Nothing in the app configures a custom Storage host today (no useEmulator call anywhere in AscendApp), and the tightening was explicitly requested, so this is a note on the coupling rather than a defect: failing toward &#39;deletable&#39; is the conservative direction, and the behaviour is pinned by recognisesTheExplicitPortTheStorageSDKEmits and recognisesClosedObjectsBehindTheStorageEmulator.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npm run test:firebase-rules` (86/86, includes the new tests/firebase-rules/workout-media-storage-contract.test.mjs)</code>
- <code>New rules test against the base commit&#39;s rules: `git show 1e9b75d:storage.rules &gt; storage.rules &amp;&amp; npx firebase-tools@15.22.1 emulators:exec --only storage &#34;node --test tests/firebase-rules/workout-media-storage-contract.test.mjs&#34;` - 3 failures, rules then restored with `git checkout storage.rules`</code>
- <code>Manual attack replay on the Storage emulator (throwaway harness, deleted afterwards): intruder-uid getBytes/deleteObject on `photos/…jpg` and `videos/…mov`, plus owner read/upload/delete on `users/{uid}/photos/…`, run once against the pre-change rules and once against the merged rules, with a rules-disabled bucket listing as ground truth</code>
- <code>Manual render check on the Storage emulator: `getDownloadURL` on a closed-prefix object, then an unauthenticated `fetch` of that tokenized URL (the RemoteMediaLoader path) - HTTP 200, image/jpeg, bytes returned, while the SDK read is denied</code>
- <code>`xcodebuild ... -only-testing:AscendAppTests/ClosedLegacyMediaPathTests -only-testing:AscendAppTests/PhotoServiceDeletionTests -only-testing:AscendAppTests/AccountDeletionServiceTests test` (27 tests, 3 suites)</code>
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp-Staging&#34; -configuration Staging -destination &#34;platform=iOS Simulator,name=iPhone 17 Pro&#34; ENABLE_TESTABILITY=YES test` (811 tests, 141 suites)</code>
- <code>`grep -rn &#34;deleteLegacyMedia|sweepLegacyMedia|deleteLegacyFlatPathMedia&#34;` across app, tests, functions, and scripts to confirm no caller survives the removal</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

