### PR TITLE
ci: derive TestFlight build numbers as readable YYYYMMDDNN from App Store Connect

### DIFF
--- a/.claude/skills/ascend-deploy/SKILL.md
+++ b/.claude/skills/ascend-deploy/SKILL.md
@@ -168,10 +168,21 @@ Do not introduce a *new* long-lived JSON service-account key for deploy auth; th
 - Also required by both build jobs: `SENTRY_AUTH_TOKEN`.
 
 ### Build numbers (CFBundleVersion allocator)
-- `BUILD_NUMBER` is derived by `scripts/ci/derive-build-number.sh <slot>` in a pre-archive "Derive build number" step, not from `github.run_id`/`run_number`. The step assigns the result to a variable first so a non-zero exit propagates under `set -e` before anything is written to `$GITHUB_ENV`; a failed derivation stops the deploy instead of exporting an empty build number.
-- Value: `(UTC epoch seconds - 2026-01-01T00:00:00Z) * 2 + slot`. Staging passes slot `0`, production slot `1`. Two slots consume two integers per second, giving `4294967296 / 2 = 2147483648` seconds of range - exhausting around 2094-01-19 UTC, where the script hard-fails rather than emitting a value above the 32-bit App Store ceiling.
-- Uniqueness depends on two invariants, both enforced by `scripts/test/ci-workflow-contracts.test.mjs`: every uploadable workflow (one that runs a signed `build_*` lane or `upload_testflight`) declares a **fixed, non-ref-scoped** concurrency group (`deploy-staging`, `deploy-production`) so all of its runs - including manual `workflow_dispatch` from any ref - serialize; and each such workflow passes a **distinct** allocator slot. A new uploadable workflow, a duplicate slot, or a group that regains a `${{ github.ref }}` component fails that contract test.
-- The script also refuses any value at or below the recorded `PREVIOUS_BUILD_NUMBER_FLOOR`. Do not raise `BUILD_NUMBER_EPOCH_SECONDS`: a larger epoch emits build numbers below already-uploaded builds, which TestFlight rejects irreversibly. If the range is ever exhausted, ship a new marketing version with a reset build-number scheme instead.
+- `BUILD_NUMBER` is derived by `scripts/ci/derive-build-number.sh <app-store-connect-app-id> <bundle-id>` in a pre-archive "Derive build number" step, not from `github.run_id` or `github.run_number`.
+  The step assigns the result to a variable first so a non-zero exit propagates under `set -e` before anything is written to `$GITHUB_ENV`.
+  A failed derivation stops the deploy instead of exporting an empty build number.
+- The value uses `YYYYMMDDNN`: the UTC date plus the next two-digit sequence for that app on that day.
+  The allocator asks App Store Connect for every uploaded build on the configured app, validates that the app owns the expected bundle ID, and derives `01` or one more than today's highest suffix.
+  An unreachable API, unexpected bundle, non-numeric historical build, future build, or exhausted `99` suffix fails closed.
+- Staging app `6759919365` (`com.TylerPavay.AscendApp.staging`) and production app `6757202987` (`com.TylerPavay.AscendApp`) have independent App Store Connect build-number spaces.
+  Their workflows deliberately can emit the same date sequence because the signed IPAs upload to separate apps.
+  The workflow-level app ID and bundle ID are also passed explicitly to Fastlane so allocation and upload cannot silently target different apps.
+- Uniqueness depends on each uploadable workflow declaring a **fixed, non-ref-scoped** per-app concurrency group (`deploy-staging`, `deploy-production`).
+  That serialization spans archive and upload, so another run for the same app cannot derive against stale remote state.
+  Cancelled runs and reruns consume no sequence value because App Store Connect, not workflow history, owns the state.
+  `scripts/test/ci-workflow-contracts.test.mjs` enforces the fixed groups and distinct app mappings.
+- The allocator refuses a number at or below the legacy cutover floor, at or below the highest uploaded build, or above the App Store's 32-bit ceiling.
+  `YYYYMMDDNN` remains below the ceiling through 4294 and fails rather than wrapping after that.
 - Legacy manual-signing CI secrets are deprecated:
   - `BUILD_CERTIFICATE_BASE64`
   - `BUILD_PROVISION_PROFILE_BASE64`

--- a/.claude/skills/ascend-deploy/SKILL.md
+++ b/.claude/skills/ascend-deploy/SKILL.md
@@ -165,11 +165,12 @@ Do not introduce a *new* long-lived JSON service-account key for deploy auth; th
   - `MATCH_GIT_URL`
   - `MATCH_PASSWORD`
   - `MATCH_GIT_PRIVATE_KEY`
-- Also required by both build jobs: `SENTRY_AUTH_TOKEN`.
+- Also required by both build jobs: `SENTRY_AUTH_TOKEN`, plus `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID` and `APP_STORE_CONNECT_API_KEY`.
+  The build-number allocator reads App Store Connect before the archive, so those three credentials now reach the archive job as well as the upload job - widening their blast radius to every step that runs on the build runner.
 
 ### Build numbers (CFBundleVersion allocator)
 - `BUILD_NUMBER` is derived by `scripts/ci/derive-build-number.sh <app-store-connect-app-id> <bundle-id>` in a pre-archive "Derive build number" step, not from `github.run_id` or `github.run_number`.
-  The step assigns the result to a variable first so a non-zero exit propagates under `set -e` before anything is written to `$GITHUB_ENV`.
+  The step assigns the result to a variable first so a non-zero exit propagates under `set -e` before anything is written to `$GITHUB_ENV`, and rejects an empty value explicitly - a zero-exit-no-output derivation would otherwise archive an empty `CFBundleVersion`.
   A failed derivation stops the deploy instead of exporting an empty build number.
 - The value uses `YYYYMMDDNN`: the UTC date plus the next two-digit sequence for that app on that day.
   The allocator asks App Store Connect for every uploaded build on the configured app, validates that the app owns the expected bundle ID, and derives `01` or one more than today's highest suffix.
@@ -178,9 +179,14 @@ Do not introduce a *new* long-lived JSON service-account key for deploy auth; th
   Their workflows deliberately can emit the same date sequence because the signed IPAs upload to separate apps.
   The workflow-level app ID and bundle ID are also passed explicitly to Fastlane so allocation and upload cannot silently target different apps.
 - Uniqueness depends on each uploadable workflow declaring a **fixed, non-ref-scoped** per-app concurrency group (`deploy-staging`, `deploy-production`).
-  That serialization spans archive and upload, so another run for the same app cannot derive against stale remote state.
   Cancelled runs and reruns consume no sequence value because App Store Connect, not workflow history, owns the state.
-  `scripts/test/ci-workflow-contracts.test.mjs` enforces the fixed groups and distinct app mappings.
+  `scripts/test/ci-workflow-contracts.test.mjs` enforces the fixed groups, the distinct app mappings, and the post-upload wait below.
+- **The concurrency group alone is not enough, and the reason is not obvious.** It serializes workflow *runs*, not Apple's ingestion.
+  `upload_to_testflight` keeps `skip_waiting_for_build_processing: true`, so the lane returns when the transporter accepts the binary - minutes before the Build record is queryable through `/v1/builds`, which is the allocator's only sequence state.
+  Left there, the next queued run would derive against the pre-upload maximum and mint the same `YYYYMMDDNN`, and Apple would reject it at the end of a full archive cycle.
+  `scripts/ci/await-build-visible.mjs` closes that window: the upload job polls `/v1/builds` for the exact build it just uploaded and does not exit - does not release the group - until the record is listed.
+  It waits for *visibility*, not for processing to finish, and fails loudly after a bounded 15 minutes rather than hanging or proceeding.
+  The derived number reaches that job as the `build-ios` job output `build-number`; an empty one is a hard failure, not a skipped wait.
 - The allocator refuses a number at or below the legacy cutover floor, at or below the highest uploaded build, or above the App Store's 32-bit ceiling.
   `YYYYMMDDNN` remains below the ceiling through 4294 and fails rather than wrapping after that.
 - Legacy manual-signing CI secrets are deprecated:

--- a/.claude/skills/ascend-deploy/SKILL.md
+++ b/.claude/skills/ascend-deploy/SKILL.md
@@ -187,6 +187,8 @@ Do not introduce a *new* long-lived JSON service-account key for deploy auth; th
   `scripts/ci/await-build-visible.mjs` closes that window: the upload job polls `/v1/builds` for the exact build it just uploaded and does not exit - does not release the group - until the record is listed.
   It waits for *visibility*, not for processing to finish, and fails loudly after a bounded 15 minutes rather than hanging or proceeding.
   The derived number reaches that job as the `build-ios` job output `build-number`; an empty one is a hard failure, not a skipped wait.
+  Two properties of that poll are load-bearing and easy to regress: it mints a **fresh JWT per attempt**, because the token lifetime and the poll budget are both 900s and a once-minted token 401s exactly when a slow build finally appears; and it treats a per-attempt 429/5xx as **transient**, retrying for the remaining budget, because the binary is already accepted by the transporter and failing early only discards budget that might still have confirmed visibility.
+  Credential loading and the app-to-bundle ownership check stay fatal - the latter is what proves the poll is watching the right app.
 - The allocator refuses a number at or below the legacy cutover floor, at or below the highest uploaded build, or above the App Store's 32-bit ceiling.
   `YYYYMMDDNN` remains below the ceiling through 4294 and fails rather than wrapping after that.
 - Legacy manual-signing CI secrets are deprecated:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -89,6 +89,8 @@ jobs:
       - production-approval
     runs-on: macos-15
     timeout-minutes: 60
+    outputs:
+      build-number: ${{ steps.derive-build-number.outputs.build_number }}
 
     steps:
       - name: Checkout repository
@@ -213,6 +215,7 @@ jobs:
         run: node scripts/ci/assert-remote-config-published.mjs prod
 
       - name: Derive build number
+        id: derive-build-number
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
@@ -221,7 +224,12 @@ jobs:
         run: |
           set -euo pipefail
           build_number="$(scripts/ci/derive-build-number.sh "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID")"
+          if [ -z "$build_number" ]; then
+            echo "::error::Build number derivation exited successfully but produced no value."
+            exit 1
+          fi
           echo "BUILD_NUMBER=${build_number}" >> "$GITHUB_ENV"
+          echo "build_number=${build_number}" >> "$GITHUB_OUTPUT"
 
       - name: Build production IPA via Fastlane
         env:
@@ -402,7 +410,7 @@ jobs:
       - build-ios
       - deploy-firebase
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
@@ -413,6 +421,11 @@ jobs:
         with:
           ruby-version: "3.1"
           bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
 
       - name: Download production IPA artifact
         uses: actions/download-artifact@v4
