### PR TITLE
ci: derive required-check fallback contexts from the real iOS verify jobs

### DIFF
--- a/.claude/skills/ascend-deploy/SKILL.md
+++ b/.claude/skills/ascend-deploy/SKILL.md
@@ -61,7 +61,10 @@ Every verify job is gated on the changed paths, so a functions-only PR skips the
 `.github/workflows/ci-required-check-fallback.yml` is the companion required-check router, and unlike `ci.yml` it is unfiltered: it runs on every PR targeting `develop` or `main`, whatever the changed paths.
 Its `route` job lists the PR's changed files and hands them to `scripts/ci/classify-required-check-route.mjs`, which decides through `scripts/lib/required-check-routing.mjs`.
 Its fallback matrix derives every required iOS context from the marked jobs in `ci.yml`, then claims those exact names only when the route job succeeded *and* returned `fallback_eligible=true`.
-For anything else the fallback jobs take distinct `Fallback (Not Required)` display names and are skipped, so they can never satisfy branch protection in place of the real checks.
+For anything else every matrix leg falls back to the one static `iOS Verify Fallback (Not Required)` name and is skipped, so none of them can ever satisfy branch protection in place of the real checks.
+The derivation is positional: `scripts/ci/list-required-check-contexts.mjs` reads the `name:` of every job between the `# required-check-contexts:start` and `# required-check-contexts:end` comments in `ci.yml`.
+A required iOS verify job declared outside that block is invisible to the matrix, so branch protection would demand a context the eligible fallback never publishes - which is the original defect.
+`scripts/test/ci-workflow-contracts.test.mjs` fails on either mistake: an `iOS Verify` job outside the block, or a non-verify job inside it.
 
 **The router is an allowlist, not the inverse of the CI trigger.** `classifyChangedPaths` answers "is every changed path positively known to need no verification?" - `VERIFICATION_IRRELEVANT_PATHS` is `docs/**`, `AppStoreAssets/**`, `data/ascend-support-page-and-product-page-package/**`, `.claude/skills/**`, `README.md`, and `.gitignore`, and CI-relevance is evaluated first so the four gated `docs/*.md` files still route to real CI.
 Anything unrecognised is blocked, which is the deliberate fail-closed default.

--- a/.claude/skills/ascend-deploy/SKILL.md
+++ b/.claude/skills/ascend-deploy/SKILL.md
@@ -59,8 +59,9 @@ Every verify job is gated on the changed paths, so a functions-only PR skips the
   `ProcessInfoPlistFile` runs independently of compilation, which is why the check reads the built bundle plist instead of `AscendApp/Info.plist`.
 
 `.github/workflows/ci-required-check-fallback.yml` is the companion required-check router, and unlike `ci.yml` it is unfiltered: it runs on every PR targeting `develop` or `main`, whatever the changed paths.
-Its `route` job lists the PR's changed files and hands them to `scripts/ci/classify-required-check-route.mjs`, which decides through `scripts/lib/required-check-routing.mjs`; the `fallback` job claims the required `iOS Verify (Staging)` name only when that job succeeded *and* returned `fallback_eligible=true`.
-For anything else the fallback job takes a different display name and is skipped, so it can never satisfy branch protection in place of the real check.
+Its `route` job lists the PR's changed files and hands them to `scripts/ci/classify-required-check-route.mjs`, which decides through `scripts/lib/required-check-routing.mjs`.
+Its fallback matrix derives every required iOS context from the marked jobs in `ci.yml`, then claims those exact names only when the route job succeeded *and* returned `fallback_eligible=true`.
+For anything else the fallback jobs take distinct `Fallback (Not Required)` display names and are skipped, so they can never satisfy branch protection in place of the real checks.
 
 **The router is an allowlist, not the inverse of the CI trigger.** `classifyChangedPaths` answers "is every changed path positively known to need no verification?" - `VERIFICATION_IRRELEVANT_PATHS` is `docs/**`, `AppStoreAssets/**`, `data/ascend-support-page-and-product-page-package/**`, `.claude/skills/**`, `README.md`, and `.gitignore`, and CI-relevance is evaluated first so the four gated `docs/*.md` files still route to real CI.
 Anything unrecognised is blocked, which is the deliberate fail-closed default.
@@ -70,7 +71,7 @@ The Ruby path runs `ruby-verify` - which resolves the bundle under the pinned de
 Firebase rules, Firebase configuration, the root rules-test package, Ruby dependencies, and `fastlane/**` are all in the CI-relevant contract.
 Do not add any of them to the fallback allowlist.
 Their dedicated jobs are the verification that makes routing them to real CI safe.
-`iOS Verify (Staging)` is still the only name branch protection requires: `firebase-verify` and `ruby-verify` run and report, but they are advisory until someone adds their names to branch protection.
+`iOS Verify (Staging)` and `iOS Verify (Release)` are the names branch protection requires: `firebase-verify` and `ruby-verify` run and report, but they are advisory until someone adds their names to branch protection.
 
 The contract lives once, in `CI_RELEVANT_PATHS`, and `scripts/test/ci-required-check-routing.test.mjs` asserts it byte-identical to the `required-check-paths` block in `ci.yml`.
 That contract must stay a superset of every job-level `dorny/paths-filter` path in `ci.yml`; the test derives the filters itself and fails on any path a verify job gates on that the trigger omits - so adding a path to the `scripts` or `ios` filter without adding it to the contract is a build failure, not a silent coverage hole.

--- a/.github/workflows/ci-required-check-fallback.yml
+++ b/.github/workflows/ci-required-check-fallback.yml
@@ -35,8 +35,8 @@ jobs:
       # The classifier is an allowlist over the whole diff, which dorny cannot
       # express: it ORs its rules per file, so a negated rule reads as "any file
       # that is not this" rather than as an exclusion. Every failure here leaves
-      # the job unsuccessful, and the fallback job below refuses to claim the
-      # required name unless this job succeeded.
+      # the job unsuccessful, and the fallback jobs below refuse to claim the
+      # required names unless this job succeeded.
       - name: Classify changed paths
         id: classify
         env:

--- a/.github/workflows/ci-required-check-fallback.yml
+++ b/.github/workflows/ci-required-check-fallback.yml
@@ -19,10 +19,18 @@ jobs:
     timeout-minutes: 5
     outputs:
       fallback_eligible: ${{ steps.classify.outputs.fallback_eligible }}
