### PR TITLE
fix(routines): drop the window coach mark's spotlight ring so the strip carries one lime outline

### DIFF
--- a/AscendApp/Features/Routines/Models/RoutineCoachMarkPresentation.swift
+++ b/AscendApp/Features/Routines/Models/RoutineCoachMarkPresentation.swift
@@ -10,4 +10,29 @@ struct RoutineCoachMarkPresentation: Equatable {
     let stepIndex: Int
     let primaryActionTitle: String
     let showsSkip: Bool
+    /// Whether the overlay outlines the spotlit target. Default yes - a mark points at a control
+    /// that has no outline of its own, so the ring is what says *this one*. A mark opts out only
+    /// when its target already draws a lime outline, because a second concentric one reads as a
+    /// box in a box and hides the very thing the card is naming.
+    ///
+    /// The dim's punch-out is not this: the target stays lit either way.
+    let drawsSpotlightRing: Bool
+
+    init(
+        title: String,
+        message: String,
+        stepCount: Int,
+        stepIndex: Int,
+        primaryActionTitle: String,
+        showsSkip: Bool,
+        drawsSpotlightRing: Bool = true
+    ) {
+        self.title = title
+        self.message = message
+        self.stepCount = stepCount
+        self.stepIndex = stepIndex
+        self.primaryActionTitle = primaryActionTitle
+        self.showsSkip = showsSkip
+        self.drawsSpotlightRing = drawsSpotlightRing
+    }
 }

--- a/AscendApp/Features/Routines/Models/RoutineWindowCoachMark.swift
+++ b/AscendApp/Features/Routines/Models/RoutineWindowCoachMark.swift
@@ -18,7 +18,12 @@ enum RoutineWindowCoachMark {
         stepCount: 1,
         stepIndex: 0,
         primaryActionTitle: "Got it",
-        showsSkip: false
+        showsSkip: false,
+        // The window it names is already a lime rounded rect. A spotlight ring around the strip
+        // put a second lime outline around the first, and the box in a box obscured the one
+        // element the card exists to point at. This mark alone opts out; the walkthrough's
+        // three targets carry no outline of their own and keep theirs.
+        drawsSpotlightRing: false
     )
 
     /// Once, the first time the window arrives - and never over the first-open walkthrough,

--- a/AscendApp/Features/Routines/Views/Components/RoutineBuilderCoachMarkOverlay.swift
+++ b/AscendApp/Features/Routines/Views/Components/RoutineBuilderCoachMarkOverlay.swift
@@ -29,7 +29,8 @@ extension View {
 }
 
 /// One spotlight and one card. The dim is punched out over the target so the control being