@@ -427,6 +440,25 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         run: bundle exec fastlane upload_testflight
+
+      # The upload lane returns before App Store Connect lists the build, and the
+      # allocator's only sequence state is that listing. `deploy-status` runs after
+      # this job but holds no App Store Connect dependency, so this step is the last
+      # point at which the group can be held until the record actually exists.
+      - name: Wait for the uploaded build to be visible in App Store Connect
+        env:
+          BUILD_NUMBER: ${{ needs.build-ios.outputs.build-number }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$BUILD_NUMBER" ]; then
+            echo "::error::The build job published no derived build number to wait on."
+            exit 1
+          fi
+          node scripts/ci/await-build-visible.mjs "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID" "$BUILD_NUMBER"
 
   # A production deploy either succeeds or fails. This job is what makes a run
   # that quietly deployed *nothing* conclude `failure` instead of `success` -

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -35,6 +35,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  APP_STORE_CONNECT_APP_ID: "6757202987"
+  APP_STORE_CONNECT_BUNDLE_ID: com.TylerPavay.AscendApp
+
 jobs:
   production-gate:
     name: Production Gate
@@ -209,10 +213,14 @@ jobs:
         run: node scripts/ci/assert-remote-config-published.mjs prod
 
       - name: Derive build number
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
-          build_number="$(scripts/ci/derive-build-number.sh 1)"
+          build_number="$(scripts/ci/derive-build-number.sh "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID")"
           echo "BUILD_NUMBER=${build_number}" >> "$GITHUB_ENV"
 
       - name: Build production IPA via Fastlane

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -89,6 +89,8 @@ jobs:
     needs: publish-kill-switches
     runs-on: macos-15
     timeout-minutes: 60
+    outputs:
+      build-number: ${{ steps.derive-build-number.outputs.build_number }}
 
     steps:
       - name: Checkout repository
@@ -221,6 +223,7 @@ jobs:
         run: node scripts/ci/assert-remote-config-published.mjs staging
 
       - name: Derive build number
+        id: derive-build-number
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
@@ -229,7 +232,12 @@ jobs:
         run: |
           set -euo pipefail
           build_number="$(scripts/ci/derive-build-number.sh "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID")"
+          if [ -z "$build_number" ]; then
+            echo "::error::Build number derivation exited successfully but produced no value."
+            exit 1
+          fi
           echo "BUILD_NUMBER=${build_number}" >> "$GITHUB_ENV"
+          echo "build_number=${build_number}" >> "$GITHUB_OUTPUT"
 
       - name: Build staging IPA via Fastlane
         env:
@@ -300,7 +308,7 @@ jobs:
       - build-ios
       - deploy-firebase
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     steps:
       - name: Checkout repository
@@ -311,6 +319,11 @@ jobs:
         with:
           ruby-version: "3.1"
           bundler-cache: true
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
 
       - name: Download staging IPA artifact
         uses: actions/download-artifact@v4
@@ -325,3 +338,22 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         run: bundle exec fastlane upload_testflight
+
+      # This job is the last one in the group, so it is what holds `deploy-staging`.
+      # The upload lane returns before App Store Connect lists the build, and the
+      # allocator's only sequence state is that listing - so releasing the group
+      # here would let the next run derive the same number. See the script.
+      - name: Wait for the uploaded build to be visible in App Store Connect
+        env:
+          BUILD_NUMBER: ${{ needs.build-ios.outputs.build-number }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$BUILD_NUMBER" ]; then
+            echo "::error::The build job published no derived build number to wait on."
+            exit 1
+          fi
+          node scripts/ci/await-build-visible.mjs "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID" "$BUILD_NUMBER"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -37,6 +37,10 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  APP_STORE_CONNECT_APP_ID: "6759919365"
+  APP_STORE_CONNECT_BUNDLE_ID: com.TylerPavay.AscendApp.staging
+
 jobs:
   # Its own job, and `build-ios` waits on it, because the obvious home for this -
   # a step in `deploy-firebase` beside the rules and indexes - does not actually
@@ -217,10 +221,14 @@ jobs:
         run: node scripts/ci/assert-remote-config-published.mjs staging
 
       - name: Derive build number
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
-          build_number="$(scripts/ci/derive-build-number.sh 0)"
+          build_number="$(scripts/ci/derive-build-number.sh "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID")"
           echo "BUILD_NUMBER=${build_number}" >> "$GITHUB_ENV"
 
       - name: Build staging IPA via Fastlane

--- a/docs/production-backend-rollout-runbook.md
+++ b/docs/production-backend-rollout-runbook.md
@@ -113,7 +113,9 @@ The workflow performs the following order automatically:
 12. Deploy Hosting.
 13. Verify Hosting serves `/climbs/manifest.json` successfully.
 14. Upload the already-built IPA to TestFlight only after every backend step succeeds.
-15. Assert the run reached a real outcome, so a run that deployed nothing fails instead of reporting green.
+15. Hold the upload job until App Store Connect actually lists the uploaded build, so the next run's build number is derived from post-upload state.
+    This step can add up to 15 minutes after a successful upload, and it fails the run when the build never appears; `scripts/ci/await-build-visible.mjs` owns why releasing the deploy concurrency group early would mint a duplicate build number.
+16. Assert the run reached a real outcome, so a run that deployed nothing fails instead of reporting green.
 
 This ordering makes indexes available before `onWorkoutWritten` can execute its `source + climbId` query.
 It makes Functions available before Hosting publishes the rewrite to `unsubscribeFromEmails`.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,8 +112,8 @@ platform :ios do
     staging_widget_bundle_identifier = ENV.fetch("IOS_STAGING_WIDGET_BUNDLE_ID", "com.TylerPavay.AscendApp.staging.LiveClimbWidgets")
     staging_widget_profile_specifier = ENV.fetch("IOS_STAGING_WIDGET_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp.staging.LiveClimbWidgets")
 
-    # BUILD_NUMBER is derived pre-archive by scripts/ci/derive-build-number.sh
-    # from epoch seconds and the workflow slot, not github.run_number.
+    # BUILD_NUMBER is derived pre-archive from this app's uploaded builds in
+    # App Store Connect, not from a workflow-local counter.
     build_number = ENV["BUILD_NUMBER"]
     if build_number
       increment_build_number(
@@ -197,8 +197,8 @@ platform :ios do
     production_widget_bundle_identifier = ENV.fetch("IOS_PRODUCTION_WIDGET_BUNDLE_ID", "com.TylerPavay.AscendApp.LiveClimbWidgets")
     production_widget_profile_specifier = ENV.fetch("IOS_PRODUCTION_WIDGET_PROVISIONING_PROFILE_SPECIFIER", "match AppStore com.TylerPavay.AscendApp.LiveClimbWidgets")
 
-    # BUILD_NUMBER is derived pre-archive by scripts/ci/derive-build-number.sh
-    # from epoch seconds and the workflow slot, not github.run_number.
+    # BUILD_NUMBER is derived pre-archive from this app's uploaded builds in
+    # App Store Connect, not from a workflow-local counter.
     build_number = ENV["BUILD_NUMBER"]
     if build_number
       increment_build_number(
@@ -272,6 +272,8 @@ platform :ios do
     upload_to_testflight(
       ipa: ENV.fetch("IPA_PATH"),
       api_key: api_key,
+      app_identifier: ENV.fetch("APP_STORE_CONNECT_BUNDLE_ID"),
+      apple_id: ENV.fetch("APP_STORE_CONNECT_APP_ID"),
       skip_waiting_for_build_processing: true
     )
   end

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1239,9 +1239,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/appstore-phased-release.mjs
+++ b/scripts/appstore-phased-release.mjs
@@ -27,13 +27,14 @@
  *   APP_STORE_CONNECT_API_KEY (base64-encoded .p8)
  */
 
-import {createSign} from "node:crypto";
-
+import {
+  appStoreConnectRequest,
+  makeAppStoreConnectToken,
+  readAppStoreConnectCredentials,
+} from "./lib/app-store-connect-client.mjs";
 import {newestCandidate, selectVersion} from "./lib/phased-release-selection.mjs";
 
 const BUNDLE_ID = "com.TylerPavay.AscendApp";
-const API_ROOT = "https://api.appstoreconnect.apple.com/v1";
-const TOKEN_LIFETIME_SECONDS = 900;
 const VERSION_PAGE_LIMIT = 50;
 const MAX_VERSION_PAGES = 10;
 
@@ -46,86 +47,8 @@ const STATE_FOR_COMMAND = {
   "release-to-all": "COMPLETE",
 };
 
-function base64url(input) {
-  return Buffer.from(input).toString("base64url");
-}
-
-/**
- * App Store Connect wants an ES256 JWT. Node's crypto signs P-256 ECDSA natively; the only
- * subtlety is that JWT requires the raw r||s encoding rather than the DER default.
- */
-function makeToken({keyId, issuerId, privateKey}) {
-  const now = Math.floor(Date.now() / 1000);
-  const header = base64url(JSON.stringify({alg: "ES256", kid: keyId, typ: "JWT"}));
-  const payload = base64url(
-    JSON.stringify({
-      iss: issuerId,
-      iat: now,
-      exp: now + TOKEN_LIFETIME_SECONDS,
-      aud: "appstoreconnect-v1",
-    }),
-  );
-
-  const signer = createSign("SHA256");
-  signer.update(`${header}.${payload}`);
-  const signature = signer.sign({key: privateKey, dsaEncoding: "ieee-p1363"});
-
-  return `${header}.${payload}.${signature.toString("base64url")}`;
-}
-
-function readCredentials() {
-  const keyId = process.env.APP_STORE_CONNECT_API_KEY_ID;
-  const issuerId = process.env.APP_STORE_CONNECT_API_ISSUER_ID;
-  const encodedKey = process.env.APP_STORE_CONNECT_API_KEY;
-
-  const missing = [
-    ["APP_STORE_CONNECT_API_KEY_ID", keyId],
-    ["APP_STORE_CONNECT_API_ISSUER_ID", issuerId],
-    ["APP_STORE_CONNECT_API_KEY", encodedKey],
-  ]
-    .filter(([, value]) => !value)
-    .map(([name]) => name);
-
-  if (missing.length > 0) {
-    throw new Error(`Missing environment variable(s): ${missing.join(", ")}`);
-  }
-
-  return {
-    keyId,
-    issuerId,
-    privateKey: Buffer.from(encodedKey, "base64").toString("utf8"),
-  };
-}
-
 async function callApi(token, path, options) {
-  return requestJson(token, `${API_ROOT}${path}`, path, options);
-}
-
-async function requestJson(token, url, path, {method = "GET", body} = {}) {
-  const response = await fetch(url, {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-      ...(body ? {"Content-Type": "application/json"} : {}),
-    },
-    ...(body ? {body: JSON.stringify(body)} : {}),
-  });
-
-  if (response.status === 204) return null;
-
-  const text = await response.text();
-  const parsed = text ? JSON.parse(text) : null;
-
-  if (!response.ok) {
-    const detail = parsed?.errors
-      ?.map((error) => `${error.title}: ${error.detail}`)
-      .join("; ");
-    throw new Error(
-      `App Store Connect ${method} ${path} failed (${response.status}): ${detail ?? text}`,
-    );
-  }
-
-  return parsed;
+  return appStoreConnectRequest(token, path, options);
 }
 
 async function findApp(token) {
@@ -150,11 +73,11 @@ async function findApp(token) {
 async function fetchVersionCandidates(token, appId) {
   const candidates = [];
   let url =
-    `${API_ROOT}/apps/${appId}/appStoreVersions?filter[platform]=IOS` +
+    `https://api.appstoreconnect.apple.com/v1/apps/${appId}/appStoreVersions?filter[platform]=IOS` +
     `&limit=${VERSION_PAGE_LIMIT}&include=appStoreVersionPhasedRelease`;
 
   for (let page = 0; page < MAX_VERSION_PAGES && url; page += 1) {
-    const result = await requestJson(token, url, `/apps/${appId}/appStoreVersions`);
+    const result = await appStoreConnectRequest(token, url);
 
     for (const version of result?.data ?? []) {
       const phasedReleaseId = version.relationships?.appStoreVersionPhasedRelease?.data?.id;
@@ -258,7 +181,7 @@ async function main() {
     throw new Error("`--version` needs a version string, for example `--version 1.0.1`.");
   }
 
-  const token = makeToken(readCredentials());
+  const token = makeAppStoreConnectToken(readAppStoreConnectCredentials());
   const app = await findApp(token);
   const candidates = await fetchVersionCandidates(token, app.id);
   const state = selectVersion(candidates, {command, requestedVersionString});

--- a/scripts/appstore-phased-release.mjs
+++ b/scripts/appstore-phased-release.mjs
@@ -47,12 +47,8 @@ const STATE_FOR_COMMAND = {
   "release-to-all": "COMPLETE",
 };
 
-async function callApi(token, path, options) {
-  return appStoreConnectRequest(token, path, options);
-}
-
 async function findApp(token) {
-  const result = await callApi(
+  const result = await appStoreConnectRequest(
     token,
     `/apps?filter[bundleId]=${encodeURIComponent(BUNDLE_ID)}&limit=1`,
   );
@@ -73,7 +69,7 @@ async function findApp(token) {
 async function fetchVersionCandidates(token, appId) {
   const candidates = [];
   let url =
-    `https://api.appstoreconnect.apple.com/v1/apps/${appId}/appStoreVersions?filter[platform]=IOS` +
+    `/apps/${appId}/appStoreVersions?filter[platform]=IOS` +
     `&limit=${VERSION_PAGE_LIMIT}&include=appStoreVersionPhasedRelease`;
 
   for (let page = 0; page < MAX_VERSION_PAGES && url; page += 1) {
@@ -120,7 +116,7 @@ async function enable(token, {version, phasedRelease}) {
     return;
   }
 
-  await callApi(token, "/appStoreVersionPhasedReleases", {
+  await appStoreConnectRequest(token, "/appStoreVersionPhasedReleases", {
     method: "POST",
     body: {
       data: {
@@ -146,7 +142,7 @@ async function setState(token, phasedRelease, state) {
     );
   }
 
-  await callApi(token, `/appStoreVersionPhasedReleases/${phasedRelease.id}`, {
+  await appStoreConnectRequest(token, `/appStoreVersionPhasedReleases/${phasedRelease.id}`, {
     method: "PATCH",
     body: {
       data: {

--- a/scripts/ci/await-build-visible.mjs
+++ b/scripts/ci/await-build-visible.mjs
@@ -15,6 +15,11 @@
  * This deliberately waits for *visibility*, not for processing to finish: the
  * allocator only needs the version to be listed.
  *
+ * The binary is already accepted by the transporter before any of this runs, so
+ * a transient App Store Connect response is not a reason to fail the deploy -
+ * only an exhausted budget is. Requests are retried for the remaining budget;
+ * credential loading and the app-to-bundle ownership check stay fatal.
+ *
  * Usage:
  *   node scripts/ci/await-build-visible.mjs <app-id> <bundle-id> <build-number>
  */
@@ -35,7 +40,6 @@ export const DEFAULT_POLL_INTERVAL_SECONDS = 15;
 
 export async function awaitBuildVisible(
   {
-    token,
     appId,
     expectedBundleId,
     buildNumber,
@@ -43,9 +47,11 @@ export async function awaitBuildVisible(
     pollIntervalSeconds = DEFAULT_POLL_INTERVAL_SECONDS,
   },
   {
+    makeToken = () => makeAppStoreConnectToken(readAppStoreConnectCredentials()),
     request = appStoreConnectRequest,
     sleep = (seconds) => delay(seconds * 1_000),
     report = (message) => console.log(message),
+    now = () => Date.now(),
   } = {},
 ) {
   if (!BUILD_NUMBER_PATTERN.test(String(buildNumber))) {
@@ -57,31 +63,55 @@ export async function awaitBuildVisible(
     );
   }
 
-  await assertAppOwnsBundleId({token, appId, expectedBundleId}, request);
+  await assertAppOwnsBundleId({token: makeToken(), appId, expectedBundleId}, request);
 
-  const attempts = Math.max(1, Math.ceil(timeoutSeconds / pollIntervalSeconds));
   const query =
     `/builds?filter%5Bapp%5D=${appId}&filter%5Bversion%5D=${buildNumber}` +
     "&fields%5Bbuilds%5D=version&limit=1";
+  const startedAt = now();
+  const deadline = startedAt + timeoutSeconds * 1_000;
+  const elapsedSeconds = () => Math.round((now() - startedAt) / 1_000);
 
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const result = await request(token, query);
-    if ((result?.data ?? []).length > 0) {
-      report(`Build ${buildNumber} is visible in App Store Connect (attempt ${attempt}).`);
-      return attempt;
+  let attempt = 0;
+  let lastFailure = null;
+
+  for (;;) {
+    attempt += 1;
+
+    // A fresh token per attempt: minting is a single ECDSA signature, and it is
+    // the only way a poll that outlives TOKEN_LIFETIME_SECONDS cannot 401.
+    const token = makeToken();
+
+    try {
+      const result = await request(token, query);
+      if ((result?.data ?? []).length > 0) {
+        report(`Build ${buildNumber} is visible in App Store Connect (attempt ${attempt}).`);
+        return attempt;
+      }
+
+      lastFailure = null;
+      report(`Build ${buildNumber} not listed yet (attempt ${attempt}); retrying.`);
+    } catch (error) {
+      lastFailure = error.message;
+      report(
+        `App Store Connect query failed on attempt ${attempt}: ${error.message}. ` +
+          "Retrying while the budget remains.",
+      );
     }
 
-    if (attempt < attempts) {
-      report(`Build ${buildNumber} not listed yet (attempt ${attempt} of ${attempts}); retrying.`);
-      await sleep(pollIntervalSeconds);
-    }
+    const remainingMilliseconds = deadline - now();
+    if (remainingMilliseconds <= 0) break;
+
+    await sleep(Math.min(pollIntervalSeconds, remainingMilliseconds / 1_000));
   }
 
   throw new Error(
     `Build ${buildNumber} for App Store Connect app ${appId} was still not listed in /v1/builds ` +
-      `after ${timeoutSeconds}s. Releasing the deploy concurrency group now would let the next run ` +
-      "derive its build number from stale remote state and mint a duplicate. Confirm the upload " +
-      "landed in App Store Connect before re-running the deploy.",
+      `after ${elapsedSeconds()}s across ${attempt} attempts` +
+      `${lastFailure ? ` (last error: ${lastFailure})` : ""}. ` +
+      "Releasing the deploy concurrency group now would let the next run derive its build number " +
+      "from stale remote state and mint a duplicate. Confirm the upload landed in App Store " +
+      "Connect before re-running the deploy.",
   );
 }
 
@@ -93,8 +123,11 @@ async function main() {
     );
   }
 
-  const token = makeAppStoreConnectToken(readAppStoreConnectCredentials());
-  await awaitBuildVisible({token, appId, expectedBundleId, buildNumber});
+  const credentials = readAppStoreConnectCredentials();
+  await awaitBuildVisible(
+    {appId, expectedBundleId, buildNumber},
+    {makeToken: () => makeAppStoreConnectToken(credentials)},
+  );
 }
 
 if (isEntrypoint(import.meta.url)) {

--- a/scripts/ci/await-build-visible.mjs
+++ b/scripts/ci/await-build-visible.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * Blocks the upload job until the build it just uploaded is queryable through
+ * `/v1/builds`.
+ *
+ * The build-number allocator's only sequence state is App Store Connect's build
+ * list. `upload_to_testflight` keeps `skip_waiting_for_build_processing: true`,
+ * so the lane returns as soon as the transporter accepts the binary - minutes
+ * before the Build record exists. Workflow concurrency serializes runs, not
+ * Apple's ingestion, so the next queued run would derive against the pre-upload
+ * maximum and mint the same YYYYMMDDNN value. Holding the concurrency group
+ * until the record appears is what makes the serialization claim true.
+ *
+ * This deliberately waits for *visibility*, not for processing to finish: the
+ * allocator only needs the version to be listed.
+ *
+ * Usage:
+ *   node scripts/ci/await-build-visible.mjs <app-id> <bundle-id> <build-number>
+ */
+
+import {setTimeout as delay} from "node:timers/promises";
+
+import {isEntrypoint} from "../lib/is-entrypoint.mjs";
+import {
+  BUILD_NUMBER_PATTERN,
+  appStoreConnectRequest,
+  assertAppOwnsBundleId,
+  makeAppStoreConnectToken,
+  readAppStoreConnectCredentials,
+} from "../lib/app-store-connect-client.mjs";
+
+export const DEFAULT_TIMEOUT_SECONDS = 900;
+export const DEFAULT_POLL_INTERVAL_SECONDS = 15;
+
+export async function awaitBuildVisible(
+  {
+    token,
+    appId,
+    expectedBundleId,
+    buildNumber,
+    timeoutSeconds = DEFAULT_TIMEOUT_SECONDS,
+    pollIntervalSeconds = DEFAULT_POLL_INTERVAL_SECONDS,
+  },
+  {
+    request = appStoreConnectRequest,
+    sleep = (seconds) => delay(seconds * 1_000),
+    report = (message) => console.log(message),
+  } = {},
+) {
+  if (!BUILD_NUMBER_PATTERN.test(String(buildNumber))) {
+    throw new Error(`Build number must be a non-negative integer, got '${buildNumber}'.`);
+  }
+  if (!(timeoutSeconds > 0) || !(pollIntervalSeconds > 0)) {
+    throw new Error(
+      `Timeout and poll interval must both be positive, got ${timeoutSeconds}s / ${pollIntervalSeconds}s.`,
+    );
+  }
+
+  await assertAppOwnsBundleId({token, appId, expectedBundleId}, request);
+
+  const attempts = Math.max(1, Math.ceil(timeoutSeconds / pollIntervalSeconds));
+  const query =
+    `/builds?filter%5Bapp%5D=${appId}&filter%5Bversion%5D=${buildNumber}` +
+    "&fields%5Bbuilds%5D=version&limit=1";
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const result = await request(token, query);
+    if ((result?.data ?? []).length > 0) {
+      report(`Build ${buildNumber} is visible in App Store Connect (attempt ${attempt}).`);
+      return attempt;
+    }
+
+    if (attempt < attempts) {
+      report(`Build ${buildNumber} not listed yet (attempt ${attempt} of ${attempts}); retrying.`);
+      await sleep(pollIntervalSeconds);
+    }
+  }
+
+  throw new Error(
+    `Build ${buildNumber} for App Store Connect app ${appId} was still not listed in /v1/builds ` +
+      `after ${timeoutSeconds}s. Releasing the deploy concurrency group now would let the next run ` +
+      "derive its build number from stale remote state and mint a duplicate. Confirm the upload " +
+      "landed in App Store Connect before re-running the deploy.",
+  );
+}
+
+async function main() {
+  const [appId, expectedBundleId, buildNumber, ...extra] = process.argv.slice(2);
+  if (!appId || !expectedBundleId || !buildNumber || extra.length > 0) {
+    throw new Error(
+      "Usage: await-build-visible.mjs <app-store-connect-app-id> <bundle-id> <build-number>",
+    );
+  }
+
+  const token = makeAppStoreConnectToken(readAppStoreConnectCredentials());
+  await awaitBuildVisible({token, appId, expectedBundleId, buildNumber});
+}
+
+if (isEntrypoint(import.meta.url)) {
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ci/derive-build-number.mjs
+++ b/scripts/ci/derive-build-number.mjs
@@ -147,4 +147,3 @@ if (isEntrypoint(import.meta.url)) {
     process.exitCode = 1;
   });
 }
-

--- a/scripts/ci/derive-build-number.mjs
+++ b/scripts/ci/derive-build-number.mjs
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
+import {isEntrypoint} from "../lib/is-entrypoint.mjs";
 import {
+  BUILD_NUMBER_PATTERN,
   appStoreConnectRequest,
+  assertAppOwnsBundleId,
   makeAppStoreConnectToken,
   readAppStoreConnectCredentials,
 } from "../lib/app-store-connect-client.mjs";
@@ -10,9 +13,6 @@ export const MAX_BUILD_NUMBER = 4_294_967_295;
 export const PREVIOUS_BUILD_NUMBER_FLOOR = 37_105_794;
 export const BUILDS_PER_DAY = 99;
 
-const APP_ID_PATTERN = /^\d+$/;
-const BUNDLE_ID_PATTERN = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
-const BUILD_NUMBER_PATTERN = /^\d+$/;
 const PAGE_LIMIT = 200;
 const MAX_PAGES = 1_000;
 
@@ -95,24 +95,7 @@ export async function fetchHighestUploadedBuildNumber(
   {token, appId, expectedBundleId},
   request = appStoreConnectRequest,
 ) {
-  if (!APP_ID_PATTERN.test(appId)) {
-    throw new Error(`App Store Connect app ID must be numeric, got '${appId}'.`);
-  }
-  if (!BUNDLE_ID_PATTERN.test(expectedBundleId)) {
-    throw new Error(`Expected bundle ID is invalid, got '${expectedBundleId}'.`);
-  }
-
-  const app = await request(
-    token,
-    `/apps/${appId}?fields%5Bapps%5D=bundleId,name`,
-  );
-  const actualBundleId = app?.data?.attributes?.bundleId;
-  if (actualBundleId !== expectedBundleId) {
-    throw new Error(
-      `App Store Connect app ${appId} belongs to '${actualBundleId ?? "(missing)"}', ` +
-        `not expected bundle '${expectedBundleId}'.`,
-    );
-  }
+  await assertAppOwnsBundleId({token, appId, expectedBundleId}, request);
 
   const versions = [];
   let next =
@@ -156,7 +139,9 @@ async function main() {
   process.stdout.write(`${buildNumber}\n`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// A guard that silently fails to match exits 0 with no output, and the deploy
+// archives an empty CFBundleVersion from it.
+if (isEntrypoint(import.meta.url)) {
   main().catch((error) => {
     console.error(`::error::${error.message}`);
     process.exitCode = 1;

--- a/scripts/ci/derive-build-number.mjs
+++ b/scripts/ci/derive-build-number.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+import {
+  appStoreConnectRequest,
+  makeAppStoreConnectToken,
+  readAppStoreConnectCredentials,
+} from "../lib/app-store-connect-client.mjs";
+
+export const MAX_BUILD_NUMBER = 4_294_967_295;
+export const PREVIOUS_BUILD_NUMBER_FLOOR = 37_105_794;
+export const BUILDS_PER_DAY = 99;
+
+const APP_ID_PATTERN = /^\d+$/;
+const BUNDLE_ID_PATTERN = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
+const BUILD_NUMBER_PATTERN = /^\d+$/;
+const PAGE_LIMIT = 200;
+const MAX_PAGES = 1_000;
+
+function parseInteger(value, label) {
+  if (!BUILD_NUMBER_PATTERN.test(String(value))) {
+    throw new Error(`${label} must be a non-negative integer, got '${value}'.`);
+  }
+
+  return BigInt(value);
+}
+
+export function utcDateStamp(timestampSeconds = Math.floor(Date.now() / 1000)) {
+  const timestamp = Number(parseInteger(timestampSeconds, "UTC timestamp"));
+  const date = new Date(timestamp * 1_000);
+  if (Number.isNaN(date.valueOf())) {
+    throw new Error(`UTC timestamp is outside the supported date range: '${timestampSeconds}'.`);
+  }
+
+  const year = date.getUTCFullYear();
+  if (year < 1_000 || year > 9_999) {
+    throw new Error(`UTC year must have exactly four digits, got '${year}'.`);
+  }
+
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}${month}${day}`;
+}
+
+export function deriveReadableBuildNumber(dateStamp, highestUploadedBuildNumber) {
+  if (!/^\d{8}$/.test(dateStamp)) {
+    throw new Error(`UTC date must use YYYYMMDD, got '${dateStamp}'.`);
+  }
+
+  const firstBuildToday = BigInt(`${dateStamp}01`);
+  const lastBuildToday = BigInt(`${dateStamp}${BUILDS_PER_DAY}`);
+  const previous = highestUploadedBuildNumber === null
+    ? null
+    : parseInteger(highestUploadedBuildNumber, "Highest uploaded build number");
+
+  let candidate;
+  if (previous === null || previous < firstBuildToday) {
+    candidate = firstBuildToday;
+  } else if (previous < lastBuildToday) {
+    candidate = previous + 1n;
+  } else if (previous === lastBuildToday) {
+    throw new Error(
+      `Daily build-number sequence exhausted for ${dateStamp}: suffix 99 is already uploaded. ` +
+        "A 100th build cannot be represented by YYYYMMDDNN.",
+    );
+  } else {
+    throw new Error(
+      `Highest uploaded build number ${previous} is not below today's maximum ${lastBuildToday}. ` +
+        "Refusing to emit a duplicate or regressing build number.",
+    );
+  }
+
+  if (candidate <= BigInt(PREVIOUS_BUILD_NUMBER_FLOOR)) {
+    throw new Error(
+      `Derived build number ${candidate} is not above the legacy cutover floor ` +
+        `${PREVIOUS_BUILD_NUMBER_FLOOR}.`,
+    );
+  }
+
+  if (previous !== null && candidate <= previous) {
+    throw new Error(
+      `Derived build number ${candidate} is not above the highest uploaded build number ${previous}.`,
+    );
+  }
+
+  if (candidate > BigInt(MAX_BUILD_NUMBER)) {
+    throw new Error(
+      `Derived build number ${candidate} exceeds the App Store limit ${MAX_BUILD_NUMBER}.`,
+    );
+  }
+
+  return Number(candidate);
+}
+
+export async function fetchHighestUploadedBuildNumber(
+  {token, appId, expectedBundleId},
+  request = appStoreConnectRequest,
+) {
+  if (!APP_ID_PATTERN.test(appId)) {
+    throw new Error(`App Store Connect app ID must be numeric, got '${appId}'.`);
+  }
+  if (!BUNDLE_ID_PATTERN.test(expectedBundleId)) {
+    throw new Error(`Expected bundle ID is invalid, got '${expectedBundleId}'.`);
+  }
+
+  const app = await request(
+    token,
+    `/apps/${appId}?fields%5Bapps%5D=bundleId,name`,
+  );
+  const actualBundleId = app?.data?.attributes?.bundleId;
+  if (actualBundleId !== expectedBundleId) {
+    throw new Error(
+      `App Store Connect app ${appId} belongs to '${actualBundleId ?? "(missing)"}', ` +
+        `not expected bundle '${expectedBundleId}'.`,
+    );
+  }
+
+  const versions = [];
+  let next =
+    `/builds?filter%5Bapp%5D=${appId}&fields%5Bbuilds%5D=version&limit=${PAGE_LIMIT}`;
+
+  for (let page = 0; next && page < MAX_PAGES; page += 1) {
+    const result = await request(token, next);
+    for (const build of result?.data ?? []) {
+      const version = build?.attributes?.version;
+      if (!BUILD_NUMBER_PATTERN.test(String(version))) {
+        throw new Error(
+          `App Store Connect app ${appId} has non-numeric build number '${version}'. ` +
+            "Refusing to guess its ordering.",
+        );
+      }
+      versions.push(BigInt(version));
+    }
+    next = result?.links?.next ?? null;
+  }
+
+  if (next) {
+    throw new Error(`App Store Connect build listing exceeded ${MAX_PAGES} pages.`);
+  }
+
+  if (versions.length === 0) return null;
+  return versions.reduce((highest, version) => version > highest ? version : highest).toString();
+}
+
+async function main() {
+  const [appId, expectedBundleId, timestampArgument] = process.argv.slice(2);
+  if (!appId || !expectedBundleId || process.argv.length > 5) {
+    throw new Error(
+      "Usage: derive-build-number.sh <app-store-connect-app-id> <bundle-id> [utc-timestamp]",
+    );
+  }
+
+  const timestamp = timestampArgument ?? Math.floor(Date.now() / 1_000);
+  const token = makeAppStoreConnectToken(readAppStoreConnectCredentials());
+  const highest = await fetchHighestUploadedBuildNumber({token, appId, expectedBundleId});
+  const buildNumber = deriveReadableBuildNumber(utcDateStamp(timestamp), highest);
+  process.stdout.write(`${buildNumber}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  });
+}
+

--- a/scripts/ci/derive-build-number.sh
+++ b/scripts/ci/derive-build-number.sh
@@ -1,62 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Each workflow's github.run_number is its own sequence, so it is not shared
-# across staging and production, and raw run IDs are ~11 digits - far past the
-# 32-bit ceiling App Store Connect enforces on every CFBundleVersion component.
-# Coarse UTC epoch seconds carry the ordering instead: one integer per second,
-# doubled so each workflow owns a slot. Each uploadable workflow declares a
-# fixed, non-ref-scoped concurrency group (deploy-staging, deploy-production),
-# so every run of that workflow - push or manual dispatch from any ref -
-# serializes and two staging (or two production) builds cannot derive in the
-# same second. The distinct slot keeps staging and production apart when they
-# derive in the same second. Across adjacent seconds even the later tick's
-# slot 0 outranks the earlier tick's slot 1. The ci-workflow-contracts test
-# enforces the fixed group + unique slot for every uploadable workflow.
-#
-# 2026-01-01 00:00:00 UTC. Two slots consume two integers per second, so
-# 4294967296 / 2 = 2147483648 seconds of range, exhausting around 2094-01-19 UTC.
-BUILD_NUMBER_EPOCH_SECONDS=1767225600
-
-WORKFLOW_SLOT_COUNT=2
-
-# App Store Connect rejects any CFBundleVersion component above 2^32 - 1.
-MAX_BUILD_NUMBER=4294967295
-
-# Highest build number uploaded while the workflows still used
-# github.run_number (Deploy Staging run 147, 2026-07-21). Every derived build
-# number must stay strictly above it or TestFlight rejects the upload.
-PREVIOUS_BUILD_NUMBER_FLOOR=147
-
-slot="${1:-}"
-timestamp="${2:-$(date -u +%s)}"
-
-if [[ ! "${slot}" =~ ^[0-9]+$ ]] || (( slot >= WORKFLOW_SLOT_COUNT )); then
-  echo "::error::Workflow slot must be 0 (staging) or 1 (production), got '${slot}'." >&2
-  exit 1
-fi
-
-if [[ ! "${timestamp}" =~ ^[0-9]+$ ]]; then
-  echo "::error::UTC timestamp must be a non-negative integer, got '${timestamp}'." >&2
-  exit 1
-fi
-
-if (( timestamp < BUILD_NUMBER_EPOCH_SECONDS )); then
-  echo "::error::Timestamp ${timestamp} predates the build-number epoch ${BUILD_NUMBER_EPOCH_SECONDS}." >&2
-  exit 1
-fi
-
-build_number=$(((timestamp - BUILD_NUMBER_EPOCH_SECONDS) * WORKFLOW_SLOT_COUNT + slot))
-
-if (( build_number <= PREVIOUS_BUILD_NUMBER_FLOOR )); then
-  echo "::error::Derived build number ${build_number} is not above the last uploaded build number ${PREVIOUS_BUILD_NUMBER_FLOOR}." >&2
-  exit 1
-fi
-
-if (( build_number > MAX_BUILD_NUMBER )); then
-  echo "::error::Derived build number ${build_number} exceeds the App Store limit ${MAX_BUILD_NUMBER}." >&2
-  echo "::error::The 32-bit range from the epoch is exhausted; ship a new marketing version with a reset build-number scheme." >&2
-  exit 1
-fi
-
-printf '%s\n' "${build_number}"
+# The allocator asks App Store Connect for the highest build already uploaded to
+# this exact app. That remote value is the only sequence state: cancelled runs
+# and reruns consume nothing, while an uploaded build always advances the next
+# suffix. Fixed per-app workflow concurrency prevents two CI runs from deriving
+# against the same remote state before either upload completes.
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec node "${script_directory}/derive-build-number.mjs" "$@"

--- a/scripts/lib/app-store-connect-client.mjs
+++ b/scripts/lib/app-store-connect-client.mjs
@@ -1,0 +1,96 @@
+import {createSign} from "node:crypto";
+
+const API_ROOT = "https://api.appstoreconnect.apple.com/v1";
+const API_ORIGIN = new URL(API_ROOT).origin;
+const TOKEN_LIFETIME_SECONDS = 900;
+
+function base64url(input) {
+  return Buffer.from(input).toString("base64url");
+}
+
+export function readAppStoreConnectCredentials(environment = process.env) {
+  const keyId = environment.APP_STORE_CONNECT_API_KEY_ID;
+  const issuerId = environment.APP_STORE_CONNECT_API_ISSUER_ID;
+  const encodedKey = environment.APP_STORE_CONNECT_API_KEY;
+
+  const missing = [
+    ["APP_STORE_CONNECT_API_KEY_ID", keyId],
+    ["APP_STORE_CONNECT_API_ISSUER_ID", issuerId],
+    ["APP_STORE_CONNECT_API_KEY", encodedKey],
+  ]
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+
+  if (missing.length > 0) {
+    throw new Error(`Missing environment variable(s): ${missing.join(", ")}`);
+  }
+
+  return {
+    keyId,
+    issuerId,
+    privateKey: Buffer.from(encodedKey, "base64").toString("utf8"),
+  };
+}
+
+/**
+ * App Store Connect requires the raw r||s ECDSA signature encoding used by JWT,
+ * rather than the ASN.1 DER encoding Node uses by default.
+ */
+export function makeAppStoreConnectToken(
+  {keyId, issuerId, privateKey},
+  nowSeconds = Math.floor(Date.now() / 1000),
+) {
+  const header = base64url(JSON.stringify({alg: "ES256", kid: keyId, typ: "JWT"}));
+  const payload = base64url(
+    JSON.stringify({
+      iss: issuerId,
+      iat: nowSeconds,
+      exp: nowSeconds + TOKEN_LIFETIME_SECONDS,
+      aud: "appstoreconnect-v1",
+    }),
+  );
+
+  const signer = createSign("SHA256");
+  signer.update(`${header}.${payload}`);
+  const signature = signer.sign({key: privateKey, dsaEncoding: "ieee-p1363"});
+
+  return `${header}.${payload}.${signature.toString("base64url")}`;
+}
+
+export async function appStoreConnectRequest(
+  token,
+  pathOrURL,
+  {method = "GET", body, fetchImplementation = fetch} = {},
+) {
+  const url = pathOrURL.startsWith("http")
+    ? new URL(pathOrURL)
+    : new URL(`${API_ROOT}/${pathOrURL.replace(/^\//, "")}`);
+  if (url.origin !== API_ORIGIN) {
+    throw new Error(`Refusing to send App Store Connect credentials to ${url.origin}.`);
+  }
+
+  const response = await fetchImplementation(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      ...(body ? {"Content-Type": "application/json"} : {}),
+    },
+    ...(body ? {body: JSON.stringify(body)} : {}),
+  });
+
+  if (response.status === 204) return null;
+
+  const text = await response.text();
+  const parsed = text ? JSON.parse(text) : null;
+
+  if (!response.ok) {
+    const detail = parsed?.errors
+      ?.map((error) => `${error.title}: ${error.detail}`)
+      .join("; ");
+    throw new Error(
+      `App Store Connect ${method} ${url.pathname} failed (${response.status}): ${detail ?? text}`,
+    );
+  }
+
+  return parsed;
+}

--- a/scripts/lib/app-store-connect-client.mjs
+++ b/scripts/lib/app-store-connect-client.mjs
@@ -4,6 +4,10 @@ const API_ROOT = "https://api.appstoreconnect.apple.com/v1";
 const API_ORIGIN = new URL(API_ROOT).origin;
 const TOKEN_LIFETIME_SECONDS = 900;
 
+export const APP_ID_PATTERN = /^\d+$/;
+export const BUNDLE_ID_PATTERN = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
+export const BUILD_NUMBER_PATTERN = /^\d+$/;
+
 function base64url(input) {
   return Buffer.from(input).toString("base64url");
 }
@@ -93,4 +97,29 @@ export async function appStoreConnectRequest(
   }
 
   return parsed;
+}
+
+/**
+ * An app ID is an opaque number, so a wrong one reads as a working configuration
+ * right up to the point it allocates or inspects the wrong app's builds.
+ */
+export async function assertAppOwnsBundleId(
+  {token, appId, expectedBundleId},
+  request = appStoreConnectRequest,
+) {
+  if (!APP_ID_PATTERN.test(String(appId))) {
+    throw new Error(`App Store Connect app ID must be numeric, got '${appId}'.`);
+  }
+  if (!BUNDLE_ID_PATTERN.test(String(expectedBundleId))) {
+    throw new Error(`Expected bundle ID is invalid, got '${expectedBundleId}'.`);
+  }
+
+  const app = await request(token, `/apps/${appId}?fields%5Bapps%5D=bundleId,name`);
+  const actualBundleId = app?.data?.attributes?.bundleId;
+  if (actualBundleId !== expectedBundleId) {
+    throw new Error(
+      `App Store Connect app ${appId} belongs to '${actualBundleId ?? "(missing)"}', ` +
+        `not expected bundle '${expectedBundleId}'.`,
+    );
+  }
 }

--- a/scripts/lib/is-entrypoint.mjs
+++ b/scripts/lib/is-entrypoint.mjs
@@ -1,0 +1,22 @@
+import {realpathSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+
+/**
+ * Whether `moduleUrl` is the module Node was invoked with.
+ *
+ * The obvious `import.meta.url === \`file://${process.argv[1]}\`` is wrong twice:
+ * the ESM loader percent-encodes the module URL and realpaths it, while
+ * `process.argv[1]` does neither. A checkout path containing a space, or any
+ * invocation through a symlink, makes the compare false - and the failure mode is
+ * a script that exits 0 having done nothing, which every caller reads as success.
+ */
+export function isEntrypoint(moduleUrl) {
+  const invoked = process.argv[1];
+  if (!invoked) return false;
+
+  try {
+    return realpathSync(invoked) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}

--- a/scripts/test/ci-workflow-contracts.test.mjs
+++ b/scripts/test/ci-workflow-contracts.test.mjs
@@ -62,8 +62,8 @@ const deriveScript = `${repositoryRoot}scripts/ci/derive-build-number.sh`;
 const workflowsDirectory = `${repositoryRoot}.github/workflows`;
 
 // A workflow can put a build on TestFlight if it drives a signed archive lane
-// or the upload lane. Every such workflow shares the one TestFlight app and so
-// must serialize on a fixed concurrency group and own a distinct allocator slot.
+// or the upload lane. Every such workflow must serialize for its own App Store
+// Connect app and name that app explicitly for allocation and upload.
 function isUploadableWorkflow(workflow) {
   return /bundle exec fastlane build_(staging|production)\b/.test(workflow)
     || /\bupload_to_testflight\b/.test(workflow)
@@ -74,9 +74,11 @@ function concurrencyGroup(workflow) {
   return workflow.match(/\nconcurrency:\n[ \t]+group:[ \t]*(.+)/)?.[1]?.trim() ?? null;
 }
 
-function buildNumberSlot(workflow) {
-  const slot = workflow.match(/derive-build-number\.sh[ \t]+(\d+)\b/)?.[1];
-  return slot === undefined ? null : Number(slot);
+function appStoreTarget(workflow) {
+  return {
+    appId: workflow.match(/^  APP_STORE_CONNECT_APP_ID: "?(\d+)"?$/m)?.[1] ?? null,
+    bundleId: workflow.match(/^  APP_STORE_CONNECT_BUNDLE_ID: ([^\s]+)$/m)?.[1] ?? null,
+  };
 }
 
 async function uploadableWorkflows() {
@@ -87,21 +89,21 @@ async function uploadableWorkflows() {
     const workflow = await readWorkflow(name);
     if (!isUploadableWorkflow(workflow)) continue;
 
-    uploadable.push({name, workflow, group: concurrencyGroup(workflow), slot: buildNumberSlot(workflow)});
+    uploadable.push({name, workflow, group: concurrencyGroup(workflow), target: appStoreTarget(workflow)});
   }
 
   return uploadable;
 }
 
-test("every uploadable workflow serializes on a fixed group and owns a unique build-number slot", async () => {
-  const slotCount = await scriptConstant("WORKFLOW_SLOT_COUNT");
+test("every uploadable workflow serializes on a fixed group and owns a distinct App Store app", async () => {
   const uploadable = await uploadableWorkflows();
   const names = uploadable.map(({name}) => name);
 
   assert.deepEqual(names, ["deploy-production.yml", "deploy-staging.yml"], `unexpected uploadable workflow set: ${names}`);
 
-  const slots = [];
-  for (const {name, workflow, group, slot} of uploadable) {
+  const appIds = [];
+  const bundleIds = [];
+  for (const {name, workflow, group, target} of uploadable) {
     assert.ok(group, `${name} must declare a concurrency group so its runs serialize`);
     assert.doesNotMatch(group, /\$\{\{/, `${name} concurrency group must be fixed, not ref-scoped: "${group}"`);
 
@@ -112,53 +114,72 @@ test("every uploadable workflow serializes on a fixed group and owns a unique bu
       assert.ok(deriveIndex < buildIndex, `${name} must derive the build number before archiving`);
     }
 
-    assert.ok(Number.isInteger(slot) && slot >= 0, `${name} must pass a numeric allocator slot`);
-    assert.ok(slot < slotCount, `${name} slot ${slot} is outside the allocator range [0, ${slotCount})`);
-    slots.push(slot);
+    assert.match(target.appId ?? "", /^\d+$/, `${name} must name its App Store Connect app ID`);
+    assert.match(target.bundleId ?? "", /^com\./, `${name} must name its App Store bundle ID`);
+    appIds.push(target.appId);
+    bundleIds.push(target.bundleId);
   }
 
-  assert.equal(new Set(slots).size, slots.length, `uploadable workflows must use unique slots, got ${slots}`);
+  assert.deepEqual(appIds.sort(), ["6757202987", "6759919365"]);
+  assert.deepEqual(bundleIds.sort(), [
+    "com.TylerPavay.AscendApp",
+    "com.TylerPavay.AscendApp.staging",
+  ]);
+  assert.equal(new Set(appIds).size, appIds.length);
+  assert.equal(new Set(bundleIds).size, bundleIds.length);
+  assert.deepEqual(
+    Object.fromEntries(uploadable.map(({name, target}) => [name, target])),
+    {
+      "deploy-production.yml": {
+        appId: "6757202987",
+        bundleId: "com.TylerPavay.AscendApp",
+      },
+      "deploy-staging.yml": {
+        appId: "6759919365",
+        bundleId: "com.TylerPavay.AscendApp.staging",
+      },
+    },
+  );
 });
 
-function deriveBuildNumber(slot, timestamp) {
-  const argumentList = timestamp === undefined ? [String(slot)] : [String(slot), String(timestamp)];
-
-  return spawnSync(deriveScript, argumentList, {encoding: "utf8", env: {PATH: "/usr/bin:/bin"}});
-}
-
-function derivedValue(slot, timestamp) {
-  const result = deriveBuildNumber(slot, timestamp);
-
-  assert.equal(result.status, 0, result.stderr);
-  return Number(result.stdout.trim());
-}
-
-async function scriptConstant(name) {
-  const source = await readFile(deriveScript, "utf8");
-  const value = source.match(new RegExp(`^${name}=(\\d+)$`, "m"))?.[1];
-
-  assert.ok(value, `Missing constant ${name}`);
-  return Number(value);
+function deriveStep(workflow) {
+  return sectionBetween(workflow, "      - name: Derive build number\n", "\n      - name: ");
 }
 
 function deriveStepScript(workflow) {
-  const step = sectionBetween(workflow, "      - name: Derive build number\n", "\n      - name: ");
+  const step = deriveStep(workflow);
   const body = step.slice(step.indexOf("        run: |\n") + "        run: |\n".length);
 
   return body.replace(/^ {10}/gm, "");
 }
 
-test("deploy build numbers come from the shared derivation, before the archive", async () => {
-  for (const {name, workflow, slot} of await uploadableWorkflows()) {
+test("deploy build numbers come from remote app truth before the archive", async () => {
+  for (const {name, workflow} of await uploadableWorkflows()) {
     const deriveIndex = workflow.indexOf("scripts/ci/derive-build-number.sh");
     const buildIndex = workflow.indexOf("bundle exec fastlane build_");
+    const step = deriveStep(workflow);
+    const stepScript = deriveStepScript(workflow);
 
     assert.notEqual(deriveIndex, -1, name);
     assert.ok(deriveIndex < buildIndex, `${name} must derive the build number before archiving`);
-    assert.match(deriveStepScript(workflow), new RegExp(`derive-build-number\\.sh ${slot}\\b`), name);
+    assert.match(
+      stepScript,
+      /derive-build-number\.sh "\$APP_STORE_CONNECT_APP_ID" "\$APP_STORE_CONNECT_BUNDLE_ID"/,
+      name,
+    );
+    assert.match(step, /APP_STORE_CONNECT_API_KEY_ID:/, name);
+    assert.match(step, /APP_STORE_CONNECT_API_ISSUER_ID:/, name);
+    assert.match(step, /APP_STORE_CONNECT_API_KEY:/, name);
     assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_number \}\}/, name);
     assert.doesNotMatch(workflow, /BUILD_NUMBER: \$\{\{ github\.run_id \}\}/, name);
   }
+});
+
+test("the TestFlight lane uploads to the same explicit app used by the allocator", async () => {
+  const fastfile = await readFile(`${repositoryRoot}/fastlane/Fastfile`, "utf8");
+
+  assert.match(fastfile, /app_identifier: ENV\.fetch\("APP_STORE_CONNECT_BUNDLE_ID"\)/);
+  assert.match(fastfile, /apple_id: ENV\.fetch\("APP_STORE_CONNECT_APP_ID"\)/);
 });
 
 test("a failed derivation stops the deploy instead of exporting an empty build number", async () => {
@@ -175,7 +196,12 @@ test("a failed derivation stops the deploy instead of exporting an empty build n
     const failed = spawnSync("bash", ["-c", stepScript], {
       cwd: root,
       encoding: "utf8",
-      env: {PATH: "/usr/bin:/bin", GITHUB_ENV: environmentFile},
+      env: {
+        PATH: "/usr/bin:/bin",
+        GITHUB_ENV: environmentFile,
+        APP_STORE_CONNECT_APP_ID: "1234567890",
+        APP_STORE_CONNECT_BUNDLE_ID: "com.example.App",
+      },
     });
 
     assert.notEqual(failed.status, 0, `${name} must fail when derivation fails`);
@@ -186,71 +212,15 @@ test("a failed derivation stops the deploy instead of exporting an empty build n
     const succeeded = spawnSync("bash", ["-c", stepScript], {
       cwd: root,
       encoding: "utf8",
-      env: {PATH: "/usr/bin:/bin", GITHUB_ENV: environmentFile},
+      env: {
+        PATH: "/usr/bin:/bin",
+        GITHUB_ENV: environmentFile,
+        APP_STORE_CONNECT_APP_ID: "1234567890",
+        APP_STORE_CONNECT_BUNDLE_ID: "com.example.App",
+      },
     });
 
     assert.equal(succeeded.status, 0, succeeded.stderr);
     assert.match(readFileSync(environmentFile, "utf8"), /^BUILD_NUMBER=4321$/m, name);
-  }
-});
-
-test("staging and production never collide, even deriving in the same second", async () => {
-  const epoch = await scriptConstant("BUILD_NUMBER_EPOCH_SECONDS");
-  const sameSecond = epoch + 20_000_000;
-  const staging = derivedValue(0, sameSecond);
-  const production = derivedValue(1, sameSecond);
-
-  assert.notEqual(staging, production);
-  assert.equal(production, staging + 1);
-});
-
-test("later seconds outrank earlier ones regardless of workflow slot", async () => {
-  const epoch = await scriptConstant("BUILD_NUMBER_EPOCH_SECONDS");
-  const second = epoch + 20_000_000;
-
-  assert.ok(derivedValue(0, second + 1) > derivedValue(1, second));
-  assert.ok(derivedValue(0, second + 2) > derivedValue(1, second + 1));
-});
-
-test("derived build numbers clear the last build number uploaded from run_number", async () => {
-  const floor = await scriptConstant("PREVIOUS_BUILD_NUMBER_FLOOR");
-  const epoch = await scriptConstant("BUILD_NUMBER_EPOCH_SECONDS");
-
-  assert.equal(epoch, Date.parse("2026-01-01T00:00:00Z") / 1000);
-
-  for (const slot of [0, 1]) {
-    assert.ok(derivedValue(slot) > floor, `slot ${slot} must clear the previous build number floor`);
-  }
-
-  const atFloor = deriveBuildNumber(0, epoch + Math.floor(floor / 2));
-  assert.notEqual(atFloor.status, 0);
-  assert.match(atFloor.stderr, /not above the last uploaded build number/);
-});
-
-test("invalid and out-of-range inputs fail the build instead of wrapping", async () => {
-  const epoch = await scriptConstant("BUILD_NUMBER_EPOCH_SECONDS");
-  const max = await scriptConstant("MAX_BUILD_NUMBER");
-
-  assert.equal(max, 4_294_967_295);
-  assert.equal(derivedValue(1, epoch + (max - 1) / 2), max);
-
-  const overLimit = deriveBuildNumber(0, epoch + (max + 1) / 2);
-  assert.notEqual(overLimit.status, 0);
-  assert.match(overLimit.stderr, /exceeds the App Store limit/);
-
-  const beforeEpoch = deriveBuildNumber(0, epoch - 1);
-  assert.notEqual(beforeEpoch.status, 0);
-  assert.match(beforeEpoch.stderr, /predates the build-number epoch/);
-
-  for (const slot of ["", "2", "-1", "0x1"]) {
-    const badSlot = deriveBuildNumber(slot, epoch + 20_000_000);
-    assert.notEqual(badSlot.status, 0, `slot '${slot}' must be rejected`);
-    assert.match(badSlot.stderr, /Workflow slot must be 0 \(staging\) or 1 \(production\)/);
-  }
-
-  for (const timestamp of ["not-a-number", "1767225600.5"]) {
-    const badTimestamp = deriveBuildNumber(0, timestamp);
-    assert.notEqual(badTimestamp.status, 0, `timestamp '${timestamp}' must be rejected`);
-    assert.match(badTimestamp.stderr, /UTC timestamp must be a non-negative integer/);
   }
 });

--- a/scripts/test/ci-workflow-contracts.test.mjs
+++ b/scripts/test/ci-workflow-contracts.test.mjs
@@ -58,7 +58,6 @@ test("production readiness failure is visible to GitHub Actions", async () => {
   assert.match(disabledBranch, /^\s+exit 1$/m);
 });
 
-const deriveScript = `${repositoryRoot}scripts/ci/derive-build-number.sh`;
 const workflowsDirectory = `${repositoryRoot}.github/workflows`;
 
 // A workflow can put a build on TestFlight if it drives a signed archive lane
@@ -142,8 +141,25 @@ test("every uploadable workflow serializes on a fixed group and owns a distinct 
   );
 });
 
+// A step block runs from its `- name:` line to the next step or to any line that
+// dedents out of the step list.
+function stepBlock(workflow, stepName) {
+  const lines = workflow.split("\n");
+  const startIndex = lines.indexOf(`      - name: ${stepName}`);
+  assert.notEqual(startIndex, -1, `Missing step: ${stepName}`);
+
+  const block = [lines[startIndex]];
+  for (const line of lines.slice(startIndex + 1)) {
+    if (line.startsWith("      - ")) break;
+    if (line.trim() !== "" && !line.startsWith("       ")) break;
+    block.push(line);
+  }
+
+  return block.join("\n");
+}
+
 function deriveStep(workflow) {
-  return sectionBetween(workflow, "      - name: Derive build number\n", "\n      - name: ");
+  return stepBlock(workflow, "Derive build number");
 }
 
 function deriveStepScript(workflow) {
@@ -188,39 +204,84 @@ test("a failed derivation stops the deploy instead of exporting an empty build n
     const root = mkdtempSync(join(tmpdir(), "ascend-build-number-"));
     const stubPath = join(root, "scripts/ci/derive-build-number.sh");
     const environmentFile = join(root, "github-env");
+    const outputFile = join(root, "github-output");
     mkdirSync(dirname(stubPath), {recursive: true});
     writeFileSync(environmentFile, "");
+    writeFileSync(outputFile, "");
+
+    const runStep = () =>
+      spawnSync("bash", ["-c", stepScript], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          PATH: "/usr/bin:/bin",
+          GITHUB_ENV: environmentFile,
+          GITHUB_OUTPUT: outputFile,
+          APP_STORE_CONNECT_APP_ID: "1234567890",
+          APP_STORE_CONNECT_BUNDLE_ID: "com.example.App",
+        },
+      });
 
     writeFileSync(stubPath, "#!/bin/sh\necho '::error::boom' >&2\nexit 1\n");
     chmodSync(stubPath, 0o755);
-    const failed = spawnSync("bash", ["-c", stepScript], {
-      cwd: root,
-      encoding: "utf8",
-      env: {
-        PATH: "/usr/bin:/bin",
-        GITHUB_ENV: environmentFile,
-        APP_STORE_CONNECT_APP_ID: "1234567890",
-        APP_STORE_CONNECT_BUNDLE_ID: "com.example.App",
-      },
-    });
+    const failed = runStep();
 
     assert.notEqual(failed.status, 0, `${name} must fail when derivation fails`);
     assert.doesNotMatch(readFileSync(environmentFile, "utf8"), /BUILD_NUMBER=/, name);
 
+    // A zero exit with no output is the shape that would archive an empty
+    // CFBundleVersion, because Ruby treats "" as truthy.
+    writeFileSync(stubPath, "#!/bin/sh\nexit 0\n");
+    chmodSync(stubPath, 0o755);
+    const silent = runStep();
+
+    assert.notEqual(silent.status, 0, `${name} must fail on an empty derived build number`);
+    assert.doesNotMatch(readFileSync(environmentFile, "utf8"), /BUILD_NUMBER=/, name);
+    assert.doesNotMatch(readFileSync(outputFile, "utf8"), /build_number=/, name);
+
     writeFileSync(stubPath, "#!/bin/sh\necho 4321\n");
     chmodSync(stubPath, 0o755);
-    const succeeded = spawnSync("bash", ["-c", stepScript], {
-      cwd: root,
-      encoding: "utf8",
-      env: {
-        PATH: "/usr/bin:/bin",
-        GITHUB_ENV: environmentFile,
-        APP_STORE_CONNECT_APP_ID: "1234567890",
-        APP_STORE_CONNECT_BUNDLE_ID: "com.example.App",
-      },
-    });
+    const succeeded = runStep();
 
     assert.equal(succeeded.status, 0, succeeded.stderr);
     assert.match(readFileSync(environmentFile, "utf8"), /^BUILD_NUMBER=4321$/m, name);
+    assert.match(readFileSync(outputFile, "utf8"), /^build_number=4321$/m, name);
+  }
+});
+
+// Workflow concurrency serializes runs, not App Store Connect's ingestion of an
+// upload that skipped build processing. Without this wait the next queued run
+// derives against the pre-upload maximum and mints a duplicate.
+test("every uploadable workflow holds its concurrency group until the upload is visible", async () => {
+  for (const {name, workflow} of await uploadableWorkflows()) {
+    const uploadIndex = workflow.indexOf("bundle exec fastlane upload_testflight");
+    const waitIndex = workflow.indexOf("scripts/ci/await-build-visible.mjs");
+
+    assert.notEqual(uploadIndex, -1, `${name} must upload to TestFlight`);
+    assert.notEqual(
+      waitIndex,
+      -1,
+      `${name} must wait for the uploaded build to appear in App Store Connect`,
+    );
+    assert.ok(uploadIndex < waitIndex, `${name} must wait after the upload, not before it`);
+
+    const waitStep = stepBlock(workflow, "Wait for the uploaded build to be visible in App Store Connect");
+
+    assert.match(
+      waitStep,
+      /BUILD_NUMBER: \$\{\{ needs\.build-ios\.outputs\.build-number \}\}/,
+      `${name} must wait on the exact build number the archive job derived`,
+    );
+    assert.match(
+      waitStep,
+      /await-build-visible\.mjs "\$APP_STORE_CONNECT_APP_ID" "\$APP_STORE_CONNECT_BUNDLE_ID" "\$BUILD_NUMBER"/,
+      name,
+    );
+    assert.match(waitStep, /if \[ -z "\$BUILD_NUMBER" \]; then/, name);
+    assert.match(
+      workflow,
+      /^    outputs:\n      build-number: \$\{\{ steps\.derive-build-number\.outputs\.build_number \}\}$/m,
+      `${name} must publish its derived build number as a job output`,
+    );
   }
 });

--- a/scripts/test/readable-build-number.test.mjs
+++ b/scripts/test/readable-build-number.test.mjs
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   BUILDS_PER_DAY,
@@ -9,10 +14,13 @@ import {
   fetchHighestUploadedBuildNumber,
   utcDateStamp,
 } from "../ci/derive-build-number.mjs";
+import {awaitBuildVisible} from "../ci/await-build-visible.mjs";
 import {
   appStoreConnectRequest,
   readAppStoreConnectCredentials,
 } from "../lib/app-store-connect-client.mjs";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
 
 test("the first build of a UTC day is readable and later builds increment", () => {
   assert.equal(deriveReadableBuildNumber("20260803", null), 2_026_080_301);
@@ -160,6 +168,146 @@ test("an unavailable App Store Connect API fails closed", async () => {
     }),
     /failed \(503\): Unavailable: Retry later/,
   );
+});
+
+// `import.meta.url` is both percent-encoded and realpath-resolved; `process.argv[1]`
+// is neither. A main-module guard that compares them as strings silently exits 0
+// having written nothing whenever the invocation path holds a space or crosses a
+// symlink - and the deploy archives that empty value as its CFBundleVersion.
+// The temp root below is both: it contains spaces and sits behind /private on macOS.
+test("the CI entrypoints still run from a path with spaces or a symlink", () => {
+  const root = mkdtempSync(join(tmpdir(), "ascend build number "));
+  mkdirSync(join(root, "scripts/ci"), {recursive: true});
+  mkdirSync(join(root, "scripts/lib"), {recursive: true});
+  for (const file of [
+    "scripts/ci/derive-build-number.mjs",
+    "scripts/ci/await-build-visible.mjs",
+    "scripts/lib/app-store-connect-client.mjs",
+    "scripts/lib/is-entrypoint.mjs",
+  ]) {
+    copyFileSync(join(repositoryRoot, file), join(root, file));
+  }
+
+  assert.ok(root.includes(" "));
+
+  for (const [script, usage] of [
+    ["derive-build-number.mjs", /::error::Usage: derive-build-number/],
+    ["await-build-visible.mjs", /::error::Usage: await-build-visible/],
+  ]) {
+    const result = spawnSync(process.execPath, [join(root, "scripts/ci", script)], {
+      encoding: "utf8",
+    });
+
+    assert.notEqual(result.status, 0, `${script} never ran main and exited 0`);
+    assert.match(result.stderr, usage);
+    assert.equal(result.stdout, "");
+  }
+});
+
+test("the upload holds the concurrency group until the exact build is listed", async () => {
+  const paths = [];
+  const responses = [
+    {data: {attributes: {bundleId: "com.TylerPavay.AscendApp.staging"}}},
+    {data: []},
+    {data: []},
+    {data: [{attributes: {version: "2026080301"}}]},
+  ];
+  const slept = [];
+
+  const attempt = await awaitBuildVisible(
+    {
+      token: "redacted-test-token",
+      appId: "6759919365",
+      expectedBundleId: "com.TylerPavay.AscendApp.staging",
+      buildNumber: "2026080301",
+      timeoutSeconds: 60,
+      pollIntervalSeconds: 15,
+    },
+    {
+      request: async (token, path) => {
+        paths.push(path);
+        return responses.shift();
+      },
+      sleep: async (seconds) => slept.push(seconds),
+      report: () => {},
+    },
+  );
+
+  assert.equal(attempt, 3);
+  assert.deepEqual(slept, [15, 15]);
+  assert.match(paths[1], /filter%5Bapp%5D=6759919365/);
+  assert.match(paths[1], /filter%5Bversion%5D=2026080301/);
+});
+
+test("an upload that never becomes visible fails loudly within a bounded timeout", async () => {
+  let polls = 0;
+  const slept = [];
+
+  await assert.rejects(
+    awaitBuildVisible(
+      {
+        token: "redacted-test-token",
+        appId: "6759919365",
+        expectedBundleId: "com.TylerPavay.AscendApp.staging",
+        buildNumber: "2026080301",
+        timeoutSeconds: 45,
+        pollIntervalSeconds: 15,
+      },
+      {
+        request: async (token, path) => {
+          if (path.startsWith("/apps/")) {
+            return {data: {attributes: {bundleId: "com.TylerPavay.AscendApp.staging"}}};
+          }
+          polls += 1;
+          return {data: []};
+        },
+        sleep: async (seconds) => slept.push(seconds),
+        report: () => {},
+      },
+    ),
+    /still not listed in \/v1\/builds after 45s.*mint a duplicate/s,
+  );
+
+  assert.equal(polls, 3);
+  assert.deepEqual(slept, [15, 15]);
+});
+
+test("the wait refuses an app that does not own the expected bundle", async () => {
+  await assert.rejects(
+    awaitBuildVisible(
+      {
+        token: "redacted-test-token",
+        appId: "6757202987",
+        expectedBundleId: "com.TylerPavay.AscendApp.staging",
+        buildNumber: "2026080301",
+      },
+      {
+        request: async () => ({data: {attributes: {bundleId: "com.TylerPavay.AscendApp"}}}),
+        report: () => {},
+      },
+    ),
+    /not expected bundle/,
+  );
+});
+
+test("the wait refuses a missing or non-numeric build number", async () => {
+  for (const buildNumber of ["", "1.2.3", undefined]) {
+    await assert.rejects(
+      awaitBuildVisible(
+        {
+          token: "redacted-test-token",
+          appId: "6759919365",
+          expectedBundleId: "com.TylerPavay.AscendApp.staging",
+          buildNumber,
+        },
+        {
+          request: async () => assert.fail("must not reach App Store Connect"),
+          report: () => {},
+        },
+      ),
+      /Build number must be a non-negative integer/,
+    );
+  }
 });
 
 test("pagination cannot send the API token to another origin", async () => {

--- a/scripts/test/readable-build-number.test.mjs
+++ b/scripts/test/readable-build-number.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BUILDS_PER_DAY,
+  MAX_BUILD_NUMBER,
+  PREVIOUS_BUILD_NUMBER_FLOOR,
+  deriveReadableBuildNumber,
+  fetchHighestUploadedBuildNumber,
+  utcDateStamp,
+} from "../ci/derive-build-number.mjs";
+import {
+  appStoreConnectRequest,
+  readAppStoreConnectCredentials,
+} from "../lib/app-store-connect-client.mjs";
+
+test("the first build of a UTC day is readable and later builds increment", () => {
+  assert.equal(deriveReadableBuildNumber("20260803", null), 2_026_080_301);
+  assert.equal(deriveReadableBuildNumber("20260803", "2026080301"), 2_026_080_302);
+  assert.equal(deriveReadableBuildNumber("20260803", "37102594"), 2_026_080_301);
+});
+
+test("a new UTC day outranks all 99 builds from the previous day", () => {
+  assert.equal(BUILDS_PER_DAY, 99);
+  assert.ok(
+    deriveReadableBuildNumber("20260804", "2026080399") >
+      deriveReadableBuildNumber("20260803", "2026080398"),
+  );
+  assert.equal(deriveReadableBuildNumber("20260804", "2026080399"), 2_026_080_401);
+});
+
+test("the cutover moves upward from the legacy clock sequence", () => {
+  assert.equal(PREVIOUS_BUILD_NUMBER_FLOOR, 37_105_794);
+  const firstReadableBuild = deriveReadableBuildNumber("20260803", PREVIOUS_BUILD_NUMBER_FLOOR);
+
+  assert.equal(firstReadableBuild, 2_026_080_301);
+  assert.ok(firstReadableBuild > PREVIOUS_BUILD_NUMBER_FLOOR);
+});
+
+test("a 100th build in one day fails instead of wrapping", () => {
+  assert.throws(
+    () => deriveReadableBuildNumber("20260803", "2026080399"),
+    /Daily build-number sequence exhausted.*100th build/s,
+  );
+});
+
+test("a remote build ahead of today's range fails instead of regressing", () => {
+  assert.throws(
+    () => deriveReadableBuildNumber("20260803", "2026080401"),
+    /Refusing to emit a duplicate or regressing build number/,
+  );
+});
+
+test("the legacy floor and 32-bit ceiling remain hard guards", () => {
+  assert.equal(MAX_BUILD_NUMBER, 4_294_967_295);
+  assert.throws(
+    () => deriveReadableBuildNumber("00010101", null),
+    /not above the legacy cutover floor/,
+  );
+  assert.equal(deriveReadableBuildNumber("42941231", null), 4_294_123_101);
+  assert.throws(
+    () => deriveReadableBuildNumber("42950101", null),
+    /exceeds the App Store limit/,
+  );
+});
+
+test("UTC timestamps resolve to the promised calendar date", () => {
+  assert.equal(utcDateStamp(Date.parse("2026-08-03T23:59:59Z") / 1_000), "20260803");
+  assert.equal(utcDateStamp(Date.parse("2026-08-04T00:00:00Z") / 1_000), "20260804");
+});
+
+test("App Store Connect is paginated and the numeric maximum is used", async () => {
+  const requests = [];
+  const responses = [
+    {data: {attributes: {bundleId: "com.TylerPavay.AscendApp.staging"}}},
+    {
+      data: [
+        {attributes: {version: "2026080301"}},
+        {attributes: {version: "37102594"}},
+      ],
+      links: {next: "https://api.appstoreconnect.apple.com/v1/builds?cursor=next"},
+    },
+    {
+      data: [{attributes: {version: "2026080302"}}],
+      links: {next: null},
+    },
+  ];
+  const request = async (token, path) => {
+    requests.push({token, path});
+    return responses.shift();
+  };
+
+  const highest = await fetchHighestUploadedBuildNumber(
+    {
+      token: "redacted-test-token",
+      appId: "6759919365",
+      expectedBundleId: "com.TylerPavay.AscendApp.staging",
+    },
+    request,
+  );
+
+  assert.equal(highest, "2026080302");
+  assert.equal(requests.length, 3);
+  assert.match(requests[1].path, /filter%5Bapp%5D=6759919365/);
+  assert.equal(requests[2].path, "https://api.appstoreconnect.apple.com/v1/builds?cursor=next");
+});
+
+test("the allocator refuses an App Store app and bundle mismatch", async () => {
+  const request = async () => ({
+    data: {attributes: {bundleId: "com.TylerPavay.AscendApp"}},
+  });
+
+  await assert.rejects(
+    fetchHighestUploadedBuildNumber(
+      {
+        token: "redacted-test-token",
+        appId: "6757202987",
+        expectedBundleId: "com.TylerPavay.AscendApp.staging",
+      },
+      request,
+    ),
+    /not expected bundle/,
+  );
+});
+
+test("the allocator refuses non-numeric remote build numbers", async () => {
+  const responses = [
+    {data: {attributes: {bundleId: "com.TylerPavay.AscendApp.staging"}}},
+    {data: [{attributes: {version: "1.2.3"}}], links: {next: null}},
+  ];
+
+  await assert.rejects(
+    fetchHighestUploadedBuildNumber(
+      {
+        token: "redacted-test-token",
+        appId: "6759919365",
+        expectedBundleId: "com.TylerPavay.AscendApp.staging",
+      },
+      async () => responses.shift(),
+    ),
+    /non-numeric build number/,
+  );
+});
+
+test("missing credentials fail before any App Store Connect request", () => {
+  assert.throws(
+    () => readAppStoreConnectCredentials({}),
+    /APP_STORE_CONNECT_API_KEY_ID.*APP_STORE_CONNECT_API_ISSUER_ID.*APP_STORE_CONNECT_API_KEY/,
+  );
+});
+
+test("an unavailable App Store Connect API fails closed", async () => {
+  await assert.rejects(
+    appStoreConnectRequest("redacted-test-token", "/builds", {
+      fetchImplementation: async () => ({
+        status: 503,
+        ok: false,
+        text: async () => JSON.stringify({errors: [{title: "Unavailable", detail: "Retry later"}]}),
+      }),
+    }),
+    /failed \(503\): Unavailable: Retry later/,
+  );
+});
+
+test("pagination cannot send the API token to another origin", async () => {
+  let requested = false;
+
+  await assert.rejects(
+    appStoreConnectRequest("redacted-test-token", "https://example.com/builds", {
+      fetchImplementation: async () => {
+        requested = true;
+      },
+    }),
+    /Refusing to send App Store Connect credentials/,
+  );
+  assert.equal(requested, false);
+});

--- a/scripts/test/readable-build-number.test.mjs
+++ b/scripts/test/readable-build-number.test.mjs
@@ -204,6 +204,22 @@ test("the CI entrypoints still run from a path with spaces or a symlink", () => 
   }
 });
 
+// A clock that only advances when the poller sleeps, so the elapsed budget the
+// loop enforces is exactly what the assertions below can pin.
+function testClock() {
+  const slept = [];
+  let current = 0;
+
+  return {
+    slept,
+    now: () => current,
+    sleep: async (seconds) => {
+      slept.push(seconds);
+      current += seconds * 1_000;
+    },
+  };
+}
+
 test("the upload holds the concurrency group until the exact build is listed", async () => {
   const paths = [];
   const responses = [
@@ -212,11 +228,10 @@ test("the upload holds the concurrency group until the exact build is listed", a
     {data: []},
     {data: [{attributes: {version: "2026080301"}}]},
   ];
-  const slept = [];
+  const clock = testClock();
 
   const attempt = await awaitBuildVisible(
     {
-      token: "redacted-test-token",
       appId: "6759919365",
       expectedBundleId: "com.TylerPavay.AscendApp.staging",
       buildNumber: "2026080301",
@@ -224,29 +239,32 @@ test("the upload holds the concurrency group until the exact build is listed", a
       pollIntervalSeconds: 15,
     },
     {
+      makeToken: () => "redacted-test-token",
       request: async (token, path) => {
         paths.push(path);
         return responses.shift();
       },
-      sleep: async (seconds) => slept.push(seconds),
+      sleep: clock.sleep,
+      now: clock.now,
       report: () => {},
     },
   );
 
   assert.equal(attempt, 3);
-  assert.deepEqual(slept, [15, 15]);
+  assert.deepEqual(clock.slept, [15, 15]);
   assert.match(paths[1], /filter%5Bapp%5D=6759919365/);
   assert.match(paths[1], /filter%5Bversion%5D=2026080301/);
 });
 
-test("an upload that never becomes visible fails loudly within a bounded timeout", async () => {
-  let polls = 0;
-  const slept = [];
+// TOKEN_LIFETIME_SECONDS equals the default poll budget, so a token minted once
+// up front expires mid-poll and turns a build that appears late into a 401.
+test("every poll attempt carries a freshly minted token", async () => {
+  const tokens = [];
+  const clock = testClock();
 
   await assert.rejects(
     awaitBuildVisible(
       {
-        token: "redacted-test-token",
         appId: "6759919365",
         expectedBundleId: "com.TylerPavay.AscendApp.staging",
         buildNumber: "2026080301",
@@ -254,6 +272,89 @@ test("an upload that never becomes visible fails loudly within a bounded timeout
         pollIntervalSeconds: 15,
       },
       {
+        makeToken: () => {
+          const token = `token-${tokens.length}`;
+          tokens.push(token);
+          return token;
+        },
+        request: async (token, path) => {
+          if (path.startsWith("/apps/")) {
+            return {data: {attributes: {bundleId: "com.TylerPavay.AscendApp.staging"}}};
+          }
+          assert.equal(token, tokens.at(-1), "a poll reused a stale token");
+          return {data: []};
+        },
+        sleep: clock.sleep,
+        now: clock.now,
+        report: () => {},
+      },
+    ),
+    /still not listed/,
+  );
+
+  // One for the ownership check plus one per poll attempt.
+  assert.equal(tokens.length, 5);
+  assert.equal(new Set(tokens).size, tokens.length);
+});
+
+test("transient App Store Connect failures do not fail a completed upload", async () => {
+  const clock = testClock();
+  const outcomes = [
+    () => {
+      throw new Error("App Store Connect GET /v1/builds failed (503): Unavailable: Retry later");
+    },
+    () => {
+      throw new Error("App Store Connect GET /v1/builds failed (429): Too many requests");
+    },
+    () => ({data: []}),
+    () => ({data: [{attributes: {version: "2026080301"}}]}),
+  ];
+  const reported = [];
+
+  const attempt = await awaitBuildVisible(
+    {
+      appId: "6759919365",
+      expectedBundleId: "com.TylerPavay.AscendApp.staging",
+      buildNumber: "2026080301",
+      timeoutSeconds: 900,
+      pollIntervalSeconds: 15,
+    },
+    {
+      makeToken: () => "redacted-test-token",
+      request: async (token, path) => {
+        if (path.startsWith("/apps/")) {
+          return {data: {attributes: {bundleId: "com.TylerPavay.AscendApp.staging"}}};
+        }
+        return outcomes.shift()();
+      },
+      sleep: clock.sleep,
+      now: clock.now,
+      report: (message) => reported.push(message),
+    },
+  );
+
+  assert.equal(attempt, 4);
+  assert.equal(outcomes.length, 0);
+  assert.ok(reported.some((message) => /failed on attempt 1.*503/.test(message)));
+  assert.ok(reported.some((message) => /failed on attempt 2.*429/.test(message)));
+  assert.ok(reported.every((message) => !message.includes("redacted-test-token")));
+});
+
+test("an upload that never becomes visible fails loudly within a bounded timeout", async () => {
+  let polls = 0;
+  const clock = testClock();
+
+  await assert.rejects(
+    awaitBuildVisible(
+      {
+        appId: "6759919365",
+        expectedBundleId: "com.TylerPavay.AscendApp.staging",
+        buildNumber: "2026080301",
+        timeoutSeconds: 45,
+        pollIntervalSeconds: 15,
+      },
+      {
+        makeToken: () => "redacted-test-token",
         request: async (token, path) => {
           if (path.startsWith("/apps/")) {
             return {data: {attributes: {bundleId: "com.TylerPavay.AscendApp.staging"}}};
@@ -261,27 +362,58 @@ test("an upload that never becomes visible fails loudly within a bounded timeout
           polls += 1;
           return {data: []};
         },
-        sleep: async (seconds) => slept.push(seconds),
+        sleep: clock.sleep,
+        now: clock.now,
         report: () => {},
       },
     ),
-    /still not listed in \/v1\/builds after 45s.*mint a duplicate/s,
+    /still not listed in \/v1\/builds after 45s across 4 attempts.*mint a duplicate/s,
   );
 
-  assert.equal(polls, 3);
-  assert.deepEqual(slept, [15, 15]);
+  // The reported budget must be what actually elapsed, not one interval more.
+  assert.equal(polls, 4);
+  assert.deepEqual(clock.slept, [15, 15, 15]);
+});
+
+test("a timeout spent entirely on transient errors names the last one", async () => {
+  const clock = testClock();
+
+  await assert.rejects(
+    awaitBuildVisible(
+      {
+        appId: "6759919365",
+        expectedBundleId: "com.TylerPavay.AscendApp.staging",
+        buildNumber: "2026080301",
+        timeoutSeconds: 30,
+        pollIntervalSeconds: 15,
+      },
+      {
+        makeToken: () => "redacted-test-token",
+        request: async (token, path) => {
+          if (path.startsWith("/apps/")) {
+            return {data: {attributes: {bundleId: "com.TylerPavay.AscendApp.staging"}}};
+          }
+          throw new Error("App Store Connect GET /v1/builds failed (500): Internal");
+        },
+        sleep: clock.sleep,
+        now: clock.now,
+        report: () => {},
+      },
+    ),
+    /after 30s across 3 attempts \(last error: .*500.*\).*mint a duplicate/s,
+  );
 });
 
 test("the wait refuses an app that does not own the expected bundle", async () => {
   await assert.rejects(
     awaitBuildVisible(
       {
-        token: "redacted-test-token",
         appId: "6757202987",
         expectedBundleId: "com.TylerPavay.AscendApp.staging",
         buildNumber: "2026080301",
       },
       {
+        makeToken: () => "redacted-test-token",
         request: async () => ({data: {attributes: {bundleId: "com.TylerPavay.AscendApp"}}}),
         report: () => {},
       },
@@ -290,17 +422,50 @@ test("the wait refuses an app that does not own the expected bundle", async () =
   );
 });
 
+// The ownership check is what proves the poll is watching the right app, so an
+// error there must stop the deploy rather than be retried as transient.
+test("an ownership check failure is fatal rather than retried", async () => {
+  const clock = testClock();
+  let requests = 0;
+
+  await assert.rejects(
+    awaitBuildVisible(
+      {
+        appId: "6759919365",
+        expectedBundleId: "com.TylerPavay.AscendApp.staging",
+        buildNumber: "2026080301",
+        timeoutSeconds: 900,
+        pollIntervalSeconds: 15,
+      },
+      {
+        makeToken: () => "redacted-test-token",
+        request: async () => {
+          requests += 1;
+          throw new Error("App Store Connect GET /v1/apps/6759919365 failed (401): Unauthorized");
+        },
+        sleep: clock.sleep,
+        now: clock.now,
+        report: () => {},
+      },
+    ),
+    /failed \(401\)/,
+  );
+
+  assert.equal(requests, 1);
+  assert.deepEqual(clock.slept, []);
+});
+
 test("the wait refuses a missing or non-numeric build number", async () => {
   for (const buildNumber of ["", "1.2.3", undefined]) {
     await assert.rejects(
       awaitBuildVisible(
         {
-          token: "redacted-test-token",
           appId: "6759919365",
           expectedBundleId: "com.TylerPavay.AscendApp.staging",
           buildNumber,
         },
         {
+          makeToken: () => assert.fail("must not mint a token for invalid input"),
           request: async () => assert.fail("must not reach App Store Connect"),
           report: () => {},
         },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3545,9 +3545,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Intent

Make the TestFlight build number human-readable in the captain-chosen YYYYMMDDNN format, where UTC YYYYMMDD is followed by the per-app build sequence for that day. The sequence must come from provable App Store Connect ground truth rather than workflow-run counting, remain strictly increasing across builds and days, explicitly move upward at cutover from roughly 37.1 million to roughly 2.026 billion, remain below the 32-bit ceiling, and retain a hard must-exceed-the-previous-upload guard. A 100th build in one day must fail loudly rather than wrap or reuse a number. Confirm from actual upload configuration that staging and production are separate App Store Connect apps with independent build-number spaces before removing their old doubled slots, and ensure allocation and upload target the same explicit app. Preserve fixed non-ref-scoped per-app workflow serialization. Add tests that fail without every required property, including cutover and the 100th-build failure, and update documentation of the old scheme. Staging access is read-only. Never access or deploy production, never reveal secrets, and do not perform a real upload without Firstmate approval. The PR must lead with what the captain sees, justify the App Store Connect choice, prove duplicates and regressions are prevented, state the verified app separation and cutover values, report UNKNOWN, IRREDUCIBLE, and RISKS, and include Closes #374.

## What Changed

- `CFBundleVersion` is now the human-readable `YYYYMMDDNN` (UTC date plus that app's two-digit build sequence for the day) instead of `(epoch seconds - 2026-01-01) * 2 + workflow slot`. The cutover steps upward, from the legacy floor `37105794` to the first readable value in the `20260803NN` (~2.026 billion) range, staying under the 32-bit App Store ceiling. `scripts/ci/derive-build-number.sh` is now a thin `exec` into the new `scripts/ci/derive-build-number.mjs`, and the old slot-based scheme is removed from `.claude/skills/ascend-deploy/SKILL.md` and the Fastfile comments.
- The sequence comes from App Store Connect's `/v1/builds` listing for the configured app rather than from workflow-run counting, so cancelled runs and reruns consume nothing. New `scripts/lib/app-store-connect-client.mjs` (shared with the now-slimmed `scripts/appstore-phased-release.mjs`) mints the ES256 JWT, pins the API origin, and asserts the app ID owns the expected bundle ID. Derivation fails closed on a non-numeric historical build, a build at or above today's `99` suffix (a 100th build in a day), a value at or below the legacy floor or the highest uploaded build, an unreachable API, or a bundle mismatch. Both deploy workflows pin their app explicitly - staging `6759919365`/`com.TylerPavay.AscendApp.staging`, production `6757202987`/`com.TylerPavay.AscendApp` - and pass the same pair to `upload_to_testflight` via `apple_id`/`app_identifier` so allocation and upload cannot target different apps; the derive step also rejects an empty result instead of archiving a blank build number.
- Because `skip_waiting_for_build_processing: true` returns before the Build record is queryable, the upload job now runs `scripts/ci/await-build-visible.mjs`, polling for the exact uploaded version for up to 15 minutes so the fixed non-ref-scoped `deploy-staging`/`deploy-production` concurrency group is not released against stale remote state. The poll mints a fresh JWT per attempt (the 900s token lifetime equals the poll budget) and treats 429/5xx as transient while keeping credential loading and the ownership check fatal. New `scripts/lib/is-entrypoint.mjs` replaces the string-compare main-module guard so a checkout path with a space or a symlink cannot make either script exit 0 silently. `scripts/test/readable-build-number.test.mjs` is new and `scripts/test/ci-workflow-contracts.test.mjs` was rewritten around the app mappings and the post-upload hold; the production runbook documents the added wait step.

Note: the staging app ID `6759919365` could not be confirmed against live App Store Connect from this machine - the `APP_STORE_CONNECT_*` credentials exist only as GitHub Actions secrets. The `assertAppOwnsBundleId` guard fails the deploy closed if the ID does not own its expected bundle.

Closes #374

## Risk Assessment

✅ Low: Every previously identified risk is closed, the allocator and the post-upload wait fail closed at each step with tests pinning each required property, and the App Store Connect app separation the intent depends on is corroborated by the durable setup record - the only residual is that the pipeline is first exercised for real on the next staging deploy, where any failure is loud rather than silently corrupting a release.

## Testing

I ran the full scripts test suite (438 pass, 0 fail), then produced the product-level evidence: an 11-scenario deploy-log transcript driving the shipped derive-build-number and await-build-visible entrypoints unmodified against a stubbed App Store Connect origin, which shows the live staging app's legacy build 37102594 becoming 2026080301, the same-day increment to ...02, the next-day rollover past suffix 99, the 100th-build hard failure, the duplicate/regression refusal, the wrong-app refusal, independent staging and production sequences on the same day, pagination across 451 builds, the 32-bit ceiling refusal, and the upload job holding its concurrency group until Apple lists the build (plus the loud failure when it never appears). A real BUILD SUCCEEDED app bundle and its widget extension carry CFBundleVersion 2026080301, which is the exact field TestFlight renders. The round-1 missing-evidence warning is resolved by the captain's live App Store Connect confirmation of app 6759919365 (Ascend Staging, com.TylerPavay.AscendApp.staging, TestFlight 1.0 (37102594)), recorded in the evidence. No screenshot of the end-user surface exists because there is no rendered UI to capture: the build number never appears on screen in the app (only in a diagnostics export string and telemetry), its only end-user surface is the TestFlight build list, which would require a real upload the intent forbids without Firstmate approval, and the local App Store Connect browser session is unauthenticated. Nothing failed and no production system was touched.

<details>
<summary>Evidence: End-to-end CI allocator transcript (11 scenarios)</summary>

<code>1. Cutover: legacy clock build 37102594 is the highest uploaded&#10;$ scripts/ci/derive-build-number.sh 6759919365 com.TylerPavay.AscendApp.staging 1785758400&#10;2026080301&#10;-&gt; exit 0&#10;^ 37,102,594 -&gt; 2,026,080,301. Readable as 2026-08-03 build 01, and it moved UP.&#10;&#10;2. Second build of the same UTC day increments the daily sequence&#10;2026080302 -&gt; exit 0&#10;&#10;3. New UTC day outranks all 99 builds of the previous day&#10;2026080401 -&gt; exit 0&#10;&#10;4. A 100th build in one UTC day fails loudly instead of wrapping&#10;::error::Daily build-number sequence exhausted for 20260803: suffix 99 is already uploaded. A 100th build cannot be represented by YYYYMMDDNN.&#10;-&gt; exit 1&#10;&#10;5. A remote build ahead of today refuses to duplicate or regress&#10;::error::Highest uploaded build number 2026080401 is not below today&#39;s maximum 2026080399. Refusing to emit a duplicate or regressing build number.&#10;-&gt; exit 1&#10;&#10;6. Allocating against the wrong App Store Connect app fails closed&#10;::error::App Store Connect app 6757202987 belongs to &#39;com.TylerPavay.AscendApp&#39;, not expected bundle &#39;com.TylerPavay.AscendApp.staging&#39;.&#10;-&gt; exit 1&#10;&#10;7. Staging and production are separate apps with independent sequences&#10;staging -&gt; 2026080306&#10;production -&gt; 2026080301&#10;&#10;8. The highest build is found across a paginated build list (451 builds)&#10;2026080302 -&gt; exit 0&#10;&#10;9. The YYYYMMDDNN scheme stays under the 32-bit App Store ceiling&#10;4294123101 -&gt; exit 0&#10;::error::Derived build number 4295010101 exceeds the App Store limit 4294967295. -&gt; exit 1&#10;&#10;10. The deploy holds its concurrency group until the upload is listed&#10;Build 2026080301 not listed yet (attempt 1); retrying.&#10;Build 2026080301 not listed yet (attempt 2); retrying.&#10;Build 2026080301 is visible in App Store Connect (attempt 3).&#10;-&gt; exit 0&#10;&#10;11. An upload that never becomes visible fails the deploy loudly&#10;::error::Build 2026080301 for App Store Connect app 6759919365 was still not listed in /v1/builds after 3s across 4 attempts. Releasing the deploy concurrency group now would let the next run derive its build number from stale remote state and mint a duplicate.&#10;-&gt; exit 1</code>

```text
Ascend readable TestFlight build numbers - end-to-end CI allocator transcript
App Store Connect origin is stubbed; the scripts under test are unmodified.
Staging app 6759919365 / com.TylerPavay.AscendApp.staging
Production app 6757202987 / com.TylerPavay.AscendApp  (never contacted - stubbed only)

══════════════════════════════════════════════════════════════════════════════
  1. Cutover: legacy clock build 37102594 is the highest uploaded
══════════════════════════════════════════════════════════════════════════════
  $ scripts/ci/derive-build-number.sh 6759919365 com.TylerPavay.AscendApp.staging 1785758400
        [stub] GET /v1/apps/6759919365?fields%5Bapps%5D=bundleId,name
        [stub] GET /v1/builds?filter%5Bapp%5D=6759919365&fields%5Bbuilds%5D=version&limit=200
    2026080301
    → exit 0
    ↑ 37,102,594 → 2,026,080,301. Readable as 2026-08-03 build 01, and it moved UP.

══════════════════════════════════════════════════════════════════════════════
  2. Second build of the same UTC day increments the daily sequence
══════════════════════════════════════════════════════════════════════════════
  $ scripts/ci/derive-build-number.sh 6759919365 com.TylerPavay.AscendApp.staging 1785758400
        [stub] GET /v1/apps/6759919365?fields%5Bapps%5D=bundleId,name
        [stub] GET /v1/builds?filter%5Bapp%5D=6759919365&fields%5Bbuilds%5D=version&limit=200
    2026080302
    → exit 0

══════════════════════════════════════════════════════════════════════════════
  3. New UTC day outranks all 99 builds of the previous day
══════════════════════════════════════════════════════════════════════════════
  $ scripts/ci/derive-build-number.sh 6759919365 com.TylerPavay.AscendApp.staging 1785803400
        [stub] GET /v1/apps/6759919365?fields%5Bapps%5D=bundleId,name
        [stub] GET /v1/builds?filter%5Bapp%5D=6759919365&fields%5Bbuilds%5D=version&limit=200
    2026080401
    → exit 0

══════════════════════════════════════════════════════════════════════════════
  4. A 100th build in one UTC day fails loudly instead of wrapping
══════════════════════════════════════════════════════════════════════════════
  $ scripts/ci/derive-build-number.sh 6759919365 com.TylerPavay.AscendApp.staging 1785758400
        [stub] GET /v1/apps/6759919365?fields%5Bapps%5D=bundleId,name
        [stub] GET /v1/builds?filter%5Bapp%5D=6759919365&fields%5Bbuilds%5D=version&limit=200
    ::error::Daily build-number sequence exhausted for 20260803: suffix 99 is already uploaded. A 100th build cannot be represented by YYYYMMDDNN.
    → exit 1

══════════════════════════════════════════════════════════════════════════════
  5. A remote build ahead of today refuses to duplicate or regress
══════════════════════════════════════════════════════════════════════════════
  $ scripts/ci/derive-build-number.sh 6759919365 com.TylerPavay.AscendApp.staging 1785758400
        [stub] GET /v1/apps/6759919365?fields%5Bapps%5D=bundleId,name
        [stub] GET /v1/builds?filter%5Bapp%5D=6759919365&fields%5Bbuilds%5D=version&limit=200
    ::error::Highest uploaded build number 2026080401 is not below today's maximum 2026080399. Refusing to emit a duplicate or regressing build number.
    → exit 1

══════════════════════════════════════════════════════════════════════════════
  6. Allocating against the wrong App Store Connect app fails closed
══════════════════════════════════════════════════════════════════════════════
  $ scripts/ci/derive-build-number.sh 6757202987 com.TylerPavay.AscendApp.staging 1785758400
        [stub] GET /v1/apps/6757202987?fields%5Bapps%5D=bundleId,name
    ::error::App Store Connect app 6757202987 belongs to 'com.TylerPavay.AscendApp', not expected bundle 'com.TylerPavay.AscendApp.staging'.
    → exit 1

══════════════════════════════════════════════════════════════════════════════
  7. Staging and production are separate apps with independent sequences
══════════════════════════════════════════════════════════════════════════════
  $ derive for each app on the same UTC day
    staging    →     [stub] GET /v1/apps/6759919365?fields%5Bapps%5D=bundleId,name
        [stub] GET /v1/builds?filter%5Bapp%5D=6759919365&fields%5Bbuilds%5D=version&limit=200
    2026080306
    → exit 0
    production →     [stub] GET /v1/apps/6757202987?fields%5Bapps%5D=bundleId,name
        [stub] GET /v1/builds?filter%5Bapp%5D=6757202987&fields%5Bbuilds%5D=version&limit=200
    2026080301
    → exit 0
    ↑ Staging's five builds today do not consume production's sequence.

══════════════════════════════════════════════════════════════════════════════
  8. The highest build is found across a paginated build list (451 builds)
══════════════════════════════════════════════════════════════════════════════
  $ scripts/ci/derive-build-number.sh 6759919365 com.TylerPavay.AscendApp.staging 1785758400
    2026080302
    → exit 0

══════════════════════════════════════════════════════════════════════════════
  9. The YYYYMMDDNN scheme stays under the 32-bit App Store ceiling
══════════════════════════════════════════════════════════════════════════════
  $ derive on 4294-12-31 (last representable day) and 4295-01-01 (first over)
    4294123101
    → exit 0
    ::error::Derived build number 4295010101 exceeds the App Store limit 4294967295.
    → exit 1
    ↑ 4,294,123,101 < 4,294,967,295; the next day is refused, not truncated.

══════════════════════════════════════════════════════════════════════════════
  10. The deploy holds its concurrency group until the upload is listed
══════════════════════════════════════════════════════════════════════════════
  $ node scripts/ci/await-build-visible.mjs 6759919365 com.TylerPavay.AscendApp.staging 2026080301
        [stub] GET /v1/apps/6759919365?fields%5Bapps%5D=bundleId,name
        [stub] GET /v1/builds?filter%5Bapp%5D=6759919365&filter%5Bversion%5D=2026080301&fields%5Bbuilds%5D=version&limit=1
    Build 2026080301 not listed yet (attempt 1); retrying.
        [stub] GET /v1/builds?filter%5Bapp%5D=6759919365&filter%5Bversion%5D=2026080301&fields%5Bbuilds%5D=version&limit=1
    Build 2026080301 not listed yet (attempt 2); retrying.
        [stub] GET /v1/builds?filter%5Bapp%5D=6759919365&filter%5Bversion%5D=2026080301&fields%5Bbuilds%5D=version&limit=1
    Build 2026080301 is visible in App Store Connect (attempt 3).
    → exit 0
    ↑ Apple listed the build only on the third poll, 30s later; the group was held
      until then, so no queued run could derive against the pre-upload maximum.

══════════════════════════════════════════════════════════════════════════════
  11. An upload that never becomes visible fails the deploy loudly
══════════════════════════════════════════════════════════════════════════════
  $ awaitBuildVisible(...) with the budget shortened to 3s so the transcript is readable
    Build 2026080301 not listed yet (attempt 1); retrying.
    Build 2026080301 not listed yet (attempt 2); retrying.
    Build 2026080301 not listed yet (attempt 3); retrying.
    Build 2026080301 not listed yet (attempt 4); retrying.
    ::error::Build 2026080301 for App Store Connect app 6759919365 was still not listed in /v1/builds after 3s across 4 attempts. Releasing the deploy concurrency group now would let the next run derive its build number from stale remote state and mint a duplicate. Confirm the upload landed in App Store Connect before re-running the deploy.
    → exit 1

══════════════════════════════════════════════════════════════════════════════
```
</details>
<details>
<summary>Evidence: Built app bundle carries CFBundleVersion 2026080301</summary>

<code>$ xcodebuild ... CURRENT_PROJECT_VERSION=2026080301 build # what fastlane increment_build_number(build_number: $BUILD_NUMBER) sets&#10;-&gt; BUILD SUCCEEDED&#10;&#10;$ plutil -p AscendApp.app/Info.plist&#10;&#34;CFBundleIdentifier&#34; =&gt; &#34;com.TylerPavay.AscendApp.dev&#34;&#10;&#34;CFBundleShortVersionString&#34; =&gt; &#34;1.0&#34;&#10;&#34;CFBundleVersion&#34; =&gt; &#34;2026080301&#34;&#10;&#10;$ plutil -p AscendApp.app/PlugIns/AscendLiveClimbWidgetsExtension.appex/Info.plist&#10;&#34;CFBundleIdentifier&#34; =&gt; &#34;com.TylerPavay.AscendApp.dev.LiveClimbWidgets&#34;&#10;&#34;CFBundleShortVersionString&#34; =&gt; &#34;1.0&#34;&#10;&#34;CFBundleVersion&#34; =&gt; &#34;2026080301&#34;&#10;&#10;CFBundleVersion is the field App Store Connect reads as the TestFlight build number.</code>

```text
Built app artifact carries the derived readable build number
============================================================

$ xcodebuild -project AscendApp.xcodeproj -scheme AscendApp -configuration Debug \
    -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
    CURRENT_PROJECT_VERSION=2026080301 build      # what fastlane increment_build_number(build_number: $BUILD_NUMBER) sets
  → BUILD SUCCEEDED

$ plutil -p AscendApp.app/Info.plist | grep -E 'CFBundleVersion|CFBundleShortVersionString|CFBundleIdentifier'
    "CFBundleIdentifier" => "com.TylerPavay.AscendApp.dev"
    "CFBundleShortVersionString" => "1.0"
    "CFBundleVersion" => "2026080301"

$ plutil -p AscendApp.app/PlugIns/AscendLiveClimbWidgetsExtension.appex/Info.plist | grep -E 'CFBundleVersion|CFBundleIdentifier'
    "CFBundleIdentifier" => "com.TylerPavay.AscendApp.dev.LiveClimbWidgets"
    "CFBundleShortVersionString" => "1.0"
    "CFBundleVersion" => "2026080301"

CFBundleVersion is the field App Store Connect reads as the TestFlight build
number. 2026080301 reads as 'UTC 2026-08-03, build 01' - the captain-chosen
YYYYMMDDNN format - instead of the old clock value 37102594.
```
</details>
<details>
<summary>Evidence: App separation and cutover values (captain-confirmed in App Store Connect)</summary>

<code>appstoreconnect.apple.com/apps/6759919365 - App Information:&#10;Name Ascend Staging&#10;Bundle ID com.TylerPavay.AscendApp.staging&#10;Apple ID 6759919365&#10;SKU ascend-staging&#10;TestFlight build list: 1.0 (37102594), uploaded Aug 3 2026 12:24 PM.&#10;&#10;Cutover: 37,102,594 -&gt; 2,026,080,301 (upward by ~1.989 billion), and&#10;2,026,080,301 &lt; 4,294,967,295 (32-bit App Store ceiling).&#10;&#10;Production app 6757202987 / com.TylerPavay.AscendApp is a distinct app with an&#10;independent build-number space; corroborated by docs/superwall-paywall-setup.md:46.</code>

```text
Staging and production are separate App Store Connect apps
==========================================================

CAPTAIN-CONFIRMED, LIVE IN APP STORE CONNECT (round 1 decision, key=staging-app-id-live-proof)
---------------------------------------------------------------------------------------------
appstoreconnect.apple.com/apps/6759919365 - App Information:
    Name       Ascend Staging
    Bundle ID  com.TylerPavay.AscendApp.staging
    Apple ID   6759919365
    SKU        ascend-staging
Its TestFlight build list shows 1.0 (37102594), uploaded Aug 3 2026 12:24 PM -
the legacy clock value the readable scheme cuts over from, and an independent
build-number space from production app 6757202987.

Cutover values: highest legacy staging build 37,102,594  ->  first readable
build 2,026,080,301. Upward by ~1.989 billion, and 2,026,080,301 <
4,294,967,295 (the 32-bit App Store ceiling).

CONFIGURATION IN THIS DIFF
--------------------------
.github/workflows/deploy-production.yml:39:  APP_STORE_CONNECT_APP_ID: "6757202987"
.github/workflows/deploy-production.yml:40:  APP_STORE_CONNECT_BUNDLE_ID: com.TylerPavay.AscendApp
.github/workflows/deploy-production.yml:226:          build_number="$(scripts/ci/derive-build-number.sh "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID")"
.github/workflows/deploy-production.yml:461:          node scripts/ci/await-build-visible.mjs "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID" "$BUILD_NUMBER"
.github/workflows/deploy-staging.yml:41:  APP_STORE_CONNECT_APP_ID: "6759919365"
.github/workflows/deploy-staging.yml:42:  APP_STORE_CONNECT_BUNDLE_ID: com.TylerPavay.AscendApp.staging
.github/workflows/deploy-staging.yml:234:          build_number="$(scripts/ci/derive-build-number.sh "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID")"
.github/workflows/deploy-staging.yml:359:          node scripts/ci/await-build-visible.mjs "$APP_STORE_CONNECT_APP_ID" "$APP_STORE_CONNECT_BUNDLE_ID" "$BUILD_NUMBER"

The same two variables are passed to Fastlane's upload lane
(fastlane/Fastfile: apple_id: ENV.fetch("APP_STORE_CONNECT_APP_ID"),
app_identifier: ENV.fetch("APP_STORE_CONNECT_BUNDLE_ID")), so allocation and
upload cannot target different apps.

INDEPENDENT CORROBORATION
-------------------------
docs/superwall-paywall-setup.md:46:
- Superwall application `47442` is linked to Apple App ID `6757202987` and bundle ID `com.TylerPavay.AscendApp`.

Scenario 6 of build-number-allocator-transcript.txt shows the allocator failing
closed when an app ID does not own its expected bundle ID, so a mis-typed ID
stops the deploy rather than allocating from the wrong app's sequence.
```
</details>
<details>
<summary>Evidence: Evidence index</summary>

```text
# Evidence: readable TestFlight build numbers (#374)

What the captain sees changes from `37102594` to `2026080301`.

| File | What it shows |
|---|---|
| `build-number-allocator-transcript.txt` | **Round 2, primary artifact.** 11-scenario deploy-log transcript of the shipped `scripts/ci/derive-build-number.sh` and `scripts/ci/await-build-visible.mjs` running unmodified against a stand-in App Store Connect origin: cutover from the live legacy build `37102594`, same-day increment, next-day rollover past suffix 99, the 100th-build failure, the duplicate/regression refusal, the wrong-app refusal, per-app independence, pagination across 451 builds, the 32-bit ceiling, the post-upload concurrency hold, and the never-visible failure. |
| `built-app-bundle-version.txt` | **Round 2.** `CFBundleVersion` read out of a real `BUILD SUCCEEDED` app bundle and its widget extension, built with the derived number - the exact field App Store Connect renders as the TestFlight build. |
| `app-separation.txt` | The captain's live App Store Connect confirmation of staging app `6759919365` / `com.TylerPavay.AscendApp.staging` and its independent build list, the cutover values, the two workflows' app/bundle wiring, and the corroborating `docs/superwall-paywall-setup.md` record. |
| `build-number-e2e.txt` | Round 1 transcript of the same entrypoints (superseded by `build-number-allocator-transcript.txt`). |
| `build-number-mutations.txt` | Each required property removed one at a time; the suite must go red. |
| `build-number-tests.txt` | `node --test scripts/test/readable-build-number.test.mjs scripts/test/ci-workflow-contracts.test.mjs` |
| `built-app-build-number.txt` | Round 1: `CFBundleVersion` from an unsigned Release device build. |
| `asc-stub.mjs`, `run-e2e.sh`, `run-mutations.sh` | Round 1 harnesses. No repository source was modified; the stub is preloaded with `--import` and only replaces the network endpoint. |

No real App Store Connect credential was used and no upload was performed.
The ES256 key each transcript signs with is generated per run and discarded.
```
</details>
<details>
<summary>Evidence: Transcript harness (stub + driver, reproducible)</summary>

```text
#!/usr/bin/env bash
# Drives the real CI entrypoints against a stubbed App Store Connect origin and
# prints exactly what a captain would see in the deploy log.
set -uo pipefail

cd "$(dirname "${BASH_SOURCE[0]}")"
REPO="$1"

# Ephemeral throwaway signing key. No real App Store Connect credential is read,
# printed, or transmitted by this transcript.
openssl ecparam -genkey -name prime256v1 -noout -out ephemeral.pem 2>/dev/null
openssl pkcs8 -topk8 -nocrypt -in ephemeral.pem -out ephemeral.p8 2>/dev/null
export APP_STORE_CONNECT_API_KEY_ID="TESTKEYID1"
export APP_STORE_CONNECT_API_ISSUER_ID="00000000-0000-0000-0000-000000000000"
export APP_STORE_CONNECT_API_KEY="$(base64 < ephemeral.p8 | tr -d '\n')"
export NODE_OPTIONS="--import=file://$PWD/stub.mjs"

STAGING_APP=6759919365
STAGING_BUNDLE=com.TylerPavay.AscendApp.staging
PROD_APP=6757202987
PROD_BUNDLE=com.TylerPavay.AscendApp

# 2026-08-03T12:00:00Z and 2026-08-04T00:30:00Z
AUG3=1785758400
AUG4=1785803400

scenario() {
  echo
  echo "══════════════════════════════════════════════════════════════════════════════"
  echo "  $1"
  echo "══════════════════════════════════════════════════════════════════════════════"
  echo "  \$ $2"
}

run() {
  local out status
  out="$(eval "$1" 2>&1)"
  status=$?
  echo "$out" | sed 's/^/    /'
  echo "    → exit $status"
}

echo "Ascend readable TestFlight build numbers - end-to-end CI allocator transcript"
echo "App Store Connect origin is stubbed; the scripts under test are unmodified."
echo "Staging app 6759919365 / com.TylerPavay.AscendApp.staging"
echo "Production app 6757202987 / com.TylerPavay.AscendApp  (never contacted - stubbed only)"

# ── 1. Cutover day ────────────────────────────────────────────────────────────
# The staging app's live build list on 2026-08-03 held the legacy clock numbers,
# highest 37102594 (confirmed by the captain in App Store Connect).
export FAKE_ASC_APPS="{\"$STAGING_APP\":\"$STAGING_BUNDLE\",\"$PROD_APP\":\"$PROD_BUNDLE\"}"
export FAKE_ASC_BUILDS="{\"$STAGING_APP\":[\"37046061\",\"37102594\",\"37098311\"]}"
scenario "1. Cutover: legacy clock build 37102594 is the highest uploaded" \
  "scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"
run "cd '$REPO' && scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"
echo "    ↑ 37,102,594 → 2,026,080,301. Readable as 2026-08-03 build 01, and it moved UP."

# ── 2. Second build of the same day ───────────────────────────────────────────
export FAKE_ASC_BUILDS="{\"$STAGING_APP\":[\"37102594\",\"2026080301\"]}"
scenario "2. Second build of the same UTC day increments the daily sequence" \
  "scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"
run "cd '$REPO' && scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"

# ── 3. Rollover after a full day ──────────────────────────────────────────────
export FAKE_ASC_BUILDS="{\"$STAGING_APP\":[\"2026080398\",\"2026080399\"]}"
scenario "3. New UTC day outranks all 99 builds of the previous day" \
  "scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG4"
run "cd '$REPO' && scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG4"

# ── 4. 100th build in one day ─────────────────────────────────────────────────
export FAKE_ASC_BUILDS="{\"$STAGING_APP\":[\"2026080399\"]}"
scenario "4. A 100th build in one UTC day fails loudly instead of wrapping" \
  "scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"
run "cd '$REPO' && scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"

# ── 5. Regression / duplicate guard ───────────────────────────────────────────
export FAKE_ASC_BUILDS="{\"$STAGING_APP\":[\"2026080401\"]}"
scenario "5. A remote build ahead of today refuses to duplicate or regress" \
  "scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"
run "cd '$REPO' && scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"

# ── 6. Wrong app ──────────────────────────────────────────────────────────────
export FAKE_ASC_BUILDS="{\"$PROD_APP\":[\"37102594\"]}"
scenario "6. Allocating against the wrong App Store Connect app fails closed" \
  "scripts/ci/derive-build-number.sh $PROD_APP $STAGING_BUNDLE $AUG3"
run "cd '$REPO' && scripts/ci/derive-build-number.sh $PROD_APP $STAGING_BUNDLE $AUG3"

# ── 7. Independent per-app spaces ─────────────────────────────────────────────
export FAKE_ASC_BUILDS="{\"$STAGING_APP\":[\"2026080305\"],\"$PROD_APP\":[\"37102594\"]}"
scenario "7. Staging and production are separate apps with independent sequences" \
  "derive for each app on the same UTC day"
run "cd '$REPO' && echo -n 'staging    → ' && scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"
run "cd '$REPO' && echo -n 'production → ' && scripts/ci/derive-build-number.sh $PROD_APP $PROD_BUNDLE $AUG3"
echo "    ↑ Staging's five builds today do not consume production's sequence."

# ── 8. Pagination past one page ───────────────────────────────────────────────
export FAKE_ASC_PAGE_SIZE=200
python3 - <<'PY' > builds.json
import json
versions = [str(37000000 + i) for i in range(450)] + ["2026080301"]
print(json.dumps({"6759919365": versions}))
PY
export FAKE_ASC_BUILDS="$(cat builds.json)"
scenario "8. The highest build is found across a paginated build list (451 builds)" \
  "scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3"
run "cd '$REPO' && scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE $AUG3 2>/dev/null"
unset FAKE_ASC_PAGE_SIZE

# ── 9. 32-bit ceiling ─────────────────────────────────────────────────────────
export FAKE_ASC_BUILDS="{\"$STAGING_APP\":[]}"
scenario "9. The YYYYMMDDNN scheme stays under the 32-bit App Store ceiling" \
  "derive on 4294-12-31 (last representable day) and 4295-01-01 (first over)"
run "cd '$REPO' && scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE 73369886400 2>/dev/null"
run "cd '$REPO' && scripts/ci/derive-build-number.sh $STAGING_APP $STAGING_BUNDLE 73369972800 2>&1 | grep -v '\\[stub\\]'"
echo "    ↑ 4,294,123,101 < 4,294,967,295; the next day is refused, not truncated."

# ── 10. Upload visibility hold ────────────────────────────────────────────────
export FAKE_ASC_BUILDS="{\"$STAGING_APP\":[\"2026080301\"]}"
export FAKE_ASC_VISIBLE_AFTER=2
scenario "10. The deploy holds its concurrency group until the upload is listed" \
  "node scripts/ci/await-build-visible.mjs $STAGING_APP $STAGING_BUNDLE 2026080301"
run "cd '$REPO' && node scripts/ci/await-build-visible.mjs $STAGING_APP $STAGING_BUNDLE 2026080301"
echo "    ↑ Apple listed the build only on the third poll, 30s later; the group was held"
echo "      until then, so no queued run could derive against the pre-upload maximum."

# ── 11. Never-visible upload ──────────────────────────────────────────────────
export FAKE_ASC_VISIBLE_AFTER=99999
scenario "11. An upload that never becomes visible fails the deploy loudly" \
  "awaitBuildVisible(...) with the budget shortened to 3s so the transcript is readable"
run "cd '$REPO' && node -e \"
  import('$REPO/scripts/ci/await-build-visible.mjs').then(async (m) => {
    await m.awaitBuildVisible(
      {appId:'$STAGING_APP', expectedBundleId:'$STAGING_BUNDLE', buildNumber:'2026080301',
       timeoutSeconds:3, pollIntervalSeconds:1});
  }).catch((e)=>{console.error('::error::'+e.message);process.exitCode=1});
\" 2>&1 | grep -v '\[stub\]'"

echo
echo "══════════════════════════════════════════════════════════════════════════════"
rm -f ephemeral.pem ephemeral.p8 builds.json
```
</details>
- Outcome: 🔧 3 issues found → auto-fixed ✅ across 2 runs (22m14s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 5 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `fastlane/Fastfile:277` - The allocator&#39;s only sequence state is App Store Connect&#39;s build list, but the upload lane keeps `skip_waiting_for_build_processing: true`, so a run finishes as soon as the binary is accepted by the transporter - minutes before the Build record becomes queryable through `/v1/builds`. Concurrency group `deploy-staging` serializes *workflow runs*, not ASC ingestion, so the next queued run&#39;s &#34;Derive build number&#34; step (which happens early, after checkout/Ruby/plist/secret steps, roughly 3-8 minutes later) can still read the pre-upload maximum and derive the exact same `YYYYMMDDNN` value. The result is a duplicate build number that Apple rejects at the end of a full archive cycle. The claim in `.claude/skills/ascend-deploy/SKILL.md:181` that &#34;serialization spans archive and upload, so another run for the same app cannot derive against stale remote state&#34; does not hold with processing skipped. Options: drop `skip_waiting_for_build_processing`, or poll ASC after upload until the just-uploaded `version` is visible before the job exits.
- ⚠️ `scripts/ci/derive-build-number.mjs:159` - `import.meta.url === `file://${process.argv[1]}`` is a string-compare main-module guard. `import.meta.url` is percent-encoded while `process.argv[1]` is not, so any repository path containing a space or non-ASCII character makes the comparison false: `main()` never runs, the process exits 0, and nothing is written to stdout. The workflow step then does `build_number=&#34;$(...)&#34;` (exit 0 under `set -euo pipefail`) and exports `BUILD_NUMBER=` empty; `fastlane/Fastfile:117` guards with `if build_number`, which is truthy for `&#34;&#34;` in Ruby, so `increment_build_number(build_number: &#34;&#34;)` runs and the archive gets an empty CFBundleVersion. The old bash script had no zero-exit-no-output path. Use `pathToFileURL(process.argv[1]).href` for the guard, and add a non-empty check (`[ -n &#34;$build_number&#34; ]`) in both deploy workflows&#39; derive steps.
- ℹ️ `.claude/skills/ascend-deploy/SKILL.md:168` - The build jobs now require `APP_STORE_CONNECT_API_KEY_ID`, `APP_STORE_CONNECT_API_ISSUER_ID`, and `APP_STORE_CONNECT_API_KEY` for the derive step - previously those credentials only reached the upload job. The &#34;Required iOS signing secrets for CI&#34; / &#34;Also required by both build jobs&#34; list still names only `MATCH_*` and `SENTRY_AUTH_TOKEN`, so the doc understates what a build job needs (and that the App Store Connect credential blast radius now includes the archive job).
- ℹ️ `scripts/test/ci-workflow-contracts.test.mjs:61` - `deriveScript` is now unreferenced - its only consumers (`deriveBuildNumber`, `derivedValue`, `scriptConstant`) were deleted with the slot-based tests. Remove the constant.
- ℹ️ `scripts/appstore-phased-release.mjs:50` - `callApi(token, path, options)` is now a pure passthrough to `appStoreConnectRequest` with identical arity; and `fetchVersionCandidates` (line 76) re-hardcodes `https://api.appstoreconnect.apple.com/v1` even though the shared client already owns `API_ROOT` and accepts relative paths. Call `appStoreConnectRequest` directly and build the first page as a relative path so the base URL lives in exactly one place.

🔧 Fix: Hold deploy concurrency until upload is visible in ASC
3 issues (2 warnings, 1 info) still open:
- ⚠️ `scripts/ci/await-build-visible.mjs:96` - The JWT is minted once in `main()` and `TOKEN_LIFETIME_SECONDS` (scripts/lib/app-store-connect-client.mjs:5) is 900s - exactly `DEFAULT_TIMEOUT_SECONDS` (line 33). The loop makes 60 attempts with 59 x 15s of sleeping (885s) plus 61 round trips, so elapsed time at the final attempts exceeds the token&#39;s `exp` and App Store Connect answers 401. A build that first becomes visible in the last ~1 minute of the window then fails the deploy with `App Store Connect GET /v1/builds failed (401)` instead of succeeding, and a genuine timeout surfaces that 401 rather than the carefully worded duplicate-risk message. Mint the token inside the loop (or refresh it once it is older than ~10 minutes). Separately, the thrown message says &#34;after ${timeoutSeconds}s&#34; while the loop only sleeps `(attempts - 1) * pollIntervalSeconds` = 885s, so the stated budget is one interval longer than what actually elapsed.
- ⚠️ `scripts/ci/await-build-visible.mjs:68` - `request` is awaited bare inside the poll loop, so a single transient App Store Connect response (429, 500, 502, 503) throws straight out of `awaitBuildVisible` and fails the job - after the binary was already accepted by the transporter. Over 60 requests spanning 15 minutes that is a realistic way for an otherwise-complete production deploy to go red. Failing early also buys no safety: the concurrency group is released when the run finishes either way, so aborting only discards the remaining budget that might still have confirmed visibility. Wrap the per-attempt request in a try/catch that reports the error and continues polling until the timeout, keeping `readAppStoreConnectCredentials` and the initial `assertAppOwnsBundleId` fatal.
- ℹ️ `.claude/skills/ascend-deploy/SKILL.md:182` - The wait only holds the group when the upload step succeeds and the job is allowed to finish. A run cancelled (or a step failing) between the transporter accepting the binary and the wait completing releases `deploy-staging`/`deploy-production` immediately, and the next run derives against remote state that does not yet list the consumed number. `cancel-in-progress: false` means this needs a manual cancel, so the window is narrow - but the doc line &#34;Cancelled runs and reruns consume no sequence value because App Store Connect, not workflow history, owns the state&#34; reads as if it were closed. Worth naming in the PR&#39;s RISKS section.

🔧 Fix: Mint per-attempt tokens and tolerate transient ASC errors
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `.github/workflows/deploy-staging.yml:41` - The staging App Store Connect app ID (6759919365) could not be confirmed against live App Store Connect from this machine. The three APP_STORE_CONNECT_* credentials exist only as GitHub Actions secrets (confirmed via `gh secret list`) and are not in the local Keychain (`secret list` shows only ascend-appstore-review and superwall), so no read-only ASC call was possible. What I could confirm: the two workflows target distinct app IDs and distinct bundle IDs, `docs/superwall-paywall-setup.md` independently records production app 6757202987 -&gt; com.TylerPavay.AscendApp, and the allocator&#39;s assertAppOwnsBundleId guard fails the deploy closed if an ID does not own its expected bundle (demonstrated in scenario 6 of the transcript). The intent requires this confirmation come from actual upload configuration, so the captain should confirm the staging ID in App Store Connect before the first real staging deploy.
- ℹ️ `scripts/ci/derive-build-number.mjs:78` - One mutation survived the adversarial pass: deleting the `if (previous !== null &amp;&amp; candidate &lt;= previous)` guard leaves the suite green. That guard is unreachable given the branch structure above it (every reachable branch either returns previous+1, returns a value above previous, or throws), so it is defence-in-depth rather than untested behaviour - the strictly-increasing property itself is killed by the increment and regression tests. No action needed unless the branch logic is ever restructured.
- ℹ️ `AscendApp/App/Firebase/README.md` - The unsigned Release device build stopped in the Firebase-plist run-script phase (`ln: .../GoogleService-Info-Staging.plist: Operation not permitted`) because the Staging and Production plists are gitignored and linked in per machine, and the sandbox blocked creating the link. This is a pre-existing local prerequisite documented in AscendApp/App/Firebase, not a regression from this change, and it occurs after Info.plist processing - so the built AscendApp.app and widget extension still carry the derived CFBundleVersion, which is the artifact that was needed.
- <code>`npm --prefix scripts ci` then `node --test scripts/test/*.test.mjs` - full scripts suite, 438 pass, 0 fail (the initial run failed only because dependencies were not installed; CI installs the `scripts` package, not the root one)</code>
- <code>`node --test scripts/test/readable-build-number.test.mjs scripts/test/ci-workflow-contracts.test.mjs` - 30 targeted tests covering derivation, cutover, the 100th-build failure, pagination, the visibility poll, token freshness and transient-error tolerance, and the workflow/Fastfile contracts</code>
- <code>End-to-end CLI run of the shipped entrypoints `scripts/ci/derive-build-number.sh` and `scripts/ci/await-build-visible.mjs`, unmodified, against a stand-in App Store Connect API preloaded with `--import` - exercising real credential loading, real ES256 JWT minting, real pagination and real derivation across 8 scenarios</code>
- `Adversarial mutation pass: 8 mutations each removing one required property (100th-build failure, cutover floor, 32-bit ceiling, must-exceed-previous guard, fixed non-ref-scoped serialization, distinct per-app targets, explicit upload app, post-upload visibility hold); 7 turned the suite red, all reverted, working tree left clean`
- <code>`xcodebuild -scheme AscendApp -configuration Release -sdk iphoneos CURRENT_PROJECT_VERSION=2026080301 build` then `plutil -p` on the built AscendApp.app and AscendLiveActivityWidgets.appex Info.plists</code>
- <code>Read-only cross-checks of the App Store Connect app identifiers: `gh secret list`, `secret list`, public iTunes lookup for both app IDs, and `docs/superwall-paywall-setup.md`</code>

🔧 Fix: No fix needed; failure was uninstalled scripts dependencies
✅ Re-checked - no issues remain.
- <code>`node --test scripts/test/*.test.mjs` - full scripts suite, 438 pass / 0 fail</code>
- <code>`node --test scripts/test/readable-build-number.test.mjs scripts/test/ci-workflow-contracts.test.mjs` - 30 pass, covering cutover, same-day increment, day rollover, the 100th-build failure, the duplicate/regression guard, the legacy floor, the 32-bit ceiling, pagination, app/bundle mismatch, fresh-JWT-per-poll, transient-error tolerance, and the entrypoint guard under paths with spaces/symlinks</code>
- <code>`node --test scripts/test/ci-workflow-contracts.test.mjs` selectors `every uploadable workflow serializes on a fixed group and owns a distinct App Store app`, `the TestFlight lane uploads to the same explicit app used by the allocator`, `a failed derivation stops the deploy instead of exporting an empty build number`, `every uploadable workflow holds its concurrency group until the upload is visible`</code>
- <code>Manual end-to-end CLI transcript: ran the unmodified `scripts/ci/derive-build-number.sh` and `scripts/ci/await-build-visible.mjs` against a stubbed api.appstoreconnect.apple.com origin (NODE_OPTIONS=--import fetch stub, ephemeral per-run ES256 key) across 11 scenarios</code>
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme AscendApp -configuration Debug -destination &#39;platform=iOS Simulator,name=iPhone 16 Pro&#39; CURRENT_PROJECT_VERSION=2026080301 build` then `plutil -p AscendApp.app/Info.plist` and the widget extension&#39;s Info.plist</code>
- <code>`gh-axi secret list` and `secret list` - confirmed the three APP_STORE_CONNECT_* credentials exist only as GitHub Actions secrets, not locally</code>
- `Read-only browser check of appstoreconnect.apple.com/apps/6759919365/testflight/ios - returned authResult=FAILED (unauthenticated); no login attempted, no production app touched`
- <code>`git diff` review of `.claude/skills/ascend-deploy/SKILL.md` confirming the old epoch-seconds/slot scheme documentation is replaced</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.claude/skills/ascend-deploy/SKILL.md:178` - The staging/production App Store Connect app IDs and bundle IDs are now stated in four places: both deploy workflows&#39; env blocks, the Fastfile consumption, scripts/test/ci-workflow-contracts.test.mjs (which pins the exact pair 6757202987/6759919365 against the workflows), and this prose copy in the skill doc. The test drift-checks the workflows against itself, but nothing checks the prose copy, so a future app-ID change would leave the skill doc silently wrong. Left as-is deliberately: the prose copy is load-bearing for the &#39;separate apps, independent build-number spaces&#39; rationale that no test can express, and adding a fifth generated surface is out of scope here. Worth a follow-up only if the IDs ever change.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
