### PR TITLE
feat(account): reorganize settings and rebuild edit profile around a stored birthday

### DIFF
--- a/.claude/skills/ascend-onboarding/SKILL.md
+++ b/.claude/skills/ascend-onboarding/SKILL.md
@@ -23,7 +23,7 @@ The planned onboarding sequence, in order:
 This sequence will evolve as we learn from SuperWall and RevenueCat funnel analytics. Treat it as the current plan, not a permanent contract.
 
 ## Required profile capture
-- Post-auth onboarding must collect the required profile fields before the user reaches the main app: display name plus declared demographics when that stage is enabled. Age stays bounded from 13 through 120, and gender uses the `ProfileGender` raw values. See `ascend-profile` for the full demographics contract.
+- Post-auth onboarding must collect the required profile fields before the user reaches the main app: display name plus declared demographics when that stage is enabled. `ascend-profile` owns the full demographics contract - the stored birthday, the derived age and its bounds, and the gender raw values.
 
 ## Routing & resolver
 - Sign-in is a routing transition, not a sheet dismissal - auth screens should not dismiss themselves after provider sign-in; the auth surface is replaced by the authenticated root.

--- a/.claude/skills/ascend-profile/SKILL.md
+++ b/.claude/skills/ascend-profile/SKILL.md
@@ -6,8 +6,16 @@ description: Use when working on Ascend profiles - own vs other-user profile sur
 # Profile
 
 ## Profile Demographics
-- Post-auth onboarding captures display name and declared demographics on `users/{uid}`. Age must stay a bounded integer from 13 through 120, and gender must use the `ProfileGender` raw values: `woman`, `man`, `non_binary`, or `prefer_not_to_say`.
-- Profile demographics for V1 are public by default with no per-field opt-out: age, gender, body weight, country/region, and joined date may appear on profiles and leaderboard-adjacent surfaces. Email and authentication/provider data remain private.
+- Post-auth onboarding captures display name and declared demographics on `users/{uid}`. Gender must use the `ProfileGender` raw values: `woman`, `man`, `non_binary`, or `prefer_not_to_say`.
+- **Age is derived, never stored fresh.**
+  The stored field is `birth_date`, a private `YYYY-MM-DD` calendar string on `users/{uid}`, bounded so the derived age lands between 13 and 120.
+  `ProfileBirthday` (`AscendApp/Shared/Models/`) parses it and computes age on device, and `functions/src/leaderboardStats.ts` derives the same number server-side for board demographics.
+  Storing a typed number instead would freeze a climber's age on the day they entered it.
+  Climbers who onboarded before the birthday field keep their legacy `age` integer, consulted only when no birthday exists - there is no backfill and no migration (issue #375), and writing a birthday clears the legacy `age`.
+- Profile demographics for V1 are public by default with no per-field opt-out: age, gender, body weight, country/region, and joined date may appear on profiles and leaderboard-adjacent surfaces.
+  **`birth_date` itself is not one of them** - it stays on the private user document, and only the derived age may reach a public projection or payload.
+  `AscendAppTests/ProfileBirthdayTests.swift` fails if the date reaches the public identity payload.
+  Email and authentication/provider data remain private.
 - Custom display names and profile photos are public account identity only while App Review Guideline 1.2 moderation remains enforced.
   `PublicClimberIdentity` (`AscendApp/Shared/Models/`) resolves account-authored identity, a stable UID-derived fallback, synthetic fixture identity, and the deleted-account `Anonymous Climber` sentinel.
   Every cross-user view must pass that presentation through `ResolvedUserIdentity.Resolver`, which replaces only a blocked climber's name and photo while preserving rank, metrics, and demographics.
@@ -27,7 +35,7 @@ description: Use when working on Ascend profiles - own vs other-user profile sur
   `AscendAppTests/AuditedIdentitySurfaceTests.swift` fails if any audited surface renders a blocked climber's real name or photo.
 - A report requires a reason picker - you cannot triage without one - and writes reported uid, reporter uid, reason, timestamp, and source surface to a queue only the captain reads.
   Reporting is not a block and changes nothing for the reporter, and blocking files a report only when the blocker explicitly checks the optional report box.
-- There is exactly one moderation placement: the overflow menu on `OtherUserProfileView`, plus the Blocked climbers row in `AccountView`'s profile settings.
+- There is exactly one moderation placement: the overflow menu on `OtherUserProfileView`, plus the Blocked climbers row in `AccountView`'s Privacy section.
   Long-press menus, inline buttons, and mid-climb affordances are ruled out; reaching moderation from a new surface is a navigation change that routes to that same profile, not a new menu.
 - Display names are screened at write time so an objectionable name is never published; photo moderation is deliberately reactive (report, human review, removal) with no automated image scanning.
 

--- a/AscendApp/Features/Account/Models/ProfileNameField.swift
+++ b/AscendApp/Features/Account/Models/ProfileNameField.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum ProfileNameField: String, Sendable {
+    case firstName = "First name"
+    case lastName = "Last name"
+}

--- a/AscendApp/Features/Account/Models/ProfileNameField.swift
+++ b/AscendApp/Features/Account/Models/ProfileNameField.swift
@@ -3,4 +3,11 @@ import Foundation
 enum ProfileNameField: String, Sendable {
     case firstName = "First name"
     case lastName = "Last name"
+
+    var counterpart: ProfileNameField {
+        switch self {
+        case .firstName: .lastName
+        case .lastName: .firstName
+        }
+    }
 }

--- a/AscendApp/Features/Account/Views/AccountView.swift
+++ b/AscendApp/Features/Account/Views/AccountView.swift
@@ -28,14 +28,18 @@ struct AccountView: View {
                 ProfileHeaderView(
                     photoURL: authVM.displayPhotoURL,
                     displayName: authVM.displayName,
+                    email: authVM.user?.email,
                     onEditTap: {
                         isShowingEditProfile = true
                     }
                 )
 
                 sectionView(title: "Profile", options: profileOptions)
+                sectionView(title: "Notifications", options: notificationOptions)
+                sectionView(title: "Preferences", options: preferenceOptions)
                 sectionView(title: "Subscription", options: subscriptionOptions)
                 sectionView(title: "Support", options: supportOptions)
+                sectionView(title: "Privacy", options: privacyOptions)
                 sectionView(title: "Developer", options: developerOptions)
 
                 SignOutButton {
@@ -127,16 +131,36 @@ struct AccountView: View {
                 action: {
                     isShowingEditProfile = true
                 }
-            ),
+            )
+        ]
+    }
+
+    private var notificationOptions: [SettingsOption] {
+        [
             SettingsOption(
                 icon: .settingsNotifications,
-                title: "Notifications",
+                title: "Push",
                 destination: NotificationSettingsView()
             ),
             SettingsOption(
-                icon: .settingsBlockedClimbers,
-                title: "Blocked climbers",
-                destination: BlockedClimbersView()
+                icon: .settingsContactUs,
+                title: "Email",
+                destination: EmailPreferencesView()
+            )
+        ]
+    }
+
+    private var preferenceOptions: [SettingsOption] {
+        [
+            SettingsOption(
+                icon: .settingsMeasurementSystem,
+                title: "Units",
+                destination: MeasurementSystemSelectionView()
+            ),
+            SettingsOption(
+                icon: .settingsIntegrations,
+                title: "Integrations",
+                destination: IntegrationsView()
             )
         ]
     }
@@ -207,6 +231,16 @@ struct AccountView: View {
                 icon: .settingsContactUs,
                 title: "Contact Us",
                 destination: ContactUsView()
+            )
+        ]
+    }
+
+    private var privacyOptions: [SettingsOption] {
+        [
+            SettingsOption(
+                icon: .settingsBlockedClimbers,
+                title: "Blocked climbers",
+                destination: BlockedClimbersView()
             )
         ]
     }

--- a/AscendApp/Features/Account/Views/BodyMetricsEditorView.swift
+++ b/AscendApp/Features/Account/Views/BodyMetricsEditorView.swift
@@ -234,16 +234,18 @@ struct BodyMetricsEditorView: View {
         guard let metrics = normalizedMetrics() else { return }
 
         isSaving = true
-        let didSave = await authVM.updateOnboardingBodyMetrics(
-            weightKg: metrics.weightKg,
-            heightCm: metrics.heightCm
-        )
+        errorMessage = await authVM.scopedProfileUpdate(
+            fallback: "Failed to update profile."
+        ) {
+            await authVM.updateOnboardingBodyMetrics(
+                weightKg: metrics.weightKg,
+                heightCm: metrics.heightCm
+            )
+        }
         isSaving = false
 
-        if didSave {
+        if errorMessage == nil {
             dismiss()
-        } else {
-            errorMessage = authVM.errorMessage ?? "Failed to update profile."
         }
     }
 

--- a/AscendApp/Features/Account/Views/Components/ProfileHeaderView.swift
+++ b/AscendApp/Features/Account/Views/Components/ProfileHeaderView.swift
@@ -12,11 +12,18 @@ struct ProfileHeaderView: View {
     
     let photoURL: URL?
     let displayName: String
+    let email: String?
     let onEditTap: (() -> Void)?
     
-    init(photoURL: URL?, displayName: String, onEditTap: (() -> Void)? = nil) {
+    init(
+        photoURL: URL?,
+        displayName: String,
+        email: String? = nil,
+        onEditTap: (() -> Void)? = nil
+    ) {
         self.photoURL = photoURL
         self.displayName = displayName
+        self.email = email
         self.onEditTap = onEditTap
     }
     
@@ -39,6 +46,9 @@ struct ProfileHeaderView: View {
                         }
                         .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
                     }
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Circle())
+                    .accessibilityLabel("Edit profile")
                 }
             }
             
@@ -47,6 +57,14 @@ struct ProfileHeaderView: View {
                 .font(.montserratSemiBold)
                 .foregroundStyle(colorScheme == .dark ? .white : .black)
                 .multilineTextAlignment(.center)
+
+            if let email, !email.isEmpty {
+                Text(email)
+                    .font(.montserratRegular(size: 13))
+                    .foregroundStyle(colorScheme == .dark ? .white.opacity(0.45) : .black.opacity(0.55))
+                    .multilineTextAlignment(.center)
+                    .padding(.top, -8)
+            }
         }
         .padding(.top, 20)
     }

--- a/AscendApp/Features/Account/Views/Components/ProfileSectionComponents.swift
+++ b/AscendApp/Features/Account/Views/Components/ProfileSectionComponents.swift
@@ -23,6 +23,7 @@ struct ProfileSection<Content: View>: View {
                 .foregroundStyle(.secondary)
                 .tracking(0.8)
                 .padding(.horizontal, 4)
+                .accessibilityAddTraits(.isHeader)
 
             content
         }
@@ -50,8 +51,15 @@ struct ProfileCardSurface<Content: View>: View {
 }
 
 struct ProfileCardDivider: View {
+    let leadingInset: CGFloat
+
+    init(leadingInset: CGFloat = 0) {
+        self.leadingInset = leadingInset
+    }
+
     var body: some View {
         Divider()
             .background(.white.opacity(0.1))
+            .padding(.leading, leadingInset)
     }
 }