-/// described stays legible underneath.
+/// described stays legible underneath, and a ring outlines it unless the presentation says the
+/// target already outlines itself - see `drawsSpotlightRing`.
 struct RoutineBuilderCoachMarkOverlay: View {
     let presentation: RoutineCoachMarkPresentation
     let targetRect: CGRect?
@@ -50,7 +51,7 @@ struct RoutineBuilderCoachMarkOverlay: View {
         ZStack(alignment: .topLeading) {
             dimmedBackdrop
 
-            if let spotlightRect {
+            if let spotlightRect, presentation.drawsSpotlightRing {
                 RoundedRectangle(cornerRadius: 20, style: .continuous)
                     .stroke(Color.accent, lineWidth: 2)
                     .frame(width: spotlightRect.width, height: spotlightRect.height)

--- a/AscendAppTests/RoutineCoachMarkSpotlightRingTests.swift
+++ b/AscendAppTests/RoutineCoachMarkSpotlightRingTests.swift
@@ -1,0 +1,295 @@
+import CoreGraphics
+import Foundation
+import SwiftUI
+import Testing
+import UIKit
+@testable import AscendApp
+
+/// What the captain saw on the shipped build: with the window engaged, the strip carried two
+/// nested lime rounded outlines - the coach mark's spotlight ring around the whole strip, and
+/// inside it the working window itself. A box in a box, with the tip obscuring the one element
+/// it existed to name.
+///
+/// These read the drawn pixels rather than the view tree, because "one outline, not two" is a
+/// claim about what lands on the screen. A row of pixels crossing the strip crosses two lime
+/// runs when there is one outline and four when there are two, so the count is the finding.
+@MainActor
+struct RoutineCoachMarkSpotlightRingTests {
+    /// A twenty-interval pyramid, so the window is a slice in the middle of the ridge with
+    /// clear air either side of it - a flush window edge and a ring edge would be one run.
+    private var pyramid: [RoutineInterval] {
+        (0..<20).map { index in
+            RoutineInterval(
+                duration: 120,
+                intensityValue: index < 10 ? 5 + index * 2 : 23 - (index - 10) * 2,
+                order: index
+            )
+        }
+    }
+
+    /// The eighth interval is where the overview arrives, so this is the first routine that can
+    /// ever show this mark.
+    private var eightIntervals: [RoutineInterval] {
+        let levels = [6, 22, 8, 22, 8, 18, 8, 22]
+        return levels.enumerated().map { index, level in
+            RoutineInterval(duration: index == 0 ? 60 : 30, intensityValue: level, order: index)
+        }
+    }
+
+    // MARK: - The fix
+
+    @Test
+    func theWindowMarkLeavesExactlyOneLimeOutlineOnTheStrip() throws {
+        let pixels = try RenderedStrip(
+            intervals: pyramid,
+            visibleRange: 6..<13,
+            presentation: RoutineWindowCoachMark.presentation
+        )
+
+        #expect(
+            pixels.widestLimeCrossing == 2,
+            "The strip should carry the working window's outline and nothing else"
+        )
+        #expect(pixels.hasLime, "The working window's own outline must survive - it is the real UI")
+    }
+
+    /// The threshold routine, not just the long one: eight intervals is the first count that can
+    /// raise this mark at all.
+    @Test
+    func theStripStaysSingleOutlinedAtTheEighthInterval() throws {
+        #expect(RoutineTimelineWindow.isEngaged(intervalCount: 8, availableWidth: 334))
+
+        let pixels = try RenderedStrip(
+            intervals: eightIntervals,
+            visibleRange: 1..<8,
+            presentation: RoutineWindowCoachMark.presentation
+        )
+
+        #expect(pixels.widestLimeCrossing == 2)
+        #expect(pixels.hasLime)
+    }
+
+    /// The defect itself, so the count above is measuring something real: the same mark with the
+    /// ring left on draws the four crossings the captain photographed.
+    @Test
+    func theSameMarkWithItsRingLeftOnDrawsTheNestedPair() throws {
+        let pixels = try RenderedStrip(
+            intervals: pyramid,
+            visibleRange: 6..<13,
+            presentation: RoutineCoachMarkPresentation(
+                title: RoutineWindowCoachMark.title,
+                message: RoutineWindowCoachMark.message,
+                stepCount: 1,
+                stepIndex: 0,
+                primaryActionTitle: "Got it",
+                showsSkip: false,
+                drawsSpotlightRing: true
+            )
+        )
+
+        #expect(
+            pixels.widestLimeCrossing == 4,
+            "Two nested outlines are four lime crossings - this is what was removed"
+        )
+    }
+
+    // MARK: - Nothing else changed
+
+    /// His explicit constraint. The three walkthrough marks point at controls that carry no
+    /// outline of their own, so each one keeps its ring - drawn here over the same strip, which
+    /// is the only surface with a lime outline underneath to count against.
+    @Test(arguments: RoutineBuilderCoachMark.allCases)
+    func everyWalkthroughMarkStillDrawsItsRing(_ mark: RoutineBuilderCoachMark) throws {
+        let pixels = try RenderedStrip(
+            intervals: pyramid,
+            visibleRange: 6..<13,
+            presentation: mark.presentation
+        )
+
+        #expect(
+            pixels.widestLimeCrossing == 4,
+            "\(mark) lost its spotlight ring - the opt-out reached the shared default"
+        )
+    }
+
+    @Test
+    func theRingIsTheSharedDefaultAndOnlyTheWindowMarkOptsOut() {
+        for mark in RoutineBuilderCoachMark.allCases {
+            #expect(mark.presentation.drawsSpotlightRing)
+        }
+
+        #expect(RoutineWindowCoachMark.presentation.drawsSpotlightRing == false)
+
+        // A presentation that says nothing about the ring draws it: the seam is an opt-out, not
+        // a new thing every mark has to remember to ask for.
+        let unstated = RoutineCoachMarkPresentation(
+            title: "Anything.",
+            message: "Anything at all.",
+            stepCount: 1,
+            stepIndex: 0,
+            primaryActionTitle: "Got it",
+            showsSkip: false
+        )
+        #expect(unstated.drawsSpotlightRing)
+    }
+
+    /// Dropping the ring must not dim the thing it was ringing: the punch-out is a separate
+    /// mechanism, and the strip stays lit under the backdrop either way.
+    @Test
+    func theStripStaysLitUnderTheDimWithoutTheRing() throws {
+        let withoutOverlay = try RenderedStrip(
+            intervals: pyramid,
+            visibleRange: 6..<13,
+            presentation: nil
+        )
+        let withOverlay = try RenderedStrip(
+            intervals: pyramid,
+            visibleRange: 6..<13,
+            presentation: RoutineWindowCoachMark.presentation
+        )
+
+        // Dimmed rather than punched out, the window's #86D30A would fall to (46, 72, 3) and stop
+        // reading as lime at all, so this is the difference between all of it and none of it.
+        #expect(withOverlay.limePixelCount >= withoutOverlay.limePixelCount * 9 / 10)
+        #expect(withoutOverlay.limePixelCount > 0)
+    }
+}
+
+/// One rendered strip, and the lime it carries.
+///
+/// Lime is read as the accent's green dominance (`#86D30A`), which nothing else on this surface
+/// has: the ridge is drawn from the heat map, which is red at every level, and the label is grey.
+@MainActor
+private struct RenderedStrip {
+    /// The strip's bounds inside the device, which is also the rect the overlay spotlights - in
+    /// the app it is the anchor `RoutineTimelineOverview` publishes.
+    static let strip = CGRect(x: 34, y: 200, width: 334, height: 62)
+    static let device = CGSize(width: 402, height: 874)
+
+    /// The band the counting runs over: the spotlight rect, which is the strip plus the overlay's
+    /// own 4pt inset. Anything the card draws sits well below it.
+    private static var band: CGRect { strip.insetBy(dx: -4, dy: -4) }
+
+    private static let scale = 3
+
+    private let width: Int
+    private let height: Int
+    private let bytes: [UInt8]
+
+    init(
+        intervals: [RoutineInterval],
+        visibleRange: Range<Int>,
+        presentation: RoutineCoachMarkPresentation?
+    ) throws {
+        let probe = ZStack(alignment: .topLeading) {
+            Color.black
+
+            RoutineTimelineOverview(
+                intervals: intervals,
+                visibleRange: visibleRange,
+                onScrub: { _ in },
+                onStep: { _ in },
+                onScrubbingChange: { _ in }
+            )
+            .frame(width: Self.strip.width, height: Self.strip.height, alignment: .top)
+            .offset(x: Self.strip.minX, y: Self.strip.minY)
+
+            if let presentation {
+                RoutineBuilderCoachMarkOverlay(
+                    presentation: presentation,
+                    targetRect: Self.strip,
+                    containerSize: Self.device,
+                    onNext: {},
+                    onSkip: {}
+                )
+            }
+        }
+        .frame(width: Self.device.width, height: Self.device.height)
+        .environment(\.colorScheme, .dark)
+
+        let renderer = ImageRenderer(content: probe)
+        renderer.scale = CGFloat(Self.scale)
+
+        let image = try #require(renderer.uiImage, "ImageRenderer produced no image")
+        let bitmap = try #require(image.cgImage, "The render carried no bitmap")
+
+        let pixelWidth = bitmap.width
+        let pixelHeight = bitmap.height
+        width = pixelWidth
+        height = pixelHeight
+
+        var buffer = [UInt8](repeating: 0, count: pixelWidth * pixelHeight * 4)
+        try buffer.withUnsafeMutableBytes { raw in
+            let context = try #require(
+                CGContext(
+                    data: raw.baseAddress,
+                    width: pixelWidth,
+                    height: pixelHeight,
+                    bitsPerComponent: 8,
+                    bytesPerRow: pixelWidth * 4,
+                    space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                ),
+                "Could not open a bitmap over the render"
+            )
+            context.draw(bitmap, in: CGRect(x: 0, y: 0, width: pixelWidth, height: pixelHeight))
+        }
+        bytes = buffer
+    }
+
+    /// The most lime runs any single row of the band crosses. Two nested outlines put four
+    /// vertical strokes in a row's path; one outline puts two.
+    var widestLimeCrossing: Int {
+        rows.map(limeRunCount(inRow:)).max() ?? 0
+    }
+
+    var limePixelCount: Int {
+        rows.reduce(0) { total, y in
+            columns.reduce(total) { $0 + (isLime(x: $1, y: y) ? 1 : 0) }
+        }
+    }
+
+    var hasLime: Bool {
+        limePixelCount > 0
+    }
+
+    private var rows: Range<Int> {
+        pixelRange(from: Self.band.minY, to: Self.band.maxY, limit: height)
+    }
+
+    private var columns: Range<Int> {
+        pixelRange(from: Self.band.minX, to: Self.band.maxX, limit: width)
+    }
+
+    private func pixelRange(from lower: CGFloat, to upper: CGFloat, limit: Int) -> Range<Int> {
+        let start = max(Int(lower) * Self.scale, 0)
+        let end = min(Int(upper.rounded(.up)) * Self.scale, limit)
+        return start..<max(start, end)
+    }
+
+    private func limeRunCount(inRow y: Int) -> Int {
+        var runs = 0
+        var wasLime = false
+
+        for x in columns {
+            let lime = isLime(x: x, y: y)
+            if lime, !wasLime {
+                runs += 1
+            }
+            wasLime = lime
+        }
+
+        return runs
+    }
+
+    private func isLime(x: Int, y: Int) -> Bool {
+        let offset = (y * width + x) * 4
+        let red = Int(bytes[offset])
+        let green = Int(bytes[offset + 1])
+        let blue = Int(bytes[offset + 2])
+
+        // #86D30A is (134, 211, 10): bright, green-dominant, almost no blue. The heat map's
+        // reds are all red-dominant, so nothing else in the band can pass this.
+        return green > 128 && green > red * 13 / 10 && blue < 90
+    }
+}

--- a/AscendAppTests/RoutineTimelineEditorSnapshotTests.swift
+++ b/AscendAppTests/RoutineTimelineEditorSnapshotTests.swift
@@ -217,7 +217,8 @@ struct RoutineTimelineEditorSnapshotTests {
     }
 
     /// The one-off mark, spotlighting the overview rather than the timeline, with a single
-    /// dot and a single Got it.
+    /// dot and a single Got it. No ring around the strip: the working window is already a lime
+    /// outline, and a second one around it read as a box in a box.
     @Test
     func theWindowCoachMarkSpotlightsTheOverview() throws {
         let device = CGSize(width: 402, height: 874)


### PR DESCRIPTION
## Intent

Fix a visual defect the captain found testing the shipped TestFlight build of the routine builder's working-window feature (the overview strip shipped in PR #383).

WHAT HE SAW: On the New Routine screen with 8 intervals, the 'Drag the window.' coach mark is showing, and the overview strip then has TWO nested bright-lime rounded outlines: (1) an outer ring the coach mark draws around the whole WHOLE ROUTINE strip as its spotlight, and (2) the inner ring that is the working-window indicator itself, the real permanent UI. Two concentric lime outlines around the same element read as one confusing box-in-a-box, and the spotlight obscures the very thing the tip is pointing at. His words: 'the only thing that's not clear or that's not good about the window is that we draw this extra window around it, and it kind of makes it look confusing. Maybe we don't have the window for this one. I don't want to mess up the other ones if it's shared code.'

THE GOAL: Remove the coach mark's own highlight/spotlight ring for this ONE coach mark, so the only lime outline on the strip is the genuine working-window indicator. The tip card, its copy and its dismissal stay exactly as they are.

HIS EXPLICIT CONSTRAINT: do not change how the other coach marks look. The spotlight ring does come from shared code (RoutineBuilderCoachMarkOverlay draws it for every mark), so this was made an opt-out for this single mark rather than a change to the shared default, and the seam added was deliberately the narrowest one that works - the coach-mark system was NOT redesigned.

HOW IT WAS DONE (deliberate decisions a reviewer reading only the diff would not know):
- RoutineCoachMarkPresentation gains a 'drawsSpotlightRing: Bool' with an explicit memberwise init defaulting it to true. Defaulting to true is the point: the shared default is unchanged, and a presentation that says nothing about the ring still gets one. The hand-written init exists solely to give that default; it is not an accidental replacement of the synthesized one.
- RoutineWindowCoachMark.presentation sets drawsSpotlightRing: false. It is the only opt-out in the codebase, by design.
- RoutineBuilderCoachMarkOverlay gates ONLY the RoundedRectangle(...).stroke(Color.accent, lineWidth: 2) on that flag. The dim backdrop's destinationOut punch-out is deliberately left alone - it is a separate mechanism, and the strip must stay lit under the dim either way. Removing the punch-out too would have dimmed the window indicator to (46,72,3) and made it unreadable.

EXPLICITLY OUT OF SCOPE / DELIBERATELY NOT CHANGED (he confirmed all of these are already right, so a reviewer should not propose touching them):
- The coach mark copy. It is his, verbatim: 'Drag the window.' / 'Change which intervals you're viewing.'
- The working-window indicator itself, the drag behaviour, the edge-advance threshold, and the appear/disappear animation at the 7-interval boundary. He confirmed dragging works properly and that removing intervals down to 7 animates the navigation out and back in cleanly at the edge.
- No animation was added. Under Reduce Motion everything in this feature lands instantly with nil animation; that was settled the hard way in earlier work and must not be reopened.
- No schema change, no Firestore rules change. This is a view-layer-only change.

TESTS (new file AscendAppTests/RoutineCoachMarkSpotlightRingTests.swift): the definition of done is a claim about drawn pixels ('exactly one lime outline'), so the tests render the real components through ImageRenderer and read the bitmap rather than inspecting the view tree. They count how many lime runs a single row of pixels crosses on the strip: two nested outlines are 4 crossings, one outline is 2. Coverage: window mark over a 20-interval pyramid -> 2; window mark at 8 intervals (the first count that can raise this mark at all) -> 2; the SAME mark with drawsSpotlightRing forced back to true -> 4, which is the adversarial control proving the count measures the real defect; all three walkthrough marks (.timeline, .stepControl, .add) over the same strip -> 4 each, proving the opt-out did not reach the shared default; the strip stays lit under the dim without the ring; and a presentation that omits the flag still draws the ring. The 'lime' classifier reads the accent's green dominance (#86D30A is (134,211,10)) - nothing else in the scanned band can pass it because the ridge is drawn from the heat map, which is red-dominant at every level. The classifier and that reasoning are commented in place.

VERIFICATION ALREADY DONE: full iOS suite passes, 1066 tests in 163 suites. Visual evidence was rendered and eyeballed: the window mark now shows exactly one lime outline (the window), and the walkthrough's .timeline mark still draws its ring around the plot.

PR BODY REQUIREMENT: lead the PR body with what he saw - two nested outlines around the same strip, so the tip obscured what it was pointing at.

## What Changed

- On the routine builder with 8+ intervals, the "Drag the window." coach mark drew its own lime spotlight ring around the whole overview strip, stacking a second outline concentrically around the working-window indicator that already lives there - two nested boxes around the same element, with the tip's own highlight obscuring the thing it was pointing at. `RoutineWindowCoachMark.presentation` now opts out of that ring, leaving the genuine working-window indicator as the only lime outline on the strip. The card, its copy, and its dismissal are untouched.
- `RoutineCoachMarkPresentation` gains `drawsSpotlightRing`, with a hand-written memberwise init that defaults it to `true` so the shared default is unchanged and any presentation that says nothing about the ring still gets one. `RoutineBuilderCoachMarkOverlay` gates only the `RoundedRectangle(...).stroke(Color.accent, lineWidth: 2)` on the flag; the dim backdrop's `destinationOut` punch-out is deliberately left alone, since the strip must stay lit under the dim either way. The window mark is the only opt-out in the codebase - the three walkthrough marks are unaffected.
- New `RoutineCoachMarkSpotlightRingTests` renders the real components through `ImageRenderer` and counts lime runs across a pixel row of the strip, because the definition of done is a claim about drawn pixels: two nested outlines cross 4 runs, one crosses 2. It covers the window mark over a 20-interval pyramid and at the 8-interval threshold (2 each), the same mark with the ring forced back on as an adversarial control (4), all three walkthrough marks (4 each, proving the opt-out did not reach the shared default), the strip staying lit under the dim, and a presentation omitting the flag still drawing a ring. The shipped `RoutineTimelineEditorSnapshotTests` evidence was re-rendered and its comment updated.

View-layer only: no schema, rules, animation, or drag-behavior changes. The full iOS suite passes at 1066 tests across 163 suites, and the rendered PNGs were eyeballed to confirm one lime outline with the window mark up and the walkthrough's `.timeline` mark still ringing the plot.

## Risk Assessment

✅ Low: A view-layer-only change of three effective lines behind an opt-out flag that defaults to the existing behavior, with the only opt-out at a single call site, no schema/rules/API surface touched, and pixel-level tests that fail closed if the geometry ever drifts.

## Testing

Ran the full iOS suite (1066 tests, 163 suites, all passing) plus the new pixel-counting ring suite and the routine snapshot suite, then produced visual evidence from the real components: a side-by-side render of the New Routine screen with the 'Drag the window.' coach mark showing the two nested lime outlines the captain reported (ring forced on) next to the shipped single-outline result, a full-device render of the shipped state, and a render of the walkthrough's .timeline mark proving its spotlight ring is untouched. The card copy, dot and 'Got it' are identical across before and after, and the strip stays lit under the dim.

- Evidence: Before/after: the window coach mark&#39;s two nested lime outlines vs the shipped single working-window outline (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ77ZSGDGENE3QG02B910AY9/before-after-window-coach-mark.png</code>)
- Evidence: Shipped state, full device: &#39;Drag the window.&#39; with only the working-window outline on the strip (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ77ZSGDGENE3QG02B910AY9/after-window-coach-mark-one-lime-outline.png</code>)
- Evidence: Constraint held: the walkthrough&#39;s .timeline coach mark still draws its spotlight ring around the plot (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ77ZSGDGENE3QG02B910AY9/walkthrough-timeline-mark-still-rings.png</code>)
<details>
<summary>Evidence: Lime-crossing counts: window mark = 2, ring-forced-on control = 4, every walkthrough mark = 4</summary>

```text
✔ Test theWindowMarkLeavesExactlyOneLimeOutlineOnTheStrip() passed
✔ Test theStripStaysSingleOutlinedAtTheEighthInterval() passed
✔ Test theSameMarkWithItsRingLeftOnDrawsTheNestedPair() passed
✔ Test everyWalkthroughMarkStillDrawsItsRing(_:) with 3 test cases passed
(mark → .timeline, mark → .stepControl, mark → .add)
✔ Test theRingIsTheSharedDefaultAndOnlyTheWindowMarkOptsOut() passed
✔ Test theStripStaysLitUnderTheDimWithoutTheRing() passed
✔ Test run with 1066 tests in 163 suites passed after 36.569 seconds.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp-Staging&#34; -configuration Staging -destination &#34;platform=iOS Simulator,id=DC178358-9383-496A-A885-050EC9F6FD0D&#34; ENABLE_TESTABILITY=YES test` - full iOS suite, 1066 tests in 163 suites, passed (the CI-documented iPhone 16 Pro destination does not exist on this machine; iPhone 17 Pro / iOS 26.2 is the available simulator)</code>
- <code>`-only-testing:AscendAppTests/RoutineCoachMarkSpotlightRingTests` - the new ImageRenderer pixel suite: window mark over a 20-interval pyramid and at the 8-interval threshold each cross 2 lime runs, the ring-forced-on control crosses 4, all three walkthrough marks cross 4, the strip stays lit under the dim, and an unstated presentation still draws a ring</code>
- <code>`-only-testing:AscendAppTests/RoutineTimelineEditorSnapshotTests` - re-rendered the shipped snapshot evidence, including `theWindowCoachMarkSpotlightsTheOverview` and `theWalkthroughSpotlightsTheTimeline`</code>
- `Manual visual verification: viewed the rendered PNGs and confirmed one lime outline on the strip with the window mark up, and the walkthrough .timeline mark still ringing the plot`
- <code>Wrote a throwaway test (`AscendAppTests/TempRingBeforeAfterEvidenceTests.swift`) that renders the identical surface twice - `drawsSpotlightRing: true` vs the shipped `RoutineWindowCoachMark.presentation` - to capture the before/after side by side, then deleted it; the worktree is back to a clean `git status`</code>
- <code>Build setup: copied the gitignored `GoogleService-Info-Staging.plist` in from `~/.config/ascend/firebase` because the Xcode run-script phase cannot create its symlink under the build sandbox, then removed it after the runs</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