+      required_contexts: ${{ steps.required-contexts.outputs.required_contexts }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # The real CI workflow owns the context names. Deriving the matrix from
+      # those jobs keeps a future required iOS check from needing a second,
+      # easy-to-miss update in this fallback workflow.
+      - name: Read required check contexts
+        id: required-contexts
+        run: node scripts/ci/list-required-check-contexts.mjs .github/workflows/ci.yml
 
       # The classifier is an allowlist over the whole diff, which dorny cannot
       # express: it ORs its rules per file, so a negated rule reads as "any file
@@ -52,11 +60,15 @@ jobs:
 
   fallback:
     needs: route
-    name: ${{ needs.route.result == 'success' && needs.route.outputs.fallback_eligible == 'true' && 'iOS Verify (Staging)' || 'iOS Verify Fallback (Not Required)' }}
+    name: ${{ needs.route.result == 'success' && needs.route.outputs.fallback_eligible == 'true' && matrix.context || 'iOS Verify Fallback (Not Required)' }}
     if: needs.route.result == 'success' && needs.route.outputs.fallback_eligible == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        context: ${{ fromJSON(needs.route.outputs.required_contexts) }}
 
     steps:
       - name: Satisfy required check for non-CI changes
-        run: echo "Every changed path is verification-irrelevant. The required iOS verification check is satisfied by the fallback."
+        run: echo "Every changed path is verification-irrelevant. The required iOS verification checks are satisfied by the fallback."

--- a/.github/workflows/ci-required-check-fallback.yml
+++ b/.github/workflows/ci-required-check-fallback.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       fallback_eligible: ${{ steps.classify.outputs.fallback_eligible }}
-      required_contexts: ${{ steps.required-contexts.outputs.required_contexts }}
+      required_contexts: ${{ steps.required-contexts.outputs.required_contexts || '[]' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,6 +410,7 @@ jobs:
       - name: Validate Fastlane lanes
         run: bundle exec fastlane lanes
 
+# required-check-contexts:start
   ios-verify:
     name: iOS Verify (Staging)
     needs: changes
@@ -744,3 +745,4 @@ jobs:
           path: build-logs/
           retention-days: 7
           if-no-files-found: warn
+# required-check-contexts:end

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ Resolve work to a GitHub issue before implementing:
 - `.firebaserc` - project aliases (dev, staging, prod)
 - `firebase.json` - hosting, functions, firestore config
 - `firestore.rules`, `storage.rules`, `firestore.indexes.json` - security rules and indexes
-- `.github/workflows/ci.yml` - PR validation; `ci-required-check-fallback.yml` routes the required check for PRs that change no CI-relevant path (`ascend-deploy`)
+- `.github/workflows/ci.yml` - PR validation; `ci-required-check-fallback.yml` routes the required checks for PRs that change no CI-relevant path (`ascend-deploy`)
 - `.github/workflows/deploy-staging.yml`, `deploy-production.yml` - deploy pipelines (prod gated)
 - `Gemfile`, `fastlane/Appfile`, `fastlane/Fastfile`, `fastlane/Matchfile` - build/signing/TestFlight
 - `remoteconfig.template.json` - the kill-switch parameters; CI publishes new ones additively to dev and staging only, full replaces stay manual via `scripts/deploy-remote-config.mjs` (`docs/remote-config-kill-switches.md`)

--- a/scripts/ci/classify-required-check-route.mjs
+++ b/scripts/ci/classify-required-check-route.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // Decides whether the CI required-check fallback may claim the required
-// `iOS Verify (Staging)` name. Every failure path exits non-zero so the routing
-// job fails and the fallback job's `if:` guard keeps it from claiming the name.
+// required iOS check names. Every failure path exits non-zero so the routing
+// job fails and the fallback job's `if:` guard keeps it from claiming them.
 //
 // This file is argv and stdio plumbing only. Every routing decision, including
 // the truncated-diff refusal, lives in the module below so it can be tested.

--- a/scripts/ci/list-required-check-contexts.mjs
+++ b/scripts/ci/list-required-check-contexts.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import { appendFileSync, readFileSync } from "node:fs";
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+const [workflowPath] = process.argv.slice(2);
+
+if (!workflowPath) {
+  fail("Usage: list-required-check-contexts.mjs <ci-workflow.yml>");
+}
+
+let workflow;
+
+try {
+  workflow = readFileSync(workflowPath, "utf8");
+} catch (error) {
+  fail(`Could not read the CI workflow: ${error.message}`);
+}
+
+const startMarker = "# required-check-contexts:start\n";
+const endMarker = "# required-check-contexts:end";
+const startIndex = workflow.indexOf(startMarker);
+const endIndex = workflow.indexOf(endMarker, startIndex + startMarker.length);
+
+if (startIndex === -1 || endIndex === -1) {
+  fail("The CI workflow must contain one required-check-contexts marker block.");
+}
+
+const markedJobs = workflow.slice(startIndex + startMarker.length, endIndex);
+const contexts = [...markedJobs.matchAll(/^ {4}name:\s+(?<name>.+?)\s*$/gm)].map(
+  (match) => match.groups.name,
+);
+
+if (contexts.length === 0) {
+  fail("The required-check-contexts marker block must contain at least one named job.");
+}
+
+if (contexts.some((context) => context.includes("${{"))) {
+  fail("Required check context names must be static strings.");
+}
+
+if (new Set(contexts).size !== contexts.length) {
+  fail("Required check context names must be unique.");
+}
+
+const serialized = JSON.stringify(contexts);
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `required_contexts=${serialized}\n`);
+} else {
+  console.log(serialized);
+}

--- a/scripts/lib/required-check-routing.mjs
+++ b/scripts/lib/required-check-routing.mjs
@@ -1,7 +1,7 @@
-// The required `iOS Verify (Staging)` check is owned by ci.yml's ios-verify job
+// The required iOS check names are owned by ci.yml's marked verify jobs
 // whenever ci.yml triggers. This module decides the one case where the fallback
-// workflow may claim that name instead: a pull request whose every changed path
-// is positively known to need no verification.
+// workflow may claim those names instead: a pull request whose every changed
+// path is positively known to need no verification.
 //
 // It is an allowlist, not the inverse of the CI trigger. ci.yml gates only the
 // paths its jobs verify. Anything unrecognised stays blocked.

--- a/scripts/test/ci-required-check-routing.test.mjs
+++ b/scripts/test/ci-required-check-routing.test.mjs
@@ -220,36 +220,32 @@ test("the pattern guard rejects every glob shape the model cannot evaluate", () 
   }
 });
 