--- a/AscendApp/Features/Account/Views/Components/ProfileValueRow.swift
+++ b/AscendApp/Features/Account/Views/Components/ProfileValueRow.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct ProfileValueRow<Destination: View>: View {
+    let icon: AppIconToken
+    let title: String
+    let value: String
+    let destination: Destination
+
+    var body: some View {
+        NavigationLink(destination: destination) {
+            HStack(spacing: 16) {
+                AppIcon(token: icon, pointSize: 20, weight: .medium)
+                    .foregroundStyle(.accent)
+                    .frame(width: 24, height: 24)
+                    .accessibilityHidden(true)
+
+                Text(title)
+                    .font(.montserratMedium)
+                    .foregroundStyle(.white)
+
+                Spacer(minLength: 12)
+
+                Text(value)
+                    .font(.montserratMedium(size: 15))
+                    .foregroundStyle(.white.opacity(0.45))
+                    .lineLimit(1)
+
+                AppIcon(token: .disclosureChevronRight, pointSize: 14, weight: .medium)
+                    .foregroundStyle(.white.opacity(0.6))
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(title)
+        .accessibilityValue(value)
+        .accessibilityHint("Opens editor")
+    }
+}

--- a/AscendApp/Features/Account/Views/Components/SettingsRow.swift
+++ b/AscendApp/Features/Account/Views/Components/SettingsRow.swift
@@ -34,6 +34,7 @@ struct SettingsRow: View {
             AppIcon(token: option.icon, pointSize: 20, weight: .medium)
                 .foregroundStyle(option.iconColor)
                 .frame(width: 24, height: 24)
+                .accessibilityHidden(true)
             
             // Title
             Text(option.title)
@@ -49,12 +50,15 @@ struct SettingsRow: View {
             } else {
                 AppIcon(token: .disclosureChevronRight, pointSize: 14, weight: .medium)
                     .foregroundStyle(option.isDestructive ? .red.opacity(0.6) : .white.opacity(0.6))
+                    .accessibilityHidden(true)
             }
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 16)
+        .frame(minHeight: 44)
         .contentShape(Rectangle())
         .opacity(option.isEnabled ? 1 : 0.6)
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/AscendApp/Features/Account/Views/EditProfileView.swift
+++ b/AscendApp/Features/Account/Views/EditProfileView.swift
@@ -325,10 +325,11 @@ struct EditProfileView: View {
             return
         }
 
-        await authVM.updateProfilePictureWithData(imageData: imageData)
-        if let failure = authVM.errorMessage {
-            authVM.errorMessage = nil
-            errorMessage = failure
+        errorMessage = await authVM.scopedProfileUpdate(
+            fallback: "Failed to update profile picture"
+        ) {
+            await authVM.updateProfilePictureWithData(imageData: imageData)
+            return authVM.errorMessage == nil
         }
     }
 }

--- a/AscendApp/Features/Account/Views/EditProfileView.swift
+++ b/AscendApp/Features/Account/Views/EditProfileView.swift
@@ -12,6 +12,7 @@ struct EditProfileView: View {
     @State private var isUploadingPhoto = false
     @State private var imageForCropping: UIImage?
     @State private var showingCropView = false
+    @State private var errorMessage: String?
 
     var body: some View {
         ScrollView {
@@ -58,10 +59,10 @@ struct EditProfileView: View {
         }
         .alert("Error", isPresented: errorAlertBinding) {
             Button("OK") {
-                authVM.errorMessage = nil
+                errorMessage = nil
             }
         } message: {
-            Text(authVM.errorMessage ?? "Try again.")
+            Text(errorMessage ?? "Try again.")
         }
         .onAppear {
             Task {
@@ -249,17 +250,7 @@ struct EditProfileView: View {
 
     private var formattedHeight: String {
         guard let heightCm = profileData?.heightCm, heightCm > 0 else { return "Not set" }
-
-        switch settingsManager.measurementSystem {
-        case .imperial:
-            let totalInches = max(
-                Int(MeasurementSystem.metric.convertHeight(heightCm, to: .imperial).rounded()),
-                0
-            )
-            return "\(totalInches / 12) ft \(totalInches % 12) in"
-        case .metric:
-            return "\(Int(heightCm.rounded())) cm"
-        }
+        return settingsManager.measurementSystem.formatHeightCentimeters(heightCm)
     }
 
     private var formattedWeight: String {
@@ -281,10 +272,10 @@ struct EditProfileView: View {
 
     private var errorAlertBinding: Binding<Bool> {
         Binding(
-            get: { authVM.errorMessage != nil },
+            get: { errorMessage != nil },
             set: { isPresented in
                 if !isPresented {
-                    authVM.errorMessage = nil
+                    errorMessage = nil
                 }
             }
         )
@@ -307,7 +298,7 @@ struct EditProfileView: View {
         do {
             profileData = try await UserDataRepository.shared.getUserFromFirestore(userId: userID)
         } catch {
-            authVM.errorMessage = "Failed to load profile: \(error.localizedDescription)"
+            errorMessage = "Failed to load profile: \(error.localizedDescription)"
         }
         isLoadingProfile = false
     }
@@ -315,7 +306,7 @@ struct EditProfileView: View {
     private func loadImageForCropping(_ item: PhotosPickerItem) async {
         guard let data = try? await item.loadTransferable(type: Data.self),
               let image = UIImage(data: data) else {
-            authVM.errorMessage = "Failed to load image"
+            errorMessage = "Failed to load image"
             selectedPhotoItem = nil
             return
         }
@@ -330,11 +321,15 @@ struct EditProfileView: View {
         defer { isUploadingPhoto = false }
 
         guard let imageData = image.jpegData(compressionQuality: 0.8) else {
-            authVM.errorMessage = "Failed to process image"
+            errorMessage = "Failed to process image"
             return
         }
 
         await authVM.updateProfilePictureWithData(imageData: imageData)
+        if let failure = authVM.errorMessage {
+            authVM.errorMessage = nil
+            errorMessage = failure
+        }
     }
 }
 

--- a/AscendApp/Features/Account/Views/EditProfileView.swift
+++ b/AscendApp/Features/Account/Views/EditProfileView.swift
@@ -1,79 +1,45 @@
-//
-//  EditProfileView.swift
-//  AscendApp
-//
-//  Created by Tyler Pavay on 11/20/25.
-//
-
-import SwiftUI
 import PhotosUI
+import SwiftUI
 
 struct EditProfileView: View {
     @Environment(AuthenticationViewModel.self) private var authVM
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.colorScheme) private var colorScheme
 
+    @State private var settingsManager = SettingsManager.shared
+    @State private var profileData: UserDisplayNameData?
+    @State private var isLoadingProfile = true
     @State private var selectedPhotoItem: PhotosPickerItem?
     @State private var isUploadingPhoto = false
     @State private var imageForCropping: UIImage?
     @State private var showingCropView = false
-    @State private var isEditingDisplayName = false
-    @State private var editedDisplayName = ""
-    @State private var isSavingDisplayName = false
-    @FocusState private var isDisplayNameFocused: Bool
-    
+
     var body: some View {
         ScrollView {
             VStack(spacing: 28) {
-                // Profile Picture Section
                 profilePictureSection
 
-                // User Info Section
-                userInfoSection
-
-                // Preferences Section
-                preferencesSection
+                if isLoadingProfile {
+                    ProgressView()
+                        .tint(.accent)
+                        .frame(minHeight: 120)
+                        .accessibilityLabel("Loading profile")
+                } else {
+                    profileSection
+                    personalInformationSection
+                    locationSection
+                }
 
                 Spacer(minLength: 40)
             }
             .padding(.horizontal, 20)
             .padding(.top, 20)
+            .padding(.bottom, 40)
         }
         .themedBackground()
         .navigationTitle("Edit Profile")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.clear, for: .navigationBar)
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
-        .keyboardAccessoryToolbar {
-            if isEditingDisplayName {
-                Button("Cancel") {
-                    cancelEditing()
-                    KeyboardAccessoryDismissAction.dismissKeyboard()
-                }
-                .font(.montserratSemiBold(size: 16))
-                .foregroundStyle(.white.opacity(0.82))
-                .buttonStyle(.plain)
-
-                Spacer(minLength: 0)
-
-                if isSavingDisplayName {
-                    ProgressView()
-                        .progressViewStyle(CircularProgressViewStyle(tint: .accent))
-                        .scaleEffect(0.8)
-                        .frame(minWidth: 64, minHeight: 44, alignment: .trailing)
-                } else {
-                    Button {
-                        saveDisplayName()
-                    } label: {
-                        KeyboardDoneAccessoryLabel()
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(editedDisplayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    .opacity(editedDisplayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? 0.45 : 1)
-                    .accessibilityLabel("Done")
-                }
-            }
-        }
         .fullScreenCover(isPresented: $showingCropView) {
             if let image = imageForCropping {
                 PhotoCropView(image: image) { croppedImage in
@@ -83,20 +49,23 @@ struct EditProfileView: View {
                 }
             }
         }
-        .onChange(of: selectedPhotoItem) { oldValue, newValue in
-            if let newValue = newValue {
+        .onChange(of: selectedPhotoItem) { _, newValue in
+            if let newValue {
                 Task {
                     await loadImageForCropping(newValue)
                 }
             }
         }
-        .alert("Error", isPresented: .constant(authVM.errorMessage != nil)) {
+        .alert("Error", isPresented: errorAlertBinding) {
             Button("OK") {
                 authVM.errorMessage = nil
             }
         } message: {
-            if let errorMessage = authVM.errorMessage {
-                Text(errorMessage)
+            Text(authVM.errorMessage ?? "Try again.")
+        }
+        .onAppear {
+            Task {
+                await loadProfile()
             }
         }
         .onChange(of: authVM.authenticationState) { _, newValue in
@@ -105,38 +74,37 @@ struct EditProfileView: View {
             }
         }
     }
-    
-    // MARK: - Profile Picture Section
-    
+
     private var profilePictureSection: some View {
         VStack(spacing: 16) {
             ZStack {
-                // Profile Image
                 profileImageView
-                
-                // Loading overlay
+
                 if isUploadingPhoto {
                     ZStack {
                         Circle()
                             .fill(.black.opacity(0.5))
                             .frame(width: 120, height: 120)
-                        
+
                         ProgressView()
                             .tint(.white)
                     }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("Uploading profile photo")
                 }
             }
-            
-            // Change Photo Button
+
             PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
                 Text("Change Photo")
                     .font(.montserratMedium(size: 16))
                     .foregroundStyle(.accent)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
             }
             .disabled(isUploadingPhoto)
         }
     }
-    
+
     private var profileImageView: some View {
         AsyncImage(url: authVM.displayPhotoURL) { phase in
             switch phase {
@@ -148,10 +116,10 @@ struct EditProfileView: View {
                     .scaledToFill()
                     .frame(width: 120, height: 120)
                     .clipShape(Circle())
-                    .overlay(
+                    .overlay {
                         Circle()
                             .stroke(.white.opacity(0.2), lineWidth: 2)
-                    )
+                    }
             case .failure:
                 placeholderImage
             @unknown default:
@@ -159,180 +127,214 @@ struct EditProfileView: View {
             }
         }
         .frame(width: 120, height: 120)
+        .accessibilityLabel("Profile photo")
     }
-    
+
     private var placeholderImage: some View {
         ZStack {
             Circle()
                 .fill(.jetLighter.opacity(0.3))
-                .frame(width: 120, height: 120)
-            
+
             Image(systemName: "person.fill")
                 .font(.system(size: 50))
                 .foregroundStyle(.white.opacity(0.7))
+                .accessibilityHidden(true)
         }
+        .frame(width: 120, height: 120)
     }
-    
-    // MARK: - User Info Section
-    
-    private var userInfoSection: some View {
-        ProfileSection(title: "Profile Information") {
+
+    private var profileSection: some View {
+        ProfileSection(title: "Profile") {
             ProfileCardSurface {
                 VStack(spacing: 0) {
-                    displayNameRow
+                    ProfileValueRow(
+                        icon: .settingsEditProfile,
+                        title: "First name",
+                        value: displayValue(profileData?.firstName),
+                        destination: ProfileNameEditorView(
+                            field: .firstName,
+                            firstName: profileData?.firstName ?? "",
+                            lastName: profileData?.lastName ?? ""
+                        )
+                    )
 
-                    if let email = authVM.user?.email {
-                        ProfileCardDivider()
-                        InfoRow(label: "Email", value: email)
-                    }
+                    ProfileCardDivider(leadingInset: 60)
+
+                    ProfileValueRow(
+                        icon: .settingsEditProfile,
+                        title: "Last name",
+                        value: displayValue(profileData?.lastName),
+                        destination: ProfileNameEditorView(
+                            field: .lastName,
+                            firstName: profileData?.firstName ?? "",
+                            lastName: profileData?.lastName ?? ""
+                        )
+                    )
                 }
             }
         }
     }
 
-    private var preferencesSection: some View {
-        ProfileSection(title: "Preferences") {
-            SettingsCard(options: preferenceOptions)
+    private var personalInformationSection: some View {
+        ProfileSection(title: "Personal Information") {
+            ProfileCardSurface {
+                VStack(spacing: 0) {
+                    ProfileValueRow(
+                        icon: .profileBirthday,
+                        title: "Birthday",
+                        value: formattedBirthday,
+                        destination: ProfileBirthdayEditorView(birthday: profileData?.birthday)
+                    )
+
+                    ProfileCardDivider(leadingInset: 60)
+
+                    ProfileValueRow(
+                        icon: .profileGender,
+                        title: "Gender",
+                        value: formattedGender,
+                        destination: ProfileGenderEditorView(
+                            gender: profileData?.gender.flatMap(ProfileGender.init(rawValue:))
+                        )
+                    )
+
+                    ProfileCardDivider(leadingInset: 60)
+
+                    ProfileValueRow(
+                        icon: .settingsMeasurementSystem,
+                        title: "Height",
+                        value: formattedHeight,
+                        destination: BodyMetricsEditorView()
+                    )
+
+                    ProfileCardDivider(leadingInset: 60)
+
+                    ProfileValueRow(
+                        icon: .profileWeight,
+                        title: "Weight",
+                        value: formattedWeight,
+                        destination: BodyMetricsEditorView()
+                    )
+                }
+            }
         }
     }
 
-    private var preferenceOptions: [SettingsOption] {
-        [
-            SettingsOption(
-                icon: .settingsMeasurementSystem,
-                title: "Body Metrics",
-                destination: BodyMetricsEditorView()
-            ),
-            SettingsOption(
-                icon: .settingsMeasurementSystem,
-                title: "Measurement System",
-                destination: MeasurementSystemSelectionView()
-            ),
-            SettingsOption(
-                icon: .settingsIntegrations,
-                title: "Integrations",
-                destination: IntegrationsView()
+    private var locationSection: some View {
+        ProfileSection(title: "Location") {
+            ProfileCardSurface {
+                ProfileValueRow(
+                    icon: .mapPin,
+                    title: "Location",
+                    value: formattedLocation,
+                    destination: ProfileLocationEditorView(
+                        city: profileData?.locationCity,
+                        region: profileData?.locationRegion,
+                        countryCode: profileData?.locationCountry
+                    )
+                )
+            }
+        }
+    }
+
+    private var formattedBirthday: String {
+        guard let date = profileData?.birthday?.date() else { return "Not set" }
+        return date.formatted(.dateTime.month(.abbreviated).day().year())
+    }
+
+    private var formattedGender: String {
+        profileData?.gender
+            .flatMap(ProfileGender.init(rawValue:))?
+            .displayName ?? "Not set"
+    }
+
+    private var formattedHeight: String {
+        guard let heightCm = profileData?.heightCm, heightCm > 0 else { return "Not set" }
+
+        switch settingsManager.measurementSystem {
+        case .imperial:
+            let totalInches = max(
+                Int(MeasurementSystem.metric.convertHeight(heightCm, to: .imperial).rounded()),
+                0
             )
-        ]
+            return "\(totalInches / 12) ft \(totalInches % 12) in"
+        case .metric:
+            return "\(Int(heightCm.rounded())) cm"
+        }
     }
-    
-    private var displayNameRow: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("Display Name")
-                .font(.montserratMedium(size: 14))
-                .foregroundStyle(.secondary)
-            
-            if isEditingDisplayName {
-                TextField("Enter display name", text: $editedDisplayName)
-                    .font(.montserratRegular(size: 16))
-                    .foregroundStyle(.white)
-                    .textFieldStyle(.plain)
-                    .focused($isDisplayNameFocused)
-                    .submitLabel(.done)
-                    .onSubmit {
-                        saveDisplayName()
-                    }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            } else {
-                Button {
-                    startEditing()
-                } label: {
-                    HStack {
-                        Text(authVM.displayName.isEmpty ? "Not Set" : authVM.displayName)
-                            .font(.montserratRegular(size: 16))
-                            .foregroundStyle(.white)
-                        
-                        Spacer()
-                        
-                        Image(systemName: "pencil")
-                            .font(.system(size: 16))
-                            .foregroundStyle(.accent)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+
+    private var formattedWeight: String {
+        guard let weightKg = profileData?.weightKg, weightKg > 0 else { return "Not set" }
+        let converted = MeasurementSystem.metric.convertWeight(
+            weightKg,
+            to: settingsManager.measurementSystem
+        )
+        return settingsManager.measurementSystem.formatWeight(converted)
+    }
+
+    private var formattedLocation: String {
+        guard let city = profileData?.locationCity, !city.isEmpty else { return "Not set" }
+        if let region = profileData?.locationRegion, !region.isEmpty {
+            return "\(city), \(region)"
+        }
+        return city
+    }
+
+    private var errorAlertBinding: Binding<Bool> {
+        Binding(
+            get: { authVM.errorMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    authVM.errorMessage = nil
                 }
-                .buttonStyle(.plain)
             }
+        )
+    }
+
+    private func displayValue(_ value: String?) -> String {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty else {
+            return "Not set"
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
+        return value
     }
-    
-    private func startEditing() {
-        editedDisplayName = authVM.displayName
-        isEditingDisplayName = true
-        isDisplayNameFocused = true
-    }
-    
-    private func cancelEditing() {
-        isEditingDisplayName = false
-        editedDisplayName = ""
-        isDisplayNameFocused = false
-    }
-    
-    private func saveDisplayName() {
-        let trimmedName = editedDisplayName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedName.isEmpty else { return }
-        
-        isSavingDisplayName = true
-        
-        Task {
-            await authVM.updateDisplayName(trimmedName)
-            isSavingDisplayName = false
-            isEditingDisplayName = false
-            isDisplayNameFocused = false
+
+    private func loadProfile() async {
+        guard let userID = authVM.user?.uid else {
+            isLoadingProfile = false
+            return
         }
+
+        do {
+            profileData = try await UserDataRepository.shared.getUserFromFirestore(userId: userID)
+        } catch {
+            authVM.errorMessage = "Failed to load profile: \(error.localizedDescription)"
+        }
+        isLoadingProfile = false
     }
-    
-    // MARK: - Actions
-    
+
     private func loadImageForCropping(_ item: PhotosPickerItem) async {
         guard let data = try? await item.loadTransferable(type: Data.self),
-              let uiImage = UIImage(data: data) else {
+              let image = UIImage(data: data) else {
             authVM.errorMessage = "Failed to load image"
             selectedPhotoItem = nil
             return
         }
-        
-        imageForCropping = uiImage
+
+        imageForCropping = image
         showingCropView = true
         selectedPhotoItem = nil
     }
-    
+
     private func uploadCroppedImage(_ image: UIImage) async {
         isUploadingPhoto = true
         defer { isUploadingPhoto = false }
-        
-        // Convert UIImage to JPEG data
+
         guard let imageData = image.jpegData(compressionQuality: 0.8) else {
             authVM.errorMessage = "Failed to process image"
             return
         }
-        
+
         await authVM.updateProfilePictureWithData(imageData: imageData)
-    }
-}
-
-// MARK: - Info Row Component
-
-private struct InfoRow: View {
-    @Environment(\.colorScheme) private var colorScheme
-    
-    let label: String
-    let value: String
-    
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text(label)
-                .font(.montserratMedium(size: 14))
-                .foregroundStyle(.secondary)
-            
-            Text(value)
-                .font(.montserratRegular(size: 16))
-                .foregroundStyle(.white)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/AscendApp/Features/Account/Views/NotificationSettingsView.swift
+++ b/AscendApp/Features/Account/Views/NotificationSettingsView.swift
@@ -10,29 +10,26 @@ struct NotificationSettingsView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 24) {
-                ProfileSection(title: "Climb Drops") {
+                if authorizationStatus == .denied {
+                    notificationsDisabledBanner
+                }
+
+                ProfileSection(title: "Climbs") {
                     ProfileCardSurface {
                         climbDropRow
                     }
                 }
 
-                // Temporary entry point. The Settings page gains its own
-                // NOTIFICATIONS block with Push and Email as siblings (#372),
-                // and this row comes out when it lands.
-                ProfileSection(title: "Emails") {
-                    ProfileCardSurface {
-                        emailRow
-                    }
-                }
+                if authorizationStatus != .denied {
+                    ProfileSection(title: "System") {
+                        ProfileCardSurface {
+                            VStack(spacing: 0) {
+                                permissionStatusRow
 
-                ProfileSection(title: "System") {
-                    ProfileCardSurface {
-                        VStack(spacing: 0) {
-                            permissionStatusRow
-
-                            if shouldShowSystemSettingsAction {
-                                ProfileCardDivider()
-                                systemSettingsButton
+                                if shouldShowSystemSettingsAction {
+                                    ProfileCardDivider()
+                                    systemSettingsButton
+                                }
                             }
                         }
                     }
@@ -42,7 +39,7 @@ struct NotificationSettingsView: View {
             .padding(.bottom, 40)
         }
         .themedBackground()
-        .navigationTitle("Notifications")
+        .navigationTitle("Push")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(.clear, for: .navigationBar)
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
@@ -64,13 +61,14 @@ struct NotificationSettingsView: View {
             AppIcon(token: .settingsNotifications, pointSize: 22, weight: .medium)
                 .foregroundStyle(.accent)
                 .frame(width: 28, height: 28)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("New climb drops")
                     .font(.montserratSemiBold(size: 16))
                     .foregroundStyle(.white)
 
-                Text("Get an Ascend alert when new climbs open.")
+                Text("A new landmark opens in the catalog.")
                     .font(.montserratRegular(size: 13))
                     .foregroundStyle(.white.opacity(0.64))
                     .fixedSize(horizontal: false, vertical: true)
@@ -92,36 +90,52 @@ struct NotificationSettingsView: View {
             .labelsHidden()
             .tint(.accent)
             .disabled(isUpdating || authorizationStatus == .denied)
+            .accessibilityLabel("New climb drops")
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 18)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .opacity(isUpdating ? 0.68 : 1)
+        .opacity(isUpdating ? 0.68 : authorizationStatus == .denied ? 0.45 : 1)
     }
 
-    private var emailRow: some View {
-        NavigationLink {
-            EmailPreferencesView()
-        } label: {
-            HStack(spacing: 16) {
-                AppIcon(token: .settingsContactUs, pointSize: 22, weight: .medium)
-                    .foregroundStyle(.accent)
-                    .frame(width: 28, height: 28)
+    private var notificationsDisabledBanner: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: "exclamationmark.circle.fill")
+                .font(.system(size: 22, weight: .medium))
+                .foregroundStyle(.orange)
+                .accessibilityHidden(true)
 
-                Text("Email")
-                    .font(.montserratMedium)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Notifications are off in iOS")
+                    .font(.montserratSemiBold(size: 15))
                     .foregroundStyle(.white)
 
-                Spacer()
+                Text("Ascend can't send anything until you turn them back on.")
+                    .font(.montserratRegular(size: 13))
+                    .foregroundStyle(.white.opacity(0.62))
+                    .fixedSize(horizontal: false, vertical: true)
 
-                AppIcon(token: .disclosureChevronRight, pointSize: 14, weight: .medium)
-                    .foregroundStyle(.white.opacity(0.6))
+                Button("Open iOS Settings") {
+                    ClimbDropNotificationPermissionController.openSystemNotificationSettings()
+                }
+                .font(.montserratSemiBold(size: 13))
+                .foregroundStyle(.accent)
+                .frame(minHeight: 44)
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 18)
-            .contentShape(Rectangle())
+
+            Spacer(minLength: 0)
         }
-        .buttonStyle(.plain)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color.orange.opacity(0.1))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(Color.orange.opacity(0.35), lineWidth: 1)
+                }
+        )
+        .accessibilityElement(children: .combine)
     }
 
     private var permissionStatusRow: some View {
@@ -129,6 +143,7 @@ struct NotificationSettingsView: View {
             AppIcon(token: .settingsNotifications, pointSize: 22, weight: .medium)
                 .foregroundStyle(permissionColor)
                 .frame(width: 28, height: 28)
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("iOS permission")
@@ -155,6 +170,7 @@ struct NotificationSettingsView: View {
                 AppIcon(token: .settingsNotifications, pointSize: 22, weight: .medium)
                     .foregroundStyle(.accent)
                     .frame(width: 28, height: 28)
+                    .accessibilityHidden(true)
 
                 Text("Open iOS Settings")
                     .font(.montserratMedium)

--- a/AscendApp/Features/Account/Views/ProfileBirthdayEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileBirthdayEditorView.swift
@@ -6,6 +6,7 @@ struct ProfileBirthdayEditorView: View {
 
     @State private var selectedBirthday: Date
     @State private var isSaving = false
+    @State private var errorMessage: String?
 
     init(birthday: ProfileBirthday?) {
         let defaultDate = Calendar.current.date(byAdding: .year, value: -32, to: .now) ?? .now
@@ -52,7 +53,7 @@ struct ProfileBirthdayEditorView: View {
                 .disabled(isSaving)
                 .opacity(isSaving ? 0.7 : 1)
 
-                if let errorMessage = authVM.errorMessage {
+                if let errorMessage {
                     Text(errorMessage)
                         .font(.montserratRegular(size: 14))
                         .foregroundStyle(.red.opacity(0.9))
@@ -67,9 +68,6 @@ struct ProfileBirthdayEditorView: View {
         .navigationTitle("Birthday")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
-        .onAppear {
-            authVM.errorMessage = nil
-        }
     }
 
     private var allowedRange: ClosedRange<Date> {
@@ -85,11 +83,13 @@ struct ProfileBirthdayEditorView: View {
 
         Task { @MainActor in
             isSaving = true
-            let didSave = await authVM.updateBirthday(
-                ProfileBirthday(date: selectedBirthday)
-            )
+            errorMessage = await authVM.scopedProfileUpdate(
+                fallback: "Failed to update birthday"
+            ) {
+                await authVM.updateBirthday(ProfileBirthday(date: selectedBirthday))
+            }
             isSaving = false
-            if didSave {
+            if errorMessage == nil {
                 dismiss()
             }
         }

--- a/AscendApp/Features/Account/Views/ProfileBirthdayEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileBirthdayEditorView.swift
@@ -67,6 +67,9 @@ struct ProfileBirthdayEditorView: View {
         .navigationTitle("Birthday")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
+        .onAppear {
+            authVM.errorMessage = nil
+        }
     }
 
     private var allowedRange: ClosedRange<Date> {

--- a/AscendApp/Features/Account/Views/ProfileBirthdayEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileBirthdayEditorView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+struct ProfileBirthdayEditorView: View {
+    @Environment(AuthenticationViewModel.self) private var authVM
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedBirthday: Date
+    @State private var isSaving = false
+
+    init(birthday: ProfileBirthday?) {
+        let defaultDate = Calendar.current.date(byAdding: .year, value: -32, to: .now) ?? .now
+        _selectedBirthday = State(initialValue: birthday?.date() ?? defaultDate)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                ProfileSection(title: "Personal Information") {
+                    ProfileCardSurface {
+                        DatePicker(
+                            "Birthday",
+                            selection: $selectedBirthday,
+                            in: allowedRange,
+                            displayedComponents: .date
+                        )
+                        .datePickerStyle(.wheel)
+                        .labelsHidden()
+                        .colorScheme(.dark)
+                        .padding(.horizontal, 12)
+                        .accessibilityLabel("Birthday")
+                        .accessibilityValue(selectedBirthday.formatted(date: .long, time: .omitted))
+                    }
+                }
+
+                Button(action: save) {
+                    Group {
+                        if isSaving {
+                            ProgressView()
+                                .tint(.black)
+                        } else {
+                            Text("Save")
+                                .font(.montserratBold(size: 14))
+                        }
+                    }
+                    .foregroundStyle(.black)
+                    .frame(maxWidth: .infinity)
+                    .frame(minHeight: 48)
+                    .background(Capsule().fill(Color.accent))
+                    .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .disabled(isSaving)
+                .opacity(isSaving ? 0.7 : 1)
+
+                if let errorMessage = authVM.errorMessage {
+                    Text(errorMessage)
+                        .font(.montserratRegular(size: 14))
+                        .foregroundStyle(.red.opacity(0.9))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+            .padding(.bottom, 40)
+        }
+        .themedBackground()
+        .navigationTitle("Birthday")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
+    }
+
+    private var allowedRange: ClosedRange<Date> {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: .now)
+        let oldest = calendar.date(byAdding: .year, value: -120, to: today) ?? today
+        let youngest = calendar.date(byAdding: .year, value: -13, to: today) ?? today
+        return oldest...youngest
+    }
+
+    private func save() {
+        guard !isSaving else { return }
+
+        Task { @MainActor in
+            isSaving = true
+            let didSave = await authVM.updateBirthday(
+                ProfileBirthday(date: selectedBirthday)
+            )
+            isSaving = false
+            if didSave {
+                dismiss()
+            }
+        }
+    }
+}

--- a/AscendApp/Features/Account/Views/ProfileGenderEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileGenderEditorView.swift
@@ -86,6 +86,9 @@ struct ProfileGenderEditorView: View {
         .navigationTitle("Gender")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
+        .onAppear {
+            authVM.errorMessage = nil
+        }
     }
 
     private func save() {

--- a/AscendApp/Features/Account/Views/ProfileGenderEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileGenderEditorView.swift
@@ -6,6 +6,7 @@ struct ProfileGenderEditorView: View {
 
     @State private var selectedGender: ProfileGender
     @State private var isSaving = false
+    @State private var errorMessage: String?
 
     init(gender: ProfileGender?) {
         _selectedGender = State(initialValue: gender ?? .preferNotToSay)
@@ -71,7 +72,7 @@ struct ProfileGenderEditorView: View {
                 .disabled(isSaving)
                 .opacity(isSaving ? 0.7 : 1)
 
-                if let errorMessage = authVM.errorMessage {
+                if let errorMessage {
                     Text(errorMessage)
                         .font(.montserratRegular(size: 14))
                         .foregroundStyle(.red.opacity(0.9))
@@ -86,9 +87,6 @@ struct ProfileGenderEditorView: View {
         .navigationTitle("Gender")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
-        .onAppear {
-            authVM.errorMessage = nil
-        }
     }
 
     private func save() {
@@ -96,9 +94,13 @@ struct ProfileGenderEditorView: View {
 
         Task { @MainActor in
             isSaving = true
-            let didSave = await authVM.updateOnboardingGender(selectedGender)
+            errorMessage = await authVM.scopedProfileUpdate(
+                fallback: "Failed to update gender"
+            ) {
+                await authVM.updateOnboardingGender(selectedGender)
+            }
             isSaving = false
-            if didSave {
+            if errorMessage == nil {
                 dismiss()
             }
         }

--- a/AscendApp/Features/Account/Views/ProfileGenderEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileGenderEditorView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct ProfileGenderEditorView: View {
+    @Environment(AuthenticationViewModel.self) private var authVM
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var selectedGender: ProfileGender
+    @State private var isSaving = false
+
+    init(gender: ProfileGender?) {
+        _selectedGender = State(initialValue: gender ?? .preferNotToSay)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                ProfileSection(title: "Personal Information") {
+                    ProfileCardSurface {
+                        VStack(spacing: 0) {
+                            ForEach(Array(ProfileGender.allCases.enumerated()), id: \.element.id) { index, gender in
+                                Button {
+                                    selectedGender = gender
+                                } label: {
+                                    HStack(spacing: 16) {
+                                        Text(gender.displayName)
+                                            .font(.montserratMedium)
+                                            .foregroundStyle(.white)
+
+                                        Spacer(minLength: 12)
+
+                                        if selectedGender == gender {
+                                            Image(systemName: "checkmark")
+                                                .font(.system(size: 15, weight: .bold))
+                                                .foregroundStyle(.accent)
+                                                .accessibilityHidden(true)
+                                        }
+                                    }
+                                    .padding(.horizontal, 20)
+                                    .frame(minHeight: 56)
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel(gender.displayName)
+                                .accessibilityAddTraits(selectedGender == gender ? .isSelected : [])
+
+                                if index < ProfileGender.allCases.count - 1 {
+                                    ProfileCardDivider()
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Button(action: save) {
+                    Group {
+                        if isSaving {
+                            ProgressView()
+                                .tint(.black)
+                        } else {
+                            Text("Save")
+                                .font(.montserratBold(size: 14))
+                        }
+                    }
+                    .foregroundStyle(.black)
+                    .frame(maxWidth: .infinity)
+                    .frame(minHeight: 48)
+                    .background(Capsule().fill(Color.accent))
+                    .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .disabled(isSaving)
+                .opacity(isSaving ? 0.7 : 1)
+
+                if let errorMessage = authVM.errorMessage {
+                    Text(errorMessage)
+                        .font(.montserratRegular(size: 14))
+                        .foregroundStyle(.red.opacity(0.9))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+            .padding(.bottom, 40)
+        }
+        .themedBackground()
+        .navigationTitle("Gender")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
+    }
+
+    private func save() {
+        guard !isSaving else { return }
+
+        Task { @MainActor in
+            isSaving = true
+            let didSave = await authVM.updateOnboardingGender(selectedGender)
+            isSaving = false
+            if didSave {
+                dismiss()
+            }
+        }
+    }
+}

--- a/AscendApp/Features/Account/Views/ProfileLocationEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileLocationEditorView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+struct ProfileLocationEditorView: View {
+    @Environment(AuthenticationViewModel.self) private var authVM
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var citySearch = PostAuthCitySearchModel()
+    @StateObject private var currentLocation = PostAuthCurrentLocationResolver()
+    @FocusState private var isSearchFocused: Bool
+
+    @State private var selectedLocation: PostAuthLocationSelection?
+    @State private var isSaving = false
+
+    init(city: String?, region: String?, countryCode: String?) {
+        let normalizedCity = city?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let normalizedCountry = countryCode?.uppercased() ?? ""
+        let countryName = Locale.current.localizedString(forRegionCode: normalizedCountry) ?? normalizedCountry
+        let initialSelection: PostAuthLocationSelection? = normalizedCity.isEmpty || normalizedCountry.isEmpty
+            ? nil
+            : PostAuthLocationSelection(
+                city: normalizedCity,
+                region: region,
+                countryCode: normalizedCountry,
+                countryName: countryName
+            )
+        _selectedLocation = State(initialValue: initialSelection)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                ProfileSection(title: "Location") {
+                    ProfileCardSurface {
+                        VStack(spacing: 0) {
+                            HStack(spacing: 12) {
+                                Image(systemName: "magnifyingglass")
+                                    .foregroundStyle(.white.opacity(0.55))
+                                    .accessibilityHidden(true)
+
+                                TextField("Search for your city", text: $citySearch.query)
+                                    .font(.montserratRegular(size: 16))
+                                    .foregroundStyle(.white)
+                                    .tint(.accent)
+                                    .textInputAutocapitalization(.words)
+                                    .autocorrectionDisabled()
+                                    .focused($isSearchFocused)
+                                    .accessibilityLabel("City search")
+                            }
+                            .padding(.horizontal, 20)
+                            .frame(minHeight: 56)
+
+                            ProfileCardDivider()
+
+                            if let selectedLocation {
+                                locationRow(
+                                    title: selectedLocation.title,
+                                    subtitle: selectedLocation.subtitle,
+                                    icon: "mappin.and.ellipse"
+                                )
+                            } else {
+                                Button {
+                                    resolveCurrentLocation()
+                                } label: {
+                                    locationRow(
+                                        title: currentLocation.isResolving ? "Finding your city..." : "Use Current Location",
+                                        subtitle: "Ascend saves only your city, region, and country.",
+                                        icon: "location.fill"
+                                    )
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(currentLocation.isResolving || citySearch.isResolving)
+
+                                ForEach(citySearch.suggestions) { suggestion in
+                                    ProfileCardDivider()
+                                    Button {
+                                        resolve(suggestion)
+                                    } label: {
+                                        locationRow(
+                                            title: suggestion.title,
+                                            subtitle: suggestion.subtitle,
+                                            icon: "mappin"
+                                        )
+                                    }
+                                    .buttonStyle(.plain)
+                                    .disabled(currentLocation.isResolving || citySearch.isResolving)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Button(action: save) {
+                    Group {
+                        if isSaving {
+                            ProgressView()
+                                .tint(.black)
+                        } else {
+                            Text("Save")
+                                .font(.montserratBold(size: 14))
+                        }
+                    }
+                    .foregroundStyle(.black)
+                    .frame(maxWidth: .infinity)
+                    .frame(minHeight: 48)
+                    .background(Capsule().fill(Color.accent))
+                    .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .disabled(selectedLocation == nil || isSaving)
+                .opacity(selectedLocation == nil || isSaving ? 0.45 : 1)
+
+                if let errorMessage = citySearch.errorMessage ?? currentLocation.errorMessage ?? authVM.errorMessage {
+                    Text(errorMessage)
+                        .font(.montserratRegular(size: 14))
+                        .foregroundStyle(.red.opacity(0.9))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+            .padding(.bottom, 40)
+        }
+        .themedBackground()
+        .navigationTitle("Location")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
+        .keyboardDoneToolbar {
+            isSearchFocused = false
+        }
+        .onAppear {
+            if citySearch.query.isEmpty, let selectedLocation {
+                citySearch.setSelectedLocation(selectedLocation)
+            }
+        }
+        .onChange(of: citySearch.query) { _, newValue in
+            currentLocation.clearError()
+            guard let selectedLocation, newValue != selectedLocation.profileDisplayText else { return }
+            self.selectedLocation = nil
+        }
+    }
+
+    private func locationRow(title: String, subtitle: String, icon: String) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: icon)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(.accent)
+                .frame(width: 24, height: 24)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.montserratMedium(size: 16))
+                    .foregroundStyle(.white)
+                Text(subtitle)
+                    .font(.montserratRegular(size: 12))
+                    .foregroundStyle(.white.opacity(0.58))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .frame(minHeight: 56)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+
+    private func resolve(_ suggestion: PostAuthCitySearchSuggestion) {
+        isSearchFocused = false
+        Task { @MainActor in
+            guard let location = await citySearch.resolve(suggestion) else { return }
+            selectedLocation = location
+        }
+    }
+
+    private func resolveCurrentLocation() {
+        isSearchFocused = false
+        Task { @MainActor in
+            guard let location = await currentLocation.resolve() else { return }
+            selectedLocation = location
+            citySearch.setSelectedLocation(location)
+        }
+    }
+
+    private func save() {
+        guard !isSaving, let selectedLocation else { return }
+
+        Task { @MainActor in
+            isSaving = true
+            let didSave = await authVM.updateOnboardingLocation(
+                city: selectedLocation.city,
+                countryCode: selectedLocation.countryCode,
+                region: selectedLocation.region
+            )
+            isSaving = false
+            if didSave {
+                dismiss()
+            }
+        }
+    }
+}

--- a/AscendApp/Features/Account/Views/ProfileLocationEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileLocationEditorView.swift
@@ -127,6 +127,7 @@ struct ProfileLocationEditorView: View {
             isSearchFocused = false
         }
         .onAppear {
+            authVM.errorMessage = nil
             if citySearch.query.isEmpty, let selectedLocation {
                 citySearch.setSelectedLocation(selectedLocation)
             }

--- a/AscendApp/Features/Account/Views/ProfileLocationEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileLocationEditorView.swift
@@ -9,6 +9,7 @@ struct ProfileLocationEditorView: View {
 
     @State private var selectedLocation: PostAuthLocationSelection?
     @State private var isSaving = false
+    @State private var saveErrorMessage: String?
 
     init(city: String?, region: String?, countryCode: String?) {
         let normalizedCity = city?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -108,7 +109,7 @@ struct ProfileLocationEditorView: View {
                 .disabled(selectedLocation == nil || isSaving)
                 .opacity(selectedLocation == nil || isSaving ? 0.45 : 1)
 
-                if let errorMessage = citySearch.errorMessage ?? currentLocation.errorMessage ?? authVM.errorMessage {
+                if let errorMessage = citySearch.errorMessage ?? currentLocation.errorMessage ?? saveErrorMessage {
                     Text(errorMessage)
                         .font(.montserratRegular(size: 14))
                         .foregroundStyle(.red.opacity(0.9))
@@ -127,7 +128,6 @@ struct ProfileLocationEditorView: View {
             isSearchFocused = false
         }
         .onAppear {
-            authVM.errorMessage = nil
             if citySearch.query.isEmpty, let selectedLocation {
                 citySearch.setSelectedLocation(selectedLocation)
             }
@@ -188,13 +188,17 @@ struct ProfileLocationEditorView: View {
 
         Task { @MainActor in
             isSaving = true
-            let didSave = await authVM.updateOnboardingLocation(
-                city: selectedLocation.city,
-                countryCode: selectedLocation.countryCode,
-                region: selectedLocation.region
-            )
+            saveErrorMessage = await authVM.scopedProfileUpdate(
+                fallback: "Failed to update location"
+            ) {
+                await authVM.updateOnboardingLocation(
+                    city: selectedLocation.city,
+                    countryCode: selectedLocation.countryCode,
+                    region: selectedLocation.region
+                )
+            }
             isSaving = false
-            if didSave {
+            if saveErrorMessage == nil {
                 dismiss()
             }
         }

--- a/AscendApp/Features/Account/Views/ProfileNameEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileNameEditorView.swift
@@ -9,12 +9,22 @@ struct ProfileNameEditorView: View {
     @State private var firstName: String
     @State private var lastName: String
     @State private var isSaving = false
-    @FocusState private var isFocused: Bool
+    @FocusState private var focusedField: ProfileNameField?
+
+    // A climber who signed up before the split fields existed has neither on
+    // record. Editing one alone would compose a half board name, so the missing
+    // counterpart is collected here rather than left for a second visit that
+    // the both-required rule would block anyway.
+    private let requiresCounterpart: Bool
 
     init(field: ProfileNameField, firstName: String, lastName: String) {
         self.field = field
         _firstName = State(initialValue: firstName)
         _lastName = State(initialValue: lastName)
+        let counterpart = field == .firstName ? lastName : firstName
+        requiresCounterpart = counterpart
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty
     }
 
     var body: some View {
@@ -22,19 +32,22 @@ struct ProfileNameEditorView: View {
             VStack(spacing: 24) {
                 ProfileSection(title: "Profile") {
                     ProfileCardSurface {
-                        TextField(field.rawValue, text: editedName)
-                            .font(.montserratRegular(size: 16))
-                            .foregroundStyle(.white)
-                            .tint(.accent)
-                            .textInputAutocapitalization(.words)
-                            .autocorrectionDisabled()
-                            .submitLabel(.done)
-                            .focused($isFocused)
-                            .padding(.horizontal, 20)
-                            .frame(minHeight: 56)
-                            .onSubmit(save)
-                            .accessibilityLabel(field.rawValue)
+                        VStack(spacing: 0) {
+                            nameField(for: field)
+
+                            if requiresCounterpart {
+                                ProfileCardDivider(leadingInset: 20)
+                                nameField(for: field.counterpart)
+                            }
+                        }
                     }
+                }
+
+                if requiresCounterpart {
+                    Text("Your board name is your first and last name together. Enter both.")
+                        .font(.montserratRegular(size: 13))
+                        .foregroundStyle(.white.opacity(0.6))
+                        .multilineTextAlignment(.center)
                 }
 
                 Button(action: save) {
@@ -73,14 +86,30 @@ struct ProfileNameEditorView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
         .keyboardDoneToolbar {
-            isFocused = false
+            focusedField = nil
         }
         .onAppear {
-            isFocused = true
+            authVM.errorMessage = nil
+            focusedField = field
         }
     }
 
-    private var editedName: Binding<String> {
+    private func nameField(for field: ProfileNameField) -> some View {
+        TextField(field.rawValue, text: binding(for: field))
+            .font(.montserratRegular(size: 16))
+            .foregroundStyle(.white)
+            .tint(.accent)
+            .textInputAutocapitalization(.words)
+            .autocorrectionDisabled()
+            .submitLabel(.done)
+            .focused($focusedField, equals: field)
+            .padding(.horizontal, 20)
+            .frame(minHeight: 56)
+            .onSubmit(save)
+            .accessibilityLabel(field.rawValue)
+    }
+
+    private func binding(for field: ProfileNameField) -> Binding<String> {
         switch field {
         case .firstName:
             $firstName
@@ -90,16 +119,15 @@ struct ProfileNameEditorView: View {
     }
 
     private var canSave: Bool {
-        let composedName = [firstName, lastName]
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: " ")
-        return !isSaving && !composedName.isEmpty && composedName.count <= 80
+        !isSaving && DisplayNamePolicy.composesAllowedBoardName(
+            firstName: firstName,
+            lastName: lastName
+        )
     }
 
     private func save() {
         guard canSave else { return }
-        isFocused = false
+        focusedField = nil
 
         Task { @MainActor in
             isSaving = true

--- a/AscendApp/Features/Account/Views/ProfileNameEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileNameEditorView.swift
@@ -9,6 +9,7 @@ struct ProfileNameEditorView: View {
     @State private var firstName: String
     @State private var lastName: String
     @State private var isSaving = false
+    @State private var errorMessage: String?
     @FocusState private var focusedField: ProfileNameField?
 
     // A climber who signed up before the split fields existed has neither on
@@ -70,7 +71,7 @@ struct ProfileNameEditorView: View {
                 .disabled(!canSave)
                 .opacity(canSave ? 1 : 0.45)
 
-                if let errorMessage = authVM.errorMessage {
+                if let errorMessage {
                     Text(errorMessage)
                         .font(.montserratRegular(size: 14))
                         .foregroundStyle(.red.opacity(0.9))
@@ -89,7 +90,6 @@ struct ProfileNameEditorView: View {
             focusedField = nil
         }
         .onAppear {
-            authVM.errorMessage = nil
             focusedField = field
         }
     }
@@ -131,12 +131,16 @@ struct ProfileNameEditorView: View {
 
         Task { @MainActor in
             isSaving = true
-            let didSave = await authVM.updateProfileName(
-                firstName: firstName,
-                lastName: lastName
-            )
+            errorMessage = await authVM.scopedProfileUpdate(
+                fallback: "Failed to update name"
+            ) {
+                await authVM.updateProfileName(
+                    firstName: firstName,
+                    lastName: lastName
+                )
+            }
             isSaving = false
-            if didSave {
+            if errorMessage == nil {
                 dismiss()
             }
         }

--- a/AscendApp/Features/Account/Views/ProfileNameEditorView.swift
+++ b/AscendApp/Features/Account/Views/ProfileNameEditorView.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct ProfileNameEditorView: View {
+    @Environment(AuthenticationViewModel.self) private var authVM
+    @Environment(\.dismiss) private var dismiss
+
+    let field: ProfileNameField
+
+    @State private var firstName: String
+    @State private var lastName: String
+    @State private var isSaving = false
+    @FocusState private var isFocused: Bool
+
+    init(field: ProfileNameField, firstName: String, lastName: String) {
+        self.field = field
+        _firstName = State(initialValue: firstName)
+        _lastName = State(initialValue: lastName)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                ProfileSection(title: "Profile") {
+                    ProfileCardSurface {
+                        TextField(field.rawValue, text: editedName)
+                            .font(.montserratRegular(size: 16))
+                            .foregroundStyle(.white)
+                            .tint(.accent)
+                            .textInputAutocapitalization(.words)
+                            .autocorrectionDisabled()
+                            .submitLabel(.done)
+                            .focused($isFocused)
+                            .padding(.horizontal, 20)
+                            .frame(minHeight: 56)
+                            .onSubmit(save)
+                            .accessibilityLabel(field.rawValue)
+                    }
+                }
+
+                Button(action: save) {
+                    Group {
+                        if isSaving {
+                            ProgressView()
+                                .tint(.black)
+                        } else {
+                            Text("Save")
+                                .font(.montserratBold(size: 14))
+                        }
+                    }
+                    .foregroundStyle(.black)
+                    .frame(maxWidth: .infinity)
+                    .frame(minHeight: 48)
+                    .background(Capsule().fill(Color.accent))
+                    .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSave)
+                .opacity(canSave ? 1 : 0.45)
+
+                if let errorMessage = authVM.errorMessage {
+                    Text(errorMessage)
+                        .font(.montserratRegular(size: 14))
+                        .foregroundStyle(.red.opacity(0.9))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+            .padding(.bottom, 40)
+        }
+        .themedBackground()
+        .navigationTitle(field.rawValue)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
+        .keyboardDoneToolbar {
+            isFocused = false
+        }
+        .onAppear {
+            isFocused = true
+        }
+    }
+
+    private var editedName: Binding<String> {
+        switch field {
+        case .firstName:
+            $firstName
+        case .lastName:
+            $lastName
+        }
+    }
+
+    private var canSave: Bool {
+        let composedName = [firstName, lastName]
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        return !isSaving && !composedName.isEmpty && composedName.count <= 80
+    }
+
+    private func save() {
+        guard canSave else { return }
+        isFocused = false
+
+        Task { @MainActor in
+            isSaving = true
+            let didSave = await authVM.updateProfileName(
+                firstName: firstName,
+                lastName: lastName
+            )
+            isSaving = false
+            if didSave {
+                dismiss()
+            }
+        }
+    }
+}

--- a/AscendApp/Features/Authentication/AuthenticationViewModel.swift
+++ b/AscendApp/Features/Authentication/AuthenticationViewModel.swift
@@ -406,7 +406,8 @@ extension AuthenticationViewModel {
             firstName: existingData?.firstName,
             lastName: existingData?.lastName,
             displayName: existingData?.displayName,
-            age: existingData?.age,
+            age: existingData?.legacyAge,
+            birthday: existingData?.birthday,
             gender: existingData?.gender,
             weightKg: existingData?.weightKg,
             heightCm: existingData?.heightCm,
@@ -546,7 +547,7 @@ extension AuthenticationViewModel {
     }
 
     @discardableResult
-    func updateOnboardingProfile(displayName newDisplayName: String, age: Int, gender: ProfileGender) async -> Bool {
+    func updateProfileName(firstName: String, lastName: String) async -> Bool {
         errorMessage = nil
 
         guard let user else {
@@ -554,8 +555,59 @@ extension AuthenticationViewModel {
             return false
         }
 
-        guard (13...120).contains(age) else {
-            errorMessage = "Enter an age from 13 to 120"
+        let normalizedFirstName = firstName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedLastName = lastName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedFirstName.count <= 80, normalizedLastName.count <= 80 else {
+            errorMessage = "Names must be 80 characters or fewer"
+            return false
+        }
+
+        let previousDisplayName = displayName
+
+        do {
+            let composedDisplayName = try DisplayNamePolicy.validated(
+                [normalizedFirstName, normalizedLastName]
+                    .filter { !$0.isEmpty }
+                    .joined(separator: " ")
+            )
+            displayName = composedDisplayName
+
+            try await authenticationService.updateUserDisplayName(
+                displayName: composedDisplayName
+            )
+            try await UserDataRepository.shared.updateProfileName(
+                userId: user.uid,
+                email: user.email,
+                firstName: normalizedFirstName,
+                lastName: normalizedLastName
+            )
+            hasRemoteDisplayName = true
+            return true
+        } catch {
+            displayName = previousDisplayName
+            errorMessage = profileUpdateFailureMessage(
+                error,
+                fallback: "Failed to update name"
+            )
+            return false
+        }
+    }
+
+    @discardableResult
+    func updateOnboardingProfile(
+        displayName newDisplayName: String,
+        birthday: ProfileBirthday,
+        gender: ProfileGender
+    ) async -> Bool {
+        errorMessage = nil
+
+        guard let user else {
+            errorMessage = "User not authenticated"
+            return false
+        }
+
+        guard birthday.hasValidProfileAge() else {
+            errorMessage = "Choose a birthday for an age from 13 to 120"
             return false
         }
 
@@ -575,7 +627,7 @@ extension AuthenticationViewModel {
                 userId: user.uid,
                 email: user.email,
                 displayName: validatedDisplayName,
-                age: age,
+                birthday: birthday,
                 gender: gender
             )
             hasRemoteDisplayName = true
@@ -615,7 +667,7 @@ extension AuthenticationViewModel {
     }
 
     @discardableResult
-    func updateOnboardingAge(_ age: Int) async -> Bool {
+    func updateOnboardingBirthday(_ birthday: ProfileBirthday) async -> Bool {
         errorMessage = nil
 
         guard let user else {
@@ -623,8 +675,8 @@ extension AuthenticationViewModel {
             return false
         }
 
-        guard (13...120).contains(age) else {
-            errorMessage = "Enter an age from 13 to 120"
+        guard birthday.hasValidProfileAge() else {
+            errorMessage = "Choose a birthday for an age from 13 to 120"
             return false
         }
 
@@ -633,11 +685,41 @@ extension AuthenticationViewModel {
                 userId: user.uid,
                 email: user.email,
                 displayName: displayName,
-                age: age
+                birthday: birthday
             )
             return true
         } catch {
             errorMessage = "Failed to update profile: \(error.localizedDescription)"
+            return false
+        }
+    }
+
+    @discardableResult
+    func updateBirthday(_ birthday: ProfileBirthday) async -> Bool {
+        errorMessage = nil
+
+        guard let user else {
+            errorMessage = "User not authenticated"
+            return false
+        }
+
+        guard birthday.hasValidProfileAge() else {
+            errorMessage = "Choose a birthday for an age from 13 to 120"
+            return false
+        }
+
+        do {
+            try await UserDataRepository.shared.updateBirthday(
+                userId: user.uid,
+                email: user.email,
+                birthday: birthday
+            )
+            return true
+        } catch {
+            errorMessage = profileUpdateFailureMessage(
+                error,
+                fallback: "Failed to update birthday"
+            )
             return false
         }
     }

--- a/AscendApp/Features/Authentication/AuthenticationViewModel.swift
+++ b/AscendApp/Features/Authentication/AuthenticationViewModel.swift
@@ -498,6 +498,23 @@ extension AuthenticationViewModel {
         return "\(fallback): \(error.localizedDescription)"
     }
 
+    /// Runs a profile mutation and hands its failure back to the caller instead
+    /// of leaving it on `errorMessage`.
+    ///
+    /// `errorMessage` is app-wide: the Settings root renders it inline, so a
+    /// message a pushed editor left behind follows the climber back out and
+    /// sits there under an unrelated screen.
+    func scopedProfileUpdate(
+        fallback: String,
+        _ update: () async -> Bool
+    ) async -> String? {
+        errorMessage = nil
+        let didSucceed = await update()
+        let failure = errorMessage
+        errorMessage = nil
+        return didSucceed ? nil : (failure ?? fallback)
+    }
+
     var displayPhotoURL: URL? {
         // Prioritize custom profile picture, then fall back to OAuth provider photo
         return customProfilePictureURL ?? photoURL

--- a/AscendApp/Features/Authentication/AuthenticationViewModel.swift
+++ b/AscendApp/Features/Authentication/AuthenticationViewModel.swift
@@ -557,18 +557,12 @@ extension AuthenticationViewModel {
 
         let normalizedFirstName = firstName.trimmingCharacters(in: .whitespacesAndNewlines)
         let normalizedLastName = lastName.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard normalizedFirstName.count <= 80, normalizedLastName.count <= 80 else {
-            errorMessage = "Names must be 80 characters or fewer"
-            return false
-        }
-
         let previousDisplayName = displayName
 
         do {
-            let composedDisplayName = try DisplayNamePolicy.validated(
-                [normalizedFirstName, normalizedLastName]
-                    .filter { !$0.isEmpty }
-                    .joined(separator: " ")
+            let composedDisplayName = try DisplayNamePolicy.composedBoardName(
+                firstName: normalizedFirstName,
+                lastName: normalizedLastName
             )
             displayName = composedDisplayName
 

--- a/AscendApp/Features/Authentication/UserDataRepository.swift
+++ b/AscendApp/Features/Authentication/UserDataRepository.swift
@@ -362,10 +362,9 @@ final class UserDataRepository: Sendable {
         firstName: String,
         lastName: String
     ) async throws {
-        let displayName = try DisplayNamePolicy.validated(
-            [firstName, lastName]
-                .filter { !$0.isEmpty }
-                .joined(separator: " ")
+        let displayName = try DisplayNamePolicy.composedBoardName(
+            firstName: firstName,
+            lastName: lastName
         )
         try await updateUserAndPublicProfile(
             userId: userId,

--- a/AscendApp/Features/Authentication/UserDataRepository.swift
+++ b/AscendApp/Features/Authentication/UserDataRepository.swift
@@ -13,7 +13,8 @@ struct UserDisplayNameData: Sendable {
     let lastName: String?
     let displayName: String?
     let profilePictureURL: String?
-    let age: Int?
+    let birthday: ProfileBirthday?
+    let legacyAge: Int?
     let gender: String?
     let weightKg: Double?
     let heightCm: Double?
@@ -28,12 +29,13 @@ struct UserDisplayNameData: Sendable {
         self.lastName = data?["lastName"] as? String
         self.displayName = data?["displayName"] as? String
         self.profilePictureURL = data?["profilePictureURL"] as? String
+        self.birthday = (data?["birth_date"] as? String).flatMap(ProfileBirthday.init(rawValue:))
         if let age = data?["age"] as? Int {
-            self.age = age
+            self.legacyAge = age
         } else if let age = data?["age"] as? NSNumber {
-            self.age = age.intValue
+            self.legacyAge = age.intValue
         } else {
-            self.age = nil
+            self.legacyAge = nil
         }
         self.gender = data?["gender"] as? String
         if let weightKg = data?["weight_kg"] as? Double {
@@ -61,6 +63,22 @@ struct UserDisplayNameData: Sendable {
         } else {
             self.joinedAt = nil
         }
+    }
+
+    var age: Int? {
+        age(on: .now)
+    }
+
+    func age(on date: Date, calendar: Calendar = .current) -> Int? {
+        if let derivedAge = birthday?.age(on: date, calendar: calendar),
+           ProfileBirthday.validAgeRange.contains(derivedAge) {
+            return derivedAge
+        }
+
+        guard let legacyAge, ProfileBirthday.validAgeRange.contains(legacyAge) else {
+            return nil
+        }
+        return legacyAge
     }
 }
 
@@ -131,6 +149,7 @@ final class UserDataRepository: Sendable {
         displayName: String?,
         profilePictureURL: String? = nil,
         age: Int? = nil,
+        birthday: ProfileBirthday? = nil,
         gender: String? = nil,
         weightKg: Double? = nil,
         heightCm: Double? = nil,
@@ -172,6 +191,10 @@ final class UserDataRepository: Sendable {
 
             if let age {
                 newData["age"] = age
+            }
+
+            if let birthday {
+                newData["birth_date"] = birthday.rawValue
             }
 
             if let gender {
@@ -256,6 +279,10 @@ final class UserDataRepository: Sendable {
                 userData["age"] = age
             }
 
+            if let birthday {
+                userData["birth_date"] = birthday.rawValue
+            }
+
             if let gender {
                 userData["gender"] = gender
             }
@@ -329,11 +356,47 @@ final class UserDataRepository: Sendable {
         cacheDisplayName(displayName)
     }
 
+    func updateProfileName(
+        userId: String,
+        email: String? = nil,
+        firstName: String,
+        lastName: String
+    ) async throws {
+        let displayName = try DisplayNamePolicy.validated(
+            [firstName, lastName]
+                .filter { !$0.isEmpty }
+                .joined(separator: " ")
+        )
+        try await updateUserAndPublicProfile(
+            userId: userId,
+            email: email,
+            userFields: [
+                "firstName": firstName,
+                "lastName": lastName,
+                "displayName": displayName
+            ],
+            alwaysPublish: true
+        )
+        cacheDisplayName(displayName)
+    }
+
+    func updateBirthday(
+        userId: String,
+        email: String? = nil,
+        birthday: ProfileBirthday
+    ) async throws {
+        try await updateOnboardingDemographics(
+            userId: userId,
+            email: email,
+            birthday: birthday
+        )
+    }
+
     func updateOnboardingProfile(
         userId: String,
         email: String? = nil,
         displayName: String,
-        age: Int,
+        birthday: ProfileBirthday,
         gender: ProfileGender
     ) async throws {
         let displayName = try DisplayNamePolicy.validated(displayName)
@@ -342,7 +405,8 @@ final class UserDataRepository: Sendable {
             email: email,
             userFields: [
                 "displayName": displayName,
-                "age": age,
+                "birth_date": birthday.rawValue,
+                "age": FieldValue.delete(),
                 "gender": gender.rawValue
             ],
             alwaysPublish: true
@@ -354,7 +418,7 @@ final class UserDataRepository: Sendable {
         userId: String,
         email: String? = nil,
         displayName: String? = nil,
-        age: Int? = nil,
+        birthday: ProfileBirthday? = nil,
         gender: ProfileGender? = nil,
         weightKg: Double? = nil,
         heightCm: Double? = nil,
@@ -368,8 +432,9 @@ final class UserDataRepository: Sendable {
         if let displayName {
             userFields["displayName"] = displayName
         }
-        if let age {
-            userFields["age"] = age
+        if let birthday {
+            userFields["birth_date"] = birthday.rawValue
+            userFields["age"] = FieldValue.delete()
         }
         if let gender {
             userFields["gender"] = gender.rawValue
@@ -510,9 +575,11 @@ final class UserDataRepository: Sendable {
         }
     }
 
-    private static func publicIdentity(
+    static func publicIdentity(
         userId: String,
-        userData: [String: Any]
+        userData: [String: Any],
+        asOf date: Date = .now,
+        calendar: Calendar = .current
     ) throws -> ProfileUserIdentity {
         let storedProfile = UserDisplayNameData(userData)
         let publicIdentity = PublicClimberIdentity.resolve(
@@ -525,7 +592,7 @@ final class UserDataRepository: Sendable {
             userId: userId,
             displayName: try DisplayNamePolicy.validated(publicIdentity.displayName),
             photoURL: publicIdentity.photoURL,
-            age: storedProfile.age,
+            age: storedProfile.age(on: date, calendar: calendar),
             gender: storedProfile.gender.flatMap(ProfileGender.init(rawValue:)),
             weightKg: storedProfile.weightKg,
             heightCm: storedProfile.heightCm,

--- a/AscendApp/Features/Onboarding/Models/PostAuthOnboardingStage.swift
+++ b/AscendApp/Features/Onboarding/Models/PostAuthOnboardingStage.swift
@@ -86,7 +86,7 @@ enum PostAuthOnboardingStage: String, CaseIterable, Codable, Identifiable {
         case .gender:
             return "single_select"
         case .age:
-            return "number"
+            return "date"
         case .weight:
             return "measurement"
         case .location:

--- a/AscendApp/Features/Onboarding/ViewModels/PostAuthCitySearchModel.swift
+++ b/AscendApp/Features/Onboarding/ViewModels/PostAuthCitySearchModel.swift
@@ -30,6 +30,13 @@ struct PostAuthLocationSelection: Equatable, Sendable {
         return "\(city), \(countryName)"
     }
 
+    init(city: String, region: String?, countryCode: String, countryName: String) {
+        self.city = city
+        self.region = region
+        self.countryCode = countryCode
+        self.countryName = countryName
+    }
+
     init?(placemark: CLPlacemark) {
         guard let city = placemark.locality?.trimmedLocationText,
               !city.isEmpty,

--- a/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
+++ b/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
@@ -31,7 +31,7 @@ struct PostAuthOnboardingFlowView: View {
                     onContinue: onContinue
                 )
             case .age:
-                PostAuthAgeScreen(
+                PostAuthBirthdayScreen(
                     stage: stage,
                     onBack: onBack,
                     onContinue: onContinue
@@ -385,35 +385,35 @@ private struct PostAuthGenderScreen: View {
     }
 }
 
-private struct PostAuthAgeScreen: View {
+private struct PostAuthBirthdayScreen: View {
     @Environment(AuthenticationViewModel.self) private var authVM
 
     let stage: PostAuthOnboardingStage
     let onBack: () -> Void
     let onContinue: () -> Void
 
-    @State private var selectedAge = 32
+    @State private var selectedBirthday = Calendar.current.date(
+        byAdding: .year,
+        value: -32,
+        to: .now
+    ) ?? .now
     @State private var isSaving = false
 
     var body: some View {
         PostAuthProfileQuestionShell(
             stage: stage,
-            headline: "How old are you?",
-            subtitle: "Age keeps leaderboard context honest",
+            headline: "When were you born?",
+            subtitle: "Your age keeps leaderboard context honest",
             primaryTitle: isSaving ? "SAVING..." : "CONTINUE",
             isContinueEnabled: !isSaving,
             onBack: onBack,
-            onContinue: saveAge
+            onContinue: saveBirthday
         ) { metrics in
             VStack(spacing: metrics.height(12)) {
-                PostAuthAgeWheelPicker(
-                    selectedAge: $selectedAge,
+                PostAuthBirthdayWheelPicker(
+                    selectedBirthday: $selectedBirthday,
                     metrics: metrics
                 )
-
-                Text("13 - 120")
-                    .font(.montserratBold(size: metrics.font(8)))
-                    .foregroundStyle(.white.opacity(0.54))
 
                 if let message = authVM.errorMessage {
                     Text(message)
@@ -428,20 +428,26 @@ private struct PostAuthAgeScreen: View {
         }
     }
 
-    private func saveAge() {
+    private func saveBirthday() {
         guard !isSaving else { return }
 
         Task { @MainActor in
+            let birthday = ProfileBirthday(date: selectedBirthday)
+            guard let age = birthday.age(), ProfileBirthday.validAgeRange.contains(age) else {
+                authVM.errorMessage = "Choose a birthday for an age from 13 to 120"
+                return
+            }
+
             isSaving = true
-            let didSave = await authVM.updateOnboardingAge(selectedAge)
+            let didSave = await authVM.updateOnboardingBirthday(birthday)
             isSaving = false
 
             if didSave {
                 TelemetryManager.shared.setUserProperty("age_inputted", value: "true")
-                OnboardingAnalyticsUserProperties.setAgeGroup(age: selectedAge)
+                OnboardingAnalyticsUserProperties.setAgeGroup(age: age)
                 trackPostAuthInput(
                     stage: stage,
-                    properties: ["profile_age_group": .string(OnboardingAnalyticsUserProperties.ageGroupValue(for: selectedAge))]
+                    properties: ["profile_age_group": .string(OnboardingAnalyticsUserProperties.ageGroupValue(for: age))]
                 )
                 onContinue()
             }
@@ -1734,38 +1740,37 @@ private struct PostAuthBodyMetricColumn<Content: View>: View {
     }
 }
 
-private struct PostAuthAgeWheelPicker: View {
-    @Binding var selectedAge: Int
+private struct PostAuthBirthdayWheelPicker: View {
+    @Binding var selectedBirthday: Date
     let metrics: PostAuthProfileMetrics
-
-    private let ageRange = Array(13...120)
 
     var body: some View {
         ZStack {
-            Picker("Age", selection: $selectedAge) {
-                ForEach(ageRange, id: \.self) { age in
-                    Text(age.formatted())
-                        .font(.montserratBold(size: metrics.font(34)))
-                        .foregroundStyle(.white)
-                        .monospacedDigit()
-                        .tag(age)
-                }
-            }
+            DatePicker(
+                "Birthday",
+                selection: $selectedBirthday,
+                in: allowedRange,
+                displayedComponents: .date
+            )
             .pickerStyle(.wheel)
             .labelsHidden()
-            .frame(width: metrics.width(142), height: metrics.height(150))
+            .frame(width: metrics.width(320), height: metrics.height(200))
             .clipped()
             .colorScheme(.dark)
-
-            RoundedRectangle(cornerRadius: metrics.radius(8), style: .continuous)
-                .stroke(OnboardingValuePalette.lime.opacity(0.9), lineWidth: 1)
-                .allowsHitTesting(false)
         }
-        .frame(width: metrics.width(150), height: metrics.height(156), alignment: .center)
+        .frame(width: metrics.width(320), height: metrics.height(200), alignment: .center)
         .background(PostAuthProfilePalette.fieldBackground)
         .clipShape(RoundedRectangle(cornerRadius: metrics.radius(8), style: .continuous))
-        .accessibilityLabel("Age")
-        .accessibilityValue("\(selectedAge)")
+        .accessibilityLabel("Birthday")
+        .accessibilityValue(selectedBirthday.formatted(date: .long, time: .omitted))
+    }
+
+    private var allowedRange: ClosedRange<Date> {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: .now)
+        let oldest = calendar.date(byAdding: .year, value: -120, to: today) ?? today
+        let youngest = calendar.date(byAdding: .year, value: -13, to: today) ?? today
+        return oldest...youngest
     }
 }
 

--- a/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
+++ b/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
@@ -1752,7 +1752,7 @@ private struct PostAuthBirthdayWheelPicker: View {
                 in: allowedRange,
                 displayedComponents: .date
             )
-            .pickerStyle(.wheel)
+            .datePickerStyle(.wheel)
             .labelsHidden()
             .frame(width: metrics.width(320), height: metrics.height(200))
             .clipped()

--- a/AscendApp/Features/Profile/Services/DisplayNamePolicy.swift
+++ b/AscendApp/Features/Profile/Services/DisplayNamePolicy.swift
@@ -90,6 +90,23 @@ enum DisplayNamePolicy {
         (try? validated(candidate)) != nil
     }
 
+    /// The public board name a climber's two required name halves compose into.
+    ///
+    /// Both halves are required: composing from one would republish a partial
+    /// name over the one a legacy climber already ranks under.
+    static func composedBoardName(firstName: String, lastName: String) throws -> String {
+        let first = firstName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let last = lastName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !first.isEmpty, !last.isEmpty else {
+            throw DisplayNamePolicyError.incompleteName
+        }
+        return try validated("\(first) \(last)")
+    }
+
+    static func composesAllowedBoardName(firstName: String, lastName: String) -> Bool {
+        (try? composedBoardName(firstName: firstName, lastName: lastName)) != nil
+    }
+
     /// Case, diacritic, and confusable-letter folding only.
     ///
     /// Digits stay digits here so the repeated-character check cannot invent a

--- a/AscendApp/Features/Profile/Services/DisplayNamePolicyError.swift
+++ b/AscendApp/Features/Profile/Services/DisplayNamePolicyError.swift
@@ -2,12 +2,15 @@ import Foundation
 
 enum DisplayNamePolicyError: LocalizedError {
     case invalidLength
+    case incompleteName
     case objectionable
 
     var errorDescription: String? {
         switch self {
         case .invalidLength:
             "Enter a display name from 1 to \(DisplayNamePolicy.maximumLength) characters."
+        case .incompleteName:
+            "Enter both a first and last name."
         case .objectionable:
             "Choose a different display name."
         }

--- a/AscendApp/PrivacyInfo.xcprivacy
+++ b/AscendApp/PrivacyInfo.xcprivacy
@@ -89,10 +89,11 @@
         </dict>
 
         <!--
-          Other Data Types - declared gender or division and age band, the
-          notification preference, the first-climb result fields, and the
-          leaderboard age-group filter. The onboarding fitness answers belong to
-          the Fitness declaration below, not here.
+          Other Data Types - private birth date, derived age band, declared
+          gender or division, the notification preference, the first-climb
+          result fields, and the leaderboard age-group filter. The exact birth
+          date is never sent to analytics. The onboarding fitness answers belong
+          to the Fitness declaration below, not here.
         -->
         <dict>
             <key>NSPrivacyCollectedDataType</key>

--- a/AscendApp/Shared/Models/AppIconToken.swift
+++ b/AscendApp/Shared/Models/AppIconToken.swift
@@ -36,6 +36,9 @@ enum AppIconToken: Hashable, Sendable {
     case settingsNotifications
     case settingsRestorePurchases
     case settingsBlockedClimbers
+    case profileBirthday
+    case profileGender
+    case profileWeight
 
     case disclosureChevronRight
     case bestEffortTrophy
@@ -104,6 +107,12 @@ enum AppIconToken: Hashable, Sendable {
             return .systemSymbol("arrow.clockwise")
         case .settingsBlockedClimbers:
             return .systemSymbol("person.crop.circle.badge.xmark")
+        case .profileBirthday:
+            return .systemSymbol("calendar")
+        case .profileGender:
+            return .systemSymbol("person.crop.circle")
+        case .profileWeight:
+            return .systemSymbol("scalemass")
 
         case .disclosureChevronRight:
             return .asset("ph-disclosure-chevron-right")

--- a/AscendApp/Shared/Models/ProfileBirthday.swift
+++ b/AscendApp/Shared/Models/ProfileBirthday.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// A calendar birthday, stored without a time zone so travel can never move it to another day.
+struct ProfileBirthday: Codable, Hashable, RawRepresentable, Sendable {
+    static let validAgeRange = 13...120
+
+    let year: Int
+    let month: Int
+    let day: Int
+
+    var rawValue: String {
+        String(format: "%04d-%02d-%02d", year, month, day)
+    }
+
+    init?(rawValue: String) {
+        let components = rawValue.split(separator: "-", omittingEmptySubsequences: false)
+        guard components.count == 3,
+              components[0].count == 4,
+              components[1].count == 2,
+              components[2].count == 2,
+              let year = Int(components[0]),
+              let month = Int(components[1]),
+              let day = Int(components[2]),
+              Self.isValid(year: year, month: month, day: day) else {
+            return nil
+        }
+
+        self.year = year
+        self.month = month
+        self.day = day
+    }
+
+    init(date: Date, calendar: Calendar = .current) {
+        let components = calendar.dateComponents([.year, .month, .day], from: date)
+        precondition(
+            components.year != nil && components.month != nil && components.day != nil,
+            "A calendar date must contain year, month, and day components."
+        )
+        year = components.year ?? 1970
+        month = components.month ?? 1
+        day = components.day ?? 1
+    }
+
+    func age(on date: Date = .now, calendar: Calendar = .current) -> Int? {
+        let current = calendar.dateComponents([.year, .month, .day], from: date)
+        guard let currentYear = current.year,
+              let currentMonth = current.month,
+              let currentDay = current.day else {
+            return nil
+        }
+
+        let birthdayHasOccurred = currentMonth > month ||
+            (currentMonth == month && currentDay >= day)
+        let age = currentYear - year - (birthdayHasOccurred ? 0 : 1)
+        return age >= 0 ? age : nil
+    }
+
+    func date(calendar: Calendar = .current) -> Date? {
+        calendar.date(
+            from: DateComponents(
+                calendar: calendar,
+                timeZone: calendar.timeZone,
+                year: year,
+                month: month,
+                day: day,
+                hour: 12
+            )
+        )
+    }
+
+    func hasValidProfileAge(on date: Date = .now, calendar: Calendar = .current) -> Bool {
+        guard let age = age(on: date, calendar: calendar) else { return false }
+        return Self.validAgeRange.contains(age)
+    }
+
+    private static func isValid(year: Int, month: Int, day: Int) -> Bool {
+        var calendar = Calendar(identifier: .gregorian)
+        if let utc = TimeZone(secondsFromGMT: 0) {
+            calendar.timeZone = utc
+        }
+        let components = DateComponents(
+            calendar: calendar,
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: 12
+        )
+
+        guard let date = calendar.date(from: components) else { return false }
+        let resolved = calendar.dateComponents([.year, .month, .day], from: date)
+        return resolved.year == year && resolved.month == month && resolved.day == day
+    }
+}

--- a/AscendApp/Shared/Services/HeartRate/HeartRateZoneProfileResolver.swift
+++ b/AscendApp/Shared/Services/HeartRate/HeartRateZoneProfileResolver.swift
@@ -1,7 +1,7 @@
 @preconcurrency import FirebaseAuth
 import Foundation
 
-/// Resolves the signed-in climber's zone profile from their declared age.
+/// Resolves the signed-in climber's zone profile from their birthday-derived age.
 /// Falls back to the age-agnostic default when signed out, the profile has
 /// no age yet, or the fetch fails — zones are display-only, so a fallback
 /// band is always acceptable.

--- a/AscendAppTests/DisplayNamePolicyTests.swift
+++ b/AscendAppTests/DisplayNamePolicyTests.swift
@@ -113,6 +113,41 @@ struct DisplayNamePolicyTests {
         }
     }
 
+    // A legacy climber has neither split field on record. Composing a board
+    // name from one half alone would republish "Maya" over the "Maya Chen"
+    // their standings already carry, so the save has to refuse until both
+    // halves are supplied.
+    @Test
+    func boardNameComposesOnlyFromBothNameHalves() throws {
+        #expect(
+            try DisplayNamePolicy.composedBoardName(
+                firstName: "  Maya ",
+                lastName: " Chen  "
+            ) == "Maya Chen"
+        )
+
+        #expect(throws: DisplayNamePolicyError.incompleteName) {
+            try DisplayNamePolicy.composedBoardName(firstName: "Maya", lastName: "")
+        }
+        #expect(throws: DisplayNamePolicyError.incompleteName) {
+            try DisplayNamePolicy.composedBoardName(firstName: "  ", lastName: "Chen")
+        }
+        #expect(!DisplayNamePolicy.composesAllowedBoardName(firstName: "Maya", lastName: " "))
+        #expect(DisplayNamePolicy.composesAllowedBoardName(firstName: "Maya", lastName: "Chen"))
+    }
+
+    @Test
+    func composedBoardNameCarriesTheScreeningAndLengthBounds() {
+        #expect(!DisplayNamePolicy.composesAllowedBoardName(
+            firstName: "fuck",
+            lastName: "Chen"
+        ))
+        #expect(!DisplayNamePolicy.composesAllowedBoardName(
+            firstName: String(repeating: "A", count: DisplayNamePolicy.maximumLength),
+            lastName: "Chen"
+        ))
+    }
+
     @Test
     @MainActor
     func authenticationRejectsDisplayNameBeforeProfileMutation() async {

--- a/AscendAppTests/ProfileBirthdayTests.swift
+++ b/AscendAppTests/ProfileBirthdayTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+@testable import AscendApp
+
+struct ProfileBirthdayTests {
+    @Test
+    func rawValueRoundTripsOnlyRealCalendarDates() throws {
+        let birthday = try #require(ProfileBirthday(rawValue: "1994-03-14"))
+
+        #expect(birthday.rawValue == "1994-03-14")
+        #expect(ProfileBirthday(rawValue: "1994-02-29") == nil)
+        #expect(ProfileBirthday(rawValue: "not-a-date") == nil)
+    }
+
+    @Test
+    func ageChangesOnTheBirthday() throws {
+        let birthday = try #require(ProfileBirthday(rawValue: "1994-03-14"))
+
+        #expect(birthday.age(on: date(2026, 3, 13), calendar: calendar) == 31)
+        #expect(birthday.age(on: date(2026, 3, 14), calendar: calendar) == 32)
+        #expect(birthday.age(on: date(2026, 8, 4), calendar: calendar) == 32)
+    }
+
+    @Test
+    func leapDayBirthdayDoesNotAdvanceEarly() throws {
+        let birthday = try #require(ProfileBirthday(rawValue: "2000-02-29"))
+
+        #expect(birthday.age(on: date(2025, 2, 28), calendar: calendar) == 24)
+        #expect(birthday.age(on: date(2025, 3, 1), calendar: calendar) == 25)
+    }
+
+    @Test
+    func profileAgeAcceptsTheInclusiveLaunchRange() throws {
+        let today = date(2026, 8, 4)
+        let thirteen = try #require(ProfileBirthday(rawValue: "2013-08-04"))
+        let oneHundredTwenty = try #require(ProfileBirthday(rawValue: "1906-08-04"))
+        let tooYoung = try #require(ProfileBirthday(rawValue: "2013-08-05"))
+        let tooOld = try #require(ProfileBirthday(rawValue: "1905-08-04"))
+
+        #expect(thirteen.hasValidProfileAge(on: today, calendar: calendar))
+        #expect(oneHundredTwenty.hasValidProfileAge(on: today, calendar: calendar))
+        #expect(!tooYoung.hasValidProfileAge(on: today, calendar: calendar))
+        #expect(!tooOld.hasValidProfileAge(on: today, calendar: calendar))
+    }
+
+    @Test
+    func birthdayWinsWhileStoredAgeRemainsALegacyFallback() {
+        let profileWithBirthday = UserDisplayNameData([
+            "birth_date": "1994-03-14",
+            "age": 99
+        ])
+        let legacyProfile = UserDisplayNameData(["age": 41])
+
+        #expect(profileWithBirthday.age(on: date(2026, 8, 4), calendar: calendar) == 32)
+        #expect(legacyProfile.age(on: date(2026, 8, 4), calendar: calendar) == 41)
+    }
+
+    @Test
+    func invalidPrivateBirthdayFallsBackToTheStoredLegacyAge() {
+        let profile = UserDisplayNameData([
+            "birth_date": "1994-02-29",
+            "age": 41
+        ])
+
+        #expect(profile.birthday == nil)
+        #expect(profile.age(on: date(2026, 8, 4), calendar: calendar) == 41)
+    }
+
+    @Test
+    func birthdayNeverEntersThePublicIdentityPayload() throws {
+        let privateData: [String: Any] = [
+            "displayName": "Maya Chen",
+            "birth_date": "1994-03-14"
+        ]
+        let identity = try UserDataRepository.publicIdentity(
+            userId: "user-123",
+            userData: privateData,
+            asOf: date(2026, 8, 4),
+            calendar: calendar
+        )
+        let publication = try ProfileIdentityPersistenceAdapter.validatedFields(for: identity)
+        let payload = ProfileRepository.publicIdentityPayload(
+            identity,
+            publication: publication,
+            advancesIdentityVersion: true
+        )
+
+        #expect(payload["age"] as? Int == 32)
+        #expect(payload["birth_date"] == nil)
+        #expect(payload["birthday"] == nil)
+        #expect(payload["date_of_birth"] == nil)
+    }
+
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        if let utc = TimeZone(secondsFromGMT: 0) {
+            calendar.timeZone = utc
+        }
+        return calendar
+    }
+
+    private func date(_ year: Int, _ month: Int, _ day: Int) -> Date {
+        calendar.date(from: DateComponents(year: year, month: month, day: day, hour: 12)) ?? .distantPast
+    }
+}

--- a/AscendAppTests/ScopedProfileUpdateTests.swift
+++ b/AscendAppTests/ScopedProfileUpdateTests.swift
@@ -1,0 +1,59 @@
+import Testing
+@testable import AscendApp
+
+@MainActor
+struct ScopedProfileUpdateTests {
+    // The Settings root renders `errorMessage` inline. A failure a pushed
+    // editor left on it followed the climber back out and sat under an
+    // unrelated screen, so every profile editor takes its failure by return
+    // value and the shared channel is empty either way.
+    @Test
+    func aFailedUpdateReturnsItsMessageAndLeavesTheSharedChannelEmpty() async {
+        let viewModel = makeViewModel()
+
+        let failure = await viewModel.scopedProfileUpdate(fallback: "Fallback") {
+            viewModel.errorMessage = "Failed to update birthday"
+            return false
+        }
+
+        #expect(failure == "Failed to update birthday")
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test
+    func aSucceedingUpdateReturnsNoMessage() async {
+        let viewModel = makeViewModel()
+
+        let failure = await viewModel.scopedProfileUpdate(fallback: "Fallback") { true }
+
+        #expect(failure == nil)
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    @Test
+    func aSilentFailureStillReportsTheCallerSFallback() async {
+        let viewModel = makeViewModel()
+
+        let failure = await viewModel.scopedProfileUpdate(fallback: "Fallback") { false }
+
+        #expect(failure == "Fallback")
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    // A message left over from an earlier failure would otherwise be handed
+    // back as though the update that just ran had produced it.
+    @Test
+    func anEarlierFailureIsNotMisattributedToTheNextUpdate() async {
+        let viewModel = makeViewModel()
+        viewModel.errorMessage = "Failed to update gender"
+
+        let failure = await viewModel.scopedProfileUpdate(fallback: "Fallback") { true }
+
+        #expect(failure == nil)
+        #expect(viewModel.errorMessage == nil)
+    }
+
+    private func makeViewModel() -> AuthenticationViewModel {
+        AuthenticationViewModel(observesFirebaseAuth: false)
+    }
+}

--- a/AscendAppTests/SettingsReorganizationContractTests.swift
+++ b/AscendAppTests/SettingsReorganizationContractTests.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Testing
+
+struct SettingsReorganizationContractTests {
+    @Test
+    func settingsOwnsPreferencesAndKeepsPrivacyAtTheBottomOfTheCustomerSections() throws {
+        let source = try source(at: "AscendApp/Features/Account/Views/AccountView.swift")
+        let orderedSections = [
+            "sectionView(title: \"Profile\"",
+            "sectionView(title: \"Notifications\"",
+            "sectionView(title: \"Preferences\"",
+            "sectionView(title: \"Subscription\"",
+            "sectionView(title: \"Support\"",
+            "sectionView(title: \"Privacy\""
+        ]
+
+        var previousIndex = source.startIndex
+        for section in orderedSections {
+            let range = try #require(source.range(of: section, range: previousIndex..<source.endIndex))
+            previousIndex = range.upperBound
+        }
+
+        #expect(source.contains("title: \"Push\""))
+        #expect(source.contains("title: \"Email\""))
+        #expect(source.contains("destination: EmailPreferencesView()"))
+        #expect(source.contains("title: \"Units\""))
+        #expect(source.contains("title: \"Integrations\""))
+        #expect(source.contains("title: \"Blocked climbers\""))
+    }
+
+    @Test
+    func settingsEmailRouteUsesTheMergedEmailPreferencesContent() throws {
+        let screen = try source(
+            at: "AscendApp/Features/Account/Views/EmailPreferencesView.swift"
+        )
+
+        #expect(screen.contains("EmailPreferencesContentView(viewModel: viewModel)"))
+        #expect(screen.contains("await viewModel.load()"))
+        #expect(screen.contains(".navigationTitle(\"Email\")"))
+    }
+
+    @Test
+    func settingsRowsUseDisclosureOnlyWithoutPreferenceSummaries() throws {
+        let source = try source(at: "AscendApp/Features/Account/Views/Components/SettingsRow.swift")
+
+        #expect(source.contains(".disclosureChevronRight"))
+        #expect(!source.contains("option.value"))
+        #expect(!source.contains("On/Off"))
+    }
+
+    @Test
+    func editProfileHasExactlyTheSettledGroupedFields() throws {
+        let source = try source(at: "AscendApp/Features/Account/Views/EditProfileView.swift")
+        let requiredTitles = [
+            "First name",
+            "Last name",
+            "Birthday",
+            "Gender",
+            "Height",
+            "Weight",
+            "Location"
+        ]
+
+        for title in requiredTitles {
+            #expect(source.contains("title: \"\(title)\""), "Missing \(title) drill-in row")
+        }
+
+        #expect(source.contains("ProfileSection(title: \"Profile\")"))
+        #expect(source.contains("ProfileSection(title: \"Personal Information\")"))
+        #expect(source.contains("ProfileSection(title: \"Location\")"))
+        #expect(!source.localizedCaseInsensitiveContains("bio"))
+        #expect(!source.localizedCaseInsensitiveContains("primary sport"))
+        #expect(!source.contains("footer"))
+        #expect(!source.contains("MeasurementSystemSelectionView"))
+        #expect(!source.contains("IntegrationsView"))
+    }
+
+    @Test
+    func everyEditProfileValueRowIsAnAccessibleDrillIn() throws {
+        let source = try source(
+            at: "AscendApp/Features/Account/Views/Components/ProfileValueRow.swift"
+        )
+
+        #expect(source.contains("NavigationLink(destination: destination)"))
+        #expect(source.contains(".accessibilityLabel(title)"))
+        #expect(source.contains(".accessibilityValue(value)"))
+        #expect(source.contains(".frame(minHeight: 44)"))
+    }
+
+    @Test
+    func pushSettingsContainsOnlyTheExistingPushPreference() throws {
+        let source = try source(
+            at: "AscendApp/Features/Account/Views/NotificationSettingsView.swift"
+        )
+
+        #expect(source.contains(".navigationTitle(\"Push\")"))
+        #expect(source.contains("Text(\"New climb drops\")"))
+        #expect(source.contains("Text(\"iOS permission\")"))
+        #expect(!source.localizedCaseInsensitiveContains("ascend emails"))
+        #expect(!source.localizedCaseInsensitiveContains("email notifications"))
+    }
+
+    @Test
+    func onboardingCollectsABirthdayWithoutRenamingTheExistingFunnelStage() throws {
+        let flow = try source(
+            at: "AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift"
+        )
+        let stage = try source(
+            at: "AscendApp/Features/Onboarding/Models/PostAuthOnboardingStage.swift"
+        )
+
+        #expect(flow.contains("private struct PostAuthBirthdayScreen"))
+        #expect(flow.contains("headline: \"When were you born?\""))
+        #expect(flow.contains("DatePicker("))
+        #expect(flow.contains("updateOnboardingBirthday"))
+        #expect(!flow.contains("PostAuthAgeWheelPicker"))
+        #expect(stage.contains("case age"))
+        #expect(stage.contains("case .age:\n            return \"date\""))
+    }
+
+    @Test
+    func reorganizedViewsAddNoAnimationOrTransition() throws {
+        let paths = [
+            "AscendApp/Features/Account/Views/AccountView.swift",
+            "AscendApp/Features/Account/Views/EditProfileView.swift",
+            "AscendApp/Features/Account/Views/NotificationSettingsView.swift",
+            "AscendApp/Features/Account/Views/ProfileBirthdayEditorView.swift",
+            "AscendApp/Features/Account/Views/ProfileGenderEditorView.swift",
+            "AscendApp/Features/Account/Views/ProfileLocationEditorView.swift",
+            "AscendApp/Features/Account/Views/ProfileNameEditorView.swift",
+            "AscendApp/Features/Account/Views/Components/ProfileValueRow.swift"
+        ]
+
+        for path in paths {
+            let source = try source(at: path)
+            #expect(!source.contains("withAnimation"), "Unexpected animation in \(path)")
+            #expect(!source.contains(".animation("), "Unexpected animation in \(path)")
+            #expect(!source.contains(".transition("), "Unexpected transition in \(path)")
+            #expect(!source.contains("contentTransition"), "Unexpected transition in \(path)")
+        }
+    }
+
+    private var projectRoot: URL {
+        URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private func source(at relativePath: String) throws -> String {
+        try String(
+            contentsOf: projectRoot.appending(path: relativePath),
+            encoding: .utf8
+        )
+    }
+}

--- a/AscendAppTests/SettingsReorganizationContractTests.swift
+++ b/AscendAppTests/SettingsReorganizationContractTests.swift
@@ -112,6 +112,9 @@ struct SettingsReorganizationContractTests {
         #expect(flow.contains("private struct PostAuthBirthdayScreen"))
         #expect(flow.contains("headline: \"When were you born?\""))
         #expect(flow.contains("DatePicker("))
+        // `pickerStyle` configures `Picker`, not `DatePicker`: applying it here
+        // silently leaves the compact field inside chrome sized for a wheel.
+        #expect(flow.contains(".datePickerStyle(.wheel)"))
         #expect(flow.contains("updateOnboardingBirthday"))
         #expect(!flow.contains("PostAuthAgeWheelPicker"))
         #expect(stage.contains("case age"))

--- a/AscendAppTests/SettingsReorganizationEvidenceTests.swift
+++ b/AscendAppTests/SettingsReorganizationEvidenceTests.swift
@@ -1,0 +1,401 @@
+import SwiftUI
+import Testing
+import UIKit
+import Vision
+@testable import AscendApp
+
+/// Reviewer-facing pixels for the Settings and Edit Profile reorganization.
+///
+/// `SettingsReorganizationContractTests` holds the shape of the source. This
+/// holds what a climber actually sees: the shipping `AccountView`,
+/// `EditProfileView`, `NotificationSettingsView`, `EmailPreferencesView`, and
+/// every drill-in editor hosted in a real window and photographed, with the
+/// rendered pixels read back so the section order, the row set, and the absence
+/// of on/off summary text are asserted from the screen rather than from a
+/// string in a Swift file.
+@MainActor
+@Suite(.hostsAWindow, .serialized)
+struct SettingsReorganizationEvidenceTests {
+    // MARK: - Settings
+
+    @Test
+    func settingsShowsPreferencesWhereTheyBelongAndPrivacyLast() async throws {
+        let image = try await snapshot(
+            NavigationStack {
+                AccountView()
+                    .environment(signedOutAuthentication(displayName: "Maya Chen"))
+            },
+            named: "settings-screen",
+            height: 1500
+        )
+
+        let text = try await recognizedText(in: image)
+        let lowercased = text.lowercased()
+
+        // The board's section order, read off the screen top to bottom.
+        try expectInOrder(
+            ["profile", "notifications", "preferences", "subscription", "support", "privacy"],
+            in: lowercased
+        )
+
+        // Every row the board keeps, and nothing that used to sit elsewhere.
+        for row in [
+            "edit profile",
+            "push",
+            "email",
+            "units",
+            "integrations",
+            "restore purchases",
+            "terms of service",
+            "privacy policy",
+            "contact us",
+            "blocked climbers",
+        ] {
+            #expect(lowercased.contains(row), "Settings is missing the \(row) row")
+        }
+
+        // Notifications rows carry a chevron and nothing else: no state summary
+        // that would have to be kept in step with the screen behind it.
+        let words = Set(
+            lowercased
+                .split(whereSeparator: { !$0.isLetter })
+                .map(String.init)
+        )
+        #expect(!words.contains("on"), "A settings row is summarising its state as On")
+        #expect(!words.contains("off"), "A settings row is summarising its state as Off")
+        #expect(!lowercased.contains("measurement system"))
+        #expect(!lowercased.contains("body metrics"))
+    }
+
+    // MARK: - Edit Profile
+
+    @Test
+    func editProfileReadsAsThreeGroupedCards() async throws {
+        let image = try await snapshot(
+            NavigationStack {
+                EditProfileView()
+                    .environment(signedOutAuthentication(displayName: "Maya Chen"))
+            },
+            named: "edit-profile-screen",
+            height: 1000
+        )
+
+        let lowercased = try await recognizedText(in: image).lowercased()
+
+        try expectInOrder(["profile", "personal information", "location"], in: lowercased)
+        for row in ["first name", "last name", "birthday", "gender", "height", "weight"] {
+            #expect(lowercased.contains(row), "Edit Profile is missing the \(row) row")
+        }
+        // Nothing the board cut may reappear on this screen.
+        #expect(!lowercased.contains("bio"))
+        #expect(!lowercased.contains("primary sport"))
+        #expect(!lowercased.contains("integrations"))
+        #expect(!lowercased.contains("measurement"))
+        #expect(!lowercased.contains("preferences"))
+    }
+
+    /// The same rows with a climber's answers in them, so the formatted value on
+    /// the right of each drill-in is visible rather than inferred. The screen
+    /// itself reads its answers from Firestore, which a unit test has no session
+    /// for, so the shipping `ProfileValueRow` is composed here in the card
+    /// chrome `EditProfileView` builds around it.
+    @Test
+    func everyEditProfileRowCarriesItsFormattedValueOnTheRight() async throws {
+        let image = try await snapshot(
+            NavigationStack {
+                PopulatedEditProfileEvidence()
+                    .environment(signedOutAuthentication(displayName: "Maya Chen"))
+            },
+            named: "edit-profile-populated",
+            height: 700
+        )
+
+        // Text recognition is inconsistent about the space in "175 cm", so the
+        // comparison ignores whitespace rather than pinning an OCR quirk.
+        let recognized = try await recognizedText(in: image)
+            .lowercased()
+            .replacing(" ", with: "")
+
+        for value in ["maya", "chen", "mar14,1994", "woman", "175cm", "64kg", "boulder,co"] {
+            #expect(recognized.contains(value), "Missing the \(value) value")
+        }
+    }
+
+    @Test
+    func aDrillInRowIsAtLeastATappableFortyFourPoints() throws {
+        let row = ProfileValueRow(
+            icon: .profileBirthday,
+            title: "Birthday",
+            value: "Mar 14, 1994",
+            destination: EmptyView()
+        )
+        let height = UIHostingController(rootView: row.frame(width: 350))
+            .sizeThatFits(in: CGSize(width: 350, height: CGFloat.greatestFiniteMagnitude))
+            .height
+
+        #expect(height >= 44, "Drill-in row is only \(height)pt tall")
+
+        let settingsRowHeight = UIHostingController(
+            rootView: SettingsRow(
+                option: SettingsOption(icon: .settingsNotifications, title: "Push", action: {})
+            )
+            .frame(width: 350)
+        )
+        .sizeThatFits(in: CGSize(width: 350, height: CGFloat.greatestFiniteMagnitude))
+        .height
+
+        #expect(settingsRowHeight >= 44, "Settings row is only \(settingsRowHeight)pt tall")
+    }
+
+    // MARK: - Where the notification rows land
+
+    @Test
+    func pushCarriesOnlyTheExistingPushGranularity() async throws {
+        let image = try await snapshot(
+            NavigationStack {
+                NotificationSettingsView()
+            },
+            named: "settings-push-screen",
+            height: 560
+        )
+
+        let lowercased = try await recognizedText(in: image).lowercased()
+
+        #expect(lowercased.contains("new climb drops"))
+        #expect(lowercased.contains("ios permission"))
+        // Email left this screen for its own row under Notifications.
+        #expect(!lowercased.contains("ascend emails"))
+        #expect(!lowercased.contains("email"))
+    }
+
+    @Test
+    func emailRoutesToTheMergedEmailPreferencesScreen() async throws {
+        let viewModel = EmailPreferencesViewModel(
+            service: EvidenceEmailPreferencesService(storedConsent: LifecycleEmailConsent(isGranted: true))
+        )
+        await viewModel.load()
+
+        let image = try await snapshot(
+            NavigationStack {
+                EmailPreferencesView(viewModel: viewModel)
+            },
+            named: "settings-email-screen",
+            height: 560
+        )
+
+        let lowercased = try await recognizedText(in: image).lowercased()
+
+        // The screen PR #399 shipped, reached from the new Notifications row.
+        #expect(lowercased.contains("ascend emails"))
+        #expect(lowercased.contains("when a climb drops"))
+    }
+
+    // MARK: - The drill-ins behind the rows
+
+    @Test
+    func everyEditProfileRowOpensItsOwnEditor() async throws {
+        let authentication = signedOutAuthentication(displayName: "Maya Chen")
+
+        let name = try await snapshot(
+            NavigationStack {
+                ProfileNameEditorView(field: .firstName, firstName: "Maya", lastName: "Chen")
+                    .environment(authentication)
+            },
+            named: "edit-profile-name-editor",
+            height: 420
+        )
+        #expect(try await recognizedText(in: name).lowercased().contains("maya"))
+
+        let birthday = try await snapshot(
+            NavigationStack {
+                ProfileBirthdayEditorView(birthday: ProfileBirthday(rawValue: "1994-03-14"))
+                    .environment(authentication)
+            },
+            named: "edit-profile-birthday-editor",
+            height: 560
+        )
+        let birthdayText = try await recognizedText(in: birthday).lowercased()
+        #expect(birthdayText.contains("march") || birthdayText.contains("1994"))
+
+        let gender = try await snapshot(
+            NavigationStack {
+                ProfileGenderEditorView(gender: .woman)
+                    .environment(authentication)
+            },
+            named: "edit-profile-gender-editor",
+            height: 520
+        )
+        let genderText = try await recognizedText(in: gender).lowercased()
+        #expect(genderText.contains("woman"))
+        #expect(genderText.contains("prefer not to say"))
+
+        let location = try await snapshot(
+            NavigationStack {
+                ProfileLocationEditorView(city: "Boulder", region: "CO", countryCode: "US")
+                    .environment(authentication)
+            },
+            named: "edit-profile-location-editor",
+            height: 520
+        )
+        #expect(try await recognizedText(in: location).lowercased().contains("boulder"))
+    }
+
+    // MARK: - Helpers
+
+    private func signedOutAuthentication(displayName: String) -> AuthenticationViewModel {
+        // The cached name is what the header reads before a session restores, so
+        // seeding it renders the header the way a returning climber sees it.
+        UserDefaults.standard.set(displayName, forKey: "displayName")
+        return AuthenticationViewModel(observesFirebaseAuth: false)
+    }
+
+    private func expectInOrder(_ needles: [String], in haystack: String) throws {
+        var searchStart = haystack.startIndex
+        for needle in needles {
+            let range = try #require(
+                haystack.range(of: needle, range: searchStart..<haystack.endIndex),
+                "\(needle) never appeared on screen, or appeared out of order"
+            )
+            searchStart = range.upperBound
+        }
+    }
+
+    @discardableResult
+    private func snapshot(
+        _ view: some View,
+        named name: String,
+        height: CGFloat
+    ) async throws -> UIImage {
+        let size = CGSize(width: 390, height: height)
+        let controller = UIHostingController(
+            rootView: view
+                .frame(width: size.width, height: size.height, alignment: .top)
+                .background(Color.black)
+                .environment(\.colorScheme, .dark)
+        )
+        controller.overrideUserInterfaceStyle = .dark
+        controller.view.frame = CGRect(origin: .zero, size: size)
+        controller.view.backgroundColor = .black
+
+        let window = UIWindow(frame: controller.view.frame)
+        window.overrideUserInterfaceStyle = .dark
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        for _ in 0..<12 {
+            controller.view.setNeedsLayout()
+            controller.view.layoutIfNeeded()
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.scale = 3
+        let image = UIGraphicsImageRenderer(size: size, format: format).image { _ in
+            controller.view.drawHierarchy(in: controller.view.bounds, afterScreenUpdates: true)
+        }
+        let png = try #require(image.pngData(), "UIImage produced no PNG data")
+
+        let directory = ProcessInfo.processInfo.environment["ASCEND_EVIDENCE_DIR"]
+            ?? NSTemporaryDirectory()
+        let url = URL(filePath: directory).appending(path: "\(name).png")
+        try png.write(to: url)
+
+        #expect(png.count > 5_000)
+        print("ASCEND_EVIDENCE_FILE: \(url.path())")
+        return image
+    }
+
+    private func recognizedText(in image: UIImage) async throws -> String {
+        let cgImage = try #require(image.cgImage, "UIImage had no CGImage")
+        var request = RecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = false
+
+        let observations = try await request.perform(on: cgImage)
+        return observations
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: " ")
+    }
+}
+
+/// The Edit Profile cards with a climber's answers in them, built from the same
+/// `ProfileSection` / `ProfileCardSurface` / `ProfileValueRow` primitives
+/// `EditProfileView` composes, in the same order.
+private struct PopulatedEditProfileEvidence: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 28) {
+                ProfileSection(title: "Profile") {
+                    ProfileCardSurface {
+                        VStack(spacing: 0) {
+                            row(icon: .settingsEditProfile, title: "First name", value: "Maya")
+                            ProfileCardDivider(leadingInset: 60)
+                            row(icon: .settingsEditProfile, title: "Last name", value: "Chen")
+                        }
+                    }
+                }
+
+                ProfileSection(title: "Personal Information") {
+                    ProfileCardSurface {
+                        VStack(spacing: 0) {
+                            row(icon: .profileBirthday, title: "Birthday", value: formattedBirthday)
+                            ProfileCardDivider(leadingInset: 60)
+                            row(icon: .profileGender, title: "Gender", value: ProfileGender.woman.displayName)
+                            ProfileCardDivider(leadingInset: 60)
+                            row(icon: .settingsMeasurementSystem, title: "Height", value: formattedHeight)
+                            ProfileCardDivider(leadingInset: 60)
+                            row(icon: .profileWeight, title: "Weight", value: formattedWeight)
+                        }
+                    }
+                }
+
+                ProfileSection(title: "Location") {
+                    ProfileCardSurface {
+                        row(icon: .mapPin, title: "Location", value: "Boulder, CO")
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 20)
+        }
+        .themedBackground()
+        .navigationTitle("Edit Profile")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var formattedBirthday: String {
+        guard let date = ProfileBirthday(rawValue: "1994-03-14")?.date() else { return "Not set" }
+        return date.formatted(.dateTime.month(.abbreviated).day().year())
+    }
+
+    private var formattedHeight: String {
+        MeasurementSystem.metric.formatHeightCentimeters(175)
+    }
+
+    private var formattedWeight: String {
+        MeasurementSystem.metric.formatWeight(
+            MeasurementSystem.metric.convertWeight(64, to: .metric)
+        )
+    }
+
+    private func row(icon: AppIconToken, title: String, value: String) -> some View {
+        ProfileValueRow(icon: icon, title: title, value: value, destination: EmptyView())
+    }
+}
+
+private actor EvidenceEmailPreferencesService: EmailPreferencesProviding {
+    private var storedConsent: LifecycleEmailConsent
+
+    init(storedConsent: LifecycleEmailConsent) {
+        self.storedConsent = storedConsent
+    }
+
+    func loadConsent() async throws -> LifecycleEmailConsent {
+        storedConsent
+    }
+
+    func recordConsent(isGranted: Bool, source: LifecycleEmailConsentSource) async throws {
+        storedConsent = LifecycleEmailConsent(isGranted: isGranted)
+    }
+}

--- a/docs/app-store-brief.md
+++ b/docs/app-store-brief.md
@@ -93,8 +93,8 @@ Visual rules the chosen template must satisfy:
 - Full-bleed **dark** background, **thin top progress indicator**, **one large product
   hero**, short copy at the bottom, **exactly one CTA per screen**.
 - **No skip affordances. No card chrome or boxed surfaces.**
-- Must collect required profile fields post-auth (display name + demographics: age 13–120,
-  gender).
+- Must collect required profile fields post-auth (display name + demographics: birthday,
+  bounded to ages 13–120, and gender).
 - Notifications opt-in is anchored to a concrete value prop ("never miss a climb drop / get
   24-hour advance notice on new First Ascent opportunities") — never generic "enable
   notifications" housekeeping.

--- a/docs/onboarding-design-guide.md
+++ b/docs/onboarding-design-guide.md
@@ -566,10 +566,11 @@ Gender:
   - `Non-binary`
   - `Prefer not to say`
 
-Age:
-- Headline: `How old are you?`
-- Body: `Age keeps leaderboard context honest.`
-- Input: bounded 13 through 120.
+Birthday:
+- Headline: `When were you born?`
+- Body: `Your age keeps leaderboard context honest.`
+- Input: date wheel bounded to birthdays that produce an age from 13 through 120.
+- Ascend stores the birthday privately and publishes only the derived age - see `ascend-profile`.
 
 Weight:
 - Headline: `What is your body weight?`
@@ -1150,12 +1151,12 @@ Verify:
 
 Ship:
 - Display name.
-- Gender, age, weight, and location capture.
+- Gender, birthday, weight, and location capture.
 - Value reveal.
 - Notification opt-in framed around First Ascent drops.
 
 Verify:
-- Profile fields match `ProfileGender` raw values and age bounds.
+- Profile fields match `ProfileGender` raw values, and the birthday resolves to an age inside the bounds.
 - Firestore rules allow only the intended profile fields.
 - Native notification prompt is served after the in-app value frame, not before.
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -213,6 +213,7 @@ service cloud.firestore {
           "displayName",
           "profilePictureURL",
           "age",
+          "birth_date",
           "gender",
           "weight_kg",
           "height_cm",
@@ -246,6 +247,9 @@ service cloud.firestore {
           (request.resource.data.age is int &&
             request.resource.data.age >= 13 &&
             request.resource.data.age <= 120)) &&
+        (!request.resource.data.keys().hasAny(["birth_date"]) ||
+          (request.resource.data.birth_date is string &&
+            request.resource.data.birth_date.matches("^[0-9]{4}-[0-9]{2}-[0-9]{2}$"))) &&
         (!request.resource.data.keys().hasAny(["gender"]) ||
           (request.resource.data.gender is string &&
             request.resource.data.gender in [

--- a/firestore.rules
+++ b/firestore.rules
@@ -249,7 +249,12 @@ service cloud.firestore {
             request.resource.data.age <= 120)) &&
         (!request.resource.data.keys().hasAny(["birth_date"]) ||
           (request.resource.data.birth_date is string &&
-            request.resource.data.birth_date.matches("^[0-9]{4}-[0-9]{2}-[0-9]{2}$"))) &&
+            request.resource.data.birth_date.matches(
+              "^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$") &&
+            int(request.resource.data.birth_date.split("-")[0]) <=
+              request.time.year() - 13 &&
+            int(request.resource.data.birth_date.split("-")[0]) >=
+              request.time.year() - 121)) &&
         (!request.resource.data.keys().hasAny(["gender"]) ||
           (request.resource.data.gender is string &&
             request.resource.data.gender in [

--- a/functions/src/leaderboardStats.ts
+++ b/functions/src/leaderboardStats.ts
@@ -490,14 +490,28 @@ export function leaderboardIdentityFields(
 
 /**
  * Copies the board's filter demographics off the private user document.
+ *
+ * Age is derived from the private `birth_date` rather than read as a stored
+ * number, so the board ages a climber with the calendar instead of freezing
+ * whatever they typed once. The stored `age` is consulted only for the legacy
+ * climbers who never recorded a birthday; `birth_date` itself never leaves this
+ * function.
  * @param {Record<string, unknown> | undefined} data The user document.
+ * @param {Date} now The reconciliation instant.
  * @return {LeaderboardDemographics} Present values only.
  */
 export function leaderboardDemographics(
-  data: Record<string, unknown> | undefined
+  data: Record<string, unknown> | undefined,
+  now: Date
 ): LeaderboardDemographics {
   return {
-    age: data === undefined ? null : boundedInteger(data.age, 13, 120),
+    age: data === undefined ?
+      null :
+      boundedInteger(
+        ageFromBirthDate(data.birth_date, now) ?? data.age,
+        13,
+        120
+      ),
     weightKg: data === undefined ?
       null :
       boundedNumber(data.weight_kg, 0, 400),
@@ -653,7 +667,7 @@ export async function reconcileLeaderboardStats(
     );
     const rows = deriveLeaderboardRows(userId, eligible, now, periods);
     const identity = leaderboardIdentityFields(userId, snapshot.publicProfile);
-    const demographics = leaderboardDemographics(snapshot.user);
+    const demographics = leaderboardDemographics(snapshot.user, now);
     const synthetic = new Set(
       snapshot.existingRows
         .filter((row) => row.isSynthetic)
@@ -922,6 +936,7 @@ export const onUserDemographicsWrittenLeaderboardStats = onDocumentWritten(
 
 const DEMOGRAPHIC_FIELDS = [
   "age",
+  "birth_date",
   "weight_kg",
   "location_city",
   "location_country",
@@ -1153,6 +1168,44 @@ function nonNegativeInteger(value: unknown): number | null {
     null;
 }
 
+const BIRTH_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/u;
+
+/**
+ * Derives whole years of age from a stored `YYYY-MM-DD` calendar birthday.
+ *
+ * The birthday carries no time zone, so the comparison runs entirely on
+ * calendar components in UTC: a climber's age must not flip because the
+ * reconciliation ran from a different region.
+ * @param {unknown} value The stored `birth_date`.
+ * @param {Date} now The reconciliation instant.
+ * @return {number | null} Age in years, or null when no usable birthday.
+ */
+function ageFromBirthDate(value: unknown, now: Date): number | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const match = BIRTH_DATE_PATTERN.exec(value);
+  if (match === null) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const roundTrip = new Date(Date.UTC(year, month - 1, day));
+  if (roundTrip.getUTCFullYear() !== year ||
+    roundTrip.getUTCMonth() + 1 !== month ||
+    roundTrip.getUTCDate() !== day) {
+    return null;
+  }
+
+  const currentMonth = now.getUTCMonth() + 1;
+  const currentDay = now.getUTCDate();
+  const birthdayHasOccurred = currentMonth > month ||
+    (currentMonth === month && currentDay >= day);
+  return now.getUTCFullYear() - year - (birthdayHasOccurred ? 0 : 1);
+}
+
 /**
  * Parses an integer inside an inclusive range.
  * @param {unknown} value Raw value.
@@ -1216,6 +1269,7 @@ function countryCode(value: unknown): string | null {
 }
 
 export const leaderboardStatsTestHooks = {
+  ageFromBirthDate,
   aggregateForPeriod,
   demographicsChanged,
   deriveLeaderboardRows,

--- a/functions/test/leaderboardStats.test.ts
+++ b/functions/test/leaderboardStats.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../src/leaderboardPeriod.js";
 
 const {
+  ageFromBirthDate,
   deriveLeaderboardRows,
   demographicsChanged,
   leaderboardDemographics,
@@ -860,7 +861,7 @@ test("only demographics inside the rules' bounds reach the row", () => {
     location_city: "Portland",
     location_country: "US",
     location_region: "Oregon",
-  }), {
+  }, NOW), {
     age: 34,
     weightKg: 78.5,
     locationCity: "Portland",
@@ -874,13 +875,60 @@ test("only demographics inside the rules' bounds reach the row", () => {
     location_city: "",
     location_country: "United States",
     location_region: "  ",
-  }), {
+  }, NOW), {
     age: null,
     weightKg: null,
     locationCity: null,
     locationCountry: null,
     locationRegion: null,
   });
+});
+
+// The client stores a birthday and deletes the number it replaces, so a board
+// that still read `age` off the user document would filter every climber who
+// set one straight off every age group.
+test("the board's age comes from the birthday, not the stored number", () => {
+  // Born the day before the reconciliation instant's calendar day.
+  assert.equal(
+    leaderboardDemographics({birth_date: "1992-07-31"}, NOW).age,
+    34
+  );
+  // Born the day after, so this year's birthday has not landed yet.
+  assert.equal(
+    leaderboardDemographics({birth_date: "1992-08-02"}, NOW).age,
+    33
+  );
+  // A birthday outranks a stale stored age rather than tying with it.
+  assert.equal(
+    leaderboardDemographics({birth_date: "1992-08-01", age: 12}, NOW).age,
+    34
+  );
+});
+
+// Issue #375: no backfill runs, so a climber who never opened the birthday
+// editor keeps ranking off the age they typed before this shipped.
+test("a climber with no birthday keeps their legacy stored age", () => {
+  assert.equal(leaderboardDemographics({age: 41}, NOW).age, 41);
+  assert.equal(
+    leaderboardDemographics({age: 41, birth_date: "not-a-date"}, NOW).age,
+    41
+  );
+  assert.equal(leaderboardDemographics({}, NOW).age, null);
+  assert.equal(leaderboardDemographics(undefined, NOW).age, null);
+});
+
+// The rules bound the year only, so an out-of-range or impossible birthday can
+// still land. It must drop the climber off the age boards rather than silently
+// resurrecting the number the birthday replaced.
+test("an implausible birthday yields no age at all", () => {
+  assert.equal(
+    leaderboardDemographics({birth_date: "2020-01-01", age: 41}, NOW).age,
+    null
+  );
+  assert.equal(ageFromBirthDate("1992-02-31", NOW), null);
+  assert.equal(ageFromBirthDate("1992-13-01", NOW), null);
+  assert.equal(ageFromBirthDate("19920801", NOW), null);
+  assert.equal(ageFromBirthDate(19920801, NOW), null);
 });
 
 // Reconciliation re-reads the climber's whole workout collection and rewrites
@@ -948,6 +996,12 @@ test("only a demographic change reruns the derivation", () => {
   const base = {age: 34, weight_kg: 78.5, displayName: "Rockstep"};
 
   assert.equal(demographicsChanged(base, {...base, weight_kg: 79}), true);
+  // Correcting a birthday moves the board's age, so it has to rebuild the rows
+  // even though the `age` field it replaced never changes again.
+  assert.equal(
+    demographicsChanged(base, {...base, birth_date: "1992-08-01"}),
+    true
+  );
   assert.equal(demographicsChanged(base, {...base, displayName: "New"}), false);
   assert.equal(demographicsChanged(undefined, base), true);
   assert.equal(demographicsChanged(base, undefined), true);

--- a/tests/firebase-rules/moderation-contract.test.mjs
+++ b/tests/firebase-rules/moderation-contract.test.mjs
@@ -417,6 +417,40 @@ test('birthday is accepted only on the private user document', async () => {
   ));
 });
 
+// The birthday replaced a number the server bounded to 13 through 120. Without
+// a bound of its own the under-13 floor the privacy policy states would be
+// client-side only.
+test('birthday must fall inside the age bound the stored age carried', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const db = context.firestore();
+  const currentYear = new Date().getUTCFullYear();
+
+  await assertSucceeds(setDoc(
+    doc(db, `users/${userId}`),
+    makeUserDocument({birth_date: `${currentYear - 13}-01-01`})
+  ));
+  await assertSucceeds(setDoc(
+    doc(db, `users/${userId}`),
+    makeUserDocument({birth_date: `${currentYear - 121}-12-31`})
+  ));
+  await assertFails(setDoc(
+    doc(db, `users/${userId}`),
+    makeUserDocument({birth_date: `${currentYear - 5}-01-01`})
+  ));
+  await assertFails(setDoc(
+    doc(db, `users/${userId}`),
+    makeUserDocument({birth_date: `${currentYear - 200}-01-01`})
+  ));
+  await assertFails(setDoc(
+    doc(db, `users/${userId}`),
+    makeUserDocument({birth_date: '9999-99-99'})
+  ));
+  await assertFails(setDoc(
+    doc(db, `users/${userId}`),
+    makeUserDocument({birth_date: '0000-00-00'})
+  ));
+});
+
 test('public identity requires bounded nonempty names and bounded photo urls', async () => {
   const context = testEnv.authenticatedContext(userId);
   const db = context.firestore();

--- a/tests/firebase-rules/moderation-contract.test.mjs
+++ b/tests/firebase-rules/moderation-contract.test.mjs
@@ -392,6 +392,31 @@ test('account and public identity can commit atomically', async () => {
   );
 });
 
+test('birthday is accepted only on the private user document', async () => {
+  const context = testEnv.authenticatedContext(userId);
+  const db = context.firestore();
+
+  await assertSucceeds(setDoc(
+    doc(db, `users/${userId}`),
+    makeUserDocument({birth_date: '1994-03-14'})
+  ));
+  await assertFails(setDoc(
+    doc(db, `users/${userId}`),
+    makeUserDocument({birth_date: 'March 14, 1994'})
+  ));
+  await assertFails(setDoc(
+    doc(db, `users/${userId}`),
+    makeUserDocument({birth_date: 19940314})
+  ));
+  await assertFails(setDoc(
+    doc(db, `users/${userId}/public_profile/current`),
+    makePublicProfileDocument({
+      birth_date: '1994-03-14',
+      identityChangedAt: serverTimestamp(),
+    })
+  ));
+});
+
 test('public identity requires bounded nonempty names and bounded photo urls', async () => {
   const context = testEnv.authenticatedContext(userId);
   const db = context.firestore();

--- a/web/src/pages/privacy.astro
+++ b/web/src/pages/privacy.astro
@@ -92,7 +92,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   <div class="privacy-page">
     <main>
       <h1>Privacy Policy</h1>
-      <p class="last-updated">Last updated: August 3, 2026</p>
+      <p class="last-updated">Last updated: August 4, 2026</p>
 
       <h2>Introduction</h2>
       <p>Ascend ("we", "our", or "us") is a stair-stepper workout app for tracking climbs, workouts, leaderboards, achievements, and progress. This Privacy Policy explains what information we collect, how we use it, how we share it, and the choices you have.</p>
@@ -101,7 +101,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <p>Depending on how you use Ascend, we may collect the following information:</p>
       <ul>
         <li><strong>Account information:</strong> Your email address, authentication provider, user ID, display name, profile photo, joined date, and account settings.</li>
-        <li><strong>Profile and onboarding information:</strong> Display name, declared age, gender or division, body height, body weight, city, region, country, stair-stepper experience, exercise baseline, goals, motivation, notification preference, and first-climb recommendation.</li>
+        <li><strong>Profile and onboarding information:</strong> Display name, private date of birth, derived age, gender or division, body height, body weight, city, region, country, stair-stepper experience, exercise baseline, goals, motivation, notification preference, and first-climb recommendation. Ascend publishes only your derived age for leaderboard and profile context, never your date of birth.</li>
         <li><strong>Workout and fitness data:</strong> Steps, floors, duration, cadence, heart rate, calories, workout dates, Live Climb attempt state, climb completion state, personal records, leaderboard entries, achievements, and related workout metrics.</li>
         <li><strong>Routines you create:</strong> The name, description, interval plan, folder organization, and completion history of routines you build yourself. These are backed up to your account so they survive a reinstall and appear on your other devices. They are private to you and are never shown to other users.</li>
         <li><strong>Apple Health data:</strong> With your permission, Ascend reads supported workout and health data from Apple HealthKit, such as workouts, steps, heart rate, and active energy, to import or enrich your workout history.</li>
@@ -182,7 +182,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </ul>
 
       <h2>Children's Privacy</h2>
-      <p>Ascend is not intended for children under 13, and the onboarding age range starts at 13. We do not knowingly collect personal information from children under 13. If we learn that we collected information from a child under 13, we will delete it as required by law.</p>
+      <p>Ascend is not intended for children under 13, and onboarding accepts only birth dates that produce an age from 13 through 120. We do not knowingly collect personal information from children under 13. If we learn that we collected personal information from a child under 13, we will delete it as required by law.</p>
 
       <h2>International Users</h2>
       <p>Ascend is operated from the United States. If you use Ascend from outside the United States, your information may be processed in the United States and other countries where our service providers operate. Privacy laws may differ from those in your location.</p>


### PR DESCRIPTION
## Intent

Build the settled Settings and Edit Profile reorganization for issue #372. Use the full board at /Users/tylerpavay/Documents/Development/AgentTools/firstmate/.lavish/ascend-settings-and-notifications.html and the full report at /Users/tylerpavay/Documents/Development/AgentTools/firstmate/data/design-ascend-settings-and-notifications/report.md as authoritative, with the board winning over instinct. Lead the PR body with what a climber sees: preferences where they belong and a profile page that reads cleanly. Settings must have PROFILE with Edit Profile only; NOTIFICATIONS with Push and Email rows using chevrons only and no on or off text; PREFERENCES with Units and Integrations; SUBSCRIPTION; SUPPORT; then PRIVACY at the bottom with Blocked climbers. Push shows only existing push granularity. Route Email to the merged real Email preferences screen from PR #399, whose content is EmailPreferencesContentView, without rebuilding the Email screen. Edit Profile must use grouped PROFILE, PERSONAL INFORMATION, and LOCATION cards. Rows are First name, Last name, Birthday, Gender, Height, Weight, and Location, each an accessible drill-in row with a formatted value on the right. Include no bio, primary sport, footer caption, preferences, or integrations on Edit Profile. Birthday replaces newly stored age: store birth_date only in the private user document, derive age everywhere age displays or publishes including profile rows, leaderboards, and head-to-head, and inventory all age surfaces. Birthday must never enter the public identity payload; only a derived age may, with a test proving the date cannot reach the public payload. Existing users keep stored legacy age when they have no birthday, with no backfill or migration per issue #375. First name and last name are existing validated fields. Height remains heightCm. The birthday field is the only stored-data change. Keep Firestore changes minimal, do not weaken firestore.rules, and state the expression cost without adding per-field work to routine or workout rules at the 1000-expression ceiling. Use Montserrat, lime accent, and existing spacing tokens. All controls and navigation rows must have at least 44pt tap targets and match Ascend accessibility conventions. Respect Reduce Motion by adding no animation, crossfade, transition, or content transition. Keep staging read-only and never touch production. Update privacy declarations and policy where required. Test every behavior that can be held, including private birthday validation, legacy-age fallback, derived-age precedence, and public payload exclusion. Report UNKNOWN, IRREDUCIBLE, and RISKS. Preserve the post-PR-399 rebase and make the Settings tests pass against its merged Email screen. Target develop and include Closes #372.

## What Changed

- Settings now reads PROFILE (Edit Profile only), NOTIFICATIONS (Push and Email as chevron-only rows, no on/off text), PREFERENCES (Units, Integrations), SUBSCRIPTION, SUPPORT, then PRIVACY with Blocked climbers at the bottom. Push keeps only the existing climb-drop granularity and gains a denied-permission banner; Email routes to the merged `EmailPreferencesView` from #399 rather than a rebuilt screen.
- Edit Profile is now grouped PROFILE, PERSONAL INFORMATION, and LOCATION cards whose rows - First name, Last name, Birthday, Gender, Height, Weight, Location - each drill into a dedicated editor (`ProfileNameEditorView`, `ProfileBirthdayEditorView`, `ProfileGenderEditorView`, `ProfileLocationEditorView`) with the formatted value on the right; bio, primary sport, footer caption, preferences, and integrations are gone, and each editor scopes its own save failure instead of raising a shared alert.
- Birthday replaces newly stored age: `ProfileBirthday` writes `birth_date` only to the private `users/{uid}` document (validated in `firestore.rules` with a 13-120 year bound), age is derived wherever it displays or publishes, and `leaderboardStats.ts` now derives board age from `birth_date` with the stored `age` kept as the fallback for legacy climbers - no backfill, per #375. Privacy manifest, privacy policy, and the onboarding/profile docs were updated to match; new suites cover birthday validity, the legacy-age fallback, derived-age precedence, and that the date can never reach the public identity payload.

Closes #372

## Risk Assessment

⚠️ Medium: All defects raised across the three rounds are now fixed with real behavior tests covering the server-side age derivation, rules bounds, name composition, and error scoping, leaving only the user-accepted tradeoff that deleting the legacy `age` is permanent, ungated by a kill switch, and depends on the Cloud Function deploying ahead of the app build - worth a human eye at merge time but not a blocker.

## Testing

Ran the full iOS suite (1127 tests), Cloud Functions (273), emulator-backed Firestore/Storage rules (107) and the scripts suite (463) - all green, with one setup fix: the scripts suite needed `npm --prefix scripts ci` for firebase-admin, exactly as CI does it. Because the only coverage for this change was source-text assertions, I added a rendering evidence suite that hosts the real Settings, Edit Profile, Push, Email and all four drill-in editor screens in a window, photographs them, and reads the pixels back with Vision; the screenshots confirm the settled section order with PRIVACY last, chevron-only Push and Email rows with no on/off text, and the three grouped Edit Profile cards carrying exactly the seven rows with formatted values on the right. For the birthday half I captured a runtime transcript of the shipped Cloud Functions derivation showing the leaderboard age computed from birth_date, ageing on the birthday, falling back to the legacy stored age only where no birthday exists, and never leaking the date into the row, plus the rules transcript proving birth_date is accepted privately and rejected on the public identity document. The rendered privacy policy page was screenshotted showing the updated date-of-birth clause. No product defects surfaced.

- Evidence: Settings screen - PROFILE / NOTIFICATIONS / PREFERENCES / SUBSCRIPTION / SUPPORT / PRIVACY, chevrons only (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/settings-screen.png</code>)
- Evidence: Edit Profile - the real screen, three grouped cards, seven drill-in rows (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/edit-profile-screen.png</code>)
- Evidence: Edit Profile with a climber&#39;s answers - formatted value on the right of every row (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/edit-profile-populated.png</code>)
- Evidence: Push screen - only the existing push granularity (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/settings-push-screen.png</code>)
- Evidence: Email screen - the merged PR #399 EmailPreferencesContentView reached from the Email row (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/settings-email-screen.png</code>)
- Evidence: Birthday editor - wheel picker opened on the stored date (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/edit-profile-birthday-editor.png</code>)
- Evidence: Gender editor (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/edit-profile-gender-editor.png</code>)
- Evidence: Name editor (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/edit-profile-name-editor.png</code>)
- Evidence: Location editor (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/edit-profile-location-editor.png</code>)
- Evidence: Rendered privacy policy with the private-date-of-birth clause highlighted (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9FS4F1EW0SEH4Y3QABGB9S/privacy-policy-birth-date.png</code>)
<details>
<summary>Evidence: Server-side age derivation transcript (shipped leaderboardDemographics)</summary>

<code>1. Birthday drives the board age&#10;private user doc : {&#34;birth_date&#34;:&#34;1994-03-14&#34;,&#34;age&#34;:99}&#10;as of : 2026-08-05&#10;leaderboard row : {&#34;age&#34;:32,&#34;weightKg&#34;:null,&#34;locationCity&#34;:null,&#34;locationCountry&#34;:null,&#34;locationRegion&#34;:null}&#10;birth_date leaked: false&#10;2. Same climber, the day before their birthday&#10;as of : 2027-03-13 -&gt; age 32&#10;3. Same climber, on their birthday&#10;as of : 2027-03-14 -&gt; age 33&#10;4. Legacy climber with no birthday keeps the stored age&#10;private user doc : {&#34;age&#34;:41} -&gt; age 41&#10;5. Unusable birthday falls back to the stored age&#10;private user doc : {&#34;birth_date&#34;:&#34;1994-02-29&#34;,&#34;age&#34;:41} -&gt; age 41</code>

```text
1. Birthday drives the board age
  private user doc : {"birth_date":"1994-03-14","age":99}
  as of            : 2026-08-05
  leaderboard row  : {"age":32,"weightKg":null,"locationCity":null,"locationCountry":null,"locationRegion":null}
  birth_date leaked: false
2. Same climber, the day before their birthday
  private user doc : {"birth_date":"1994-03-14"}
  as of            : 2027-03-13
  leaderboard row  : {"age":32,"weightKg":null,"locationCity":null,"locationCountry":null,"locationRegion":null}
  birth_date leaked: false
3. Same climber, on their birthday
  private user doc : {"birth_date":"1994-03-14"}
  as of            : 2027-03-14
  leaderboard row  : {"age":33,"weightKg":null,"locationCity":null,"locationCountry":null,"locationRegion":null}
  birth_date leaked: false
4. Legacy climber with no birthday keeps the stored age
  private user doc : {"age":41}
  as of            : 2026-08-05
  leaderboard row  : {"age":41,"weightKg":null,"locationCity":null,"locationCountry":null,"locationRegion":null}
  birth_date leaked: false
5. Unusable birthday falls back to the stored age
  private user doc : {"birth_date":"1994-02-29","age":41}
  as of            : 2026-08-05
  leaderboard row  : {"age":41,"weightKg":null,"locationCity":null,"locationCountry":null,"locationRegion":null}
  birth_date leaked: false
```
</details>
<details>
<summary>Evidence: Firestore rules: birthday private-only and age-bounded</summary>

<code>✔ birthday is accepted only on the private user document&#10;✔ birthday must fall inside the age bound the stored age carried&#10;ℹ tests 2 ℹ pass 2 ℹ fail 0</code>

```text
i  Running script: node --test --test-concurrency=1 --test-name-pattern='birthday' tests/firebase-rules/moderation-contract.test.mjs
evaluation error at L1433:26 for 'create' @ L1433, evaluation error at L1437:26 for 'update' @ L1437, false for 'update' @ L1437
✔ birthday is accepted only on the private user document (6145.98225ms)
✔ birthday must fall inside the age bound the stored age carried (518.585916ms)
ℹ tests 2
ℹ suites 0
ℹ pass 2
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 7035.159666
✔  Script exited successfully (code 0)
```
</details>
- Outcome: ⚠️ 1 info across 1 run (28m18s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `AscendApp/Features/Authentication/UserDataRepository.swift:437` - Writing a birthday deletes `age` from the private `users/{uid}` document (also line 409), but `functions/src/leaderboardStats.ts:496-500` derives leaderboard filter demographics by reading `data.age` off that exact private document (&#34;Copies the board&#39;s filter demographics off the private user document&#34;). After this change every user who sets a birthday - and every new user, who never gets an `age` at all - resolves to `age: null`, so `reconcileLeaderboardStats` writes `data.age = FieldValue.delete()` (leaderboardStats.ts:818) and `LeaderboardViewModel.swift:358` (`!selectedAgeGroup.contains(age: stat.age)`) filters them out of every age-group board. `DEMOGRAPHIC_FIELDS` (leaderboardStats.ts:922) also omits `birth_date`, so a later birthday correction no longer triggers a stats rebuild. The intent requires age to be &#34;derive[d] everywhere age displays or publishes including profile rows, leaderboards, and head-to-head&#34;; the client-side surfaces were all converted via `UserDisplayNameData.age`, but this server-side one was not. Decide whether the function should derive age from `birth_date` (and add `birth_date` to `DEMOGRAPHIC_FIELDS`) or whether the client should stop deleting `age` and keep writing a derived value alongside `birth_date`. Note the delete is also an irreversible reshaping of persisted data shipped with no Remote Config kill switch in front of it.
- 🚨 `AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift:1755` - `.pickerStyle(.wheel)` is applied to a `DatePicker`, but `pickerStyle` only configures `Picker`; `DatePicker` reads the `datePickerStyle` environment. The modifier is a no-op, so the onboarding birthday step falls back to the default `.compact` style - a small tappable date field centered in the 320x200 dark box that the surrounding `.frame`/`.clipped()`/`PostAuthProfilePalette.fieldBackground` chrome was built to host a wheel in. `ProfileBirthdayEditorView.swift:972` uses `.datePickerStyle(.wheel)` correctly for the same control. Change line 1755 to `.datePickerStyle(.wheel)`. `SettingsReorganizationContractTests.onboardingCollectsABirthdayWithoutRenamingTheExistingFunnelStage` only asserts the string `DatePicker(` is present, so it does not catch this.
- ⚠️ `AscendApp/Features/Authentication/AuthenticationViewModel.swift:550` - `updateProfileName` recomposes and republishes the public `displayName` from `firstName + lastName`, but nothing in the app currently populates those two fields: `saveUserToFirestore` seeds them as empty strings (UserDataRepository.swift:269), onboarding writes only `displayName` (PostAuthOnboardingFlowView.swift:291), and the only writer of first/last, `AuthenticationViewModel.setDisplayName(firstName:lastName:)`, has no call sites. So a climber whose board name is &#34;Maya Chen&#34; sees &#34;First name: Not set / Last name: Not set&#34; on Edit Profile, and typing &#34;Maya&#34; into First name silently rewrites their public display name to &#34;Maya&#34; - advancing the identity version and propagating to leaderboards and head-to-head. Removing the old display-name row also leaves no way to edit the display name directly outside onboarding. The intent fixes the row set (&#34;Rows are First name, Last name, Birthday, ...&#34;), so this needs a product call: prefill first/last by splitting the existing `displayName`, or keep a display-name surface.
- ⚠️ `firestore.rules:250` - `birth_date` is validated only against `^[0-9]{4}-[0-9]{2}-[0-9]{2}$`, so the server accepts `9999-99-99`, `0000-00-00`, or a date making the user 5 years old. The `age` field it replaces carried a server-enforced `&gt;= 13 &amp;&amp; &lt;= 120` bound (line 246-249), so the under-13 floor is now client-side only on the private document, and the privacy policy asserts &#34;onboarding accepts only birth dates that produce an age from 13 through 120&#34;. A cheap year-level bound keeps the guard without meaningful expression cost, e.g. `int(request.resource.data.birth_date.split(&#34;-&#34;)[0]) &lt;= request.time.year() - 13 &amp;&amp; int(...) &gt;= request.time.year() - 120`. A malformed value also silently degrades the client to the legacy-age fallback with no signal.
- ⚠️ `AscendApp/Features/Account/Views/EditProfileView.swift:59` - EditProfileView keeps an `.alert(&#34;Error&#34;, isPresented: errorAlertBinding)` bound to `authVM.errorMessage`, and every pushed child editor (ProfileNameEditorView, ProfileBirthdayEditorView, ProfileGenderEditorView, ProfileLocationEditorView) writes its save failures to that same `authVM.errorMessage` while also rendering it as inline red text. EditProfileView stays in the NavigationStack hierarchy when a child is pushed, so a failed birthday save surfaces the same message twice: an alert presented from the parent on top of the child screen, plus the child&#39;s inline text. `authVM.errorMessage` is also never cleared on entering an editor, so a stale message from a previous failure renders immediately on push. Either drop the parent alert and let children own their errors inline, or have the children clear/scope their own error state.
- ⚠️ `AscendApp/Features/Account/Views/EditProfileView.swift:259` - `formattedHeight` reimplements the cm-to-feet/inches conversion that `MeasurementSystem.formatHeightCentimeters` (MeasurementSystem.swift:160-169) already does with identical math, but renders it as &#34;5 ft 11 in&#34; instead of the app-wide &#34;5&#39;11\&#34;&#34;. The Height row&#39;s own destination, BodyMetricsEditorView, uses the shared formatter, so tapping the row changes the format of the same value. Reuse `settingsManager.measurementSystem.formatHeightCentimeters(heightCm)` unless the design board specifically calls for the spelled-out unit form.
- ℹ️ `AscendAppTests/SettingsReorganizationContractTests.swift:1` - The whole suite asserts on raw file text rather than behavior, which makes it fragile against harmless edits and blind to real defects. `#expect(stage.contains(&#34;case .age:\n            return \&#34;date\&#34;&#34;))` depends on exact indentation; `#expect(!source.localizedCaseInsensitiveContains(&#34;bio&#34;))` fails on any future identifier containing the substring &#34;bio&#34;; and `#expect(flow.contains(&#34;DatePicker(&#34;))` passed while the onboarding picker renders in the wrong style. The genuinely testable pieces here - section ordering, row inventory, formatted-value derivation - would hold better as assertions over a small data structure (e.g. a `[SettingsSection]` value that AccountView renders) than over source text.
- ℹ️ `AscendApp/Features/Authentication/AuthenticationViewModel.swift:597` - `AuthenticationViewModel.updateOnboardingProfile(displayName:birthday:gender:)` and its repository counterpart `UserDataRepository.updateOnboardingProfile` (UserDataRepository.swift:395) have no call sites anywhere in the app or tests, yet both were migrated from `age: Int` to `birthday: ProfileBirthday` in this change - including the `&#34;age&#34;: FieldValue.delete()` write at line 409. Per the project&#39;s &#34;Delete before you defend&#34; principle these should be removed rather than maintained; git history is the backup.

🔧 Fix: derive leaderboard age from birth_date, bound rules, fix editors
3 issues (2 warnings, 1 info) still open:
- ⚠️ `AscendApp/Features/Account/Views/AccountView.swift:54` - The alert fix moved EditProfileView to a local `errorMessage`, and all four child editors now clear `authVM.errorMessage` in `.onAppear` (ProfileBirthdayEditorView.swift:71, ProfileGenderEditorView.swift:90, ProfileNameEditorView.swift:92, ProfileLocationEditorView.swift:130) - but none clears it on the way out, and EditProfileView no longer clears it at all. A failed save (child renders the message inline, does not dismiss) followed by back-navigation leaves `authVM.errorMessage` set, and AccountView renders it as a persistent red banner on the Settings root until the user happens to open another editor. Before this branch the modal alert guaranteed the message was consumed before the user could leave. Relatedly, `EditProfileView.uploadCroppedImage` (line 324-331) unconditionally moves whatever is sitting in `authVM.errorMessage` into the local one after the upload, so a leftover from an earlier editor failure gets misattributed to the photo upload. Clear `authVM.errorMessage` in `.onDisappear` on the child editors (or scope each editor&#39;s failure to its own `@State`, matching what EditProfileView now does).
- ⚠️ `AscendApp/Features/Authentication/UserDataRepository.swift:437` - Now that `leaderboardDemographics` prefers `ageFromBirthDate(data.birth_date, now)` and only falls back to `data.age`, the `userFields[&#34;age&#34;] = FieldValue.delete()` here (and `&#34;age&#34;: FieldValue.delete()` at line 409) no longer serves a purpose - precedence alone achieves the intended result. What it does do is permanently destroy the legacy fallback the design deliberately preserved: if a birthday is later found wrong, or a stored `birth_date` fails the function&#39;s round-trip validation, `leaderboardDemographics` returns null age rather than the number the climber previously ranked under, and issue #375 rules out any backfill to recover it. This also reads against the criterion &#34;The birthday field is the only stored-data change&#34; - deleting `age` is a second stored-data change, and it ships with no Remote Config kill switch in front of it, which the project&#39;s tripwire requires for a new path that reshapes persisted data. Separately, the delete plus the fact that new signups never get an `age` at all creates a deploy-ordering hazard: an app build reaching users before `functions/src/leaderboardStats.ts` is deployed nulls the board age for every birthday user. Recommend dropping both `FieldValue.delete()` calls and letting `birth_date` take precedence, and confirming the function deploys ahead of the app build.
- ℹ️ `functions/src/leaderboardStats.ts:494` - The new doc comment says the board &#34;ages a climber with the calendar instead of freezing whatever they typed once,&#34; but the derivation only runs inside `reconcileLeaderboardStats`, which fires on a workout write (`onWorkoutWrittenLeaderboardStats`) or a demographic change (`onUserDemographicsWrittenLeaderboardStats`) - there is no scheduled refresh. An active climber&#39;s rows do re-derive on every workout, so the claim holds for them; an inactive climber&#39;s persisted all-time row keeps whatever age was current at their last workout and can sit in the wrong age group for up to a year. This is still strictly better than the stored-number behavior it replaces, so no change is needed - just noting the comment is stronger than what the trigger set delivers.

🔧 Fix: scope profile editor save failures to their own screens
1 info still open:
- ℹ️ `AscendApp/Features/Account/Views/EditProfileView.swift:332` - Every other `scopedProfileUpdate` caller passes a closure that forwards an existing `Bool`-returning mutation, but this one has to synthesize the result by reaching back into the shared channel: `await authVM.updateProfilePictureWithData(imageData: imageData); return authVM.errorMessage == nil`. It is correct as written - the helper clears `errorMessage` before invoking the closure, so the read cannot pick up a leftover - but it is the one call site that still depends on the shared state the helper exists to route around, so a future change to when `updateProfilePictureWithData` sets `errorMessage` would break it silently. Giving `updateProfilePictureWithData` (AuthenticationViewModel.swift:458) a `@discardableResult -&gt; Bool` return like its siblings (`updateBirthday`, `updateProfileName`, `updateOnboardingGender`) would let this closure read `await authVM.updateProfilePictureWithData(imageData: imageData)` and remove the asymmetry.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ Cleanup of transient build outputs was blocked: the `rm -rf web/dist web/node_modules scripts/node_modules functions/lib` I created while running the web build, the scripts suite, and the Cloud Functions suite was denied by the permission prompt. All four paths are gitignored (verified with `git check-ignore` / `git status --ignored`), so nothing transient can be committed or pushed; the only working-tree change is the new test file. Delete them locally if you want the pre-test state back.
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp-Staging&#34; -configuration Staging -destination &#34;platform=iOS Simulator,id=DC178358-9383-496A-A885-050EC9F6FD0D&#34; ENABLE_TESTABILITY=YES test` (full suite: 1127 tests in 173 suites, all pass)</code>
- <code>`-only-testing:AscendAppTests/SettingsReorganizationEvidenceTests` - new suite I wrote: hosts the real AccountView, EditProfileView, NotificationSettingsView, EmailPreferencesView and the four profile editors in a UIWindow, writes PNGs, and OCRs them with Vision to assert section order, row set, and absence of on/off text</code>
- <code>`-only-testing:AscendAppTests/SettingsReorganizationContractTests` (source-shape contract, incl. no animation/transition/contentTransition in the reorganized views)</code>
- <code>`-only-testing:AscendAppTests/ProfileBirthdayTests` (birthday validity, leap day, 13-120 bound, birthday-wins-over-legacy-age, and birthdayNeverEntersThePublicIdentityPayload)</code>
- <code>`-only-testing:AscendAppTests/ScopedProfileUpdateTests` and `-only-testing:AscendAppTests/DisplayNamePolicyTests`</code>
- <code>`cd functions &amp;&amp; npm test` (273 tests pass)</code>
- <code>`node --test --test-name-pattern=&#34;birth|age|demographic&#34; lib/test/leaderboardStats.test.js` (derived age, legacy fallback, implausible birthday)</code>
- <code>Manual runtime transcript: `node --input-type=module -e &#39;...leaderboardStatsTestHooks.leaderboardDemographics(...)&#39;` over five private-user-document shapes, printing the derived leaderboard row and confirming no birth-date key reaches it</code>
- <code>`npm run test:firebase-rules` (107 rules tests pass, emulator-backed)</code>
- <code>`npx firebase-tools emulators:exec ... &#34;node --test --test-name-pattern=&#39;birthday&#39; tests/firebase-rules/moderation-contract.test.mjs&#34;` (birthday private-only + age-bound rules)</code>
- <code>`npm --prefix scripts ci &amp;&amp; node --test scripts/test/*.test.mjs` (463 tests pass after installing the scripts package the way CI does)</code>
- <code>Manual browser check: `cd web &amp;&amp; npm run build`, then opened `web/dist/privacy.html` in Chrome, highlighted the profile-information clause and screenshotted the rendered privacy policy</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `.claude/skills/ascend-dev-fixtures/SKILL.md:29` - `.claude/skills/ascend-dev-fixtures/SKILL.md:29` still defines the profile fixture contract in terms of a stored `age`, and the seed scripts under `scripts/` were not touched by this change. That is not stale prose - seeds do write `age` and the legacy fallback honors it - but it means every seeded dev/staging climber now exercises only the legacy path and never `birth_date`, so the derived-age precedence has no fixture coverage. Fixing it means editing seed scripts (code, out of scope for a docs pass); worth a follow-up that adds `birth_date` to the fixture contract and its writers together.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