-test("the fallback claims the real iOS job's exact check name", () => {
-  const requiredCheckName = jobName("ios-verify");
-  const claimed = fallbackWorkflow.match(
-    /name:\s+\$\{\{\s*.*?&&\s*'(?<required>[^']+)'\s*\|\|\s*'(?<inert>[^']+)'\s*\}\}/,
-  )?.groups;
+test("the fallback derives required check names from the real iOS jobs", () => {
+  assert.match(
+    fallbackWorkflow,
+    /node scripts\/ci\/list-required-check-contexts\.mjs \.github\/workflows\/ci\.yml/,
+  );
+  assert.match(
+    fallbackWorkflow,
+    /context: \$\{\{ fromJSON\(needs\.route\.outputs\.required_contexts\) \}\}/,
+  );
 
-  assert.ok(
-    claimed,
-    "the fallback job must name itself through a conditional expression",
-  );
-  assert.equal(
-    claimed.required,
-    requiredCheckName,
-    "the fallback must claim exactly the name ci.yml's ios-verify job publishes, or renaming that job leaves CI-relevant PRs with no required check at all",
-  );
-  assert.notEqual(
-    claimed.inert,
-    requiredCheckName,
-    "the fallback's non-claiming name must differ from the required check name",
-  );
+  for (const jobId of ["ios-verify", "ios-verify-release"]) {
+    assert.doesNotMatch(
+      fallbackWorkflow,
+      new RegExp(`['\"]${jobName(jobId).replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}['\"]`),
+      `${jobId}'s context must come from ci.yml instead of being copied into the fallback`,
+    );
+  }
 });
 
-test("fallback claims the required name only after a successful eligible route", () => {
+test("fallback claims each derived name only after a successful eligible route", () => {
   const safeRoute =
     "needs.route.result == 'success' && needs.route.outputs.fallback_eligible == 'true'";
-  const requiredCheckName = jobName("ios-verify");
 
   assert.ok(
     fallbackWorkflow.includes(
-      `name: \${{ ${safeRoute} && '${requiredCheckName}'`,
+      `name: \${{ ${safeRoute} && matrix.context || 'iOS Verify Fallback (Not Required)' }}`,
     ),
   );
   assert.ok(fallbackWorkflow.includes(`if: ${safeRoute}`));

--- a/scripts/test/ci-workflow-contracts.test.mjs
+++ b/scripts/test/ci-workflow-contracts.test.mjs
@@ -13,15 +13,13 @@ async function readWorkflow(name) {
   return readFile(`${repositoryRoot}/.github/workflows/${name}`, "utf8");
 }
 
+const requiredCheckStartMarker = "# required-check-contexts:start\n";
+const requiredCheckEndMarker = "# required-check-contexts:end";
+const jobNamePattern = /^ {4}name:\s+(?<name>.+?)\s*$/gm;
+
 function requiredCheckContexts(ciWorkflow) {
-  const block = sectionBetween(
-    ciWorkflow,
-    "# required-check-contexts:start\n",
-    "# required-check-contexts:end",
-  );
-  const contexts = [...block.matchAll(/^ {4}name:\s+(?<name>.+?)\s*$/gm)].map(
-    (match) => match.groups.name,
-  );
+  const block = sectionBetween(ciWorkflow, requiredCheckStartMarker, requiredCheckEndMarker);
+  const contexts = [...block.matchAll(jobNamePattern)].map((match) => match.groups.name);
 
   assert.ok(contexts.length > 0, "CI must declare at least one required check context");
   assert.equal(
@@ -51,7 +49,7 @@ test("the eligible fallback publishes every required iOS verification context", 
   assert.deepEqual(contexts, ["iOS Verify (Staging)", "iOS Verify (Release)"]);
   assert.match(
     fallbackWorkflow,
-    /required_contexts: \$\{\{ steps\.required-contexts\.outputs\.required_contexts \}\}/,
+    /required_contexts: \$\{\{ steps\.required-contexts\.outputs\.required_contexts \|\| '\[\]' \}\}/,
   );
   assert.match(
     fallbackWorkflow,
@@ -99,21 +97,64 @@ test("the eligible fallback publishes every required iOS verification context", 
 
 test("an ineligible fallback cannot publish a required verification context", async () => {
   const fallbackWorkflow = await readWorkflow("ci-required-check-fallback.yml");
+  const contexts = requiredCheckContexts(await readWorkflow("ci.yml"));
   const safeRoute =
     "needs.route.result == 'success' && needs.route.outputs.fallback_eligible == 'true'";
 
   assert.ok(fallbackWorkflow.includes(`if: ${safeRoute}`));
-  assert.ok(
-    fallbackWorkflow.includes(
-      `name: \${{ ${safeRoute} && matrix.context || 'iOS Verify Fallback (Not Required)' }}`,
-    ),
-  );
   assert.doesNotMatch(fallbackWorkflow, /^\s+paths(?:-ignore)?:/m);
 
-  for (const context of ["iOS Verify (Staging)", "iOS Verify (Release)"]) {
-    assert.notEqual("iOS Verify Fallback (Not Required)", context);
-  }
+  const inertName = fallbackWorkflow.match(
+    new RegExp(
+      `^ {4}name: \\$\\{\\{ ${escapeForRegExp(safeRoute)} && matrix\\.context \\|\\| '(?<inert>[^']+)' \\}\\}$`,
+      "m",
+    ),
+  )?.groups?.inert;
+
+  assert.ok(inertName, "the fallback job must fall back to a static non-verification name");
+  assert.ok(
+    !contexts.includes(inertName),
+    `the ineligible fallback name "${inertName}" must not be a required check context`,
+  );
 });
+
+// The marker block is a positional contract. A required iOS job declared outside
+// it is invisible to the derived matrix, so branch protection would demand a
+// context the eligible fallback never publishes - the exact defect this routing
+// exists to prevent.
+test("every required iOS verification job lives inside the marker block", async () => {
+  const ciWorkflow = await readWorkflow("ci.yml");
+  const startIndex = ciWorkflow.indexOf(requiredCheckStartMarker);
+  const endIndex = ciWorkflow.indexOf(requiredCheckEndMarker, startIndex + requiredCheckStartMarker.length);
+
+  assert.notEqual(startIndex, -1, "ci.yml must declare the required-check marker block");
+  assert.notEqual(endIndex, -1, "ci.yml must close the required-check marker block");
+
+  const iosJobNames = [];
+  for (const match of ciWorkflow.matchAll(jobNamePattern)) {
+    const inside = match.index > startIndex && match.index < endIndex;
+    const name = match.groups.name;
+
+    if (name.startsWith("iOS Verify")) {
+      assert.ok(
+        inside,
+        `"${name}" must sit inside the required-check-contexts marker block to reach the fallback matrix`,
+      );
+      iosJobNames.push(name);
+    } else {
+      assert.ok(
+        !inside,
+        `"${name}" is inside the required-check-contexts marker block but is not a required iOS verification job`,
+      );
+    }
+  }
+
+  assert.deepEqual(iosJobNames, requiredCheckContexts(ciWorkflow));
+});
+
+function escapeForRegExp(source) {
+  return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
 test("CI watches every iOS source and Firebase index definition", async () => {
   const workflow = await readWorkflow("ci.yml");

--- a/scripts/test/ci-workflow-contracts.test.mjs
+++ b/scripts/test/ci-workflow-contracts.test.mjs
@@ -13,6 +13,26 @@ async function readWorkflow(name) {
   return readFile(`${repositoryRoot}/.github/workflows/${name}`, "utf8");
 }
 
+function requiredCheckContexts(ciWorkflow) {
+  const block = sectionBetween(
+    ciWorkflow,
+    "# required-check-contexts:start\n",
+    "# required-check-contexts:end",
+  );
+  const contexts = [...block.matchAll(/^ {4}name:\s+(?<name>.+?)\s*$/gm)].map(
+    (match) => match.groups.name,
+  );
+
+  assert.ok(contexts.length > 0, "CI must declare at least one required check context");
+  assert.equal(
+    new Set(contexts).size,
+    contexts.length,
+    "required check contexts must be unique",
+  );
+
+  return contexts;
+}
+
 function sectionBetween(source, start, end) {
   const startIndex = source.indexOf(start);
   assert.notEqual(startIndex, -1, `Missing section start: ${start}`);
@@ -22,6 +42,78 @@ function sectionBetween(source, start, end) {
 
   return source.slice(startIndex, endIndex);
 }
+
+test("the eligible fallback publishes every required iOS verification context", async () => {
+  const ciWorkflow = await readWorkflow("ci.yml");
+  const fallbackWorkflow = await readWorkflow("ci-required-check-fallback.yml");
+  const contexts = requiredCheckContexts(ciWorkflow);
+
+  assert.deepEqual(contexts, ["iOS Verify (Staging)", "iOS Verify (Release)"]);
+  assert.match(
+    fallbackWorkflow,
+    /required_contexts: \$\{\{ steps\.required-contexts\.outputs\.required_contexts \}\}/,
+  );
+  assert.match(
+    fallbackWorkflow,
+    /context: \$\{\{ fromJSON\(needs\.route\.outputs\.required_contexts\) \}\}/,
+  );
+
+  const script = `${repositoryRoot}/scripts/ci/list-required-check-contexts.mjs`;
+  const workspace = mkdtempSync(join(tmpdir(), "ascend-required-contexts-"));
+  const outputPath = join(workspace, "github-output");
+  writeFileSync(outputPath, "");
+
+  const result = spawnSync(process.execPath, [script, `${repositoryRoot}/.github/workflows/ci.yml`], {
+    encoding: "utf8",
+    env: {...process.env, GITHUB_OUTPUT: outputPath},
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    readFileSync(outputPath, "utf8").trim(),
+    `required_contexts=${JSON.stringify(contexts)}`,
+  );
+
+  const expandedWorkflowPath = join(workspace, "ci-with-third-required-check.yml");
+  const expandedOutputPath = join(workspace, "expanded-github-output");
+  writeFileSync(
+    expandedWorkflowPath,
+    ciWorkflow.replace(
+      "# required-check-contexts:end",
+      "  ios-verify-third:\n    name: iOS Verify (Third)\n# required-check-contexts:end",
+    ),
+  );
+  writeFileSync(expandedOutputPath, "");
+
+  const expanded = spawnSync(process.execPath, [script, expandedWorkflowPath], {
+    encoding: "utf8",
+    env: {...process.env, GITHUB_OUTPUT: expandedOutputPath},
+  });
+
+  assert.equal(expanded.status, 0, expanded.stderr);
+  assert.equal(
+    readFileSync(expandedOutputPath, "utf8").trim(),
+    `required_contexts=${JSON.stringify([...contexts, "iOS Verify (Third)"])}`,
+  );
+});
+
+test("an ineligible fallback cannot publish a required verification context", async () => {
+  const fallbackWorkflow = await readWorkflow("ci-required-check-fallback.yml");
+  const safeRoute =
+    "needs.route.result == 'success' && needs.route.outputs.fallback_eligible == 'true'";
+
+  assert.ok(fallbackWorkflow.includes(`if: ${safeRoute}`));
+  assert.ok(
+    fallbackWorkflow.includes(
+      `name: \${{ ${safeRoute} && matrix.context || 'iOS Verify Fallback (Not Required)' }}`,
+    ),
+  );
+  assert.doesNotMatch(fallbackWorkflow, /^\s+paths(?:-ignore)?:/m);
+
+  for (const context of ["iOS Verify (Staging)", "iOS Verify (Release)"]) {
+    assert.notEqual("iOS Verify Fallback (Not Required)", context);
+  }
+});
 
 test("CI watches every iOS source and Firebase index definition", async () => {
   const workflow = await readWorkflow("ci.yml");


### PR DESCRIPTION
## Intent

Fix the launch-blocking required-check fallback defect where a pull request that changes no code can never reach main because main requires both iOS Verify (Staging) and iOS Verify (Release), while the fallback previously produced only Staging. Preserve the existing fail-closed fallback eligibility exactly: produce every required iOS context only after the route job succeeds and declares the whole diff verification-irrelevant; code and other CI-relevant changes must still receive real verification, and an ineligible fallback must retain a distinct non-verification name. Derive the required-context list from the real CI workflow instead of duplicating names so a later required iOS check does not recreate the defect, without building a general framework. Do not change branch protection, weaken eligibility, make real iOS jobs skippable, touch production, or expose secrets. Extend scripts/test/ci-workflow-contracts.test.mjs with regression coverage proving eligible changes produce both current contexts, a later third context is derived, and ineligible changes cannot receive a fallback pass. Lead the PR body with the plain concrete failure: a pull request that changes no code can never reach main, which is currently blocking the first production release. Report UNKNOWN, IRREDUCIBLE, and RISKS.

## What Changed

- A pull request that changes no code could never reach `main`: branch protection requires both `iOS Verify (Staging)` and `iOS Verify (Release)`, while `ci-required-check-fallback.yml` published only `iOS Verify (Staging)`. The fallback job is now a matrix that publishes every required iOS context, so a docs-only or asset-only PR satisfies both.
- The context list is derived, not duplicated: `ci.yml` marks its iOS verify jobs with `# required-check-contexts:start/end`, the new `scripts/ci/list-required-check-contexts.mjs` reads their `name:` values into the route job's `required_contexts` output (defaulting to `[]`), and the matrix consumes that. Eligibility is unchanged - the matrix legs still run only when the route job succeeded and declared the whole diff verification-irrelevant, and an ineligible run keeps the distinct `iOS Verify Fallback (Not Required)` name.
- `scripts/test/ci-workflow-contracts.test.mjs` gains three regression tests: eligible changes publish exactly the two current contexts, a third marked job is picked up automatically, and the ineligible name can never collide with a required context. A fourth guard fails the build if an `iOS Verify` job is declared outside the marker block (or a non-verify job inside it). `ci-required-check-routing.test.mjs` was updated to assert the derived wiring instead of the old hardcoded name, and `ascend-deploy` plus `CLAUDE.md` now document the derived matrix. The full `node --test scripts/test/*.test.mjs` suite passes (441 tests).

## Risk Assessment

✅ Low: CI-only change that leaves the fail-closed eligibility classifier byte-identical to base, derives both required context names at runtime from ci.yml, and now carries a marker-block contract guard plus a non-tautological ineligible-name test; the one remaining observation is an acknowledged naming-convention tradeoff.

## Testing

Ran the full scripts test suite (441 pass) plus the two CI contract suites, then went beyond unit tests: I simulated the real fallback workflow end-to-end, evaluating its own `${{ }}` expressions and invoking the real routing scripts, and compared the resulting check-run names against main's live branch-protection contexts fetched from the GitHub API. That transcript reproduces the launch blocker at the base commit (docs-only PR publishes only `iOS Verify (Staging)`, main unreachable) and shows it fixed at HEAD (both contexts published, main reachable), while an ineligible Swift-touching PR and a truncated-diff route failure both publish nothing and keep the distinct `iOS Verify Fallback (Not Required)` name. Two mutation runs confirm the new regression tests genuinely bite rather than pass vacuously. One local setup problem - `public-identity-contract.test.mjs` failing on a missing `firebase-admin` - was an uninstalled `npm --prefix scripts ci`, which I ran; everything passed afterward and the worktree was restored clean. No screenshots: this change has no rendered end-user surface - its user-visible artifact is the GitHub PR checks list, which I represented with the CLI transcript of the exact check-run names the workflow would publish rather than fabricating a UI mock. The PR-body wording required by the intent could not be checked because no pull request exists for this branch yet.

<details>
<summary>Evidence: Fallback workflow end-to-end simulation across 5 scenarios (defect reproduced + fixed)</summary>

<code>SCENARIO 1 - BEFORE THE FIX (base commit 1aedb9b): docs-only PR targeting main&#10;-&gt; route outputs: {&#34;fallback_eligible&#34;:&#34;true&#34;}&#10;check run published: &#34;iOS Verify (Staging)&#34; = success&#10;Branch protection on main requires:&#10;✔ satisfied by fallback: iOS Verify (Staging)&#10;✖ NOT satisfied by fallback: iOS Verify (Release)&#10;=&gt; PR can reach main on the fallback alone: NO&#10;&#10;SCENARIO 2 - AFTER THE FIX (HEAD): the same docs-only PR targeting main&#10;-&gt; route outputs: {&#34;fallback_eligible&#34;:&#34;true&#34;,&#34;required_contexts&#34;:&#34;[\&#34;iOS Verify (Staging)\&#34;,\&#34;iOS Verify (Release)\&#34;]&#34;}&#10;check run published: &#34;iOS Verify (Staging)&#34; = success&#10;check run published: &#34;iOS Verify (Release)&#34; = success&#10;=&gt; PR can reach main on the fallback alone: YES&#10;&#10;SCENARIO 3 - INELIGIBLE: a PR that touches Swift code&#10;CI-relevant paths changed, so ci.yml owns the required check for this pull request.&#10;blocked by: AscendApp/Features/Home/HomeView.swift&#10;job skipped; the name it would have used is &#34;iOS Verify Fallback (Not Required)&#34;&#10;=&gt; PR can reach main on the fallback alone: NO&#10;&#10;SCENARIO 4 - ROUTE FAILS: the files API returned a truncated diff&#10;::error::The pull request reports 3200 changed files but the API listed 3. Refusing to classify a truncated diff.&#10;-&gt; route result: failure&#10;job skipped&#10;=&gt; PR can reach main on the fallback alone: NO&#10;&#10;SCENARIO 5 - FUTURE: ci.yml gains a third required iOS job, fallback untouched&#10;matrix expands to [&#34;iOS Verify (Staging)&#34;,&#34;iOS Verify (Release)&#34;,&#34;iOS Verify (Performance)&#34;]&#10;&#10;SUMMARY&#10;baseline published [&#34;iOS Verify (Staging)&#34;] main reachable: NO&#10;fixed published [&#34;iOS Verify (Staging)&#34;,&#34;iOS Verify (Release)&#34;] main reachable: YES&#10;ineligible published [] main reachable: NO&#10;truncated published [] main reachable: NO&#10;future published [...,&#34;iOS Verify (Performance)&#34;] main reachable: YES</code>

```text

==============================================================================
SCENARIO 1 - BEFORE THE FIX (base commit 1aedb9b): docs-only PR targeting main
==============================================================================
  changed files: ["docs/remote-config-kill-switches.md","README.md",".claude/skills/ascend-deploy/SKILL.md"]
  job "route" (Detect CI-Relevant Changes)
    (this workflow revision derives no contexts)
    $ node scripts/ci/classify-required-check-route.mjs /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/fallback-sim-NhgWJ9/pull-request-files.json 3
      Every changed path is on the verification-irrelevant allowlist, so no verification job exists to run.
      -> exit 0
  -> route result: success
  -> route outputs: {"fallback_eligible":"true"}
  job "fallback"
    if: -> true; matrix expands to [null]
    check run published: "iOS Verify (Staging)" = success

  PR checks tab (from this workflow):
    ✔ iOS Verify (Staging)

  Branch protection on main requires:
    ✔ satisfied by fallback: iOS Verify (Staging)
    ✖ NOT satisfied by fallback: iOS Verify (Release)

  => PR can reach main on the fallback alone: NO

==============================================================================
SCENARIO 2 - AFTER THE FIX (HEAD): the same docs-only PR targeting main
==============================================================================
  changed files: ["docs/remote-config-kill-switches.md","README.md",".claude/skills/ascend-deploy/SKILL.md"]
  job "route" (Detect CI-Relevant Changes)
    $ node scripts/ci/list-required-check-contexts.mjs .github/workflows/ci.yml
      -> exit 0
    $ node scripts/ci/classify-required-check-route.mjs /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/fallback-sim-Tr1Eff/pull-request-files.json 3
      Every changed path is on the verification-irrelevant allowlist, so no verification job exists to run.
      -> exit 0
  -> route result: success
  -> route outputs: {"fallback_eligible":"true","required_contexts":"[\"iOS Verify (Staging)\",\"iOS Verify (Release)\"]"}
  job "fallback"
    if: -> true; matrix expands to ["iOS Verify (Staging)","iOS Verify (Release)"]
    check run published: "iOS Verify (Staging)" = success
    check run published: "iOS Verify (Release)" = success

  PR checks tab (from this workflow):
    ✔ iOS Verify (Staging)
    ✔ iOS Verify (Release)

  Branch protection on main requires:
    ✔ satisfied by fallback: iOS Verify (Staging)
    ✔ satisfied by fallback: iOS Verify (Release)

  => PR can reach main on the fallback alone: YES

==============================================================================
SCENARIO 3 - INELIGIBLE: a PR that touches Swift code
==============================================================================
  changed files: ["AscendApp/Features/Home/HomeView.swift","README.md"]
  job "route" (Detect CI-Relevant Changes)
    $ node scripts/ci/list-required-check-contexts.mjs .github/workflows/ci.yml
      -> exit 0
    $ node scripts/ci/classify-required-check-route.mjs /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/fallback-sim-TGHGLg/pull-request-files.json 2
      CI-relevant paths changed, so ci.yml owns the required check for this pull request.
        blocked by: AscendApp/Features/Home/HomeView.swift
      -> exit 0
  -> route result: success
  -> route outputs: {"fallback_eligible":"false","required_contexts":"[\"iOS Verify (Staging)\",\"iOS Verify (Release)\"]"}
  job "fallback"
    if: needs.route.result == 'success' && needs.route.outputs.fallback_eligible == 'true' -> false
    job skipped; the name it would have used is "iOS Verify Fallback (Not Required)" and it publishes no successful required context

  PR checks tab (from this workflow):
    (nothing - required verification must come from the real CI workflow)

  Branch protection on main requires:
    ✖ NOT satisfied by fallback: iOS Verify (Staging)
    ✖ NOT satisfied by fallback: iOS Verify (Release)

  => PR can reach main on the fallback alone: NO

==============================================================================
SCENARIO 4 - ROUTE FAILS: the files API returned a truncated diff
==============================================================================
  changed files: ["docs/remote-config-kill-switches.md","README.md",".claude/skills/ascend-deploy/SKILL.md"]
  job "route" (Detect CI-Relevant Changes)
    $ node scripts/ci/list-required-check-contexts.mjs .github/workflows/ci.yml
      -> exit 0
    $ node scripts/ci/classify-required-check-route.mjs /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/fallback-sim-XJn7I2/pull-request-files.json 3200
      ::error::The pull request reports 3200 changed files but the API listed 3. Refusing to classify a truncated diff.
      -> exit 1
  -> route result: failure
  -> route outputs: {"fallback_eligible":"","required_contexts":""}
  job "fallback"
    if: needs.route.result == 'success' && needs.route.outputs.fallback_eligible == 'true' -> false
    job skipped; the name it would have used is "iOS Verify Fallback (Not Required)" and it publishes no successful required context

  PR checks tab (from this workflow):
    (nothing - required verification must come from the real CI workflow)

  Branch protection on main requires:
    ✖ NOT satisfied by fallback: iOS Verify (Staging)
    ✖ NOT satisfied by fallback: iOS Verify (Release)

  => PR can reach main on the fallback alone: NO

==============================================================================
SCENARIO 5 - FUTURE: ci.yml gains a third required iOS job, fallback untouched
==============================================================================
  changed files: ["docs/remote-config-kill-switches.md","README.md",".claude/skills/ascend-deploy/SKILL.md"]
  job "route" (Detect CI-Relevant Changes)
    $ node scripts/ci/list-required-check-contexts.mjs /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/fallback-scenarios-pwxc3t/ci-with-third-required-check.yml
      -> exit 0
    $ node scripts/ci/classify-required-check-route.mjs /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/fallback-sim-5GMO7H/pull-request-files.json 3
      Every changed path is on the verification-irrelevant allowlist, so no verification job exists to run.
      -> exit 0
  -> route result: success
  -> route outputs: {"fallback_eligible":"true","required_contexts":"[\"iOS Verify (Staging)\",\"iOS Verify (Release)\",\"iOS Verify (Performance)\"]"}
  job "fallback"
    if: -> true; matrix expands to ["iOS Verify (Staging)","iOS Verify (Release)","iOS Verify (Performance)"]
    check run published: "iOS Verify (Staging)" = success
    check run published: "iOS Verify (Release)" = success
    check run published: "iOS Verify (Performance)" = success

  PR checks tab (from this workflow):
    ✔ iOS Verify (Staging)
    ✔ iOS Verify (Release)
    ✔ iOS Verify (Performance)

  Branch protection on main requires:
    ✔ satisfied by fallback: iOS Verify (Staging)
    ✔ satisfied by fallback: iOS Verify (Release)

  => PR can reach main on the fallback alone: YES

==============================================================================
SUMMARY
==============================================================================
  baseline    published ["iOS Verify (Staging)"]                             main reachable: NO
  fixed       published ["iOS Verify (Staging)","iOS Verify (Release)"]      main reachable: YES
  ineligible  published []                                                   main reachable: NO
  truncated   published []                                                   main reachable: NO
  future      published ["iOS Verify (Staging)","iOS Verify (Release)","iOS Verify (Performance)"] main reachable: YES
```
</details>
<details>
<summary>Evidence: Mutation A - reverting the fallback workflow fails the new regression tests</summary>

<code>### MUTATION A: revert the fallback workflow to its pre-fix form (a single hardcoded &#39;iOS Verify (Staging)&#39; name)&#10;&#10;not ok 4 - the fallback derives required check names from the real iOS jobs&#10;not ok 5 - fallback claims each derived name only after a successful eligible route&#10;not ok 16 - the eligible fallback publishes every required iOS verification context&#10;not ok 17 - an ineligible fallback cannot publish a required verification context&#10;# pass 22&#10;# fail 4</code>

```text
### MUTATION A: revert the fallback workflow to its pre-fix form (a single hardcoded 'iOS Verify (Staging)' name)

not ok 4 - the fallback derives required check names from the real iOS jobs
not ok 5 - fallback claims each derived name only after a successful eligible route
not ok 16 - the eligible fallback publishes every required iOS verification context
not ok 17 - an ineligible fallback cannot publish a required verification context
# pass 22
# fail 4
```
</details>
<details>
<summary>Evidence: Mutation B - a required iOS job outside the marker block is caught, and would resurrect the defect</summary>

<code>### MUTATION B: declare a required iOS job OUTSIDE the marker block (move the end marker above ios-verify-release)&#10;&#10;not ok 1 - the eligible fallback publishes every required iOS verification context&#10;not ok 3 - every required iOS verification job lives inside the marker block&#10;error: &#39;&#34;iOS Verify (Release)&#34; must sit inside the required-check-contexts marker block to reach the fallback matrix&#39;&#10;# pass 9&#10;# fail 2&#10;&#10;--- what the fallback would publish with that mutation in place ---&#10;if: -&gt; true; matrix expands to [&#34;iOS Verify (Staging)&#34;]&#10;check run published: &#34;iOS Verify (Staging)&#34; = success&#10;✔ satisfied by fallback: iOS Verify (Staging)&#10;✖ NOT satisfied by fallback: iOS Verify (Release)&#10;=&gt; PR can reach main on the fallback alone: NO</code>

```text
### MUTATION B: declare a required iOS job OUTSIDE the marker block (move the end marker above ios-verify-release)

not ok 1 - the eligible fallback publishes every required iOS verification context
not ok 3 - every required iOS verification job lives inside the marker block
  error: '"iOS Verify (Release)" must sit inside the required-check-contexts marker block to reach the fallback matrix'
# pass 9
# fail 2

--- what the fallback would publish with that mutation in place ---
    if: -> true; matrix expands to ["iOS Verify (Staging)"]
    check run published: "iOS Verify (Staging)" = success
    ✔ satisfied by fallback: iOS Verify (Staging)
    ✖ NOT satisfied by fallback: iOS Verify (Release)
  => PR can reach main on the fallback alone: NO
```
</details>
<details>
<summary>Evidence: Live branch protection on main (the premise being fixed)</summary>

`{"checks":[{"app_id":15368,"context":"iOS Verify (Staging)"},{"app_id":15368,"context":"iOS Verify (Release)"}],"contexts":["iOS Verify (Staging)","iOS Verify (Release)"],"strict":false}`

```text
{"checks":[{"app_id":15368,"context":"iOS Verify (Staging)"},{"app_id":15368,"context":"iOS Verify (Release)"}],"contexts":["iOS Verify (Staging)","iOS Verify (Release)"],"contexts_url":"https://api.github.com/repos/tpavay/AscendApp/branches/main/protection/required_status_checks/contexts","strict":false,"url":"https://api.github.com/repos/tpavay/AscendApp/branches/main/protection/required_status_checks"}
```
</details>
<details>
<summary>Evidence: CI contract + routing suites (TAP)</summary>

```text
ok 1 - the routing contract exactly matches ci.yml's trigger
ok 2 - every path ci.yml treats as CI-relevant is in the routing contract
ok 3 - the pattern guard rejects every glob shape the model cannot evaluate
ok 4 - the fallback derives required check names from the real iOS jobs
ok 5 - fallback claims each derived name only after a successful eligible route
ok 6 - the fallback routes through the classifier this suite covers
ok 7 - CI-relevant changes never reach the fallback
ok 8 - only explicitly allowlisted changes let the fallback claim the check
ok 9 - deployment inputs route to real verification rather than the fallback
ok 10 - deployment verify jobs execute the required checks
ok 11 - unclassified paths fail closed
ok 12 - a truncated or unreadable file list is refused, never classified
ok 13 - renames contribute both of their paths
ok 14 - the classifier entry point publishes and fails closed end to end
ok 15 - the allowlist never overrides the CI trigger
ok 16 - the eligible fallback publishes every required iOS verification context
ok 17 - an ineligible fallback cannot publish a required verification context
ok 18 - every required iOS verification job lives inside the marker block
ok 19 - CI watches every iOS source and Firebase index definition
ok 20 - deploy workflows watch every artifact and Firebase deployment input
ok 21 - production readiness failure is visible to GitHub Actions
ok 22 - every uploadable workflow serializes on a fixed group and owns a distinct App Store app
ok 23 - deploy build numbers come from remote app truth before the archive
ok 24 - the TestFlight lane uploads to the same explicit app used by the allocator
ok 25 - a failed derivation stops the deploy instead of exporting an empty build number
ok 26 - every uploadable workflow holds its concurrency group until the upload is visible
# pass 26
# fail 0
```
</details>
<details>
<summary>Evidence: Simulation harness (reads the real workflow YAML and runs the real CI scripts)</summary>

```text
#!/usr/bin/env node
// End-to-end simulation of the "CI Required Check Fallback" workflow.
//
// This does NOT re-implement the decision. It reads the real workflow YAML,
// evaluates the real `${{ }}` expressions with GitHub Actions' operator
// semantics, and shells out to the real scripts/ci/*.mjs the route job runs -
// then prints the check runs GitHub would publish on the pull request and
// compares them against main's live branch-protection contexts.

import { spawnSync } from "node:child_process";
import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";
import { join } from "node:path";

const [repositoryRoot, protectionContextsJson] = process.argv.slice(2);
const REQUIRED_BY_BRANCH_PROTECTION = JSON.parse(protectionContextsJson);

// ---------------------------------------------------------------------------
// A minimal GitHub Actions expression evaluator.
// `&&` and `||` return operand values (not booleans), falsy = false/0/''/null.
// ---------------------------------------------------------------------------
function evaluateExpression(expression, context) {
  const tokens =
    expression.match(/'[^']*'|\|\||&&|==|!=|[A-Za-z0-9_.-]+|\(|\)/g) ?? [];
  let position = 0;

  const peek = () => tokens[position];
  const next = () => tokens[position++];
  const truthy = (value) =>
    value !== false && value !== 0 && value !== "" && value != null;

  function primary() {
    const token = next();
    if (token === "(") {
      const value = orExpression();
      next(); // ")"
      return value;
    }
    if (token.startsWith("'")) return token.slice(1, -1);
    if (token === "fromJSON") {
      next(); // "("
      const value = orExpression();
      next(); // ")"
      return JSON.parse(value);
    }
    if (/^\d+$/.test(token)) return Number(token);
    if (token === "true") return true;
    if (token === "false") return false;
    return token
      .split(".")
      .reduce((node, key) => (node == null ? undefined : node[key]), context);
  }

  function comparison() {
    let left = primary();
    while (peek() === "==" || peek() === "!=") {
      const operator = next();
      const right = primary();
      left = operator === "==" ? left === right : left !== right;
    }
    return left;
  }

  function andExpression() {
    let left = comparison();
    while (peek() === "&&") {
      next();
      const right = comparison();
      left = truthy(left) ? right : left;
    }
    return left;
  }

  function orExpression() {
    let left = andExpression();
    while (peek() === "||") {
      next();
      const right = andExpression();
      left = truthy(left) ? left : right;
    }
    return left;
  }

  return orExpression();
}

const unwrap = (value) => value.replace(/^\$\{\{\s*|\s*\}\}$/g, "");

// ---------------------------------------------------------------------------
// Read the workflow's own expressions out of the YAML text.
// ---------------------------------------------------------------------------
function readFallbackWorkflow(path) {
  const source = readFileSync(path, "utf8");
  const routeOutputs = Object.fromEntries(
    [
      ...source
        .slice(source.indexOf("    outputs:"), source.indexOf("    steps:"))
        .matchAll(/^ {6}(?<key>[a-z_]+): (?<expression>.+)$/gm),
    ].map((match) => [match.groups.key, match.groups.expression]),
  );
  const fallback = source.slice(source.indexOf("  fallback:"));

  return {
    source,
    routeOutputs,
    derivesContexts: / {8}run: node scripts\/ci\/list-required-check-contexts\.mjs (?<workflow>\S+)/.test(
      source,
    ),
    contextsWorkflowArgument: source.match(
      /run: node scripts\/ci\/list-required-check-contexts\.mjs (?<workflow>\S+)/,
    )?.groups?.workflow,
    name: fallback.match(/^ {4}name: (?<value>.+)$/m).groups.value,
    if: fallback.match(/^ {4}if: (?<value>.+)$/m).groups.value,
    matrixContexts: fallback.match(/^ {8}context: (?<value>.+)$/m)?.groups?.value,
  };
}

// ---------------------------------------------------------------------------
// Run the route job exactly as the workflow does, then expand the fallback job.
// ---------------------------------------------------------------------------
function runWorkflow({ workflow, changedFiles, reportedChangedFileCount }) {
  const workspace = mkdtempSync(join(tmpdir(), "fallback-sim-"));
  const githubOutput = join(workspace, "github-output");
  writeFileSync(githubOutput, "");

  const stepOutputs = {};
  const log = [];
  let routeResult = "success";

  const runStep = (id, argv) => {
    const result = spawnSync(process.execPath, argv, {
      cwd: repositoryRoot,
      encoding: "utf8",
      env: { ...process.env, GITHUB_OUTPUT: githubOutput },
    });
    log.push(
      `    $ node ${argv.map((a) => a.replace(`${repositoryRoot}/`, "")).join(" ")}`,
      ...`${result.stdout}${result.stderr}`
        .trimEnd()
        .split("\n")
        .filter(Boolean)
        .map((line) => `      ${line}`),
      `      -> exit ${result.status}`,
    );
    if (result.status !== 0) routeResult = "failure";
    stepOutputs[id] = {
      outputs: Object.fromEntries(
        readFileSync(githubOutput, "utf8")
          .split("\n")
          .filter(Boolean)
          .map((line) => [
            line.slice(0, line.indexOf("=")),
            line.slice(line.indexOf("=") + 1),
          ]),
      ),
    };
  };

  log.push('  job "route" (Detect CI-Relevant Changes)');

  if (workflow.derivesContexts) {
    runStep("required-contexts", [
      join(repositoryRoot, "scripts/ci/list-required-check-contexts.mjs"),
      workflow.contextsWorkflowArgument.replace(
        ".github/workflows/ci.yml",
        join(repositoryRoot, ".github/workflows/ci.yml"),
      ),
    ]);
  } else {
    log.push("    (this workflow revision derives no contexts)");
  }

  if (routeResult === "success") {
    const filesPath = join(workspace, "pull-request-files.json");
    writeFileSync(
      filesPath,
      JSON.stringify(changedFiles.map((filename) => ({ filename }))),
    );
    runStep("classify", [
      join(repositoryRoot, "scripts/ci/classify-required-check-route.mjs"),
      filesPath,
      String(reportedChangedFileCount ?? changedFiles.length),
    ]);
  } else {
    log.push("    step \"Classify changed paths\": skipped (earlier step failed)");
  }

  const needs = {
    route: {
      result: routeResult,
      outputs: Object.fromEntries(
        Object.entries(workflow.routeOutputs).map(([key, expression]) => [
          key,
          routeResult === "success"
            ? String(evaluateExpression(unwrap(expression), { steps: stepOutputs }) ?? "")
            : "",
        ]),
      ),
    },
  };

  log.push(
    `  -> route result: ${routeResult}`,
    `  -> route outputs: ${JSON.stringify(needs.route.outputs)}`,
    '  job "fallback"',
  );

  const runs = [];
  const jobRuns = evaluateExpression(unwrap(workflow.if), { needs });

  if (!jobRuns) {
    log.push(
      `    if: ${unwrap(workflow.if)} -> false`,
      `    job skipped; the name it would have used is "${evaluateExpression(
        unwrap(workflow.name),
        { needs, matrix: {} },
      )}" and it publishes no successful required context`,
    );
  } else {
    const matrixValues = workflow.matrixContexts
      ? evaluateExpression(unwrap(workflow.matrixContexts), { needs })
      : [null];
    log.push(`    if: -> true; matrix expands to ${JSON.stringify(matrixValues)}`);
    for (const context of matrixValues) {
      const name = evaluateExpression(unwrap(workflow.name), {
        needs,
        matrix: { context },
      });
      runs.push(name);
      log.push(`    check run published: "${name}" = success`);
    }
  }

  return { log, runs };
}

function report(title, scenario) {
  const workflow = readFallbackWorkflow(scenario.workflowPath);
  const { log, runs } = runWorkflow({ ...scenario, workflow });

  console.log(`\n${"=".repeat(78)}\n${title}\n${"=".repeat(78)}`);
  console.log(`  changed files: ${JSON.stringify(scenario.changedFiles)}`);
  console.log(log.join("\n"));
  console.log("\n  PR checks tab (from this workflow):");
  console.log(
    runs.length
      ? runs.map((name) => `    ✔ ${name}`).join("\n")
      : "    (nothing - required verification must come from the real CI workflow)",
  );
  console.log("\n  Branch protection on main requires:");
  for (const context of REQUIRED_BY_BRANCH_PROTECTION) {
    console.log(
      `    ${runs.includes(context) ? "✔ satisfied" : "✖ NOT satisfied"} by fallback: ${context}`,
    );
  }
  const mergeable = REQUIRED_BY_BRANCH_PROTECTION.every((c) => runs.includes(c));
  console.log(
    `\n  => PR can reach main on the fallback alone: ${mergeable ? "YES" : "NO"}`,
  );
  return { runs, mergeable };
}

export { report, readFallbackWorkflow, runWorkflow, evaluateExpression };
```
</details>
<details>
<summary>Evidence: Scenario driver for the simulation</summary>

```text
#!/usr/bin/env node
import { execFileSync } from "node:child_process";
import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
import { tmpdir } from "node:os";
import { join } from "node:path";

const repositoryRoot = process.argv[2];
const protectionContexts = process.argv[3];
process.argv[2] = repositoryRoot;
process.argv[3] = protectionContexts;

const { report } = await import("./simulate-required-check-fallback.mjs");

const BASE_COMMIT = "1aedb9ba394141f3e187817b1d0910e17d2971d8";
const fixedFallback = join(repositoryRoot, ".github/workflows/ci-required-check-fallback.yml");
const workspace = mkdtempSync(join(tmpdir(), "fallback-scenarios-"));

// The pre-fix revision of the same workflow, straight out of git history.
const baselineFallback = join(workspace, "baseline-fallback.yml");
writeFileSync(
  baselineFallback,
  execFileSync("git", ["show", `${BASE_COMMIT}:.github/workflows/ci-required-check-fallback.yml`], {
    cwd: repositoryRoot,
    encoding: "utf8",
  }),
);

// A hypothetical future in which a third required iOS job is added to ci.yml.
const futureCi = join(workspace, "ci-with-third-required-check.yml");
writeFileSync(
  futureCi,
  readFileSync(join(repositoryRoot, ".github/workflows/ci.yml"), "utf8").replace(
    "# required-check-contexts:end",
    "  ios-verify-perf:\n    name: iOS Verify (Performance)\n# required-check-contexts:end",
  ),
);
const futureFallback = join(workspace, "future-fallback.yml");
writeFileSync(
  futureFallback,
  readFileSync(fixedFallback, "utf8").replace(".github/workflows/ci.yml", futureCi),
);

const docsOnlyDiff = [
  "docs/remote-config-kill-switches.md",
  "README.md",
  ".claude/skills/ascend-deploy/SKILL.md",
];
const codeDiff = ["AscendApp/Features/Home/HomeView.swift", "README.md"];

const results = {};

results.baseline = report(
  "SCENARIO 1 - BEFORE THE FIX (base commit 1aedb9b): docs-only PR targeting main",
  { workflowPath: baselineFallback, changedFiles: docsOnlyDiff },
);

results.fixed = report(
  "SCENARIO 2 - AFTER THE FIX (HEAD): the same docs-only PR targeting main",
  { workflowPath: fixedFallback, changedFiles: docsOnlyDiff },
);

results.ineligible = report(
  "SCENARIO 3 - INELIGIBLE: a PR that touches Swift code",
  { workflowPath: fixedFallback, changedFiles: codeDiff },
);

results.truncated = report(
  "SCENARIO 4 - ROUTE FAILS: the files API returned a truncated diff",
  {
    workflowPath: fixedFallback,
    changedFiles: docsOnlyDiff,
    reportedChangedFileCount: 3200,
  },
);

results.future = report(
  "SCENARIO 5 - FUTURE: ci.yml gains a third required iOS job, fallback untouched",
  { workflowPath: futureFallback, changedFiles: docsOnlyDiff },
);

console.log(`\n${"=".repeat(78)}\nSUMMARY\n${"=".repeat(78)}`);
for (const [name, { runs, mergeable }] of Object.entries(results)) {
  console.log(
    `  ${name.padEnd(11)} published ${JSON.stringify(runs).padEnd(52)} main reachable: ${mergeable ? "YES" : "NO"}`,
  );
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `.github/workflows/ci-required-check-fallback.yml:70` - `context: ${{ fromJSON(needs.route.outputs.required_contexts) }}` has no fallback value. The `required_contexts` output is only populated by the `Read required check contexts` step (line 31), which runs after `Checkout repository`; if the route job fails at checkout or at that step, the output is the empty string and `fromJSON(&#39;&#39;)` yields null, which is not a valid `strategy.matrix` value. In that window the fallback job can surface as a hard strategy-evaluation error rather than the clean skip it produced before this change. It stays fail-closed (the required names are never claimed), but a launch-blocking required-check router should degrade quietly rather than erroring. Fix by defaulting the route output at line 22: `required_contexts: ${{ steps.required-contexts.outputs.required_contexts || &#39;[]&#39; }}`. `[]` is safe here and cannot silently swallow a real eligible run, because whenever the `if:` guard at line 64 is true the route job succeeded, which means list-required-check-contexts.mjs ran and refused to emit an empty list.
- ⚠️ `scripts/test/ci-workflow-contracts.test.mjs:114` - `assert.notEqual(&#34;iOS Verify Fallback (Not Required)&#34;, context)` compares two string literals inside a loop over two more string literals, so it can never fail regardless of what the workflows contain. It is dead weight in the one test the intent designates as proving &#34;an ineligible fallback cannot publish a required verification context&#34;. Derive both sides instead: take the contexts from `requiredCheckContexts(await readWorkflow(&#34;ci.yml&#34;))` and parse the inert name out of the fallback workflow&#39;s `name:` expression, then assert the inert name is not among the derived contexts. That version actually fails if someone renames the inert job to a required context name.
- ℹ️ `.github/workflows/ci.yml:413` - The marker block is a positional contract with no guard: a future `iOS Verify (...)` job added outside `# required-check-contexts:start/end` is silently omitted from the derived matrix, and adding its name to branch protection would recreate exactly the defect this change fixes. `list-required-check-contexts.mjs` cannot see it, and the contracts test&#39;s hardcoded `deepEqual(contexts, [&#34;iOS Verify (Staging)&#34;, &#34;iOS Verify (Release)&#34;])` passes unchanged because the new job never enters the list. A cheap guard: assert that every ci.yml job whose display name starts with `iOS Verify` falls inside the marker block. The converse hazard is milder but real - a non-iOS job inserted between `ios-verify` and `ios-verify-release` gets published as a fallback context - and the same test would surface it.

🔧 Fix: harden required-check fallback matrix default and contract guards
1 info still open:
- ℹ️ `scripts/test/ci-workflow-contracts.test.mjs:138` - The new marker-block guard classifies required checks by the `iOS Verify` display-name prefix. It closes the case my round-1 finding named (a second `iOS Verify (...)` job added outside the block) and adds the converse guard, but a future required iOS check named off-convention - `iOS Build (Release)`, `iOS UI Tests` - declared outside the marker block would still be invisible to the derived matrix and could recreate the defect. This is a reasonable tradeoff given the intent&#39;s explicit &#34;without building a general framework&#34; constraint, and the alternative (classifying every ci.yml job by what it verifies) is the framework that constraint rules out. Noting it so the convention is a known load-bearing assumption rather than an accident; no change needed.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test scripts/test/*.test.mjs` (441 pass, after `npm --prefix scripts ci` which CI also runs)</code>
- <code>`node --test --test-reporter=tap scripts/test/ci-workflow-contracts.test.mjs scripts/test/ci-required-check-routing.test.mjs` (26 pass, including the three new regression tests)</code>
- <code>Simulated the real `ci-required-check-fallback.yml` end-to-end across 5 scenarios (pre-fix baseline, post-fix eligible, Swift-code ineligible, truncated-diff route failure, future third required job), evaluating the workflow&#39;s actual `${{ }}` expressions and shelling out to the real `scripts/ci/list-required-check-contexts.mjs` and `scripts/ci/classify-required-check-route.mjs`</code>
- <code>`gh api repos/tpavay/AscendApp/branches/main/protection` to confirm the required contexts are exactly `iOS Verify (Staging)` and `iOS Verify (Release)` (read-only)</code>
- <code>Mutation A: reverted `.github/workflows/ci-required-check-fallback.yml` to base commit `1aedb9b` and confirmed 4 contract tests fail; reverted</code>
- <code>Mutation B: moved `# required-check-contexts:end` above `ios-verify-release` and confirmed the marker-block guard fails with the exact defect message, plus simulated that the fallback would then publish only Staging; reverted</code>
- <code>`python3 -c &#34;yaml.safe_load(...)&#34;` structural parse of both workflows to confirm the matrix/name/if wiring is valid YAML, not just regex-visible text</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
