### PR TITLE
chore(functions): export server-owned subscription lifecycle events

### DIFF
--- a/.claude/skills/ascend-analytics/SKILL.md
+++ b/.claude/skills/ascend-analytics/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: ascend-analytics
-description: Use when working on Ascend analytics or telemetry - event definitions, the analytics facade, telemetry sinks (Firebase Analytics, Mixpanel, SuperWall, Crashlytics, Sentry), screen tracking, funnel/engagement/quality measurement, event parameter privacy, or the debug telemetry console. Covers what is worth logging, which destination owns which job, and the low-cardinality parameter rule.
+description: Use when working on Ascend analytics or telemetry - event definitions, the analytics facade, telemetry sinks (Firebase Analytics, Mixpanel, SuperWall, Crashlytics, Sentry), screen tracking, funnel/engagement/quality measurement, event parameter privacy, the server-exported subscription lifecycle events, or the debug telemetry console. Covers what is worth logging, which destination owns which job, and the low-cardinality parameter rule.
 paths:
   - AscendApp/Shared/Services/Telemetry/**
   - AscendApp/Features/*/Analytics/**
+  - functions/src/revenueCat/analytics*.ts
 ---
 
 # Analytics Architecture
@@ -21,7 +22,7 @@ If an event wouldn't change a decision, don't log it. Volume of events != value 
 Multiple analytics destinations are sanctioned - each is best at a different job. Route events to the right destination through a single facade; never call providers directly from feature code.
 
 - **Firebase Analytics** - broad funnel, cohort, retention analysis. Most product events go here.
-- **Mixpanel** - product funnel, retention, and behavior analytics. Implemented as `MixpanelTelemetrySink`, configured from the `AscendMixpanelToken` Info.plist key; the sink is inert when no token is present. Dev, staging, and production all report into one project and are separated by super-properties - see "Mixpanel environment tagging" below.
+- **Mixpanel** - product funnel, retention, and behavior analytics. The client sink is `MixpanelTelemetrySink`, configured from the `AscendMixpanelToken` Info.plist key; it is inert when no token is present. Client events from dev, staging, and production all report into one project and are separated by super-properties. Cloud Functions also export subscription lifecycle events straight to Mixpanel, routed per environment - see "Mixpanel environment tagging" and "Server-owned subscription lifecycle events" below.
 - **SuperWall** - onboarding-flow step-level conversion + paywall presentation analytics (its specialty).
 - **Crashlytics** - crashes, fatal errors, stability metrics.
 - **Sentry** - error/crash diagnostics mirror alongside Crashlytics (non-fatal errors, app hangs, symbolicated traces). When reading, triaging, or updating Sentry issues/events, use the `sentry` skill.
@@ -30,8 +31,8 @@ When evaluating new providers, justify them by what they uniquely measure that t
 
 ## Mixpanel environment tagging
 
-Dev, staging, and production share a single Mixpanel project (`4032860`).
-There are no per-environment projects or tokens; environments are told apart by the `app_environment`, `build_config`, `app_version`, and `build_number` super-properties on every event.
+Client events from dev, staging, and production share a single Mixpanel project (`4032860`).
+The app carries no per-environment token; environments are told apart by the `app_environment`, `build_config`, `app_version`, and `build_number` super-properties on every event.
 Those values come from `TelemetryBuildMetadata`, the same source Sentry tags its events with, so the two providers always agree for a given build.
 
 The invariant: the super-properties are registered before any event can be tracked, and re-registered after anything that clears Mixpanel SDK state - `reset()` on sign-out, opting back in to collection, or a user property whose name collides with one of those reserved keys.
@@ -39,6 +40,19 @@ The invariant: the super-properties are registered before any event can be track
 
 Events recorded before this tagging shipped carry none of these properties, and that history cannot be separated retroactively.
 Filter on `app_environment` when analyzing, and treat untagged events as unattributable rather than as clean production data.
+
+## Server-owned subscription lifecycle events
+
+Subscription transitions mostly happen while the app is closed - renewal, cancellation, uncancellation, billing issue, expiration, refund, product change - so the client cannot observe them.
+Cloud Functions export them to Mixpanel from a durable Firestore outbox filled by the RevenueCat webhook, never from device code.
+Do not add a client event for a transition that stream already reports, and do not route these through `TelemetrySink`.
+
+They carry the same `app_environment`, `build_config`, `app_version`, and `build_number` envelope as client events, with the server's own values (`build_config=server`, `app_version=cloud_functions`).
+Unlike client events, they are routed by the deployed Firebase project into a separate Mixpanel project per environment, so staging and production server events never land in the shared client project.
+Filtering on `app_environment` alone is not enough to find them; pick the right project first.
+
+`docs/revenuecat-server-entitlement-enforcement.md` owns that exporter - the exactly-once outbox contract, the destination map, the retention bound, and the captain-side Mixpanel service-account and secret setup.
+`functions/src/revenueCat/analyticsEnvironment.ts` and `LifecycleAnalyticsEventName` in `functions/src/revenueCat/analyticsTypes.ts` are the executable source of truth for the destinations and the event names; read them rather than a copy.
 
 ## Implementation principles
 - One analytics facade. Feature code never imports a provider directly; it logs through the facade, which routes to the right destination. Sinks conform to `TelemetrySink` under `AscendApp/Shared/Services/Telemetry/`.

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -330,6 +330,7 @@ jobs:
                 onPublicProfileIdentityWritten \
                 onWorkoutWritten \
                 onWorkoutReplaySplitsWritten \
+                processRevenueCatAnalyticsOutbox \
                 reconcileAppAccess \
                 revenueCatWebhook \
                 unsubscribeFromEmails

--- a/docs/production-backend-rollout-runbook.md
+++ b/docs/production-backend-rollout-runbook.md
@@ -24,10 +24,10 @@ The two missing Live Replay indexes are both collection-scoped `entries` indexes
 The current query filters per-climb and per-routine live races with `isBestForUser == true`, then reads the window ahead in ascending `stepsAtBucket` order and the window behind in descending order.
 Both matching definitions already exist exactly once in `firestore.indexes.json` after rebasing onto current `develop`, so this preparation does not add duplicates.
 
-Current `develop` declares 13 composite indexes because later work also added the `workouts(source, climbId)` projection index and the routine completion `entries(finalSteps DESCENDING, __name__ ASCENDING)` index.
-It also declares five field overrides, for `blocked.blockedUid`, `entries.userId`, `finishers.userId`, `entitlements.accessUntil`, and `_revenuecat_webhook_events.retainUntil`.
+Current `develop` declares 15 composite indexes because later work also added the `workouts(source, climbId)` projection index, the routine completion `entries(finalSteps DESCENDING, __name__ ASCENDING)` index, and the two `_revenuecat_analytics_outbox` delivery-queue indexes (`status + readyAt` and `status + processingStartedAt`).
+It also declares six field overrides, for `blocked.blockedUid`, `entries.userId`, `finishers.userId`, `entitlements.accessUntil`, `_revenuecat_webhook_events.retainUntil`, and `_revenuecat_analytics_outbox.retainUntil`.
 The first four carry a `COLLECTION_GROUP` scope, and `entries.userId` additionally restates its ascending and descending `COLLECTION`-scoped single-field indexes.
-`_revenuecat_webhook_events.retainUntil` declares no index at all: it exists to carry the TTL policy that expires the webhook dedupe ledger.
+The two `retainUntil` overrides declare no index at all: they exist to carry the TTL policies that expire the webhook dedupe ledger and the analytics outbox.
 That restatement is required because a field override replaces the field's entire index configuration, and the server's best-entry reconciliation still queries `entries` by `userId` inside a single leaderboard.
 The production workflow waits until every composite index and every scope inside every field override reports `READY` before Functions deploy.
 
@@ -108,9 +108,9 @@ The workflow performs the following order automatically:
 3. Build and retain the signed production IPA.
 4. Build the Functions and Hosting artifacts.
 5. Deploy Firestore indexes.
-6. Poll the Firestore Admin API until all 13 composite indexes and every declared query scope inside all five field overrides report `READY`.
+6. Poll the Firestore Admin API until all 15 composite indexes and every declared query scope inside all six field overrides report `READY`.
 7. Deploy Functions.
-8. Verify `cleanupDeletedUserData`, `expireRevenueCatEntitlements`, `onPublicIdentityPropagationJobWritten`, `onPublicProfileIdentityWritten`, `onWorkoutWritten`, `onWorkoutReplaySplitsWritten`, `reconcileAppAccess`, `revenueCatWebhook`, and `unsubscribeFromEmails` report `ACTIVE`.
+8. Verify `cleanupDeletedUserData`, `expireRevenueCatEntitlements`, `onPublicIdentityPropagationJobWritten`, `onPublicProfileIdentityWritten`, `onWorkoutWritten`, `onWorkoutReplaySplitsWritten`, `processRevenueCatAnalyticsOutbox`, `reconcileAppAccess`, `revenueCatWebhook`, and `unsubscribeFromEmails` report `ACTIVE`.
 9. Reconcile the whole deployed function set against this ref's `functions/src/index.ts` exports, failing on any missing, orphaned, or non-`ACTIVE` function.
 10. Deploy Firestore rules.
 11. Deploy Storage rules.
@@ -141,7 +141,7 @@ npx -y firebase-tools@15.22.1 deploy --project production \
 ```
 
 Verify the deployment does not request deletion of an unexpected index.
-Then wait for every declared index, including both `isBestForUser + stepsAtBucket` directions and all five field overrides, to become usable:
+Then wait for every declared index, including both `isBestForUser + stepsAtBucket` directions and all six field overrides, to become usable:
 
 ```sh
 firebase_bin="$(npm exec --yes --package=firebase-tools@15.22.1 -- which firebase)"
@@ -212,7 +212,7 @@ npx -y firebase-tools@15.22.1 deploy --project production \
 
 `--force` is intentionally scoped to Functions so the deployed set matches `functions/src/index.ts` without making rules, indexes, Storage, or Hosting destructive.
 
-Verify the nine gate-critical functions are active:
+Verify the ten gate-critical functions are active:
 
 ```sh
 npx -y firebase-tools@15.22.1 --json functions:list \
@@ -224,12 +224,13 @@ npx -y firebase-tools@15.22.1 --json functions:list \
       onPublicProfileIdentityWritten \
       onWorkoutWritten \
       onWorkoutReplaySplitsWritten \
+      processRevenueCatAnalyticsOutbox \
       reconcileAppAccess \
       revenueCatWebhook \
       unsubscribeFromEmails
 ```
 
-That list is curated, so it proves those nine exports and says nothing about the rest of the project.
+That list is curated, so it proves those ten exports and says nothing about the rest of the project.
 Then reconcile the whole deployed set against the checked-out source, which is what catches a function nobody thought to add to the curated list and one deleted from source but still serving traffic:
 
 ```sh

--- a/docs/production-backend-rollout-runbook.md
+++ b/docs/production-backend-rollout-runbook.md
@@ -60,7 +60,7 @@ Complete every item before starting the production workflow.
    No deploy workflow publishes it to production; dev and staging receive new switches automatically, production stays a captain-only publish.
    See "Remote Config kill switches" below for the command, and `npm run remoteconfig:drift` for what is live in all three right now.
    The production `build-ios` job now refuses to archive while any flag the build reads is unreachable in `ascend-prod-9c8f2`, so a missed publish stops the release rather than shipping a decorative lever.
-10. Complete every production captain action for server-side entitlement enforcement before this rollout: the `REVENUECAT_SERVER_CONFIG` Functions secret, the production RevenueCat webhook destination and its credentials, the App Store Server Notification URLs, the cross-service Storage-to-Firestore IAM role, and a reconciled grant for every account that already has paid access.
+10. Complete every production captain action for server-side entitlement enforcement before this rollout: the `REVENUECAT_SERVER_CONFIG` Functions secret, the project-scoped `MIXPANEL_SERVER_CONFIG` service-account secret, the production RevenueCat webhook destination and its credentials, the App Store Server Notification URLs, the cross-service Storage-to-Firestore IAM role, and a reconciled grant for every account that already has paid access.
     Firestore and Storage rules deny paid data to a signed-in account with no server-owned grant, so a missed step here is a subscriber lockout rather than a degraded feature.
     `docs/revenuecat-server-entitlement-enforcement.md` owns the full action list; do not restate it here.
 

--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -60,6 +60,26 @@ Staging must allow `ascend_staging_yearly` and `ascend_staging_monthly`.
 Production must allow `ascend_yearly` and `ascend_monthly`.
 Add a promotional product identifier only when the App Review subscriber response proves its exact value.
 
+Create `MIXPANEL_SERVER_CONFIG` as a Firebase Functions secret separately in staging and production.
+Enter it at the secret prompt so no value reaches shell history, logs, Git, chat, or the iOS bundle.
+
+The JSON shape is:
+
+```json
+{
+  "serviceAccountUsername": "<environment Mixpanel service-account username>",
+  "serviceAccountPassword": "<environment Mixpanel service-account password>"
+}
+```
+
+Create a separate project-scoped Mixpanel service account for Staging project `4051102` and Production project `4051100`.
+Grant only the Mixpanel project role required by `/import`; Mixpanel currently requires an Admin service account for that endpoint, so keep each account scoped to its one project and out of organization-wide membership.
+The server derives the destination from its deployed Firebase project and refuses every project outside this fixed map: Development `ascend-f2e4f` -> `4032860`, Staging `ascend-staging-fa7d5` -> `4051102`, Production `ascend-prod-9c8f2` -> `4051100`.
+Development has no RevenueCat webhook endpoint today, so its closed-app lifecycle stream remains intentionally empty unless that integration is added later.
+
+Set both `REVENUECAT_SERVER_CONFIG` and `MIXPANEL_SERVER_CONFIG` before deploying Functions.
+The webhook binds only the RevenueCat secret, while the independent outbox worker binds only the Mixpanel secret, so a Mixpanel outage or credential failure can never decide RevenueCat's webhook response.
+
 Before the first Storage rules deployment in each Firebase project, enable cross-service Cloud Storage Security Rules access to Cloud Firestore.
 Firebase prompts for this permission when the rules are saved from the Firebase CLI or Firebase console.
 Verify in Google Cloud IAM, with Google-provided grants visible, that the Firebase Storage service account ending in `@gcp-sa-firebasestorage.iam.gserviceaccount.com` holds the `Firebase Rules Firestore Service Agent` role.
@@ -110,18 +130,26 @@ It creates `users/{uid}/entitlements/app_access` only while the configured `app_
 It deletes that active grant when current RevenueCat state is inactive.
 7. A projection only replaces one derived from an older RevenueCat `request_date_ms`.
 The triggering event's order therefore cannot move subscriber state backward.
-8. The event is marked complete in the same transaction as the projection changes.
+8. For each verified Firebase uid and reportable subscription transition, the event-completion transaction creates one `_revenuecat_analytics_outbox` row whose stable idempotency key is derived from the RevenueCat event ID and uid.
+The row contains only the normalized lifecycle event, server environment envelope, product and entitlement classification, event time, and delivery state.
+It never contains the raw webhook, receipt, transaction ID, API credential, authorization value, HMAC secret, or vendor response.
+9. The event is marked complete in that same transaction as the projection changes and outbox writes.
 A duplicate completed event returns HTTP 200 without a second RevenueCat lookup.
-9. `expireRevenueCatEntitlements` removes a still-present active grant within five minutes after its last verified expiration or grace-period timestamp.
+10. `processRevenueCatAnalyticsOutbox` independently retries due rows into the Mixpanel project mapped from the deployed Firebase project.
+It uses Mixpanel `/import` with `strict=1` and a stable `$insert_id`, so a provider retry or a crash after Mixpanel accepts the event cannot surface a second event.
+Only a confirmed import marks the row delivered; transient network, rate-limit, authentication, and provider failures return it to the queue with bounded exponential backoff.
+11. `expireRevenueCatEntitlements` removes a still-present active grant within five minutes after its last verified expiration or grace-period timestamp.
 This fails closed if an expiration webhook is delayed and a concurrent renewal wins through Firestore transaction retry.
 The sweep pages past documents from any other `entitlements` subcollection until it has spent its budget on real `users/{uid}/entitlements/app_access` grants, because the query is ordered by `accessUntil` and a single foreign document with an ancient timestamp would otherwise sit at the head of a fixed window and starve every real expiry behind it.
 
 Webhook failures return a non-2xx response so RevenueCat retries them.
 RevenueCat currently documents five retries after 5, 10, 20, 40, and 80 minutes.
 The processor is safe after a crash because a failed attempt is reclaimable and an abandoned processing lease expires before RevenueCat's first retry.
+Mixpanel delivery failures do not fail or delay the webhook response because delivery starts only from the separately scheduled outbox worker.
 
-No raw webhook body, transaction identifier, API key, Authorization value, HMAC secret, Firebase UID, or subscriber response is stored or logged.
-The event ledger stores only event metadata, a payload digest, processing state, and counts.
+No raw webhook body, transaction identifier, API key, Authorization value, HMAC secret, or subscriber response is stored or logged.
+The event ledger stores only event metadata, a payload digest, processing state, and counts, with no Firebase UID.
+The analytics outbox stores the affected Firebase UID only as the Mixpanel `distinct_id`; account deletion removes every outbox row that still carries it.
 
 Each ledger entry carries `retainUntil`, an explicit thirty-day future timestamp, and a Firestore TTL field override deletes the entry when it passes.
 The dedupe evidence only has to outlive RevenueCat's roughly 155-minute retry ladder, so thirty days is generous while still bounding the collection.
@@ -188,7 +216,7 @@ Each paid Firestore request costs one rules document access, and each paid Stora
 
 No new SDK, device data source, or App Privacy category is introduced.
 `PrivacyInfo.xcprivacy` already declares linked Purchase History and linked User ID for app functionality, and the published privacy policy already describes subscription status, entitlements, and purchase history processed through Apple and RevenueCat.
-The server stores a minimal entitlement projection and no raw purchase receipt or transaction identifier, so no privacy manifest or policy change is required for this implementation.
+The server stores a minimal entitlement projection and bounded analytics outbox, with no raw purchase receipt or transaction identifier, so no privacy manifest or policy change is required for this implementation.
 
 ## UNKNOWN
 

--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -131,6 +131,9 @@ It deletes that active grant when current RevenueCat state is inactive.
 7. A projection only replaces one derived from an older RevenueCat `request_date_ms`.
 The triggering event's order therefore cannot move subscriber state backward.
 8. For each verified Firebase uid and reportable subscription transition, the event-completion transaction creates one `_revenuecat_analytics_outbox` row whose stable idempotency key is derived from the RevenueCat event ID and uid.
+Exactly-once therefore means one analytics event per RevenueCat event ID plus uid; two distinct event IDs are two real transitions and each exports once.
+One Apple refund is two such transitions: the `CANCELLATION` exports `subscription_cancelled`, which may still hold access to the end of the paid period, and the later `EXPIRATION` that fresh RevenueCat truth shows removed access exports `subscription_refunded`.
+Both carry `refund_attributed`, so a refund is queryable end to end without either transition being suppressed or relabelled as the other.
 The row contains only the normalized lifecycle event, server environment envelope, product and entitlement classification, event time, and delivery state.
 It never contains the raw webhook, receipt, transaction ID, API credential, authorization value, HMAC secret, or vendor response.
 9. The event is marked complete in that same transaction as the projection changes and outbox writes.
@@ -148,7 +151,9 @@ The processor is safe after a crash because a failed attempt is reclaimable and 
 Mixpanel delivery failures do not fail or delay the webhook response because delivery starts only from the separately scheduled outbox worker.
 An unresolvable analytics destination is degraded rather than fatal: the webhook logs it, skips outbox enqueueing, and still authenticates, deduplicates, and projects the entitlement, because analytics may never decide paid access.
 Each worker run stops claiming deliveries before its function timeout and immediately returns every unattempted claim to the queue, so provider latency drains instead of stranding rows until the fifteen-minute stale sweep.
+A claim released that way was never sent, so it keeps the delivery attempt count and last delivery error it already had; only a real send moves either, and the backoff ladder is unaffected by how busy a run was.
 A permanently discarded row is logged at error level with its outbox id, event name, and error code, so a dead lifecycle stream is visible rather than silent.
+A row that keeps failing retryably past its tenth attempt - a rotated Mixpanel credential answers 401, which is retryable - is logged at error level on every further attempt, so retrying forever is never the same as failing quietly.
 
 No raw webhook body, transaction identifier, API key, Authorization value, HMAC secret, or subscriber response is stored or logged.
 The event ledger stores only event metadata, a payload digest, processing state, and counts, with no Firebase UID.
@@ -158,6 +163,7 @@ Each ledger entry carries `retainUntil`, an explicit thirty-day future timestamp
 The dedupe evidence only has to outlive RevenueCat's roughly 155-minute retry ladder, so thirty days is generous while still bounding the collection.
 `receivedAt` cannot carry the policy: it is already in the past when it is written, so every entry would be eligible for deletion the moment it was created.
 Each analytics outbox row carries the same thirty-day `retainUntil` stamp and its own Firestore TTL field override, because a row holds a Firebase UID as its Mixpanel `distinct_id` and may not outlive the delivery it exists to prove.
+Every state change restamps it, so the thirty days run from the row's last movement rather than from its creation: a row still retrying cannot be deleted out from under the retry-until-delivery guarantee, and a delivered or terminally failed row gets exactly one bounded window after it settled.
 
 ## Recovering access the webhook never delivered
 

--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -75,7 +75,10 @@ The JSON shape is:
 Create a separate project-scoped Mixpanel service account for Staging project `4051102` and Production project `4051100`.
 Grant only the Mixpanel project role required by `/import`; Mixpanel currently requires an Admin service account for that endpoint, so keep each account scoped to its one project and out of organization-wide membership.
 The server derives the destination from its deployed Firebase project and refuses every project outside this fixed map: Development `ascend-f2e4f` -> `4032860`, Staging `ascend-staging-fa7d5` -> `4051102`, Production `ascend-prod-9c8f2` -> `4051100`.
-Development has no RevenueCat webhook endpoint today, so its closed-app lifecycle stream remains intentionally empty unless that integration is added later.
+Server-side subscription lifecycle analytics exists in staging and production only, which is why no dev credential is listed above.
+No repository workflow deploys Cloud Functions to `ascend-f2e4f`, and dev has no RevenueCat webhook endpoint, so dev deliberately has no server analytics credential and its closed-app lifecycle stream stays empty.
+Client analytics is untouched by this: the dev app still reports client events to `4032860` from the device.
+If a dev Functions deployment is ever added, provision a dev-project-scoped Mixpanel service account and its own `MIXPANEL_SERVER_CONFIG` before that deployment, because a bound secret that does not exist fails the whole Functions deploy exactly as it would in staging.
 
 Set both `REVENUECAT_SERVER_CONFIG` and `MIXPANEL_SERVER_CONFIG` before deploying Functions.
 The webhook binds only the RevenueCat secret, while the independent outbox worker binds only the Mixpanel secret, so a Mixpanel outage or credential failure can never decide RevenueCat's webhook response.

--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -146,6 +146,9 @@ Webhook failures return a non-2xx response so RevenueCat retries them.
 RevenueCat currently documents five retries after 5, 10, 20, 40, and 80 minutes.
 The processor is safe after a crash because a failed attempt is reclaimable and an abandoned processing lease expires before RevenueCat's first retry.
 Mixpanel delivery failures do not fail or delay the webhook response because delivery starts only from the separately scheduled outbox worker.
+An unresolvable analytics destination is degraded rather than fatal: the webhook logs it, skips outbox enqueueing, and still authenticates, deduplicates, and projects the entitlement, because analytics may never decide paid access.
+Each worker run stops claiming deliveries before its function timeout and immediately returns every unattempted claim to the queue, so provider latency drains instead of stranding rows until the fifteen-minute stale sweep.
+A permanently discarded row is logged at error level with its outbox id, event name, and error code, so a dead lifecycle stream is visible rather than silent.
 
 No raw webhook body, transaction identifier, API key, Authorization value, HMAC secret, or subscriber response is stored or logged.
 The event ledger stores only event metadata, a payload digest, processing state, and counts, with no Firebase UID.
@@ -154,6 +157,7 @@ The analytics outbox stores the affected Firebase UID only as the Mixpanel `dist
 Each ledger entry carries `retainUntil`, an explicit thirty-day future timestamp, and a Firestore TTL field override deletes the entry when it passes.
 The dedupe evidence only has to outlive RevenueCat's roughly 155-minute retry ladder, so thirty days is generous while still bounding the collection.
 `receivedAt` cannot carry the policy: it is already in the past when it is written, so every entry would be eligible for deletion the moment it was created.
+Each analytics outbox row carries the same thirty-day `retainUntil` stamp and its own Firestore TTL field override, because a row holds a Firebase UID as its Mixpanel `distinct_id` and may not outlive the delivery it exists to prove.
 
 ## Recovering access the webhook never delivered
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -293,6 +293,12 @@
       "fieldPath": "retainUntil",
       "ttl": true,
       "indexes": []
+    },
+    {
+      "collectionGroup": "_revenuecat_analytics_outbox",
+      "fieldPath": "retainUntil",
+      "ttl": true,
+      "indexes": []
     }
   ]
 }

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,6 +1,34 @@
 {
   "indexes": [
     {
+      "collectionGroup": "_revenuecat_analytics_outbox",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "readyAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "_revenuecat_analytics_outbox",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "processingStartedAt",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "workouts",
       "queryScope": "COLLECTION",
       "fields": [

--- a/firestore.rules
+++ b/firestore.rules
@@ -1640,5 +1640,9 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    match /_revenuecat_analytics_outbox/{eventId} {
+      allow read, write: if false;
+    }
+
   }
 }

--- a/functions/src/accountCleanup.ts
+++ b/functions/src/accountCleanup.ts
@@ -4,6 +4,9 @@ import * as admin from "firebase-admin";
 import {buildRatingPromptEmailDedupeKey} from "./email/automation";
 import {buildEmailJobId} from "./email/queue";
 import {PUBLIC_IDENTITY_STATE_DELETED} from "./publicIdentity";
+import {
+  ANALYTICS_OUTBOX_COLLECTION,
+} from "./revenueCat/firestoreStore";
 
 const LIVE_REPLAY_COLLECTION = "live_replay_leaderboards";
 
@@ -32,6 +35,7 @@ export interface DeletedUserCleanupPort {
   deleteModerationReports(userId: string): Promise<number>;
   deleteIncomingBlockDocuments(userId: string): Promise<number>;
   deleteLifecycleEmailJobs(userId: string): Promise<number>;
+  deleteRevenueCatAnalyticsOutbox(userId: string): Promise<number>;
   deleteRateLimitDocument(userId: string): Promise<void>;
 }
 
@@ -47,6 +51,7 @@ export interface CleanupSummary {
   deletedModerationReports: number;
   deletedIncomingBlockDocuments: number;
   deletedLifecycleEmailJobs: number;
+  deletedRevenueCatAnalyticsOutbox: number;
   failures: string[];
 }
 
@@ -67,7 +72,8 @@ export interface CleanupSummary {
  * way, so each such record needs its own step here: notification_devices,
  * leaderboard_stats, identity propagation checkpoints, replay entries,
  * userRateLimits, the replay finisher statuses, feedback, moderation_reports,
- * incoming block documents, and the uid-keyed email_jobs.
+ * incoming block documents, the uid-keyed email_jobs, and the RevenueCat
+ * analytics outbox rows that carry the uid as Mixpanel distinct_id.
  * Feedback and moderation reports are
  * hard-deleted rather than anonymized because their free-text or safety context
  * can identify the user after their account is gone.
@@ -181,6 +187,14 @@ export async function cleanupDeletedUser(
     failures.push(`email_jobs: ${errorMessage(error)}`);
   }
 
+  let deletedRevenueCatAnalyticsOutbox = 0;
+  try {
+    deletedRevenueCatAnalyticsOutbox =
+      await port.deleteRevenueCatAnalyticsOutbox(userId);
+  } catch (error) {
+    failures.push(`revenuecat_analytics_outbox: ${errorMessage(error)}`);
+  }
+
   try {
     await port.deleteRateLimitDocument(userId);
   } catch (error) {
@@ -198,6 +212,7 @@ export async function cleanupDeletedUser(
     deletedLifecycleEmailJobs,
     deletedNotificationDevices,
     deletedReplayFinisherStatuses,
+    deletedRevenueCatAnalyticsOutbox,
     deletedSubcollections,
     failures,
   };
@@ -452,6 +467,18 @@ export function makeAdminPort(
       return deleted;
     },
 
+    async deleteRevenueCatAnalyticsOutbox(userId) {
+      const snapshot = await firestore
+        .collection(ANALYTICS_OUTBOX_COLLECTION)
+        .where("distinctId", "==", userId)
+        .get();
+
+      for (const document of snapshot.docs) {
+        await document.ref.delete();
+      }
+      return snapshot.size;
+    },
+
     async deleteRateLimitDocument(userId) {
       await firestore.collection("userRateLimits").doc(userId).delete();
     },
@@ -493,6 +520,8 @@ export const cleanupDeletedUserData = onDocumentDeleted(
       deletedLifecycleEmailJobs: summary.deletedLifecycleEmailJobs,
       deletedNotificationDevices: summary.deletedNotificationDevices,
       deletedReplayFinisherStatuses: summary.deletedReplayFinisherStatuses,
+      deletedRevenueCatAnalyticsOutbox:
+        summary.deletedRevenueCatAnalyticsOutbox,
       deletedSubcollections: summary.deletedSubcollections,
       userId,
     });

--- a/functions/src/accountCleanup.ts
+++ b/functions/src/accountCleanup.ts
@@ -6,7 +6,7 @@ import {buildEmailJobId} from "./email/queue";
 import {PUBLIC_IDENTITY_STATE_DELETED} from "./publicIdentity";
 import {
   ANALYTICS_OUTBOX_COLLECTION,
-} from "./revenueCat/firestoreStore";
+} from "./revenueCat/analyticsFirestoreOutbox";
 
 const LIVE_REPLAY_COLLECTION = "live_replay_leaderboards";
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -33,6 +33,9 @@ export {
   updatePushNotificationPreferences,
 } from "./pushNotifications";
 export {revenueCatWebhook} from "./revenueCat/webhook";
+export {
+  processRevenueCatAnalyticsOutbox,
+} from "./revenueCat/analyticsExporter";
 export {reconcileAppAccess} from "./revenueCat/reconciliation";
 export {
   expireRevenueCatEntitlements,

--- a/functions/src/revenueCat/analyticsConfig.ts
+++ b/functions/src/revenueCat/analyticsConfig.ts
@@ -1,0 +1,75 @@
+import {defineSecret} from "firebase-functions/params";
+
+export interface MixpanelServerConfig {
+  serviceAccountUsername: string;
+  serviceAccountPassword: string;
+}
+
+export const mixpanelServerConfig =
+  defineSecret("MIXPANEL_SERVER_CONFIG");
+
+const MAX_USERNAME_LENGTH = 255;
+const MIN_PASSWORD_LENGTH = 32;
+const MAX_PASSWORD_LENGTH = 1024;
+
+/**
+ * Parses the server-only Mixpanel service-account credential.
+ * @param {string} rawConfig - Secret Manager JSON value
+ * @return {MixpanelServerConfig} Validated credential
+ */
+export function parseMixpanelServerConfig(
+  rawConfig: string
+): MixpanelServerConfig {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawConfig) as unknown;
+  } catch {
+    throw new Error("MIXPANEL_SERVER_CONFIG must be valid JSON");
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("MIXPANEL_SERVER_CONFIG is missing or invalid");
+  }
+
+  const username = parsed.serviceAccountUsername;
+  const password = parsed.serviceAccountPassword;
+  if (typeof username !== "string" ||
+    username.length === 0 ||
+    username.length > MAX_USERNAME_LENGTH ||
+    username.includes(":") ||
+    containsControlCharacter(username)) {
+    throw new Error(
+      "MIXPANEL_SERVER_CONFIG.serviceAccountUsername is invalid"
+    );
+  }
+  if (typeof password !== "string" ||
+    password.length < MIN_PASSWORD_LENGTH ||
+    password.length > MAX_PASSWORD_LENGTH ||
+    containsControlCharacter(password)) {
+    throw new Error(
+      "MIXPANEL_SERVER_CONFIG.serviceAccountPassword is invalid"
+    );
+  }
+  return {
+    serviceAccountUsername: username,
+    serviceAccountPassword: password,
+  };
+}
+
+/**
+ * Reads the deployed credential without logging or exposing it.
+ * @return {MixpanelServerConfig} Validated credential
+ */
+export function getMixpanelServerConfig(): MixpanelServerConfig {
+  return parseMixpanelServerConfig(mixpanelServerConfig.value());
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function containsControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 31 || codePoint === 127;
+  });
+}

--- a/functions/src/revenueCat/analyticsEnvironment.ts
+++ b/functions/src/revenueCat/analyticsEnvironment.ts
@@ -41,6 +41,29 @@ export function analyticsEnvironmentForFirebaseProject(
   };
 }
 
+/**
+ * Resolves the analytics destination for a caller that must not fail on it.
+ *
+ * Entitlement ingress owns paid access, so an unresolvable analytics
+ * destination degrades the lifecycle export rather than rejecting the webhook
+ * that projects the grant.
+ * @param {string | undefined} firebaseProjectId - Deployed project, if known
+ * @param {string} revision - Cloud Run revision for producer attribution
+ * @return {RevenueCatAnalyticsEnvironment | null} Envelope, or null
+ */
+export function optionalAnalyticsEnvironment(
+  firebaseProjectId: string | undefined,
+  revision: string
+): RevenueCatAnalyticsEnvironment | null {
+  if (!firebaseProjectId || !isKnownFirebaseProject(firebaseProjectId)) {
+    console.error("RevenueCat analytics destination is unresolved", {
+      firebaseProjectId: firebaseProjectId ?? "unknown",
+    });
+    return null;
+  }
+  return analyticsEnvironmentForFirebaseProject(firebaseProjectId, revision);
+}
+
 function isKnownFirebaseProject(
   projectId: string
 ): projectId is keyof typeof PROJECT_DESTINATIONS {

--- a/functions/src/revenueCat/analyticsEnvironment.ts
+++ b/functions/src/revenueCat/analyticsEnvironment.ts
@@ -1,0 +1,48 @@
+import type {RevenueCatAnalyticsEnvironment} from "./analyticsTypes";
+
+const PROJECT_DESTINATIONS = {
+  "ascend-f2e4f": {
+    appEnvironment: "dev",
+    mixpanelProjectId: "4032860",
+  },
+  "ascend-staging-fa7d5": {
+    appEnvironment: "staging",
+    mixpanelProjectId: "4051102",
+  },
+  "ascend-prod-9c8f2": {
+    appEnvironment: "production",
+    mixpanelProjectId: "4051100",
+  },
+} as const;
+
+const BUILD_NUMBER_PATTERN = /^[A-Za-z0-9._-]{1,100}$/;
+
+/**
+ * Resolves the only permitted Firebase-to-Mixpanel destination mapping.
+ * @param {string} firebaseProjectId - Deployed Firebase project identifier
+ * @param {string} revision - Cloud Run revision for producer attribution
+ * @return {RevenueCatAnalyticsEnvironment} Required server envelope
+ */
+export function analyticsEnvironmentForFirebaseProject(
+  firebaseProjectId: string,
+  revision: string
+): RevenueCatAnalyticsEnvironment {
+  if (!isKnownFirebaseProject(firebaseProjectId)) {
+    throw new Error("Unsupported Firebase project for analytics export");
+  }
+  const destination = PROJECT_DESTINATIONS[firebaseProjectId];
+  return {
+    firebaseProjectId,
+    mixpanelProjectId: destination.mixpanelProjectId,
+    appEnvironment: destination.appEnvironment,
+    buildConfig: "server",
+    appVersion: "cloud_functions",
+    buildNumber: BUILD_NUMBER_PATTERN.test(revision) ? revision : "unknown",
+  };
+}
+
+function isKnownFirebaseProject(
+  projectId: string
+): projectId is keyof typeof PROJECT_DESTINATIONS {
+  return Object.prototype.hasOwnProperty.call(PROJECT_DESTINATIONS, projectId);
+}

--- a/functions/src/revenueCat/analyticsEvent.ts
+++ b/functions/src/revenueCat/analyticsEvent.ts
@@ -96,8 +96,14 @@ function lifecycleEventName(
   case "BILLING_ISSUE":
     return "subscription_billing_issue";
   case "EXPIRATION":
-    return event.lifecycleReason === "customer_support" ?
-      "subscription_refunded" : "subscription_expired";
+    if (event.lifecycleReason === "customer_support") {
+      // One refund arrives twice: CANCELLATION(customer_support) at the refund
+      // itself, then EXPIRATION(customer_support) for the access it removed.
+      // The cancellation row owns subscription_refunded, so exporting this one
+      // too would make one refund look like two.
+      return null;
+    }
+    return "subscription_expired";
   case "PRODUCT_CHANGE":
     return "subscription_product_changed";
   default:

--- a/functions/src/revenueCat/analyticsEvent.ts
+++ b/functions/src/revenueCat/analyticsEvent.ts
@@ -1,0 +1,115 @@
+import {createHash} from "node:crypto";
+import type {
+  LifecycleAnalyticsEvent,
+  LifecycleAnalyticsEventName,
+  RevenueCatAnalyticsEnvironment,
+} from "./analyticsTypes";
+import type {
+  AppAccessProjection,
+  RevenueCatServerConfig,
+  RevenueCatWebhookEvent,
+} from "./types";
+
+/**
+ * Normalizes one authenticated RevenueCat lifecycle transition for Mixpanel.
+ * @param {RevenueCatWebhookEvent} event - Bounded webhook event
+ * @param {AppAccessProjection} projection - Fresh subscriber truth
+ * @param {RevenueCatServerConfig} config - Environment entitlement contract
+ * @param {RevenueCatAnalyticsEnvironment} environment - Server envelope
+ * @return {LifecycleAnalyticsEvent | null} Reportable event, if any
+ */
+export function buildLifecycleAnalyticsEvent(
+  event: RevenueCatWebhookEvent,
+  projection: AppAccessProjection,
+  config: RevenueCatServerConfig,
+  environment: RevenueCatAnalyticsEnvironment
+): LifecycleAnalyticsEvent | null {
+  const eventName = lifecycleEventName(event, projection);
+  if (!eventName || config.entitlementId !== "app_access") {
+    return null;
+  }
+
+  const productId = event.type === "PRODUCT_CHANGE" ?
+    event.newProductId ?? projection.productId :
+    event.productId ?? projection.productId;
+  if (!productId || !config.allowedProductIds.includes(productId)) {
+    return null;
+  }
+
+  const previousProductId = event.type === "PRODUCT_CHANGE" &&
+    event.productId &&
+    config.allowedProductIds.includes(event.productId) ?
+    event.productId : null;
+  const insertId = createHash("sha256")
+    .update(event.id, "utf8")
+    .update("\0", "utf8")
+    .update(projection.uid, "utf8")
+    .digest("hex")
+    .slice(0, 32);
+
+  return {
+    schemaVersion: 1,
+    eventName,
+    eventVersion: 1,
+    source: "revenuecat_webhook",
+    distinctId: projection.uid,
+    insertId,
+    eventTimestampMs: event.eventTimestampMs,
+    entitlementId: "app_access",
+    productId,
+    previousProductId,
+    store: event.store,
+    periodType: event.periodType,
+    lifecycleReason: event.lifecycleReason,
+    entitlementActive: projection.isActive,
+    effectiveExpirationAtMs: effectiveExpirationAtMs(event, projection),
+    firebaseProjectId: environment.firebaseProjectId,
+    appEnvironment: environment.appEnvironment,
+    buildConfig: environment.buildConfig,
+    appVersion: environment.appVersion,
+    buildNumber: environment.buildNumber,
+  };
+}
+
+function lifecycleEventName(
+  event: RevenueCatWebhookEvent,
+  projection: AppAccessProjection
+): LifecycleAnalyticsEventName | null {
+  switch (event.type) {
+  case "INITIAL_PURCHASE":
+    return event.periodType === "trial" ?
+      "subscription_trial_started" : "subscription_started";
+  case "RENEWAL":
+    return event.isTrialConversion ?
+      "subscription_trial_converted" : "subscription_renewed";
+  case "CANCELLATION":
+    if (event.lifecycleReason === "billing_error") {
+      // RevenueCat emits BILLING_ISSUE for this same transition. Exporting
+      // both webhook rows would make one billing failure look like two.
+      return null;
+    }
+    return event.lifecycleReason === "customer_support" &&
+      !projection.isActive ?
+      "subscription_refunded" : "subscription_cancelled";
+  case "UNCANCELLATION":
+    return "subscription_uncancelled";
+  case "BILLING_ISSUE":
+    return "subscription_billing_issue";
+  case "EXPIRATION":
+    return event.lifecycleReason === "customer_support" ?
+      "subscription_refunded" : "subscription_expired";
+  case "PRODUCT_CHANGE":
+    return "subscription_product_changed";
+  default:
+    return null;
+  }
+}
+
+function effectiveExpirationAtMs(
+  event: RevenueCatWebhookEvent,
+  projection: AppAccessProjection
+): number | null {
+  return projection.expiresAt?.getTime() ??
+    event.gracePeriodExpirationAtMs ??
+    event.expirationAtMs;
+}

--- a/functions/src/revenueCat/analyticsEvent.ts
+++ b/functions/src/revenueCat/analyticsEvent.ts
@@ -61,6 +61,7 @@ export function buildLifecycleAnalyticsEvent(
     store: event.store,
     periodType: event.periodType,
     lifecycleReason: event.lifecycleReason,
+    refundAttributed: isRefundAttributed(event),
     entitlementActive: projection.isActive,
     effectiveExpirationAtMs: effectiveExpirationAtMs(event, projection),
     firebaseProjectId: environment.firebaseProjectId,
@@ -69,6 +70,15 @@ export function buildLifecycleAnalyticsEvent(
     appVersion: environment.appVersion,
     buildNumber: environment.buildNumber,
   };
+}
+
+/**
+ * Marks the two transitions Apple's refund produces so both stay queryable as
+ * one commercial refund without either being suppressed.
+ */
+function isRefundAttributed(event: RevenueCatWebhookEvent): boolean {
+  return event.lifecycleReason === "customer_support" &&
+    (event.type === "CANCELLATION" || event.type === "EXPIRATION");
 }
 
 function lifecycleEventName(
@@ -88,22 +98,18 @@ function lifecycleEventName(
       // both webhook rows would make one billing failure look like two.
       return null;
     }
-    return event.lifecycleReason === "customer_support" &&
-      !projection.isActive ?
-      "subscription_refunded" : "subscription_cancelled";
+    // A support refund cancels first and may leave access running to period
+    // end, so this transition stays a cancellation and carries the refund
+    // attribution instead of borrowing the expiration's meaning.
+    return "subscription_cancelled";
   case "UNCANCELLATION":
     return "subscription_uncancelled";
   case "BILLING_ISSUE":
     return "subscription_billing_issue";
   case "EXPIRATION":
-    if (event.lifecycleReason === "customer_support") {
-      // One refund arrives twice: CANCELLATION(customer_support) at the refund
-      // itself, then EXPIRATION(customer_support) for the access it removed.
-      // The cancellation row owns subscription_refunded, so exporting this one
-      // too would make one refund look like two.
-      return null;
-    }
-    return "subscription_expired";
+    return event.lifecycleReason === "customer_support" &&
+      !projection.isActive ?
+      "subscription_refunded" : "subscription_expired";
   case "PRODUCT_CHANGE":
     return "subscription_product_changed";
   default:

--- a/functions/src/revenueCat/analyticsExporter.ts
+++ b/functions/src/revenueCat/analyticsExporter.ts
@@ -1,0 +1,44 @@
+import * as admin from "firebase-admin";
+import {onSchedule} from "firebase-functions/v2/scheduler";
+import {
+  getMixpanelServerConfig,
+  mixpanelServerConfig,
+} from "./analyticsConfig";
+import {
+  analyticsEnvironmentForFirebaseProject,
+} from "./analyticsEnvironment";
+import {FirestoreAnalyticsOutboxStore} from "./analyticsFirestoreOutbox";
+import {
+  MixpanelLifecycleAnalyticsClient,
+} from "./analyticsMixpanelClient";
+import {processAnalyticsOutbox} from "./analyticsOutboxProcessor";
+
+/**
+ * Retries durable RevenueCat lifecycle analytics independently of the webhook.
+ */
+export const processRevenueCatAnalyticsOutbox = onSchedule(
+  {
+    schedule: "* * * * *",
+    secrets: [mixpanelServerConfig],
+    timeZone: "Etc/UTC",
+    timeoutSeconds: 120,
+  },
+  async () => {
+    const firebaseProjectId = admin.app().options.projectId;
+    if (!firebaseProjectId) {
+      throw new Error("Firebase project is unavailable to analytics exporter");
+    }
+    const environment = analyticsEnvironmentForFirebaseProject(
+      firebaseProjectId,
+      process.env.K_REVISION ?? "unknown"
+    );
+    const config = getMixpanelServerConfig();
+    const summary = await processAnalyticsOutbox({
+      store: new FirestoreAnalyticsOutboxStore(admin.firestore()),
+      client: new MixpanelLifecycleAnalyticsClient(config, environment),
+      environment,
+      now: () => new Date(),
+    });
+    console.log("RevenueCat analytics outbox run completed", summary);
+  }
+);

--- a/functions/src/revenueCat/analyticsFirestoreOutbox.ts
+++ b/functions/src/revenueCat/analyticsFirestoreOutbox.ts
@@ -15,6 +15,12 @@ export const ANALYTICS_OUTBOX_COLLECTION =
 // RevenueCat's roughly 155-minute retry ladder; thirty days matches the event
 // ledger and leaves a human-inspectable trail. The Firestore TTL policy on
 // `retainUntil` does the deleting.
+//
+// Every state transition restamps it, so the bound measures thirty days from
+// the row's last movement rather than from its creation: a row still retrying
+// cannot be deleted out from under the retry-until-delivery guarantee, while a
+// delivered or terminally failed row gets exactly one bounded window after it
+// settled.
 export const ANALYTICS_OUTBOX_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 const STALE_PROCESSING_MS = 15 * 60 * 1000;
@@ -62,6 +68,7 @@ implements AnalyticsOutboxStore {
             processingStartedAt: null,
             claimId: null,
             updatedAt: admin.firestore.Timestamp.fromDate(now),
+            retainUntil: retentionStamp(now),
           });
           return true;
         }
@@ -109,6 +116,7 @@ implements AnalyticsOutboxStore {
       claimId: null,
       lastErrorCode: null,
       updatedAt: admin.firestore.Timestamp.fromDate(now),
+      retainUntil: retentionStamp(now),
     });
   }
 
@@ -125,6 +133,22 @@ implements AnalyticsOutboxStore {
       claimId: null,
       lastErrorCode: errorCode,
       updatedAt: admin.firestore.Timestamp.fromDate(now),
+      retainUntil: retentionStamp(now),
+    });
+  }
+
+  async release(
+    claim: AnalyticsOutboxClaim,
+    now: Date
+  ): Promise<void> {
+    await this.updateClaimed(claim, {
+      status: "queued",
+      readyAt: admin.firestore.Timestamp.fromDate(now),
+      processingStartedAt: null,
+      claimId: null,
+      attemptCount: Math.max(claim.attemptCount - 1, 0),
+      updatedAt: admin.firestore.Timestamp.fromDate(now),
+      retainUntil: retentionStamp(now),
     });
   }
 
@@ -139,6 +163,7 @@ implements AnalyticsOutboxStore {
       claimId: null,
       lastErrorCode: errorCode,
       updatedAt: admin.firestore.Timestamp.fromDate(now),
+      retainUntil: retentionStamp(now),
     });
   }
 
@@ -231,6 +256,12 @@ export function serializeAnalyticsOutboxEvent(
   };
 }
 
+function retentionStamp(now: Date): admin.firestore.Timestamp {
+  return admin.firestore.Timestamp.fromMillis(
+    now.getTime() + ANALYTICS_OUTBOX_RETENTION_MS
+  );
+}
+
 function parseLifecycleAnalyticsEvent(
   value: admin.firestore.DocumentData | undefined
 ): LifecycleAnalyticsEvent | null {
@@ -249,6 +280,7 @@ function parseLifecycleAnalyticsEvent(
     !isBoundedString(value.store, 30) ||
     !isBoundedString(value.periodType, 30) ||
     !isNullableBoundedString(value.lifecycleReason, 40) ||
+    !isOptionalBoolean(value.refundAttributed) ||
     typeof value.entitlementActive !== "boolean" ||
     !isNullablePositiveInteger(value.effectiveExpirationAtMs) ||
     !isBoundedString(value.firebaseProjectId, 100) ||
@@ -272,6 +304,7 @@ function parseLifecycleAnalyticsEvent(
     store: value.store,
     periodType: value.periodType,
     lifecycleReason: value.lifecycleReason,
+    refundAttributed: value.refundAttributed === true,
     entitlementActive: value.entitlementActive,
     effectiveExpirationAtMs: value.effectiveExpirationAtMs,
     firebaseProjectId: value.firebaseProjectId,
@@ -291,6 +324,10 @@ function isAppEnvironment(
   value: unknown
 ): value is "dev" | "staging" | "production" {
   return value === "dev" || value === "staging" || value === "production";
+}
+
+function isOptionalBoolean(value: unknown): value is boolean | undefined {
+  return value === undefined || typeof value === "boolean";
 }
 
 function isBoundedString(value: unknown, max: number): value is string {

--- a/functions/src/revenueCat/analyticsFirestoreOutbox.ts
+++ b/functions/src/revenueCat/analyticsFirestoreOutbox.ts
@@ -1,14 +1,21 @@
 import {randomUUID} from "node:crypto";
 import * as admin from "firebase-admin";
-import {
-  ANALYTICS_OUTBOX_COLLECTION,
-} from "./firestoreStore";
 import type {
   AnalyticsOutboxClaim,
   AnalyticsOutboxStore,
   LifecycleAnalyticsEvent,
   LifecycleAnalyticsEventName,
 } from "./analyticsTypes";
+
+export const ANALYTICS_OUTBOX_COLLECTION =
+  "_revenuecat_analytics_outbox";
+
+// A row carries the affected Firebase UID as its Mixpanel `distinct_id`, so it
+// may not outlive the reason it exists. Delivery dedupe only has to outlive
+// RevenueCat's roughly 155-minute retry ladder; thirty days matches the event
+// ledger and leaves a human-inspectable trail. The Firestore TTL policy on
+// `retainUntil` does the deleting.
+export const ANALYTICS_OUTBOX_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 const STALE_PROCESSING_MS = 15 * 60 * 1000;
 const EVENT_NAMES = new Set<LifecycleAnalyticsEventName>([
@@ -77,6 +84,13 @@ implements AnalyticsOutboxStore {
 
     for (const document of snapshot.docs) {
       const claim = await this.claimOne(document.ref, nowTimestamp);
+      if (claim === "invalid_outbox_payload") {
+        console.error("RevenueCat analytics row is unreadable and discarded", {
+          outboxId: document.id,
+          lastErrorCode: "invalid_outbox_payload",
+        });
+        continue;
+      }
       if (claim) {
         claims.push(claim);
       }
@@ -135,7 +149,7 @@ implements AnalyticsOutboxStore {
   private async claimOne(
     reference: admin.firestore.DocumentReference,
     now: admin.firestore.Timestamp
-  ): Promise<AnalyticsOutboxClaim | null> {
+  ): Promise<AnalyticsOutboxClaim | "invalid_outbox_payload" | null> {
     return this.firestore.runTransaction(async (transaction) => {
       const snapshot = await transaction.get(reference);
       const readyAt = snapshot.get("readyAt");
@@ -154,7 +168,7 @@ implements AnalyticsOutboxStore {
           lastErrorCode: "invalid_outbox_payload",
           updatedAt: now,
         });
-        return null;
+        return "invalid_outbox_payload";
       }
       const attemptCount = integerAtLeast(snapshot.get("attemptCount"), 0) + 1;
       const claimId = randomUUID();
@@ -188,6 +202,33 @@ implements AnalyticsOutboxStore {
       transaction.update(reference, updates);
     });
   }
+}
+
+/**
+ * Renders one queued outbox row, including its bounded retention stamp.
+ * @param {LifecycleAnalyticsEvent} event - Normalized lifecycle event
+ * @param {admin.firestore.Timestamp} now - Write clock
+ * @return {Record<string, unknown>} Serialized queued row
+ */
+export function serializeAnalyticsOutboxEvent(
+  event: LifecycleAnalyticsEvent,
+  now: admin.firestore.Timestamp
+): Record<string, unknown> {
+  return {
+    ...event,
+    status: "queued",
+    attemptCount: 0,
+    readyAt: now,
+    processingStartedAt: null,
+    claimId: null,
+    deliveredAt: null,
+    lastErrorCode: null,
+    createdAt: now,
+    updatedAt: now,
+    retainUntil: admin.firestore.Timestamp.fromMillis(
+      now.toMillis() + ANALYTICS_OUTBOX_RETENTION_MS
+    ),
+  };
 }
 
 function parseLifecycleAnalyticsEvent(

--- a/functions/src/revenueCat/analyticsFirestoreOutbox.ts
+++ b/functions/src/revenueCat/analyticsFirestoreOutbox.ts
@@ -1,0 +1,279 @@
+import {randomUUID} from "node:crypto";
+import * as admin from "firebase-admin";
+import {
+  ANALYTICS_OUTBOX_COLLECTION,
+} from "./firestoreStore";
+import type {
+  AnalyticsOutboxClaim,
+  AnalyticsOutboxStore,
+  LifecycleAnalyticsEvent,
+  LifecycleAnalyticsEventName,
+} from "./analyticsTypes";
+
+const STALE_PROCESSING_MS = 15 * 60 * 1000;
+const EVENT_NAMES = new Set<LifecycleAnalyticsEventName>([
+  "subscription_started",
+  "subscription_trial_started",
+  "subscription_trial_converted",
+  "subscription_renewed",
+  "subscription_cancelled",
+  "subscription_uncancelled",
+  "subscription_billing_issue",
+  "subscription_expired",
+  "subscription_refunded",
+  "subscription_product_changed",
+]);
+
+export class FirestoreAnalyticsOutboxStore
+implements AnalyticsOutboxStore {
+  constructor(private readonly firestore: admin.firestore.Firestore) {}
+
+  async reclaimStale(now: Date, limit = 25): Promise<number> {
+    const threshold = admin.firestore.Timestamp.fromMillis(
+      now.getTime() - STALE_PROCESSING_MS
+    );
+    const snapshot = await this.collection()
+      .where("status", "==", "processing")
+      .where("processingStartedAt", "<=", threshold)
+      .limit(limit)
+      .get();
+    let reclaimedCount = 0;
+
+    for (const document of snapshot.docs) {
+      const didReclaim = await this.firestore.runTransaction(
+        async (transaction) => {
+          const current = await transaction.get(document.ref);
+          const startedAt = current.get("processingStartedAt");
+          if (current.get("status") !== "processing" ||
+            !(startedAt instanceof admin.firestore.Timestamp) ||
+            startedAt.toMillis() > threshold.toMillis()) {
+            return false;
+          }
+          transaction.update(document.ref, {
+            status: "queued",
+            readyAt: admin.firestore.Timestamp.fromDate(now),
+            processingStartedAt: null,
+            claimId: null,
+            updatedAt: admin.firestore.Timestamp.fromDate(now),
+          });
+          return true;
+        }
+      );
+      if (didReclaim) {
+        reclaimedCount += 1;
+      }
+    }
+    return reclaimedCount;
+  }
+
+  async claimDue(now: Date, limit = 25): Promise<AnalyticsOutboxClaim[]> {
+    const nowTimestamp = admin.firestore.Timestamp.fromDate(now);
+    const snapshot = await this.collection()
+      .where("status", "==", "queued")
+      .where("readyAt", "<=", nowTimestamp)
+      .limit(limit)
+      .get();
+    const claims: AnalyticsOutboxClaim[] = [];
+
+    for (const document of snapshot.docs) {
+      const claim = await this.claimOne(document.ref, nowTimestamp);
+      if (claim) {
+        claims.push(claim);
+      }
+    }
+    return claims;
+  }
+
+  async markDelivered(
+    claim: AnalyticsOutboxClaim,
+    now: Date
+  ): Promise<void> {
+    await this.updateClaimed(claim, {
+      status: "delivered",
+      deliveredAt: admin.firestore.Timestamp.fromDate(now),
+      processingStartedAt: null,
+      claimId: null,
+      lastErrorCode: null,
+      updatedAt: admin.firestore.Timestamp.fromDate(now),
+    });
+  }
+
+  async requeue(
+    claim: AnalyticsOutboxClaim,
+    readyAt: Date,
+    errorCode: string,
+    now: Date
+  ): Promise<void> {
+    await this.updateClaimed(claim, {
+      status: "queued",
+      readyAt: admin.firestore.Timestamp.fromDate(readyAt),
+      processingStartedAt: null,
+      claimId: null,
+      lastErrorCode: errorCode,
+      updatedAt: admin.firestore.Timestamp.fromDate(now),
+    });
+  }
+
+  async markFailed(
+    claim: AnalyticsOutboxClaim,
+    errorCode: string,
+    now: Date
+  ): Promise<void> {
+    await this.updateClaimed(claim, {
+      status: "failed",
+      processingStartedAt: null,
+      claimId: null,
+      lastErrorCode: errorCode,
+      updatedAt: admin.firestore.Timestamp.fromDate(now),
+    });
+  }
+
+  private collection(): admin.firestore.CollectionReference {
+    return this.firestore.collection(ANALYTICS_OUTBOX_COLLECTION);
+  }
+
+  private async claimOne(
+    reference: admin.firestore.DocumentReference,
+    now: admin.firestore.Timestamp
+  ): Promise<AnalyticsOutboxClaim | null> {
+    return this.firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(reference);
+      const readyAt = snapshot.get("readyAt");
+      if (!snapshot.exists ||
+        snapshot.get("status") !== "queued" ||
+        !(readyAt instanceof admin.firestore.Timestamp) ||
+        readyAt.toMillis() > now.toMillis()) {
+        return null;
+      }
+      const event = parseLifecycleAnalyticsEvent(snapshot.data());
+      if (!event || event.insertId !== reference.id) {
+        transaction.update(reference, {
+          status: "failed",
+          processingStartedAt: null,
+          claimId: null,
+          lastErrorCode: "invalid_outbox_payload",
+          updatedAt: now,
+        });
+        return null;
+      }
+      const attemptCount = integerAtLeast(snapshot.get("attemptCount"), 0) + 1;
+      const claimId = randomUUID();
+      transaction.update(reference, {
+        status: "processing",
+        attemptCount,
+        processingStartedAt: now,
+        claimId,
+        updatedAt: now,
+      });
+      return {
+        outboxId: reference.id,
+        claimId,
+        attemptCount,
+        event,
+      };
+    });
+  }
+
+  private async updateClaimed(
+    claim: AnalyticsOutboxClaim,
+    updates: Record<string, unknown>
+  ): Promise<void> {
+    const reference = this.collection().doc(claim.outboxId);
+    await this.firestore.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(reference);
+      if (snapshot.get("status") !== "processing" ||
+        snapshot.get("claimId") !== claim.claimId) {
+        return;
+      }
+      transaction.update(reference, updates);
+    });
+  }
+}
+
+function parseLifecycleAnalyticsEvent(
+  value: admin.firestore.DocumentData | undefined
+): LifecycleAnalyticsEvent | null {
+  if (!value ||
+    value.schemaVersion !== 1 ||
+    !isEventName(value.eventName) ||
+    value.eventVersion !== 1 ||
+    value.source !== "revenuecat_webhook" ||
+    !isBoundedString(value.distinctId, 128) ||
+    typeof value.insertId !== "string" ||
+    !/^[a-f0-9]{32}$/.test(value.insertId) ||
+    !isPositiveInteger(value.eventTimestampMs) ||
+    value.entitlementId !== "app_access" ||
+    !isBoundedString(value.productId, 200) ||
+    !isNullableBoundedString(value.previousProductId, 200) ||
+    !isBoundedString(value.store, 30) ||
+    !isBoundedString(value.periodType, 30) ||
+    !isNullableBoundedString(value.lifecycleReason, 40) ||
+    typeof value.entitlementActive !== "boolean" ||
+    !isNullablePositiveInteger(value.effectiveExpirationAtMs) ||
+    !isBoundedString(value.firebaseProjectId, 100) ||
+    !isAppEnvironment(value.appEnvironment) ||
+    value.buildConfig !== "server" ||
+    value.appVersion !== "cloud_functions" ||
+    !isBoundedString(value.buildNumber, 100)) {
+    return null;
+  }
+  return {
+    schemaVersion: 1,
+    eventName: value.eventName,
+    eventVersion: 1,
+    source: "revenuecat_webhook",
+    distinctId: value.distinctId,
+    insertId: value.insertId,
+    eventTimestampMs: value.eventTimestampMs,
+    entitlementId: "app_access",
+    productId: value.productId,
+    previousProductId: value.previousProductId,
+    store: value.store,
+    periodType: value.periodType,
+    lifecycleReason: value.lifecycleReason,
+    entitlementActive: value.entitlementActive,
+    effectiveExpirationAtMs: value.effectiveExpirationAtMs,
+    firebaseProjectId: value.firebaseProjectId,
+    appEnvironment: value.appEnvironment,
+    buildConfig: "server",
+    appVersion: "cloud_functions",
+    buildNumber: value.buildNumber,
+  };
+}
+
+function isEventName(value: unknown): value is LifecycleAnalyticsEventName {
+  return typeof value === "string" &&
+    EVENT_NAMES.has(value as LifecycleAnalyticsEventName);
+}
+
+function isAppEnvironment(
+  value: unknown
+): value is "dev" | "staging" | "production" {
+  return value === "dev" || value === "staging" || value === "production";
+}
+
+function isBoundedString(value: unknown, max: number): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= max;
+}
+
+function isNullableBoundedString(
+  value: unknown,
+  max: number
+): value is string | null {
+  return value === null || isBoundedString(value, max);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) && value > 0;
+}
+
+function isNullablePositiveInteger(value: unknown): value is number | null {
+  return value === null || isPositiveInteger(value);
+}
+
+function integerAtLeast(value: unknown, minimum: number): number {
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= minimum ? value : minimum;
+}

--- a/functions/src/revenueCat/analyticsMixpanelClient.ts
+++ b/functions/src/revenueCat/analyticsMixpanelClient.ts
@@ -1,0 +1,113 @@
+import type {MixpanelServerConfig} from "./analyticsConfig";
+import type {
+  LifecycleAnalyticsClient,
+  LifecycleAnalyticsEvent,
+  RevenueCatAnalyticsEnvironment,
+} from "./analyticsTypes";
+
+const MIXPANEL_IMPORT_URL = "https://api.mixpanel.com/import";
+const MIXPANEL_TIMEOUT_MS = 10_000;
+
+export class MixpanelLifecycleAnalyticsClient
+implements LifecycleAnalyticsClient {
+  constructor(
+    private readonly config: MixpanelServerConfig,
+    private readonly environment: RevenueCatAnalyticsEnvironment,
+    private readonly fetchImplementation: typeof fetch = fetch
+  ) {}
+
+  async send(event: LifecycleAnalyticsEvent): Promise<void> {
+    if (event.firebaseProjectId !== this.environment.firebaseProjectId ||
+      event.appEnvironment !== this.environment.appEnvironment) {
+      throw new MixpanelDeliveryError("environment_mismatch", false);
+    }
+
+    const url = new URL(MIXPANEL_IMPORT_URL);
+    url.searchParams.set("strict", "1");
+    url.searchParams.set("project_id", this.environment.mixpanelProjectId);
+    const credential = Buffer.from(
+      `${this.config.serviceAccountUsername}:` +
+      this.config.serviceAccountPassword,
+      "utf8"
+    ).toString("base64");
+    let response: Response;
+    try {
+      response = await this.fetchImplementation(url, {
+        method: "POST",
+        headers: {
+          "Authorization": `Basic ${credential}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify([mixpanelEvent(event)]),
+        signal: AbortSignal.timeout(MIXPANEL_TIMEOUT_MS),
+      });
+    } catch {
+      throw new MixpanelDeliveryError("network_failure", true);
+    }
+
+    if (!response.ok) {
+      throw new MixpanelDeliveryError(
+        response.status === 400 ? "validation_failed" :
+          `http_${response.status}`,
+        response.status !== 400,
+        response.status
+      );
+    }
+
+    let result: unknown;
+    try {
+      result = await response.json() as unknown;
+    } catch {
+      throw new MixpanelDeliveryError("invalid_response", true);
+    }
+    if (!isRecord(result) ||
+      result.code !== 200 ||
+      result.num_records_imported !== 1) {
+      throw new MixpanelDeliveryError("import_not_confirmed", true);
+    }
+  }
+}
+
+export class MixpanelDeliveryError extends Error {
+  constructor(
+    readonly code: string,
+    readonly retryable: boolean,
+    readonly status: number | null = null
+  ) {
+    super(code);
+    this.name = "MixpanelDeliveryError";
+  }
+}
+
+function mixpanelEvent(event: LifecycleAnalyticsEvent): {
+  event: string;
+  properties: Record<string, string | number | boolean | null>;
+} {
+  return {
+    event: event.eventName,
+    properties: {
+      "time": event.eventTimestampMs,
+      "distinct_id": event.distinctId,
+      "$insert_id": event.insertId,
+      "ip": 0,
+      "source": event.source,
+      "event_version": event.eventVersion,
+      "entitlement_id": event.entitlementId,
+      "product_id": event.productId,
+      "previous_product_id": event.previousProductId,
+      "store": event.store,
+      "period_type": event.periodType,
+      "lifecycle_reason": event.lifecycleReason,
+      "entitlement_active": event.entitlementActive,
+      "effective_expiration_at_ms": event.effectiveExpirationAtMs,
+      "app_environment": event.appEnvironment,
+      "build_config": event.buildConfig,
+      "app_version": event.appVersion,
+      "build_number": event.buildNumber,
+    },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/functions/src/revenueCat/analyticsMixpanelClient.ts
+++ b/functions/src/revenueCat/analyticsMixpanelClient.ts
@@ -98,6 +98,7 @@ function mixpanelEvent(event: LifecycleAnalyticsEvent): {
       "store": event.store,
       "period_type": event.periodType,
       "lifecycle_reason": event.lifecycleReason,
+      "refund_attributed": event.refundAttributed,
       "entitlement_active": event.entitlementActive,
       "effective_expiration_at_ms": event.effectiveExpirationAtMs,
       "app_environment": event.appEnvironment,

--- a/functions/src/revenueCat/analyticsOutboxProcessor.ts
+++ b/functions/src/revenueCat/analyticsOutboxProcessor.ts
@@ -1,0 +1,103 @@
+import {MixpanelDeliveryError} from "./analyticsMixpanelClient";
+import type {
+  AnalyticsOutboxProcessingSummary,
+  AnalyticsOutboxStore,
+  LifecycleAnalyticsClient,
+  RevenueCatAnalyticsEnvironment,
+} from "./analyticsTypes";
+
+const DEFAULT_BATCH_SIZE = 25;
+const INITIAL_RETRY_DELAY_MS = 60 * 1000;
+const MAX_RETRY_DELAY_MS = 60 * 60 * 1000;
+
+interface AnalyticsOutboxDependencies {
+  store: AnalyticsOutboxStore;
+  client: LifecycleAnalyticsClient;
+  environment: RevenueCatAnalyticsEnvironment;
+  now: () => Date;
+  batchSize?: number;
+}
+
+/**
+ * Delivers due analytics rows independently of RevenueCat webhook responses.
+ * @param {AnalyticsOutboxDependencies} dependencies - Delivery ports
+ * @return {Promise<AnalyticsOutboxProcessingSummary>} Bounded run summary
+ */
+export async function processAnalyticsOutbox(
+  dependencies: AnalyticsOutboxDependencies
+): Promise<AnalyticsOutboxProcessingSummary> {
+  const startedAt = dependencies.now();
+  const batchSize = dependencies.batchSize ?? DEFAULT_BATCH_SIZE;
+  const reclaimedCount = await dependencies.store.reclaimStale(
+    startedAt,
+    batchSize
+  );
+  const claims = await dependencies.store.claimDue(startedAt, batchSize);
+  const summary: AnalyticsOutboxProcessingSummary = {
+    reclaimedCount,
+    claimedCount: claims.length,
+    deliveredCount: 0,
+    retriedCount: 0,
+    failedCount: 0,
+  };
+
+  for (const claim of claims) {
+    if (claim.event.firebaseProjectId !==
+        dependencies.environment.firebaseProjectId ||
+      claim.event.appEnvironment !==
+        dependencies.environment.appEnvironment) {
+      await dependencies.store.markFailed(
+        claim,
+        "environment_mismatch",
+        dependencies.now()
+      );
+      summary.failedCount += 1;
+      continue;
+    }
+
+    try {
+      await dependencies.client.send(claim.event);
+    } catch (error) {
+      const deliveryError = error instanceof MixpanelDeliveryError ?
+        error : new MixpanelDeliveryError(
+          "unexpected_delivery_error",
+          true
+        );
+      if (deliveryError.retryable) {
+        await dependencies.store.requeue(
+          claim,
+          new Date(
+            startedAt.getTime() + retryDelayMs(claim.attemptCount)
+          ),
+          deliveryError.code,
+          dependencies.now()
+        );
+        summary.retriedCount += 1;
+      } else {
+        await dependencies.store.markFailed(
+          claim,
+          deliveryError.code,
+          dependencies.now()
+        );
+        summary.failedCount += 1;
+      }
+      continue;
+    }
+
+    await dependencies.store.markDelivered(
+      claim,
+      dependencies.now()
+    );
+    summary.deliveredCount += 1;
+  }
+
+  return summary;
+}
+
+export function retryDelayMs(attemptCount: number): number {
+  const exponent = Math.max(0, Math.min(attemptCount - 1, 6));
+  return Math.min(
+    INITIAL_RETRY_DELAY_MS * (2 ** exponent),
+    MAX_RETRY_DELAY_MS
+  );
+}

--- a/functions/src/revenueCat/analyticsOutboxProcessor.ts
+++ b/functions/src/revenueCat/analyticsOutboxProcessor.ts
@@ -1,5 +1,6 @@
 import {MixpanelDeliveryError} from "./analyticsMixpanelClient";
 import type {
+  AnalyticsOutboxClaim,
   AnalyticsOutboxProcessingSummary,
   AnalyticsOutboxStore,
   LifecycleAnalyticsClient,
@@ -7,6 +8,12 @@ import type {
 } from "./analyticsTypes";
 
 const DEFAULT_BATCH_SIZE = 25;
+// The scheduled worker is killed at 120 seconds and one Mixpanel request may
+// take its full 10-second timeout, so deliveries stop early enough to release
+// every claim this run will not attempt. A claim left in `processing` is
+// otherwise invisible until the 15-minute stale sweep, which turns provider
+// latency into a growing backlog instead of a draining one.
+const DEFAULT_RUN_BUDGET_MS = 75 * 1000;
 const INITIAL_RETRY_DELAY_MS = 60 * 1000;
 const MAX_RETRY_DELAY_MS = 60 * 60 * 1000;
 
@@ -16,6 +23,7 @@ interface AnalyticsOutboxDependencies {
   environment: RevenueCatAnalyticsEnvironment;
   now: () => Date;
   batchSize?: number;
+  runBudgetMs?: number;
 }
 
 /**
@@ -28,6 +36,8 @@ export async function processAnalyticsOutbox(
 ): Promise<AnalyticsOutboxProcessingSummary> {
   const startedAt = dependencies.now();
   const batchSize = dependencies.batchSize ?? DEFAULT_BATCH_SIZE;
+  const deadlineMs = startedAt.getTime() +
+    (dependencies.runBudgetMs ?? DEFAULT_RUN_BUDGET_MS);
   const reclaimedCount = await dependencies.store.reclaimStale(
     startedAt,
     batchSize
@@ -39,9 +49,22 @@ export async function processAnalyticsOutbox(
     deliveredCount: 0,
     retriedCount: 0,
     failedCount: 0,
+    deferredCount: 0,
   };
 
   for (const claim of claims) {
+    const now = dependencies.now();
+    if (now.getTime() >= deadlineMs) {
+      await dependencies.store.requeue(
+        claim,
+        now,
+        "run_deadline_reached",
+        now
+      );
+      summary.deferredCount += 1;
+      continue;
+    }
+
     if (claim.event.firebaseProjectId !==
         dependencies.environment.firebaseProjectId ||
       claim.event.appEnvironment !==
@@ -51,6 +74,7 @@ export async function processAnalyticsOutbox(
         "environment_mismatch",
         dependencies.now()
       );
+      reportPermanentFailure(claim, "environment_mismatch");
       summary.failedCount += 1;
       continue;
     }
@@ -79,6 +103,7 @@ export async function processAnalyticsOutbox(
           deliveryError.code,
           dependencies.now()
         );
+        reportPermanentFailure(claim, deliveryError.code);
         summary.failedCount += 1;
       }
       continue;
@@ -92,6 +117,18 @@ export async function processAnalyticsOutbox(
   }
 
   return summary;
+}
+
+function reportPermanentFailure(
+  claim: AnalyticsOutboxClaim,
+  errorCode: string
+): void {
+  console.error("RevenueCat analytics event was permanently discarded", {
+    outboxId: claim.outboxId,
+    eventName: claim.event.eventName,
+    attemptCount: claim.attemptCount,
+    lastErrorCode: errorCode,
+  });
 }
 
 export function retryDelayMs(attemptCount: number): number {

--- a/functions/src/revenueCat/analyticsOutboxProcessor.ts
+++ b/functions/src/revenueCat/analyticsOutboxProcessor.ts
@@ -16,6 +16,12 @@ const DEFAULT_BATCH_SIZE = 25;
 const DEFAULT_RUN_BUDGET_MS = 75 * 1000;
 const INITIAL_RETRY_DELAY_MS = 60 * 1000;
 const MAX_RETRY_DELAY_MS = 60 * 60 * 1000;
+// Backoff reaches its one-hour cap by the seventh delivery attempt, so a row
+// past this has been retrying for the better part of a day. Retrying forever is
+// the contract, but doing it silently is not: a rotated Mixpanel credential
+// answers 401, which is retryable, and would otherwise stall the whole stream
+// with no error-level signal.
+const STUCK_ATTEMPT_COUNT = 10;
 
 interface AnalyticsOutboxDependencies {
   store: AnalyticsOutboxStore;
@@ -55,12 +61,7 @@ export async function processAnalyticsOutbox(
   for (const claim of claims) {
     const now = dependencies.now();
     if (now.getTime() >= deadlineMs) {
-      await dependencies.store.requeue(
-        claim,
-        now,
-        "run_deadline_reached",
-        now
-      );
+      await dependencies.store.release(claim, now);
       summary.deferredCount += 1;
       continue;
     }
@@ -96,6 +97,14 @@ export async function processAnalyticsOutbox(
           deliveryError.code,
           dependencies.now()
         );
+        if (claim.attemptCount >= STUCK_ATTEMPT_COUNT) {
+          console.error("RevenueCat analytics delivery is not converging", {
+            outboxId: claim.outboxId,
+            eventName: claim.event.eventName,
+            attemptCount: claim.attemptCount,
+            lastErrorCode: deliveryError.code,
+          });
+        }
         summary.retriedCount += 1;
       } else {
         await dependencies.store.markFailed(

--- a/functions/src/revenueCat/analyticsTypes.ts
+++ b/functions/src/revenueCat/analyticsTypes.ts
@@ -76,4 +76,5 @@ export interface AnalyticsOutboxProcessingSummary {
   deliveredCount: number;
   retriedCount: number;
   failedCount: number;
+  deferredCount: number;
 }

--- a/functions/src/revenueCat/analyticsTypes.ts
+++ b/functions/src/revenueCat/analyticsTypes.ts
@@ -33,6 +33,7 @@ export interface LifecycleAnalyticsEvent {
   store: string;
   periodType: string;
   lifecycleReason: string | null;
+  refundAttributed: boolean;
   entitlementActive: boolean;
   effectiveExpirationAtMs: number | null;
   firebaseProjectId: string;
@@ -64,6 +65,11 @@ export interface AnalyticsOutboxStore {
     errorCode: string,
     now: Date
   ): Promise<void>;
+  /**
+   * Returns a claim the run never attempted, so the row keeps the delivery
+   * attempt count and last delivery error it had before it was claimed.
+   */
+  release(claim: AnalyticsOutboxClaim, now: Date): Promise<void>;
 }
 
 export interface LifecycleAnalyticsClient {

--- a/functions/src/revenueCat/analyticsTypes.ts
+++ b/functions/src/revenueCat/analyticsTypes.ts
@@ -1,0 +1,79 @@
+export type LifecycleAnalyticsEventName =
+  | "subscription_started"
+  | "subscription_trial_started"
+  | "subscription_trial_converted"
+  | "subscription_renewed"
+  | "subscription_cancelled"
+  | "subscription_uncancelled"
+  | "subscription_billing_issue"
+  | "subscription_expired"
+  | "subscription_refunded"
+  | "subscription_product_changed";
+
+export interface RevenueCatAnalyticsEnvironment {
+  firebaseProjectId: string;
+  mixpanelProjectId: string;
+  appEnvironment: "dev" | "staging" | "production";
+  buildConfig: "server";
+  appVersion: "cloud_functions";
+  buildNumber: string;
+}
+
+export interface LifecycleAnalyticsEvent {
+  schemaVersion: 1;
+  eventName: LifecycleAnalyticsEventName;
+  eventVersion: 1;
+  source: "revenuecat_webhook";
+  distinctId: string;
+  insertId: string;
+  eventTimestampMs: number;
+  entitlementId: "app_access";
+  productId: string;
+  previousProductId: string | null;
+  store: string;
+  periodType: string;
+  lifecycleReason: string | null;
+  entitlementActive: boolean;
+  effectiveExpirationAtMs: number | null;
+  firebaseProjectId: string;
+  appEnvironment: "dev" | "staging" | "production";
+  buildConfig: "server";
+  appVersion: "cloud_functions";
+  buildNumber: string;
+}
+
+export interface AnalyticsOutboxClaim {
+  outboxId: string;
+  claimId: string;
+  attemptCount: number;
+  event: LifecycleAnalyticsEvent;
+}
+
+export interface AnalyticsOutboxStore {
+  reclaimStale(now: Date, limit?: number): Promise<number>;
+  claimDue(now: Date, limit?: number): Promise<AnalyticsOutboxClaim[]>;
+  markDelivered(claim: AnalyticsOutboxClaim, now: Date): Promise<void>;
+  requeue(
+    claim: AnalyticsOutboxClaim,
+    readyAt: Date,
+    errorCode: string,
+    now: Date
+  ): Promise<void>;
+  markFailed(
+    claim: AnalyticsOutboxClaim,
+    errorCode: string,
+    now: Date
+  ): Promise<void>;
+}
+
+export interface LifecycleAnalyticsClient {
+  send(event: LifecycleAnalyticsEvent): Promise<void>;
+}
+
+export interface AnalyticsOutboxProcessingSummary {
+  reclaimedCount: number;
+  claimedCount: number;
+  deliveredCount: number;
+  retriedCount: number;
+  failedCount: number;
+}

--- a/functions/src/revenueCat/event.ts
+++ b/functions/src/revenueCat/event.ts
@@ -5,6 +5,35 @@ const MAX_WEBHOOK_BYTES = 256 * 1024;
 const MAX_IDENTITY_COUNT = 20;
 const EVENT_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const EVENT_TYPE_PATTERN = /^[A-Z][A-Z0-9_]{0,99}$/;
+const PRODUCT_ID_PATTERN = /^[A-Za-z0-9._:-]{1,200}$/;
+const KNOWN_STORES = new Set([
+  "AMAZON",
+  "APP_STORE",
+  "MAC_APP_STORE",
+  "PADDLE",
+  "PLAY_STORE",
+  "PROMOTIONAL",
+  "RC_BILLING",
+  "ROKU",
+  "STRIPE",
+  "TEST_STORE",
+]);
+const KNOWN_PERIOD_TYPES = new Set([
+  "INTRO",
+  "NORMAL",
+  "PREPAID",
+  "PROMOTIONAL",
+  "TRIAL",
+]);
+const KNOWN_LIFECYCLE_REASONS = new Set([
+  "BILLING_ERROR",
+  "CUSTOMER_SUPPORT",
+  "DEVELOPER_INITIATED",
+  "PRICE_INCREASE",
+  "SUBSCRIPTION_PAUSED",
+  "UNKNOWN",
+  "UNSUBSCRIBE",
+]);
 
 export interface ParsedRevenueCatWebhook {
   event: RevenueCatWebhookEvent;
@@ -66,6 +95,18 @@ export function parseRevenueCatWebhook(
       eventTimestampMs: event.event_timestamp_ms,
       appUserIds: identities.appUserIds,
       identityOverflowCount: identities.overflowCount,
+      productId: normalizedProductId(event.product_id),
+      newProductId: normalizedProductId(event.new_product_id),
+      store: normalizedEnum(event.store, KNOWN_STORES),
+      periodType: normalizedEnum(event.period_type, KNOWN_PERIOD_TYPES),
+      expirationAtMs: normalizedTimestamp(event.expiration_at_ms),
+      gracePeriodExpirationAtMs: normalizedTimestamp(
+        event.grace_period_expiration_at_ms
+      ),
+      isTrialConversion: event.is_trial_conversion === true,
+      lifecycleReason: normalizedLifecycleReason(
+        event.cancel_reason ?? event.expiration_reason
+      ),
     },
     payloadSha256: createHash("sha256").update(rawBody).digest("hex"),
   };
@@ -122,6 +163,27 @@ function collectAppUserIds(
 
 function arrayOrEmpty(value: unknown): unknown[] {
   return Array.isArray(value) ? value : [];
+}
+
+function normalizedProductId(value: unknown): string | null {
+  return typeof value === "string" && PRODUCT_ID_PATTERN.test(value) ?
+    value : null;
+}
+
+function normalizedEnum(value: unknown, allowed: Set<string>): string {
+  return typeof value === "string" && allowed.has(value) ?
+    value.toLowerCase() : "unknown";
+}
+
+function normalizedLifecycleReason(value: unknown): string | null {
+  return typeof value === "string" && KNOWN_LIFECYCLE_REASONS.has(value) ?
+    value.toLowerCase() : null;
+}
+
+function normalizedTimestamp(value: unknown): number | null {
+  return typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value > 0 ? value : null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/functions/src/revenueCat/firestoreStore.ts
+++ b/functions/src/revenueCat/firestoreStore.ts
@@ -1,5 +1,9 @@
 import * as admin from "firebase-admin";
 import {shouldReplaceProjection} from "./projectionOrdering";
+import {
+  ANALYTICS_OUTBOX_COLLECTION,
+  serializeAnalyticsOutboxEvent,
+} from "./analyticsFirestoreOutbox";
 import type {
   LifecycleAnalyticsEvent,
 } from "./analyticsTypes";
@@ -11,8 +15,6 @@ import type {
 } from "./types";
 
 const EVENT_COLLECTION = "_revenuecat_webhook_events";
-export const ANALYTICS_OUTBOX_COLLECTION =
-  "_revenuecat_analytics_outbox";
 const PROCESSING_LEASE_MS = 2 * 60 * 1000;
 
 // RevenueCat currently retries a failed delivery five times over roughly 155
@@ -334,24 +336,6 @@ implements RevenueCatEntitlementStore {
       `users/${projection.uid}/entitlements/${projection.entitlementId}`
     );
   }
-}
-
-function serializeAnalyticsOutboxEvent(
-  event: LifecycleAnalyticsEvent,
-  now: admin.firestore.Timestamp
-): Record<string, unknown> {
-  return {
-    ...event,
-    status: "queued",
-    attemptCount: 0,
-    readyAt: now,
-    processingStartedAt: null,
-    claimId: null,
-    deliveredAt: null,
-    lastErrorCode: null,
-    createdAt: now,
-    updatedAt: now,
-  };
 }
 
 function isProjectedAccessUnchanged(

--- a/functions/src/revenueCat/firestoreStore.ts
+++ b/functions/src/revenueCat/firestoreStore.ts
@@ -1,6 +1,9 @@
 import * as admin from "firebase-admin";
 import {shouldReplaceProjection} from "./projectionOrdering";
 import type {
+  LifecycleAnalyticsEvent,
+} from "./analyticsTypes";
+import type {
   AppAccessProjection,
   RevenueCatEntitlementStore,
   RevenueCatWebhookEvent,
@@ -8,6 +11,8 @@ import type {
 } from "./types";
 
 const EVENT_COLLECTION = "_revenuecat_webhook_events";
+export const ANALYTICS_OUTBOX_COLLECTION =
+  "_revenuecat_analytics_outbox";
 const PROCESSING_LEASE_MS = 2 * 60 * 1000;
 
 // RevenueCat currently retries a failed delivery five times over roughly 155
@@ -105,6 +110,7 @@ implements RevenueCatEntitlementStore {
     event: RevenueCatWebhookEvent,
     claimDigest: string,
     projections: AppAccessProjection[],
+    analyticsEvents: LifecycleAnalyticsEvent[],
     now: Date
   ): Promise<void> {
     const eventRef = this.firestore.collection(EVENT_COLLECTION).doc(event.id);
@@ -113,6 +119,10 @@ implements RevenueCatEntitlementStore {
     );
     const statusRefs = projections.map(
       (projection) => this.statusRef(projection)
+    );
+    const outboxRefs = analyticsEvents.map((analyticsEvent) =>
+      this.firestore.collection(ANALYTICS_OUTBOX_COLLECTION)
+        .doc(analyticsEvent.insertId)
     );
 
     await this.firestore.runTransaction(async (transaction) => {
@@ -123,8 +133,11 @@ implements RevenueCatEntitlementStore {
         throw new Error("RevenueCat event claim was lost before completion");
       }
 
-      const existingStatuses = statusRefs.length > 0 ?
-        await transaction.getAll(...statusRefs) : [];
+      const allRefs = [...statusRefs, ...outboxRefs];
+      const existingDocuments = allRefs.length > 0 ?
+        await transaction.getAll(...allRefs) : [];
+      const existingStatuses = existingDocuments.slice(0, statusRefs.length);
+      const existingOutboxRows = existingDocuments.slice(statusRefs.length);
       projections.forEach((projection, index) => {
         if (!shouldReplaceProjection(
           existingStatuses[index]?.get("revenueCatRequestDateMs"),
@@ -141,6 +154,14 @@ implements RevenueCatEntitlementStore {
       });
 
       const nowTimestamp = admin.firestore.Timestamp.fromDate(now);
+      analyticsEvents.forEach((analyticsEvent, index) => {
+        if (!existingOutboxRows[index].exists) {
+          transaction.create(
+            outboxRefs[index],
+            serializeAnalyticsOutboxEvent(analyticsEvent, nowTimestamp)
+          );
+        }
+      });
       transaction.update(eventRef, {
         status: "completed",
         completedAt: nowTimestamp,
@@ -313,6 +334,24 @@ implements RevenueCatEntitlementStore {
       `users/${projection.uid}/entitlements/${projection.entitlementId}`
     );
   }
+}
+
+function serializeAnalyticsOutboxEvent(
+  event: LifecycleAnalyticsEvent,
+  now: admin.firestore.Timestamp
+): Record<string, unknown> {
+  return {
+    ...event,
+    status: "queued",
+    attemptCount: 0,
+    readyAt: now,
+    processingStartedAt: null,
+    claimId: null,
+    deliveredAt: null,
+    lastErrorCode: null,
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 function isProjectedAccessUnchanged(

--- a/functions/src/revenueCat/processor.ts
+++ b/functions/src/revenueCat/processor.ts
@@ -3,6 +3,7 @@ import type {
   RevenueCatWebhookDependencies,
   RevenueCatWebhookEvent,
 } from "./types";
+import {buildLifecycleAnalyticsEvent} from "./analyticsEvent";
 import {buildAppAccessProjection} from "./subscriber";
 
 /**
@@ -44,10 +45,20 @@ export async function processRevenueCatWebhookEvent(
         dependencies.now()
       );
     }));
+    const analyticsEvents = projections.flatMap((projection) => {
+      const analyticsEvent = buildLifecycleAnalyticsEvent(
+        event,
+        projection,
+        dependencies.config,
+        dependencies.analyticsEnvironment
+      );
+      return analyticsEvent ? [analyticsEvent] : [];
+    });
     await dependencies.store.completeEvent(
       event,
       claim.claimDigest,
       projections,
+      analyticsEvents,
       dependencies.now()
     );
     return "processed";

--- a/functions/src/revenueCat/processor.ts
+++ b/functions/src/revenueCat/processor.ts
@@ -45,15 +45,17 @@ export async function processRevenueCatWebhookEvent(
         dependencies.now()
       );
     }));
-    const analyticsEvents = projections.flatMap((projection) => {
-      const analyticsEvent = buildLifecycleAnalyticsEvent(
-        event,
-        projection,
-        dependencies.config,
-        dependencies.analyticsEnvironment
-      );
-      return analyticsEvent ? [analyticsEvent] : [];
-    });
+    const analyticsEnvironment = dependencies.analyticsEnvironment;
+    const analyticsEvents = analyticsEnvironment === null ? [] :
+      projections.flatMap((projection) => {
+        const analyticsEvent = buildLifecycleAnalyticsEvent(
+          event,
+          projection,
+          dependencies.config,
+          analyticsEnvironment
+        );
+        return analyticsEvent ? [analyticsEvent] : [];
+      });
     await dependencies.store.completeEvent(
       event,
       claim.claimDigest,

--- a/functions/src/revenueCat/reconciliation.ts
+++ b/functions/src/revenueCat/reconciliation.ts
@@ -87,6 +87,14 @@ function reconciliationSourceEvent(
     eventTimestampMs: now.getTime(),
     appUserIds: [uid],
     identityOverflowCount: 0,
+    productId: null,
+    newProductId: null,
+    store: "unknown",
+    periodType: "unknown",
+    expirationAtMs: null,
+    gracePeriodExpirationAtMs: null,
+    isTrialConversion: false,
+    lifecycleReason: null,
   };
 }
 

--- a/functions/src/revenueCat/types.ts
+++ b/functions/src/revenueCat/types.ts
@@ -112,7 +112,7 @@ export interface RevenueCatWebhookDependencies {
   subscriberClient: RevenueCatSubscriberClient;
   userVerifier: FirebaseUserVerifier;
   config: RevenueCatServerConfig;
-  analyticsEnvironment: RevenueCatAnalyticsEnvironment;
+  analyticsEnvironment: RevenueCatAnalyticsEnvironment | null;
   now: () => Date;
 }
 

--- a/functions/src/revenueCat/types.ts
+++ b/functions/src/revenueCat/types.ts
@@ -1,3 +1,8 @@
+import type {
+  LifecycleAnalyticsEvent,
+  RevenueCatAnalyticsEnvironment,
+} from "./analyticsTypes";
+
 export interface RevenueCatServerConfig {
   apiKey: string;
   webhookAuthorization: string;
@@ -14,6 +19,14 @@ export interface RevenueCatWebhookEvent {
   eventTimestampMs: number;
   appUserIds: string[];
   identityOverflowCount: number;
+  productId: string | null;
+  newProductId: string | null;
+  store: string;
+  periodType: string;
+  expirationAtMs: number | null;
+  gracePeriodExpirationAtMs: number | null;
+  isTrialConversion: boolean;
+  lifecycleReason: string | null;
 }
 
 export interface RevenueCatSubscriberResponse {
@@ -74,6 +87,7 @@ export interface RevenueCatEntitlementStore {
     event: RevenueCatWebhookEvent,
     claimDigest: string,
     projections: AppAccessProjection[],
+    analyticsEvents: LifecycleAnalyticsEvent[],
     now: Date
   ): Promise<void>;
   failEvent(
@@ -98,6 +112,7 @@ export interface RevenueCatWebhookDependencies {
   subscriberClient: RevenueCatSubscriberClient;
   userVerifier: FirebaseUserVerifier;
   config: RevenueCatServerConfig;
+  analyticsEnvironment: RevenueCatAnalyticsEnvironment;
   now: () => Date;
 }
 

--- a/functions/src/revenueCat/webhook.ts
+++ b/functions/src/revenueCat/webhook.ts
@@ -4,7 +4,7 @@ import {
   authenticateRevenueCatWebhook,
 } from "./authentication";
 import {
-  analyticsEnvironmentForFirebaseProject,
+  optionalAnalyticsEnvironment,
 } from "./analyticsEnvironment";
 import {
   getRevenueCatServerConfig,
@@ -49,22 +49,18 @@ export async function handleRevenueCatWebhook(
   }
 
   let config;
-  let analyticsEnvironment;
   try {
     config = getRevenueCatServerConfig();
-    const firebaseProjectId = admin.app().options.projectId;
-    if (!firebaseProjectId) {
-      throw new Error("Firebase project is unavailable");
-    }
-    analyticsEnvironment = analyticsEnvironmentForFirebaseProject(
-      firebaseProjectId,
-      process.env.K_REVISION ?? "unknown"
-    );
   } catch {
     console.error("RevenueCat webhook server configuration is invalid");
     response.status(500).json({status: "server_configuration_error"});
     return;
   }
+
+  const analyticsEnvironment = optionalAnalyticsEnvironment(
+    deployedFirebaseProjectId(),
+    process.env.K_REVISION ?? "unknown"
+  );
 
   const rawBody = request.rawBody;
   if (!Buffer.isBuffer(rawBody)) {
@@ -134,6 +130,14 @@ export async function handleRevenueCatWebhook(
   } catch {
     console.error("RevenueCat webhook reconciliation failed");
     response.status(500).json({status: "retry"});
+  }
+}
+
+function deployedFirebaseProjectId(): string | undefined {
+  try {
+    return admin.app().options.projectId;
+  } catch {
+    return undefined;
   }
 }
 

--- a/functions/src/revenueCat/webhook.ts
+++ b/functions/src/revenueCat/webhook.ts
@@ -4,6 +4,9 @@ import {
   authenticateRevenueCatWebhook,
 } from "./authentication";
 import {
+  analyticsEnvironmentForFirebaseProject,
+} from "./analyticsEnvironment";
+import {
   getRevenueCatServerConfig,
   revenueCatServerConfig,
 } from "./config";
@@ -46,8 +49,17 @@ export async function handleRevenueCatWebhook(
   }
 
   let config;
+  let analyticsEnvironment;
   try {
     config = getRevenueCatServerConfig();
+    const firebaseProjectId = admin.app().options.projectId;
+    if (!firebaseProjectId) {
+      throw new Error("Firebase project is unavailable");
+    }
+    analyticsEnvironment = analyticsEnvironmentForFirebaseProject(
+      firebaseProjectId,
+      process.env.K_REVISION ?? "unknown"
+    );
   } catch {
     console.error("RevenueCat webhook server configuration is invalid");
     response.status(500).json({status: "server_configuration_error"});
@@ -108,6 +120,7 @@ export async function handleRevenueCatWebhook(
         subscriberClient: new HttpRevenueCatSubscriberClient(config.apiKey),
         userVerifier: new AdminFirebaseUserVerifier(),
         config,
+        analyticsEnvironment,
         now: () => new Date(),
       }
     );

--- a/functions/test/accountCleanup.test.ts
+++ b/functions/test/accountCleanup.test.ts
@@ -20,6 +20,7 @@ interface FakePortOptions {
   moderationReports?: number;
   incomingBlockDocuments?: number;
   lifecycleEmailJobs?: number;
+  revenueCatAnalyticsOutbox?: number;
   failOn?: string[];
   failListing?: boolean;
 }
@@ -129,6 +130,14 @@ function makeFakePort(options: FakePortOptions = {}): {
       }
       deleted.push("email_jobs");
       return options.lifecycleEmailJobs ?? 0;
+    },
+
+    async deleteRevenueCatAnalyticsOutbox() {
+      if (failOn.has("revenuecat_analytics_outbox")) {
+        throw new Error("cannot delete revenuecat_analytics_outbox");
+      }
+      deleted.push("revenuecat_analytics_outbox");
+      return options.revenueCatAnalyticsOutbox ?? 0;
     },
 
     async deleteRateLimitDocument() {
@@ -835,6 +844,15 @@ test("removes queued lifecycle email jobs holding a raw email", async () => {
 
   assert.equal(summary.deletedLifecycleEmailJobs, 1);
   assert.ok(deleted.includes("email_jobs"));
+});
+
+test("removes RevenueCat analytics outbox rows holding the uid", async () => {
+  const {deleted, port} = makeFakePort({revenueCatAnalyticsOutbox: 2});
+
+  const summary = await cleanupDeletedUser("user-a", port);
+
+  assert.equal(summary.deletedRevenueCatAnalyticsOutbox, 2);
+  assert.ok(deleted.includes("revenuecat_analytics_outbox"));
 });
 
 test("one failing subcollection does not abandon other PII", async () => {

--- a/functions/test/emulator/revenueCatEntitlements.test.ts
+++ b/functions/test/emulator/revenueCatEntitlements.test.ts
@@ -10,7 +10,6 @@ import assert from "node:assert/strict";
 import test, {before, beforeEach} from "node:test";
 import * as admin from "firebase-admin";
 import {
-  ANALYTICS_OUTBOX_COLLECTION,
   EVENT_RETENTION_MS,
   FirestoreRevenueCatEntitlementStore,
 } from "../../src/revenueCat/firestoreStore.js";
@@ -18,6 +17,8 @@ import {
   expireRevenueCatAccessGrants,
 } from "../../src/revenueCat/expiration.js";
 import {
+  ANALYTICS_OUTBOX_COLLECTION,
+  ANALYTICS_OUTBOX_RETENTION_MS,
   FirestoreAnalyticsOutboxStore,
 } from "../../src/revenueCat/analyticsFirestoreOutbox.js";
 import {
@@ -106,6 +107,11 @@ test("duplicate webhook delivery is durably idempotent", async () => {
   assert.equal(outbox.size, 1);
   assert.equal(outbox.docs[0].get("status"), "queued");
   assert.equal(outbox.docs[0].get("eventName"), "subscription_renewed");
+  assert.equal(
+    outbox.docs[0].get("retainUntil").toMillis(),
+    NOW.getTime() + ANALYTICS_OUTBOX_RETENTION_MS
+  );
+  assert.ok(ANALYTICS_OUTBOX_RETENTION_MS > REVENUECAT_RETRY_WINDOW_MS);
 });
 
 test("a transient Mixpanel failure requeues and later delivers", async () => {

--- a/functions/test/emulator/revenueCatEntitlements.test.ts
+++ b/functions/test/emulator/revenueCatEntitlements.test.ts
@@ -10,16 +10,31 @@ import assert from "node:assert/strict";
 import test, {before, beforeEach} from "node:test";
 import * as admin from "firebase-admin";
 import {
+  ANALYTICS_OUTBOX_COLLECTION,
   EVENT_RETENTION_MS,
   FirestoreRevenueCatEntitlementStore,
 } from "../../src/revenueCat/firestoreStore.js";
 import {
   expireRevenueCatAccessGrants,
 } from "../../src/revenueCat/expiration.js";
+import {
+  FirestoreAnalyticsOutboxStore,
+} from "../../src/revenueCat/analyticsFirestoreOutbox.js";
+import {
+  MixpanelDeliveryError,
+} from "../../src/revenueCat/analyticsMixpanelClient.js";
+import {
+  processAnalyticsOutbox,
+} from "../../src/revenueCat/analyticsOutboxProcessor.js";
 import type {
   AppAccessProjection,
   RevenueCatWebhookEvent,
 } from "../../src/revenueCat/types.js";
+import type {
+  LifecycleAnalyticsClient,
+  LifecycleAnalyticsEvent,
+  RevenueCatAnalyticsEnvironment,
+} from "../../src/revenueCat/analyticsTypes.js";
 
 const NOW = new Date("2026-08-05T12:00:00.000Z");
 // RevenueCat's documented retry ladder finishes 155 minutes after the first
@@ -27,6 +42,14 @@ const NOW = new Date("2026-08-05T12:00:00.000Z");
 const REVENUECAT_RETRY_WINDOW_MS = 155 * 60 * 1000;
 const uid = "firebase-user-1";
 const eventCollection = "_revenuecat_webhook_events";
+const analyticsEnvironment: RevenueCatAnalyticsEnvironment = {
+  firebaseProjectId: "ascend-prod-9c8f2",
+  mixpanelProjectId: "4051100",
+  appEnvironment: "production",
+  buildConfig: "server",
+  appVersion: "cloud_functions",
+  buildNumber: "test-revision",
+};
 let db: admin.firestore.Firestore;
 let store: FirestoreRevenueCatEntitlementStore;
 
@@ -44,6 +67,7 @@ before(() => {
 
 beforeEach(async () => {
   await clearCollection(eventCollection);
+  await clearCollection(ANALYTICS_OUTBOX_COLLECTION);
   await clearCollection(`users/${uid}/entitlements`);
   await clearCollection(`users/${uid}/entitlement_status`);
   await clearCollection(`users/${uid}/entitlement_reconciliations`);
@@ -61,12 +85,15 @@ test("duplicate webhook delivery is durably idempotent", async () => {
     event,
     "payload-digest",
     [projection(event, NOW.getTime())],
+    [analyticsEvent(event)],
     NOW
   );
-  assert.deepEqual(
-    await store.claimEvent(event, "payload-digest", NOW),
-    {outcome: "duplicate", claimDigest: "payload-digest"}
-  );
+  for (let replay = 0; replay < 5; replay += 1) {
+    assert.deepEqual(
+      await store.claimEvent(event, "payload-digest", NOW),
+      {outcome: "duplicate", claimDigest: "payload-digest"}
+    );
+  }
 
   const eventSnapshot = await db.doc(`${eventCollection}/${event.id}`).get();
   const entitlementSnapshot = await db.doc(
@@ -75,6 +102,51 @@ test("duplicate webhook delivery is durably idempotent", async () => {
   assert.equal(eventSnapshot.get("status"), "completed");
   assert.equal(eventSnapshot.get("attemptCount"), 1);
   assert.equal(entitlementSnapshot.get("sourceEventId"), event.id);
+  const outbox = await db.collection(ANALYTICS_OUTBOX_COLLECTION).get();
+  assert.equal(outbox.size, 1);
+  assert.equal(outbox.docs[0].get("status"), "queued");
+  assert.equal(outbox.docs[0].get("eventName"), "subscription_renewed");
+});
+
+test("a transient Mixpanel failure requeues and later delivers", async () => {
+  const event = webhookEvent("event-transient-analytics");
+  await store.claimEvent(event, "payload-digest", NOW);
+  await store.completeEvent(
+    event,
+    "payload-digest",
+    [projection(event, NOW.getTime())],
+    [analyticsEvent(event)],
+    NOW
+  );
+
+  const analyticsStore = new FirestoreAnalyticsOutboxStore(db);
+  const client = new FailOnceAnalyticsClient();
+  const first = await processAnalyticsOutbox({
+    store: analyticsStore,
+    client,
+    environment: analyticsEnvironment,
+    now: () => NOW,
+  });
+  assert.equal(first.retriedCount, 1);
+
+  const queued = await db.collection(ANALYTICS_OUTBOX_COLLECTION)
+    .doc(analyticsEvent(event).insertId)
+    .get();
+  assert.equal(queued.get("status"), "queued");
+  assert.equal(queued.get("attemptCount"), 1);
+
+  const retryAt = new Date(NOW.getTime() + 60_000);
+  const second = await processAnalyticsOutbox({
+    store: analyticsStore,
+    client,
+    environment: analyticsEnvironment,
+    now: () => retryAt,
+  });
+  assert.equal(second.deliveredCount, 1);
+  const delivered = await queued.ref.get();
+  assert.equal(delivered.get("status"), "delivered");
+  assert.equal(delivered.get("attemptCount"), 2);
+  assert.equal(client.attemptCount, 2);
 });
 
 test("the ledger carries a future retention stamp for the TTL policy", async () => {
@@ -86,6 +158,7 @@ test("the ledger carries a future retention stamp for the TTL policy", async () 
     event,
     "retention-payload",
     [projection(event, NOW.getTime())],
+    [],
     NOW
   );
   const completed = await db.doc(`${eventCollection}/${event.id}`).get();
@@ -110,6 +183,7 @@ test("a completed event refuses a redelivery whose bytes differ", async () => {
     event,
     "first-seen-digest",
     [projection(event, NOW.getTime())],
+    [],
     NOW
   );
 
@@ -143,6 +217,7 @@ test("a failed event is reclaimable when its retry bytes differ", async () => {
     event,
     claim.claimDigest,
     [projection(event, NOW.getTime())],
+    [],
     NOW
   );
 
@@ -298,6 +373,7 @@ test("out-of-order webhook completion keeps newer RevenueCat truth", async () =>
     newer,
     "newer-payload",
     [projection(newer, NOW.getTime() + 2_000)],
+    [],
     NOW
   );
   await store.claimEvent(older, "older-payload", NOW);
@@ -305,6 +381,7 @@ test("out-of-order webhook completion keeps newer RevenueCat truth", async () =>
     older,
     "older-payload",
     [projection(older, NOW.getTime() - 2_000)],
+    [],
     NOW
   );
 
@@ -332,6 +409,7 @@ test("a known RevenueCat expiry removes the active grant without the app", async
     event,
     "expiring-payload",
     [expiredProjection],
+    [],
     NOW
   );
 
@@ -354,6 +432,7 @@ test("inactive subscriber truth is recorded and removes the active grant", async
     activeEvent,
     "active-payload",
     [projection(activeEvent, NOW.getTime())],
+    [],
     NOW
   );
 
@@ -368,6 +447,7 @@ test("inactive subscriber truth is recorded and removes the active grant", async
     inactiveEvent,
     "inactive-payload",
     [inactive],
+    [],
     NOW
   );
 
@@ -406,7 +486,7 @@ test("an older unrelated document cannot starve a real expiry behind it", async 
   expired.expiresAt = new Date(NOW.getTime() - 1_000);
   expired.accessUntil = new Date(NOW.getTime() - 1_000);
   await store.claimEvent(event, "starvation-payload", NOW);
-  await store.completeEvent(event, "starvation-payload", [expired], NOW);
+  await store.completeEvent(event, "starvation-payload", [expired], [], NOW);
 
   // A one-document page proves the sweep pages past what the filter rejects
   // rather than discarding the rest of a fixed window.
@@ -429,6 +509,41 @@ function webhookEvent(id: string): RevenueCatWebhookEvent {
     eventTimestampMs: NOW.getTime(),
     appUserIds: [uid],
     identityOverflowCount: 0,
+    productId: "ascend_yearly",
+    newProductId: null,
+    store: "app_store",
+    periodType: "normal",
+    expirationAtMs: Date.parse("2027-08-05T12:00:00.000Z"),
+    gracePeriodExpirationAtMs: null,
+    isTrialConversion: false,
+    lifecycleReason: null,
+  };
+}
+
+function analyticsEvent(
+  event: RevenueCatWebhookEvent
+): LifecycleAnalyticsEvent {
+  return {
+    schemaVersion: 1,
+    eventName: "subscription_renewed",
+    eventVersion: 1,
+    source: "revenuecat_webhook",
+    distinctId: uid,
+    insertId: "0123456789abcdef0123456789abcdef",
+    eventTimestampMs: event.eventTimestampMs,
+    entitlementId: "app_access",
+    productId: "ascend_yearly",
+    previousProductId: null,
+    store: "app_store",
+    periodType: "normal",
+    lifecycleReason: null,
+    entitlementActive: true,
+    effectiveExpirationAtMs: Date.parse("2027-08-05T12:00:00.000Z"),
+    firebaseProjectId: "ascend-prod-9c8f2",
+    appEnvironment: "production",
+    buildConfig: "server",
+    appVersion: "cloud_functions",
+    buildNumber: "test-revision",
   };
 }
 
@@ -456,4 +571,15 @@ function projection(
 async function clearCollection(path: string): Promise<void> {
   const snapshot = await db.collection(path).get();
   await Promise.all(snapshot.docs.map((document) => document.ref.delete()));
+}
+
+class FailOnceAnalyticsClient implements LifecycleAnalyticsClient {
+  attemptCount = 0;
+
+  async send(): Promise<void> {
+    this.attemptCount += 1;
+    if (this.attemptCount === 1) {
+      throw new MixpanelDeliveryError("service_unavailable", true);
+    }
+  }
 }

--- a/functions/test/emulator/revenueCatEntitlements.test.ts
+++ b/functions/test/emulator/revenueCatEntitlements.test.ts
@@ -153,6 +153,73 @@ test("a transient Mixpanel failure requeues and later delivers", async () => {
   assert.equal(delivered.get("status"), "delivered");
   assert.equal(delivered.get("attemptCount"), 2);
   assert.equal(client.attemptCount, 2);
+  assert.equal(
+    delivered.get("retainUntil").toMillis(),
+    retryAt.getTime() + ANALYTICS_OUTBOX_RETENTION_MS
+  );
+});
+
+test("a still-retrying row cannot expire before it is delivered", async () => {
+  const event = webhookEvent("event-retention-refresh");
+  await store.claimEvent(event, "payload-digest", NOW);
+  await store.completeEvent(
+    event,
+    "payload-digest",
+    [projection(event, NOW.getTime())],
+    [analyticsEvent(event)],
+    NOW
+  );
+
+  const retryAt = new Date(NOW.getTime() + 20 * 24 * 60 * 60 * 1000);
+  await processAnalyticsOutbox({
+    store: new FirestoreAnalyticsOutboxStore(db),
+    client: new AlwaysFailingAnalyticsClient(),
+    environment: analyticsEnvironment,
+    now: () => retryAt,
+  });
+
+  const requeued = await db.collection(ANALYTICS_OUTBOX_COLLECTION)
+    .doc(analyticsEvent(event).insertId)
+    .get();
+  assert.equal(requeued.get("status"), "queued");
+  assert.equal(
+    requeued.get("retainUntil").toMillis(),
+    retryAt.getTime() + ANALYTICS_OUTBOX_RETENTION_MS
+  );
+  assert.ok(
+    requeued.get("retainUntil").toMillis() >
+      requeued.get("readyAt").toMillis()
+  );
+});
+
+test("a claim released at the run deadline is charged no delivery attempt", async () => {
+  const event = webhookEvent("event-deadline-release");
+  await store.claimEvent(event, "payload-digest", NOW);
+  await store.completeEvent(
+    event,
+    "payload-digest",
+    [projection(event, NOW.getTime())],
+    [analyticsEvent(event)],
+    NOW
+  );
+
+  const summary = await processAnalyticsOutbox({
+    store: new FirestoreAnalyticsOutboxStore(db),
+    client: new AlwaysFailingAnalyticsClient(),
+    environment: analyticsEnvironment,
+    now: () => NOW,
+    runBudgetMs: 0,
+  });
+
+  assert.equal(summary.deferredCount, 1);
+  assert.equal(summary.retriedCount, 0);
+  const released = await db.collection(ANALYTICS_OUTBOX_COLLECTION)
+    .doc(analyticsEvent(event).insertId)
+    .get();
+  assert.equal(released.get("status"), "queued");
+  assert.equal(released.get("attemptCount"), 0);
+  assert.equal(released.get("lastErrorCode"), null);
+  assert.equal(released.get("claimId"), null);
 });
 
 test("the ledger carries a future retention stamp for the TTL policy", async () => {
@@ -543,6 +610,7 @@ function analyticsEvent(
     store: "app_store",
     periodType: "normal",
     lifecycleReason: null,
+    refundAttributed: false,
     entitlementActive: true,
     effectiveExpirationAtMs: Date.parse("2027-08-05T12:00:00.000Z"),
     firebaseProjectId: "ascend-prod-9c8f2",
@@ -587,5 +655,11 @@ class FailOnceAnalyticsClient implements LifecycleAnalyticsClient {
     if (this.attemptCount === 1) {
       throw new MixpanelDeliveryError("service_unavailable", true);
     }
+  }
+}
+
+class AlwaysFailingAnalyticsClient implements LifecycleAnalyticsClient {
+  async send(): Promise<void> {
+    throw new MixpanelDeliveryError("service_unavailable", true);
   }
 }

--- a/functions/test/revenueCat.test.ts
+++ b/functions/test/revenueCat.test.ts
@@ -19,6 +19,10 @@ import {
 } from "../src/revenueCat/reconciliation";
 import {buildAppAccessProjection} from "../src/revenueCat/subscriber";
 import type {
+  LifecycleAnalyticsEvent,
+  RevenueCatAnalyticsEnvironment,
+} from "../src/revenueCat/analyticsTypes";
+import type {
   AppAccessProjection,
   FirebaseUserVerifier,
   RevenueCatEntitlementStore,
@@ -40,6 +44,14 @@ const CONFIG: RevenueCatServerConfig = {
   appId: "app123",
   entitlementId: "app_access",
   allowedProductIds: ["ascend_yearly", "ascend_monthly"],
+};
+const ANALYTICS_ENVIRONMENT: RevenueCatAnalyticsEnvironment = {
+  appEnvironment: "production",
+  buildConfig: "server",
+  appVersion: "cloud_functions",
+  buildNumber: "test-revision",
+  firebaseProjectId: "ascend-prod-9c8f2",
+  mixpanelProjectId: "4051100",
 };
 
 test("webhook authentication requires authorization and a current HMAC", () => {
@@ -245,6 +257,7 @@ test("a duplicate event is idempotent and re-fetches RevenueCat only once", asyn
     subscriberClient,
     userVerifier: new StubUserVerifier(),
     config: CONFIG,
+    analyticsEnvironment: ANALYTICS_ENVIRONMENT,
     now: () => NOW,
   };
   const event = webhookEvent();
@@ -254,13 +267,16 @@ test("a duplicate event is idempotent and re-fetches RevenueCat only once", asyn
     "same-payload-sha256",
     dependencies
   ), "processed");
-  assert.equal(await processRevenueCatWebhookEvent(
-    event,
-    "same-payload-sha256",
-    dependencies
-  ), "duplicate");
+  for (let replay = 0; replay < 5; replay += 1) {
+    assert.equal(await processRevenueCatWebhookEvent(
+      event,
+      "same-payload-sha256",
+      dependencies
+    ), "duplicate");
+  }
   assert.equal(subscriberClient.fetchCount, 1);
   assert.equal(store.projections.size, 1);
+  assert.equal(store.analyticsEvents.size, 1);
 });
 
 test("failed reconciliation is retry-safe", async () => {
@@ -274,6 +290,7 @@ test("failed reconciliation is retry-safe", async () => {
     subscriberClient,
     userVerifier: new StubUserVerifier(),
     config: CONFIG,
+    analyticsEnvironment: ANALYTICS_ENVIRONMENT,
     now: () => NOW,
   };
 
@@ -305,6 +322,7 @@ test("out-of-order delivery cannot replace newer subscriber truth", async () => 
     subscriberClient,
     userVerifier: new StubUserVerifier(),
     config: CONFIG,
+    analyticsEnvironment: ANALYTICS_ENVIRONMENT,
     now: () => NOW,
   };
 
@@ -364,6 +382,7 @@ test("a completed event ignores a redelivery whose bytes differ", async () => {
     subscriberClient,
     userVerifier: new StubUserVerifier(),
     config: CONFIG,
+    analyticsEnvironment: ANALYTICS_ENVIRONMENT,
     now: () => NOW,
   };
 
@@ -395,6 +414,7 @@ test("a failed event still reconciles when its retry carries different bytes", a
     subscriberClient,
     userVerifier: new StubUserVerifier(),
     config: CONFIG,
+    analyticsEnvironment: ANALYTICS_ENVIRONMENT,
     now: () => NOW,
   };
 
@@ -557,6 +577,10 @@ function eventBody(overrides: Record<string, unknown> = {}): Buffer {
       app_id: CONFIG.appId,
       event_timestamp_ms: NOW_MS,
       app_user_id: "firebase-user-1",
+      product_id: "ascend_yearly",
+      store: "APP_STORE",
+      period_type: "NORMAL",
+      expiration_at_ms: Date.parse("2027-08-05T12:00:00.000Z"),
       ...overrides,
     },
   }), "utf8");
@@ -572,6 +596,14 @@ function webhookEvent(
     eventTimestampMs: NOW_MS,
     appUserIds: ["firebase-user-1"],
     identityOverflowCount: 0,
+    productId: "ascend_yearly",
+    newProductId: null,
+    store: "app_store",
+    periodType: "normal",
+    expirationAtMs: Date.parse("2027-08-05T12:00:00.000Z"),
+    gracePeriodExpirationAtMs: null,
+    isTrialConversion: false,
+    lifecycleReason: null,
     ...overrides,
   };
 }
@@ -641,6 +673,7 @@ class RecordingSubscriberClient implements RevenueCatSubscriberClient {
 
 class InMemoryEntitlementStore implements RevenueCatEntitlementStore {
   readonly projections = new Map<string, AppAccessProjection>();
+  readonly analyticsEvents = new Map<string, LifecycleAnalyticsEvent>();
   readonly events = new Map<string, {
     payloadSha256: string;
     status: "processing" | "completed" | "failed";
@@ -675,12 +708,18 @@ class InMemoryEntitlementStore implements RevenueCatEntitlementStore {
   async completeEvent(
     event: RevenueCatWebhookEvent,
     claimDigest: string,
-    projections: AppAccessProjection[]
+    projections: AppAccessProjection[],
+    analyticsEvents: LifecycleAnalyticsEvent[]
   ): Promise<void> {
     const storedEvent = this.events.get(event.id);
     assert.equal(storedEvent?.payloadSha256, claimDigest);
     for (const projection of projections) {
       await this.writeProjection(projection);
+    }
+    for (const analyticsEvent of analyticsEvents) {
+      if (!this.analyticsEvents.has(analyticsEvent.insertId)) {
+        this.analyticsEvents.set(analyticsEvent.insertId, analyticsEvent);
+      }
     }
     if (storedEvent) {
       storedEvent.status = "completed";

--- a/functions/test/revenueCat.test.ts
+++ b/functions/test/revenueCat.test.ts
@@ -279,6 +279,28 @@ test("a duplicate event is idempotent and re-fetches RevenueCat only once", asyn
   assert.equal(store.analyticsEvents.size, 1);
 });
 
+test("an unavailable analytics destination still projects entitlements", async () => {
+  const store = new InMemoryEntitlementStore();
+  const subscriberClient = new CountingSubscriberClient(
+    subscriberResponse({productId: "ascend_yearly"})
+  );
+
+  assert.equal(await processRevenueCatWebhookEvent(
+    webhookEvent(),
+    "no-analytics-payload",
+    {
+      store,
+      subscriberClient,
+      userVerifier: new StubUserVerifier(),
+      config: CONFIG,
+      analyticsEnvironment: null,
+      now: () => NOW,
+    }
+  ), "processed");
+  assert.equal(store.projections.size, 1);
+  assert.equal(store.analyticsEvents.size, 0);
+});
+
 test("failed reconciliation is retry-safe", async () => {
   const store = new InMemoryEntitlementStore();
   const subscriberClient = new CountingSubscriberClient(

--- a/functions/test/revenueCatAnalytics.test.ts
+++ b/functions/test/revenueCatAnalytics.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/revenueCat/analyticsEvent";
 import {
   processAnalyticsOutbox,
+  retryDelayMs,
 } from "../src/revenueCat/analyticsOutboxProcessor";
 import {
   MixpanelLifecycleAnalyticsClient,
@@ -87,7 +88,7 @@ test("every server lifecycle transition has its own event name", () => {
     },
     {
       event: {
-        type: "CANCELLATION",
+        type: "EXPIRATION",
         lifecycleReason: "customer_support",
       },
       expectedName: "subscription_refunded",
@@ -134,45 +135,90 @@ test("cancellation remains active and is never relabeled as expiration", () => {
   );
 });
 
-test("support cancellation is a refund only after access is removed", () => {
-  const event = webhookEvent({
-    type: "CANCELLATION",
-    lifecycleReason: "customer_support",
-  });
-
-  assert.equal(buildLifecycleAnalyticsEvent(
-    event,
+test("a refund keeps its cancellation and its access removal distinct", () => {
+  const cancellation = buildLifecycleAnalyticsEvent(
+    webhookEvent({
+      id: "event-refund-cancellation",
+      type: "CANCELLATION",
+      lifecycleReason: "customer_support",
+    }),
     projection({isActive: true}),
     CONFIG,
     ENVIRONMENT
-  )?.eventName, "subscription_cancelled");
-  assert.equal(buildLifecycleAnalyticsEvent(
-    event,
+  );
+  const expiration = buildLifecycleAnalyticsEvent(
+    webhookEvent({
+      id: "event-refund-expiration",
+      type: "EXPIRATION",
+      lifecycleReason: "customer_support",
+    }),
     projection({isActive: false}),
     CONFIG,
     ENVIRONMENT
-  )?.eventName, "subscription_refunded");
+  );
+
+  assert.equal(cancellation?.eventName, "subscription_cancelled");
+  assert.equal(cancellation?.entitlementActive, true);
+  assert.equal(cancellation?.refundAttributed, true);
+  assert.equal(expiration?.eventName, "subscription_refunded");
+  assert.equal(expiration?.entitlementActive, false);
+  assert.equal(expiration?.refundAttributed, true);
+  assert.notEqual(cancellation?.insertId, expiration?.insertId);
 });
 
-test("one refund exports one refund event across its paired webhooks", () => {
-  assert.equal(buildLifecycleAnalyticsEvent(
+test("each refund webhook stays exactly one event across redeliveries", () => {
+  const cancellation = webhookEvent({
+    id: "event-refund-cancellation",
+    type: "CANCELLATION",
+    lifecycleReason: "customer_support",
+  });
+  const expiration = webhookEvent({
+    id: "event-refund-expiration",
+    type: "EXPIRATION",
+    lifecycleReason: "customer_support",
+  });
+  const build = (
+    event: RevenueCatWebhookEvent,
+    isActive: boolean
+  ) => buildLifecycleAnalyticsEvent(
+    event,
+    projection({isActive}),
+    CONFIG,
+    ENVIRONMENT
+  );
+
+  assert.deepEqual(
+    build(cancellation, true),
+    build(cancellation, true)
+  );
+  assert.deepEqual(
+    build(expiration, false),
+    build(expiration, false)
+  );
+});
+
+test("a support cancellation that already removed access still cancels", () => {
+  const analyticsEvent = buildLifecycleAnalyticsEvent(
     webhookEvent({type: "CANCELLATION", lifecycleReason: "customer_support"}),
     projection({isActive: false}),
     CONFIG,
     ENVIRONMENT
-  )?.eventName, "subscription_refunded");
-  assert.equal(buildLifecycleAnalyticsEvent(
-    webhookEvent({type: "EXPIRATION", lifecycleReason: "customer_support"}),
-    projection({isActive: false}),
-    CONFIG,
-    ENVIRONMENT
-  ), null);
-  assert.equal(buildLifecycleAnalyticsEvent(
+  );
+
+  assert.equal(analyticsEvent?.eventName, "subscription_cancelled");
+  assert.equal(analyticsEvent?.refundAttributed, true);
+});
+
+test("an ordinary expiration is neither a refund nor refund-attributed", () => {
+  const analyticsEvent = buildLifecycleAnalyticsEvent(
     webhookEvent({type: "EXPIRATION", lifecycleReason: "unsubscribe"}),
     projection({isActive: false}),
     CONFIG,
     ENVIRONMENT
-  )?.eventName, "subscription_expired");
+  );
+
+  assert.equal(analyticsEvent?.eventName, "subscription_expired");
+  assert.equal(analyticsEvent?.refundAttributed, false);
 });
 
 test("billing-error cancellation is not double-counted beside billing issue", () => {
@@ -311,6 +357,7 @@ test("Mixpanel import is strict, environment-bound, and retry-safe", async () =>
   assert.equal(payload[0].event, "subscription_renewed");
   assert.equal(payload[0].properties.$insert_id, event.insertId);
   assert.equal(payload[0].properties.app_environment, "production");
+  assert.equal(payload[0].properties.refund_attributed, false);
   assert.equal(payload[0].properties.ip, 0);
   assert.equal(requestBody.includes("serviceAccount"), false);
   assert.equal(requestBody.includes("test-password"), false);
@@ -394,6 +441,7 @@ test("a run past its budget requeues claims instead of stranding them", async ()
   );
   assert.ok(event);
   const store = new MultiRowAnalyticsOutboxStore(event, 3);
+  store.rows[2].lastErrorCode = "rate_limited";
   let clockMs = NOW.getTime();
   const client: LifecycleAnalyticsClient = {
     async send(): Promise<void> {
@@ -413,8 +461,75 @@ test("a run past its budget requeues claims instead of stranding them", async ()
   assert.equal(summary.deliveredCount, 2);
   assert.equal(summary.deferredCount, 1);
   assert.deepEqual(store.statuses(), ["delivered", "delivered", "queued"]);
-  assert.equal(store.rows[2].lastErrorCode, "run_deadline_reached");
   assert.equal(store.rows[2].readyAt.getTime(), clockMs);
+});
+
+test("a deferred claim is not charged a delivery attempt or a false error", async () => {
+  const event = buildLifecycleAnalyticsEvent(
+    webhookEvent(),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  );
+  assert.ok(event);
+  const store = new MultiRowAnalyticsOutboxStore(event, 1);
+  const client: LifecycleAnalyticsClient = {
+    async send(): Promise<void> {
+      assert.fail("a deferred run must not deliver");
+    },
+  };
+
+  const summary = await processAnalyticsOutbox({
+    store,
+    client,
+    environment: ENVIRONMENT,
+    now: () => NOW,
+    runBudgetMs: 0,
+  });
+
+  assert.equal(summary.deferredCount, 1);
+  assert.equal(summary.deliveredCount, 0);
+  assert.equal(store.rows[0].status, "queued");
+  assert.equal(store.rows[0].attemptCount, 0);
+  assert.equal(store.rows[0].lastErrorCode, null);
+  assert.equal(retryDelayMs(store.rows[0].attemptCount + 1), 60_000);
+});
+
+test("a delivery that never converges is reported while it keeps retrying", async () => {
+  const event = buildLifecycleAnalyticsEvent(
+    webhookEvent(),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  );
+  assert.ok(event);
+  const store = new MultiRowAnalyticsOutboxStore(event, 1);
+  store.rows[0].attemptCount = 11;
+  const client: LifecycleAnalyticsClient = {
+    async send(): Promise<void> {
+      throw new MixpanelDeliveryError("http_401", true);
+    },
+  };
+
+  const errors = await capturedErrors(async () => {
+    const summary = await processAnalyticsOutbox({
+      store,
+      client,
+      environment: ENVIRONMENT,
+      now: () => NOW,
+    });
+    assert.equal(summary.retriedCount, 1);
+  });
+
+  assert.equal(store.rows[0].status, "queued");
+  assert.equal(errors.length, 1);
+  assert.deepEqual(errors[0][1], {
+    outboxId: "outbox-1",
+    eventName: "subscription_renewed",
+    attemptCount: 12,
+    lastErrorCode: "http_401",
+  });
+  assert.equal(JSON.stringify(errors).includes(event.distinctId), false);
 });
 
 test("a permanently discarded row is reported, not silently dropped", async () => {
@@ -549,6 +664,12 @@ class InMemoryAnalyticsOutboxStore implements AnalyticsOutboxStore {
     this.readyAt = readyAt;
   }
 
+  async release(claim: AnalyticsOutboxClaim, now: Date): Promise<void> {
+    this.status = "queued";
+    this.readyAt = now;
+    this.attemptCount = Math.max(claim.attemptCount - 1, 0);
+  }
+
   async markFailed(): Promise<void> {
     this.status = "failed";
   }
@@ -615,6 +736,13 @@ class MultiRowAnalyticsOutboxStore implements AnalyticsOutboxStore {
     row.status = "queued";
     row.readyAt = readyAt;
     row.lastErrorCode = errorCode;
+  }
+
+  async release(claim: AnalyticsOutboxClaim, now: Date): Promise<void> {
+    const row = this.row(claim);
+    row.status = "queued";
+    row.readyAt = now;
+    row.attemptCount = Math.max(claim.attemptCount - 1, 0);
   }
 
   async markFailed(

--- a/functions/test/revenueCatAnalytics.test.ts
+++ b/functions/test/revenueCatAnalytics.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   analyticsEnvironmentForFirebaseProject,
+  optionalAnalyticsEnvironment,
 } from "../src/revenueCat/analyticsEnvironment";
 import {
   buildLifecycleAnalyticsEvent,
@@ -153,6 +154,27 @@ test("support cancellation is a refund only after access is removed", () => {
   )?.eventName, "subscription_refunded");
 });
 
+test("one refund exports one refund event across its paired webhooks", () => {
+  assert.equal(buildLifecycleAnalyticsEvent(
+    webhookEvent({type: "CANCELLATION", lifecycleReason: "customer_support"}),
+    projection({isActive: false}),
+    CONFIG,
+    ENVIRONMENT
+  )?.eventName, "subscription_refunded");
+  assert.equal(buildLifecycleAnalyticsEvent(
+    webhookEvent({type: "EXPIRATION", lifecycleReason: "customer_support"}),
+    projection({isActive: false}),
+    CONFIG,
+    ENVIRONMENT
+  ), null);
+  assert.equal(buildLifecycleAnalyticsEvent(
+    webhookEvent({type: "EXPIRATION", lifecycleReason: "unsubscribe"}),
+    projection({isActive: false}),
+    CONFIG,
+    ENVIRONMENT
+  )?.eventName, "subscription_expired");
+});
+
 test("billing-error cancellation is not double-counted beside billing issue", () => {
   assert.equal(buildLifecycleAnalyticsEvent(
     webhookEvent({type: "CANCELLATION", lifecycleReason: "billing_error"}),
@@ -216,6 +238,23 @@ test("Firebase project selects exactly one matching Mixpanel project", () => {
   );
   assert.throws(
     () => analyticsEnvironmentForFirebaseProject("unexpected-project", "r")
+  );
+});
+
+test("an unresolvable analytics destination degrades instead of throwing", async () => {
+  const errors = await capturedErrors(async () => {
+    assert.equal(optionalAnalyticsEnvironment(undefined, "revision-1"), null);
+    assert.equal(
+      optionalAnalyticsEnvironment("unexpected-project", "revision-1"),
+      null
+    );
+  });
+
+  assert.equal(errors.length, 2);
+  assert.equal(
+    optionalAnalyticsEnvironment("ascend-prod-9c8f2", "revision-1")
+      ?.mixpanelProjectId,
+    "4051100"
   );
 });
 
@@ -323,6 +362,7 @@ test("a transient analytics failure requeues and later delivers", async () => {
   });
   assert.deepEqual(first, {
     claimedCount: 1,
+    deferredCount: 0,
     deliveredCount: 0,
     failedCount: 0,
     reclaimedCount: 0,
@@ -344,6 +384,90 @@ test("a transient analytics failure requeues and later delivers", async () => {
   assert.equal(client.attemptCount, 2);
   assert.deepEqual(client.insertIds, [event.insertId, event.insertId]);
 });
+
+test("a run past its budget requeues claims instead of stranding them", async () => {
+  const event = buildLifecycleAnalyticsEvent(
+    webhookEvent(),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  );
+  assert.ok(event);
+  const store = new MultiRowAnalyticsOutboxStore(event, 3);
+  let clockMs = NOW.getTime();
+  const client: LifecycleAnalyticsClient = {
+    async send(): Promise<void> {
+      clockMs += 40_000;
+    },
+  };
+
+  const summary = await processAnalyticsOutbox({
+    store,
+    client,
+    environment: ENVIRONMENT,
+    now: () => new Date(clockMs),
+    runBudgetMs: 75_000,
+  });
+
+  assert.equal(summary.claimedCount, 3);
+  assert.equal(summary.deliveredCount, 2);
+  assert.equal(summary.deferredCount, 1);
+  assert.deepEqual(store.statuses(), ["delivered", "delivered", "queued"]);
+  assert.equal(store.rows[2].lastErrorCode, "run_deadline_reached");
+  assert.equal(store.rows[2].readyAt.getTime(), clockMs);
+});
+
+test("a permanently discarded row is reported, not silently dropped", async () => {
+  const event = buildLifecycleAnalyticsEvent(
+    webhookEvent(),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  );
+  assert.ok(event);
+  const store = new MultiRowAnalyticsOutboxStore(event, 1);
+  const client: LifecycleAnalyticsClient = {
+    async send(): Promise<void> {
+      throw new MixpanelDeliveryError("validation_failed", false);
+    },
+  };
+
+  const errors = await capturedErrors(async () => {
+    const summary = await processAnalyticsOutbox({
+      store,
+      client,
+      environment: ENVIRONMENT,
+      now: () => NOW,
+    });
+    assert.equal(summary.failedCount, 1);
+  });
+
+  assert.deepEqual(store.statuses(), ["failed"]);
+  assert.equal(errors.length, 1);
+  assert.deepEqual(errors[0][1], {
+    outboxId: "outbox-1",
+    eventName: "subscription_renewed",
+    attemptCount: 1,
+    lastErrorCode: "validation_failed",
+  });
+  assert.equal(JSON.stringify(errors).includes(event.distinctId), false);
+});
+
+async function capturedErrors(
+  run: () => Promise<void>
+): Promise<unknown[][]> {
+  const captured: unknown[][] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    captured.push(args);
+  };
+  try {
+    await run();
+  } finally {
+    console.error = original;
+  }
+  return captured;
+}
 
 function webhookEvent(
   overrides: Partial<RevenueCatWebhookEvent> = {}
@@ -427,6 +551,87 @@ class InMemoryAnalyticsOutboxStore implements AnalyticsOutboxStore {
 
   async markFailed(): Promise<void> {
     this.status = "failed";
+  }
+}
+
+interface AnalyticsOutboxRow {
+  outboxId: string;
+  status: "queued" | "processing" | "delivered" | "failed";
+  attemptCount: number;
+  readyAt: Date;
+  lastErrorCode: string | null;
+}
+
+class MultiRowAnalyticsOutboxStore implements AnalyticsOutboxStore {
+  readonly rows: AnalyticsOutboxRow[];
+
+  constructor(
+    private readonly event: LifecycleAnalyticsEvent,
+    rowCount: number
+  ) {
+    this.rows = Array.from({length: rowCount}, (_unused, index) => ({
+      outboxId: `outbox-${index + 1}`,
+      status: "queued" as const,
+      attemptCount: 0,
+      readyAt: NOW,
+      lastErrorCode: null,
+    }));
+  }
+
+  statuses(): string[] {
+    return this.rows.map((row) => row.status);
+  }
+
+  async reclaimStale(): Promise<number> {
+    return 0;
+  }
+
+  async claimDue(now: Date, limit = 25): Promise<AnalyticsOutboxClaim[]> {
+    return this.rows
+      .filter((row) => row.status === "queued" && row.readyAt <= now)
+      .slice(0, limit)
+      .map((row) => {
+        row.status = "processing";
+        row.attemptCount += 1;
+        return {
+          outboxId: row.outboxId,
+          claimId: `claim-${row.outboxId}-${row.attemptCount}`,
+          attemptCount: row.attemptCount,
+          event: this.event,
+        };
+      });
+  }
+
+  async markDelivered(claim: AnalyticsOutboxClaim): Promise<void> {
+    this.row(claim).status = "delivered";
+  }
+
+  async requeue(
+    claim: AnalyticsOutboxClaim,
+    readyAt: Date,
+    errorCode: string
+  ): Promise<void> {
+    const row = this.row(claim);
+    row.status = "queued";
+    row.readyAt = readyAt;
+    row.lastErrorCode = errorCode;
+  }
+
+  async markFailed(
+    claim: AnalyticsOutboxClaim,
+    errorCode: string
+  ): Promise<void> {
+    const row = this.row(claim);
+    row.status = "failed";
+    row.lastErrorCode = errorCode;
+  }
+
+  private row(claim: AnalyticsOutboxClaim): AnalyticsOutboxRow {
+    const row = this.rows.find(
+      (candidate) => candidate.outboxId === claim.outboxId
+    );
+    assert.ok(row);
+    return row;
   }
 }
 

--- a/functions/test/revenueCatAnalytics.test.ts
+++ b/functions/test/revenueCatAnalytics.test.ts
@@ -1,0 +1,444 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  analyticsEnvironmentForFirebaseProject,
+} from "../src/revenueCat/analyticsEnvironment";
+import {
+  buildLifecycleAnalyticsEvent,
+} from "../src/revenueCat/analyticsEvent";
+import {
+  processAnalyticsOutbox,
+} from "../src/revenueCat/analyticsOutboxProcessor";
+import {
+  MixpanelLifecycleAnalyticsClient,
+  MixpanelDeliveryError,
+} from "../src/revenueCat/analyticsMixpanelClient";
+import {
+  parseMixpanelServerConfig,
+} from "../src/revenueCat/analyticsConfig";
+import type {
+  AnalyticsOutboxClaim,
+  AnalyticsOutboxStore,
+  LifecycleAnalyticsClient,
+  LifecycleAnalyticsEvent,
+  RevenueCatAnalyticsEnvironment,
+} from "../src/revenueCat/analyticsTypes";
+import type {
+  AppAccessProjection,
+  RevenueCatServerConfig,
+  RevenueCatWebhookEvent,
+} from "../src/revenueCat/types";
+
+const NOW = new Date("2026-08-05T12:00:00.000Z");
+const CONFIG: RevenueCatServerConfig = {
+  apiKey: "test-api-key-123456789012345678901234",
+  webhookAuthorization: "Bearer test-authorization-secret-1234567890",
+  webhookSigningSecret: "test-signing-secret-12345678901234567890",
+  appId: "app123",
+  entitlementId: "app_access",
+  allowedProductIds: ["ascend_yearly", "ascend_monthly"],
+};
+const ENVIRONMENT: RevenueCatAnalyticsEnvironment = {
+  appEnvironment: "production",
+  buildConfig: "server",
+  appVersion: "cloud_functions",
+  buildNumber: "revenuecat-webhook-00001",
+  firebaseProjectId: "ascend-prod-9c8f2",
+  mixpanelProjectId: "4051100",
+};
+
+test("every server lifecycle transition has its own event name", () => {
+  const cases: Array<{
+    event: Partial<RevenueCatWebhookEvent>;
+    expectedName: string;
+  }> = [
+    {
+      event: {type: "INITIAL_PURCHASE", periodType: "normal"},
+      expectedName: "subscription_started",
+    },
+    {
+      event: {type: "INITIAL_PURCHASE", periodType: "trial"},
+      expectedName: "subscription_trial_started",
+    },
+    {
+      event: {type: "RENEWAL", isTrialConversion: true},
+      expectedName: "subscription_trial_converted",
+    },
+    {
+      event: {type: "RENEWAL"},
+      expectedName: "subscription_renewed",
+    },
+    {
+      event: {type: "CANCELLATION", lifecycleReason: "unsubscribe"},
+      expectedName: "subscription_cancelled",
+    },
+    {
+      event: {type: "UNCANCELLATION"},
+      expectedName: "subscription_uncancelled",
+    },
+    {
+      event: {type: "BILLING_ISSUE"},
+      expectedName: "subscription_billing_issue",
+    },
+    {
+      event: {type: "EXPIRATION"},
+      expectedName: "subscription_expired",
+    },
+    {
+      event: {
+        type: "CANCELLATION",
+        lifecycleReason: "customer_support",
+      },
+      expectedName: "subscription_refunded",
+    },
+    {
+      event: {
+        type: "PRODUCT_CHANGE",
+        newProductId: "ascend_monthly",
+      },
+      expectedName: "subscription_product_changed",
+    },
+  ];
+
+  for (const entry of cases) {
+    const analyticsEvent = buildLifecycleAnalyticsEvent(
+      webhookEvent(entry.event),
+      projection({
+        isActive: entry.expectedName !== "subscription_refunded",
+      }),
+      CONFIG,
+      ENVIRONMENT
+    );
+    assert.equal(analyticsEvent?.eventName, entry.expectedName);
+  }
+});
+
+test("cancellation remains active and is never relabeled as expiration", () => {
+  const analyticsEvent = buildLifecycleAnalyticsEvent(
+    webhookEvent({
+      type: "CANCELLATION",
+      expirationAtMs: Date.parse("2026-09-05T12:00:00.000Z"),
+      lifecycleReason: "unsubscribe",
+    }),
+    projection({isActive: true}),
+    CONFIG,
+    ENVIRONMENT
+  );
+
+  assert.equal(analyticsEvent?.eventName, "subscription_cancelled");
+  assert.equal(analyticsEvent?.entitlementActive, true);
+  assert.equal(
+    analyticsEvent?.effectiveExpirationAtMs,
+    Date.parse("2027-08-05T12:00:00.000Z")
+  );
+});
+
+test("support cancellation is a refund only after access is removed", () => {
+  const event = webhookEvent({
+    type: "CANCELLATION",
+    lifecycleReason: "customer_support",
+  });
+
+  assert.equal(buildLifecycleAnalyticsEvent(
+    event,
+    projection({isActive: true}),
+    CONFIG,
+    ENVIRONMENT
+  )?.eventName, "subscription_cancelled");
+  assert.equal(buildLifecycleAnalyticsEvent(
+    event,
+    projection({isActive: false}),
+    CONFIG,
+    ENVIRONMENT
+  )?.eventName, "subscription_refunded");
+});
+
+test("billing-error cancellation is not double-counted beside billing issue", () => {
+  assert.equal(buildLifecycleAnalyticsEvent(
+    webhookEvent({type: "CANCELLATION", lifecycleReason: "billing_error"}),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  ), null);
+  assert.equal(buildLifecycleAnalyticsEvent(
+    webhookEvent({type: "BILLING_ISSUE"}),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  )?.eventName, "subscription_billing_issue");
+});
+
+test("outbox identity is stable and carries the complete server envelope", () => {
+  const first = buildLifecycleAnalyticsEvent(
+    webhookEvent(),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  );
+  const replay = buildLifecycleAnalyticsEvent(
+    webhookEvent(),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  );
+
+  assert.deepEqual(replay, first);
+  assert.match(first?.insertId ?? "", /^[a-f0-9]{32}$/);
+  assert.equal(first?.source, "revenuecat_webhook");
+  assert.equal(first?.eventVersion, 1);
+  assert.equal(first?.entitlementId, "app_access");
+  assert.equal(first?.productId, "ascend_yearly");
+  assert.equal(first?.store, "app_store");
+  assert.equal(first?.periodType, "normal");
+  assert.equal(first?.appEnvironment, "production");
+  assert.equal(first?.buildConfig, "server");
+  assert.equal(first?.appVersion, "cloud_functions");
+  assert.equal(first?.buildNumber, "revenuecat-webhook-00001");
+});
+
+test("Firebase project selects exactly one matching Mixpanel project", () => {
+  assert.equal(
+    analyticsEnvironmentForFirebaseProject("ascend-f2e4f", "revision-1")
+      .mixpanelProjectId,
+    "4032860"
+  );
+  assert.equal(
+    analyticsEnvironmentForFirebaseProject(
+      "ascend-staging-fa7d5",
+      "revision-2"
+    ).mixpanelProjectId,
+    "4051102"
+  );
+  assert.equal(
+    analyticsEnvironmentForFirebaseProject("ascend-prod-9c8f2", "revision-3")
+      .mixpanelProjectId,
+    "4051100"
+  );
+  assert.throws(
+    () => analyticsEnvironmentForFirebaseProject("unexpected-project", "r")
+  );
+});
+
+test("Mixpanel config accepts only a bounded server credential", () => {
+  const config = parseMixpanelServerConfig(JSON.stringify({
+    serviceAccountUsername: "production-writer.mp-service-account",
+    serviceAccountPassword: "test-password-123456789012345678901234",
+  }));
+  assert.equal(
+    config.serviceAccountUsername,
+    "production-writer.mp-service-account"
+  );
+  assert.throws(() => parseMixpanelServerConfig(JSON.stringify({
+    serviceAccountUsername: "production-writer.mp-service-account",
+    serviceAccountPassword: "short",
+  })));
+});
+
+test("Mixpanel import is strict, environment-bound, and retry-safe", async () => {
+  let requestedUrl = "";
+  let requestBody = "";
+  const fetchImplementation: typeof fetch = async (input, init) => {
+    requestedUrl = input.toString();
+    requestBody = String(init?.body ?? "");
+    assert.match(String(new Headers(init?.headers).get("authorization")),
+      /^Basic /);
+    return new Response(JSON.stringify({
+      code: 200,
+      num_records_imported: 1,
+      status: "OK",
+    }), {status: 200});
+  };
+  const event = buildLifecycleAnalyticsEvent(
+    webhookEvent(),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  );
+  assert.ok(event);
+  const client = new MixpanelLifecycleAnalyticsClient({
+    serviceAccountUsername: "production-writer.mp-service-account",
+    serviceAccountPassword: "test-password-123456789012345678901234",
+  }, ENVIRONMENT, fetchImplementation);
+
+  await client.send(event);
+
+  const parsedUrl = new URL(requestedUrl);
+  assert.equal(parsedUrl.searchParams.get("strict"), "1");
+  assert.equal(parsedUrl.searchParams.get("project_id"), "4051100");
+  const payload = JSON.parse(requestBody) as Array<{
+    event: string;
+    properties: Record<string, unknown>;
+  }>;
+  assert.equal(payload[0].event, "subscription_renewed");
+  assert.equal(payload[0].properties.$insert_id, event.insertId);
+  assert.equal(payload[0].properties.app_environment, "production");
+  assert.equal(payload[0].properties.ip, 0);
+  assert.equal(requestBody.includes("serviceAccount"), false);
+  assert.equal(requestBody.includes("test-password"), false);
+});
+
+test("Mixpanel transient status is retryable but validation is terminal", async () => {
+  const event = buildLifecycleAnalyticsEvent(
+    webhookEvent(),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  );
+  assert.ok(event);
+  const config = {
+    serviceAccountUsername: "production-writer.mp-service-account",
+    serviceAccountPassword: "test-password-123456789012345678901234",
+  };
+  const failingClient = (status: number) =>
+    new MixpanelLifecycleAnalyticsClient(
+      config,
+      ENVIRONMENT,
+      async () => new Response(null, {status})
+    );
+
+  await assert.rejects(failingClient(503).send(event),
+    (error: unknown) => error instanceof MixpanelDeliveryError &&
+      error.retryable);
+  await assert.rejects(failingClient(400).send(event),
+    (error: unknown) => error instanceof MixpanelDeliveryError &&
+      !error.retryable);
+});
+
+test("a transient analytics failure requeues and later delivers", async () => {
+  const event = buildLifecycleAnalyticsEvent(
+    webhookEvent(),
+    projection(),
+    CONFIG,
+    ENVIRONMENT
+  );
+  assert.ok(event);
+  const store = new InMemoryAnalyticsOutboxStore(event);
+  const client = new FailOnceAnalyticsClient();
+
+  const first = await processAnalyticsOutbox({
+    store,
+    client,
+    environment: ENVIRONMENT,
+    now: () => NOW,
+  });
+  assert.deepEqual(first, {
+    claimedCount: 1,
+    deliveredCount: 0,
+    failedCount: 0,
+    reclaimedCount: 0,
+    retriedCount: 1,
+  });
+  assert.equal(store.status, "queued");
+  assert.equal(store.attemptCount, 1);
+
+  store.readyAt = new Date(NOW.getTime());
+  const second = await processAnalyticsOutbox({
+    store,
+    client,
+    environment: ENVIRONMENT,
+    now: () => new Date(NOW.getTime() + 60_000),
+  });
+  assert.equal(second.deliveredCount, 1);
+  assert.equal(store.status, "delivered");
+  assert.equal(store.attemptCount, 2);
+  assert.equal(client.attemptCount, 2);
+  assert.deepEqual(client.insertIds, [event.insertId, event.insertId]);
+});
+
+function webhookEvent(
+  overrides: Partial<RevenueCatWebhookEvent> = {}
+): RevenueCatWebhookEvent {
+  return {
+    id: "event-123",
+    type: "RENEWAL",
+    appId: CONFIG.appId,
+    eventTimestampMs: NOW.getTime(),
+    appUserIds: ["firebase-user-1"],
+    identityOverflowCount: 0,
+    productId: "ascend_yearly",
+    newProductId: null,
+    store: "app_store",
+    periodType: "normal",
+    expirationAtMs: Date.parse("2027-08-05T12:00:00.000Z"),
+    gracePeriodExpirationAtMs: null,
+    isTrialConversion: false,
+    lifecycleReason: null,
+    ...overrides,
+  };
+}
+
+function projection(
+  overrides: Partial<AppAccessProjection> = {}
+): AppAccessProjection {
+  const expiresAt = new Date("2027-08-05T12:00:00.000Z");
+  return {
+    schemaVersion: 1,
+    uid: "firebase-user-1",
+    entitlementId: "app_access",
+    isActive: true,
+    productId: "ascend_yearly",
+    expiresAt,
+    accessUntil: expiresAt,
+    revenueCatAppId: CONFIG.appId,
+    revenueCatRequestDateMs: NOW.getTime(),
+    sourceEventId: "event-123",
+    sourceEventType: "RENEWAL",
+    verifiedAt: NOW,
+    ...overrides,
+  };
+}
+
+class InMemoryAnalyticsOutboxStore implements AnalyticsOutboxStore {
+  status: "queued" | "processing" | "delivered" | "failed" = "queued";
+  attemptCount = 0;
+  readyAt = NOW;
+
+  constructor(private readonly event: LifecycleAnalyticsEvent) {}
+
+  async reclaimStale(): Promise<number> {
+    return 0;
+  }
+
+  async claimDue(now: Date): Promise<AnalyticsOutboxClaim[]> {
+    if (this.status !== "queued" || this.readyAt > now) {
+      return [];
+    }
+    this.status = "processing";
+    this.attemptCount += 1;
+    return [{
+      claimId: `claim-${this.attemptCount}`,
+      outboxId: "outbox-1",
+      attemptCount: this.attemptCount,
+      event: this.event,
+    }];
+  }
+
+  async markDelivered(): Promise<void> {
+    this.status = "delivered";
+  }
+
+  async requeue(
+    _claim: AnalyticsOutboxClaim,
+    readyAt: Date
+  ): Promise<void> {
+    this.status = "queued";
+    this.readyAt = readyAt;
+  }
+
+  async markFailed(): Promise<void> {
+    this.status = "failed";
+  }
+}
+
+class FailOnceAnalyticsClient implements LifecycleAnalyticsClient {
+  attemptCount = 0;
+  readonly insertIds: string[] = [];
+
+  async send(event: LifecycleAnalyticsEvent): Promise<void> {
+    this.attemptCount += 1;
+    this.insertIds.push(event.insertId);
+    if (this.attemptCount === 1) {
+      throw new MixpanelDeliveryError("rate_limited", true);
+    }
+  }
+}

--- a/scripts/test/production-backend-rollout.test.mjs
+++ b/scripts/test/production-backend-rollout.test.mjs
@@ -98,8 +98,8 @@ test("declares every server collection-group field index", () => {
   // reconciliation query run against. finishers and blocked are addressed by
   // document ID, so they need the collection-group index only. The entitlement
   // expiry sweep orders active grants by accessUntil across every user, and the
-  // webhook ledger is bounded by a TTL policy on its own future retention
-  // stamp rather than by any query.
+  // webhook ledger and the analytics outbox are each bounded by a TTL policy on
+  // their own future retention stamp rather than by any query.
   assert.deepEqual(signatures, [
     [
       "blocked",
@@ -131,6 +131,12 @@ test("declares every server collection-group field index", () => {
     ],
     [
       "_revenuecat_webhook_events",
+      "retainUntil",
+      [],
+      true,
+    ],
+    [
+      "_revenuecat_analytics_outbox",
       "retainUntil",
       [],
       true,

--- a/tests/firebase-rules/paid-access-contract.test.mjs
+++ b/tests/firebase-rules/paid-access-contract.test.mjs
@@ -129,7 +129,7 @@ test('a caller cannot forge or inspect the server-owned access projection', asyn
   await assertFails(getDoc(doc(context.firestore(), leaderboardPath)));
 });
 
-test('webhook dedupe records and inactive status are server-only', async () => {
+test('RevenueCat ledgers, outbox, and inactive status are server-only', async () => {
   const context = testEnv.authenticatedContext(paidUserId);
 
   await assertFails(getDoc(doc(
@@ -140,6 +140,12 @@ test('webhook dedupe records and inactive status are server-only', async () => {
     doc(context.firestore(), '_revenuecat_webhook_events/forged-event'),
     { status: 'completed' }
   ));
+  const analyticsOutbox = doc(
+    context.firestore(),
+    '_revenuecat_analytics_outbox/forged-event'
+  );
+  await assertFails(setDoc(analyticsOutbox, {status: 'delivered'}));
+  await assertFails(getDoc(analyticsOutbox));
   await assertFails(setDoc(
     doc(
       context.firestore(),


### PR DESCRIPTION
## Intent

Add a server-side analytics exporter beside the authenticated, deduplicated, environment-filtered RevenueCat webhook and server-owned paid-access projection from PR 400, following section 4 of the analytics trustworthiness audit without relaxing it. Use a durable Firestore analytics outbox created atomically with webhook completion, keyed by the RevenueCat event plus affected Firebase UID, and deliver from a separate retrying worker with a stable Mixpanel insert ID so repeated RevenueCat deliveries and post-send worker retries yield exactly one analytics event per real transition. Export distinct server-owned events for subscription started, trial started, trial converted, renewed, cancelled, uncancelled, billing issue or grace state, expired, refunded or revoked when fresh RevenueCat truth removes access, and product changed; cancellation must remain distinct from expiration and may retain active access through the paid period. Transient analytics failures must retry until delivery and must never determine or delay the webhook response. Route only by the deployed Firebase project: ascend-f2e4f to Mixpanel 4032860 with app_environment dev, ascend-staging-fa7d5 to 4051102 with app_environment staging, and ascend-prod-9c8f2 to 4051100 with app_environment production, carrying the same app_environment, build_config, app_version, and build_number envelope as client events. Authenticate Mixpanel with a separate project-scoped, least-privilege service account read from each environment secret manager; the credential must never enter the iOS bundle, source, logs, event properties, raw outbox payloads, or chat. Store no raw webhook, transaction ID, receipt, token, credential, or vendor response. Prove repeated webhook replay creates one outbox event, prove transient delivery failure requeues and later succeeds, deny client access to the outbox, remove UID-bearing outbox rows during account deletion, and document required captain-side Mixpanel service-account and secret setup in the production rollout guidance. Leave client analytics environment separation, purchase-event naming, and onboarding-flow counting untouched. Do not change entitlement projection decisions or webhook authentication, deduplication, or environment filtering. Do not perform RevenueCat or Apple dashboard configuration.

## What Changed

- Added a RevenueCat lifecycle analytics exporter under `functions/src/revenueCat/`: the webhook processor maps each authenticated transition (started, trial started/converted, renewed, cancelled, uncancelled, billing issue, expired, refunded, product changed) to a normalized event written into a `_revenuecat_analytics_outbox` row in the same transaction that completes the webhook, keyed by RevenueCat event id plus Firebase UID with a derived stable Mixpanel `$insert_id`. Destination routing is fixed per deployed Firebase project (`ascend-f2e4f`/dev, `ascend-staging-fa7d5`/staging, `ascend-prod-9c8f2`/production), resolved defensively so an unresolved destination degrades the export instead of failing the webhook.
- Added the scheduled `processRevenueCatAnalyticsOutbox` worker that claims due rows, delivers them to Mixpanel with a `MIXPANEL_SERVER_CONFIG` service-account secret, requeues transient failures with backoff under a run deadline, and permanently fails validation errors with an error-level log; rows carry a 30-day `retainUntil` TTL. Supporting Firestore composite and TTL index entries, server-only `firestore.rules` for the collection, deletion of UID-bearing outbox rows in `cleanupDeletedUser`, and the new function name in the production deploy allowlist are included.
- Documented the required captain-side Mixpanel service-account and secret setup (including that dev has no server analytics credential) in `docs/revenuecat-server-entitlement-enforcement.md`, `docs/production-backend-rollout-runbook.md`, and the `ascend-analytics` skill. Tests cover the mapping, outbox, and worker in `functions/test/revenueCatAnalytics.test.ts` plus emulator-backed replay, requeue-then-deliver, deadline, cleanup, and rules-denial cases.

## Risk Assessment

⚠️ Medium: Every code-level finding from the previous two rounds is now closed and covered by focused unit and emulator tests, with the entitlement path provably untouched, but the change adds a Functions secret binding whose absence in staging or production fails the entire functions deploy, so it needs that captain-side prerequisite confirmed before merge rather than after.

## Testing

Ran the three existing suites first (functions unit 310 pass, functions Firestore-emulator 34 pass, Firestore/Storage rules 115 pass), then built an end-to-end harness because passing tests alone do not show what reaches Mixpanel: it drives the shipped webhook handler over real signed HTTP against live Firestore and Auth emulators, faking only RevenueCat's subscriber API and Mixpanel's /import at the network layer so the outgoing import requests are captured verbatim. Twelve real lifecycle deliveries exported the eleven expected distinct events (billing-error cancellation correctly suppressed as the BILLING_ISSUE duplicate), five replays of each created no extra rows, a simulated Mixpanel outage requeued all eleven with backoff and delivered them on the retry under the same stable $insert_id, webhook ingress made zero Mixpanel calls, no credential or raw vendor payload appeared in a stored row, account deletion removed every UID-bearing row, and re-running for all three Firebase project IDs confirmed the fixed project-to-Mixpanel routing. Captain-side Mixpanel secret setup was verified by reading the rollout runbook and enforcement doc updates. Everything passed and the working tree is clean of transient artifacts; no UI surface exists in this change, so the reviewer-visible evidence is the captured webhook-to-Mixpanel transcript rather than a screenshot.

<details>
<summary>Evidence: End-to-end transcript: RevenueCat webhook -&gt; Firestore outbox -&gt; Mixpanel import, for all three Firebase projects</summary>

```text
Server-side RevenueCat -> Mixpanel lifecycle export, end-to-end

Harness: lifecycle-export-e2e.mjs, run inside the Firebase Firestore + Auth
emulators. Real code under test: the deployed revenueCatWebhook HTTP handler,
the webhook parser and authenticator, the entitlement projection, the
Firestore analytics outbox, the outbox worker, the Mixpanel client, and the
account-deletion cleanup port. Only the two third-party endpoints are faked:
RevenueCat's subscriber API and Mixpanel's /import, both intercepted at the
network layer so the real HTTP requests are captured verbatim.

Every RevenueCat delivery below is a real signed HTTP POST to the webhook.

========================================================================
Firebase project ascend-prod-9c8f2  ->  Mixpanel project 4051100 (app_environment production)
========================================================================

── 1. RevenueCat delivers each real subscription transition ──────────
  RevenueCat event                                webhook   outbox event exported
  INITIAL_PURCHASE   trial started (7-day free t  200 processed subscription_trial_started
  [PASS] evt-trial-started: webhook answered 200/processed
  [PASS] evt-trial-started: exported subscription_trial_started
  RENEWAL            trial converted (first paid  200 processed subscription_trial_converted
  [PASS] evt-trial-converted: webhook answered 200/processed
  [PASS] evt-trial-converted: exported subscription_trial_converted
  INITIAL_PURCHASE   subscription started (month  200 processed subscription_started
  [PASS] evt-subscription-started: webhook answered 200/processed
  [PASS] evt-subscription-started: exported subscription_started
  RENEWAL            renewed (ordinary paid rene  200 processed subscription_renewed
  [PASS] evt-renewed: webhook answered 200/processed
  [PASS] evt-renewed: exported subscription_renewed
  CANCELLATION       cancelled (auto-renew off,   200 processed subscription_cancelled
  [PASS] evt-cancelled: webhook answered 200/processed
  [PASS] evt-cancelled: exported subscription_cancelled
  UNCANCELLATION     uncancelled (auto-renew tur  200 processed subscription_uncancelled
  [PASS] evt-uncancelled: webhook answered 200/processed
  [PASS] evt-uncancelled: exported subscription_uncancelled
  BILLING_ISSUE      billing issue (grace period  200 processed subscription_billing_issue
  [PASS] evt-billing-issue: webhook answered 200/processed
  [PASS] evt-billing-issue: exported subscription_billing_issue
  CANCELLATION       billing-error cancellation   200 processed (none - deliberately suppressed)
  [PASS] evt-cancelled-billing-error: webhook answered 200/processed
  [PASS] evt-cancelled-billing-error: exported nothing
  PRODUCT_CHANGE     product changed (monthly ->  200 processed subscription_product_changed
  [PASS] evt-product-changed: webhook answered 200/processed
  [PASS] evt-product-changed: exported subscription_product_changed
  EXPIRATION         expired (paid period ended,  200 processed subscription_expired
  [PASS] evt-expired: webhook answered 200/processed
  [PASS] evt-expired: exported subscription_expired
  CANCELLATION       refund step 1: support canc  200 processed subscription_cancelled
  [PASS] evt-refund-cancellation: webhook answered 200/processed
  [PASS] evt-refund-cancellation: exported subscription_cancelled
  EXPIRATION         refund step 2: fresh Revenu  200 processed subscription_refunded
  [PASS] evt-refund-expiration: webhook answered 200/processed
  [PASS] evt-refund-expiration: exported subscription_refunded

── 2. Cancellation stays distinct from expiration and from refund ────
  subscription_cancelled  entitlement_active=true  refund_attributed=false
  refund cancellation     eventName=subscription_cancelled  entitlement_active=true  refund_attributed=true
  refund expiration       eventName=subscription_refunded  entitlement_active=false  refund_attributed=true
  ordinary expiration     eventName=subscription_expired  refund_attributed=false
  [PASS] an ordinary cancellation keeps paid access to period end
  [PASS] a refund is two distinct events, both refund-attributed
  [PASS] an ordinary expiration is not refund-attributed

── 3. RevenueCat replays every delivery five more times ──────────────
  12 events x 5 replays -> 200 duplicate
  outbox rows before replays: 11   after: 11
  [PASS] replayed deliveries created no extra outbox rows (11 rows)

── 4. Webhook ingress never talks to Mixpanel ────────────────────────
  Mixpanel requests made while answering every webhook delivery: 0
  [PASS] analytics delivery cannot decide or delay the webhook response

── 4b. Nothing sensitive is persisted in an outbox row ───────────────
  {
    "schemaVersion": 1,
    "eventName": "subscription_trial_started",
    "eventVersion": 1,
    "source": "revenuecat_webhook",
    "distinctId": "e2e-climber-uid",
    "insertId": "0d0f03877e8a54151dc85baee73e3c8e",
    "eventTimestampMs": 1785931200000,
    "entitlementId": "app_access",
    "productId": "ascend_yearly",
    "previousProductId": null,
    "store": "app_store",
    "periodType": "trial",
    "lifecycleReason": null,
    "refundAttributed": false,
    "entitlementActive": true,
    "effectiveExpirationAtMs": 1786536000000,
    "firebaseProjectId": "ascend-prod-9c8f2",
    "appEnvironment": "production",
    "buildConfig": "server",
    "appVersion": "cloud_functions",
    "buildNumber": "revenuecatanalytics-00042-abc",
    "status": "queued",
    "attemptCount": 0,
    "readyAt": {
      "_seconds": 1785956140,
      "_nanoseconds": 629000000
    },
    "processingStartedAt": null,
    "claimId": null,
    "deliveredAt": null,
    "lastErrorCode": null,
    "createdAt": {
      "_seconds": 1785956140,
      "_nanoseconds": 629000000
    },
    "updatedAt": {
      "_seconds": 1785956140,
      "_nanoseconds": 629000000
    },
    "retainUntil": {
      "_seconds": 1788548140,
      "_nanoseconds": 629000000
    }
  }
  [PASS] outbox row contains no raw transaction id
  [PASS] outbox row contains no original transaction id
  [PASS] outbox row contains no RevenueCat API key
  [PASS] outbox row contains no webhook authorization
  [PASS] outbox row contains no webhook signing secret
  [PASS] outbox row contains no Mixpanel service-account password
  [PASS] outbox row contains no price/currency vendor payload

── 5. A transient Mixpanel outage retries until it delivers ──────────
  worker run 1 (Mixpanel answering 503): {"reclaimedCount":0,"claimedCount":11,"deliveredCount":0,"retriedCount":11,"failedCount":0,"deferredCount":0}
  rows back in the queue: 11, attemptCount=1, lastErrorCode=http_503, readyAt=+60s (bounded exponential backoff)
  [PASS] a transient failure requeues instead of dropping the event
  worker run 2 (Mixpanel healthy):       {"reclaimedCount":0,"claimedCount":11,"deliveredCount":11,"retriedCount":0,"failedCount":0,"deferredCount":0}
  [PASS] every requeued event delivered on the retry
  worker run 3 (post-delivery retry):    {"reclaimedCount":0,"claimedCount":0,"deliveredCount":0,"retriedCount":0,"failedCount":0,"deferredCount":0}
  [PASS] a worker retry after delivery sends nothing again
  RevenueCat replays the same events once more, post-delivery...
  worker run 4 (after replay):          {"reclaimedCount":0,"claimedCount":0,"deliveredCount":0,"retriedCount":0,"failedCount":0,"deferredCount":0}
  [PASS] a post-delivery webhook replay re-sends nothing

── 6. What Mixpanel actually received ────────────────────────────────
  POST https://api.mixpanel.com/import?strict=1&project_id=4051100
  Authorization: Basic <base64 service-account credential, redacted>
  credential user: ascend-server-export.4f9c1a.mp-service-account  password: ************ (never in the payload)

  event                          $insert_id                        app_environment  product          previous_product
  subscription_trial_started     0d0f03877e8a541

... [5948 bytes truncated] ...

e requeues instead of dropping the event
  worker run 2 (Mixpanel healthy):       {"reclaimedCount":0,"claimedCount":1,"deliveredCount":1,"retriedCount":0,"failedCount":0,"deferredCount":0}
  [PASS] every requeued event delivered on the retry
  worker run 3 (post-delivery retry):    {"reclaimedCount":0,"claimedCount":0,"deliveredCount":0,"retriedCount":0,"failedCount":0,"deferredCount":0}
  [PASS] a worker retry after delivery sends nothing again

── 6. What Mixpanel actually received ────────────────────────────────
  POST https://api.mixpanel.com/import?strict=1&project_id=4051102
  Authorization: Basic <base64 service-account credential, redacted>
  credential user: ascend-server-export.4f9c1a.mp-service-account  password: ************ (never in the payload)

  event                          $insert_id                        app_environment  product          previous_product
  subscription_trial_started     0d0f03877e8a54151dc85baee73e3c8e staging          ascend_staging_yearly -

  full first accepted import body:
    [
      {
        "event": "subscription_trial_started",
        "properties": {
          "time": 1785931200000,
          "distinct_id": "e2e-climber-uid",
          "$insert_id": "0d0f03877e8a54151dc85baee73e3c8e",
          "ip": 0,
          "source": "revenuecat_webhook",
          "event_version": 1,
          "entitlement_id": "app_access",
          "product_id": "ascend_staging_yearly",
          "previous_product_id": null,
          "store": "app_store",
          "period_type": "trial",
          "lifecycle_reason": null,
          "refund_attributed": false,
          "entitlement_active": true,
          "effective_expiration_at_ms": 1786536000000,
          "app_environment": "staging",
          "build_config": "server",
          "app_version": "cloud_functions",
          "build_number": "revenuecatanalytics-00042-abc"
        }
      }
    ]
  [PASS] Mixpanel received exactly one accepted import per real transition (1 accepted, 1 rejected+retried)
  [PASS] every import is routed to the mapped project (project_id=4051102, strict=1)
  [PASS] every import carries the client-equivalent envelope
  [PASS] the retried import reused its stable $insert_id
  [PASS] no Mixpanel payload carries the service-account password

── result ────────────────────────────────────────────────────────────
  ALL CHECKS PASSED (ascend-staging-fa7d5)
========================================================================
Firebase project ascend-f2e4f  ->  Mixpanel project 4032860 (app_environment dev)
========================================================================

── 1. RevenueCat delivers each real subscription transition ──────────
  RevenueCat event                                webhook   outbox event exported
  INITIAL_PURCHASE   trial started (7-day free t  200 processed subscription_trial_started
  [PASS] evt-trial-started: webhook answered 200/processed
  [PASS] evt-trial-started: exported subscription_trial_started

── 4. Webhook ingress never talks to Mixpanel ────────────────────────
  Mixpanel requests made while answering every webhook delivery: 0
  [PASS] analytics delivery cannot decide or delay the webhook response

── 4b. Nothing sensitive is persisted in an outbox row ───────────────
  {
    "schemaVersion": 1,
    "eventName": "subscription_trial_started",
    "eventVersion": 1,
    "source": "revenuecat_webhook",
    "distinctId": "e2e-climber-uid",
    "insertId": "0d0f03877e8a54151dc85baee73e3c8e",
    "eventTimestampMs": 1785931200000,
    "entitlementId": "app_access",
    "productId": "ascend_dev_yearly",
    "previousProductId": null,
    "store": "app_store",
    "periodType": "trial",
    "lifecycleReason": null,
    "refundAttributed": false,
    "entitlementActive": true,
    "effectiveExpirationAtMs": 1786536000000,
    "firebaseProjectId": "ascend-f2e4f",
    "appEnvironment": "dev",
    "buildConfig": "server",
    "appVersion": "cloud_functions",
    "buildNumber": "revenuecatanalytics-00042-abc",
    "status": "queued",
    "attemptCount": 0,
    "readyAt": {
      "_seconds": 1785956148,
      "_nanoseconds": 335000000
    },
    "processingStartedAt": null,
    "claimId": null,
    "deliveredAt": null,
    "lastErrorCode": null,
    "createdAt": {
      "_seconds": 1785956148,
      "_nanoseconds": 335000000
    },
    "updatedAt": {
      "_seconds": 1785956148,
      "_nanoseconds": 335000000
    },
    "retainUntil": {
      "_seconds": 1788548148,
      "_nanoseconds": 335000000
    }
  }
  [PASS] outbox row contains no raw transaction id
  [PASS] outbox row contains no original transaction id
  [PASS] outbox row contains no RevenueCat API key
  [PASS] outbox row contains no webhook authorization
  [PASS] outbox row contains no webhook signing secret
  [PASS] outbox row contains no Mixpanel service-account password
  [PASS] outbox row contains no price/currency vendor payload

── 5. A transient Mixpanel outage retries until it delivers ──────────
  worker run 1 (Mixpanel answering 503): {"reclaimedCount":0,"claimedCount":1,"deliveredCount":0,"retriedCount":1,"failedCount":0,"deferredCount":0}
  rows back in the queue: 1, attemptCount=1, lastErrorCode=http_503, readyAt=+60s (bounded exponential backoff)
  [PASS] a transient failure requeues instead of dropping the event
  worker run 2 (Mixpanel healthy):       {"reclaimedCount":0,"claimedCount":1,"deliveredCount":1,"retriedCount":0,"failedCount":0,"deferredCount":0}
  [PASS] every requeued event delivered on the retry
  worker run 3 (post-delivery retry):    {"reclaimedCount":0,"claimedCount":0,"deliveredCount":0,"retriedCount":0,"failedCount":0,"deferredCount":0}
  [PASS] a worker retry after delivery sends nothing again

── 6. What Mixpanel actually received ────────────────────────────────
  POST https://api.mixpanel.com/import?strict=1&project_id=4032860
  Authorization: Basic <base64 service-account credential, redacted>
  credential user: ascend-server-export.4f9c1a.mp-service-account  password: ************ (never in the payload)

  event                          $insert_id                        app_environment  product          previous_product
  subscription_trial_started     0d0f03877e8a54151dc85baee73e3c8e dev              ascend_dev_yearly -

  full first accepted import body:
    [
      {
        "event": "subscription_trial_started",
        "properties": {
          "time": 1785931200000,
          "distinct_id": "e2e-climber-uid",
          "$insert_id": "0d0f03877e8a54151dc85baee73e3c8e",
          "ip": 0,
          "source": "revenuecat_webhook",
          "event_version": 1,
          "entitlement_id": "app_access",
          "product_id": "ascend_dev_yearly",
          "previous_product_id": null,
          "store": "app_store",
          "period_type": "trial",
          "lifecycle_reason": null,
          "refund_attributed": false,
          "entitlement_active": true,
          "effective_expiration_at_ms": 1786536000000,
          "app_environment": "dev",
          "build_config": "server",
          "app_version": "cloud_functions",
          "build_number": "revenuecatanalytics-00042-abc"
        }
      }
    ]
  [PASS] Mixpanel received exactly one accepted import per real transition (1 accepted, 1 rejected+retried)
  [PASS] every import is routed to the mapped project (project_id=4032860, strict=1)
  [PASS] every import carries the client-equivalent envelope
  [PASS] the retried import reused its stable $insert_id
  [PASS] no Mixpanel payload carries the service-account password

── result ────────────────────────────────────────────────────────────
  ALL CHECKS PASSED (ascend-f2e4f)
```
</details>
- Evidence: E2E harness used to produce the transcript (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZ9J318VFM8CE7TFDBGP3NSZ/lifecycle-export-e2e.mjs</code>)
<details>
<summary>Evidence: Client access to the analytics outbox is denied by firestore.rules</summary>

```text
Client access to the analytics outbox is denied by firestore.rules

$ npx firebase-tools emulators:exec --only firestore,storage \
    "node --test tests/firebase-rules/paid-access-contract.test.mjs"

A signed-in climber who DOES hold active app_access tries to read and write
_revenuecat_analytics_outbox/forged-event. Firestore answers:

    false for 'create' @ L1407, false for 'update' @ L1407
    false for 'create' @ L1640, false for 'update' @ L1640
    false for 'create' @ L1644, false for 'update' @ L1644
    false for 'create' @ L1418, false for 'update' @ L1418

(L1640 is the webhook-event ledger rule, L1644 the new analytics outbox
 rule; the outbox read is denied too, which produces no write-stream log.)

✔ an authenticated but unpaid caller cannot read the paid leaderboard (6182.230292ms)
✔ a caller cannot forge or inspect the server-owned access projection (152.938875ms)
✔ RevenueCat ledgers, outbox, and inactive status are server-only (204.704792ms)
ℹ tests 8
ℹ pass 8
ℹ fail 0
```
</details>
<details>
<summary>Evidence: What Mixpanel actually received for the production project (excerpt)</summary>

```text
POST https://api.mixpanel.com/import?strict=1&project_id=4051100
Authorization: Basic <base64 service-account credential, redacted>

event $insert_id app_environment product previous_product
subscription_trial_started 0d0f03877e8a54151dc85baee73e3c8e production ascend_yearly -
subscription_uncancelled 24438774799ede0e7a10f704f1b277c7 production ascend_yearly -
subscription_started 2d35fc99ab0f2c81bbc3bdf2a9f1188d production ascend_monthly -
subscription_cancelled 41e5988305b537d6f2f49bb33fb21911 production ascend_yearly -
subscription_trial_converted 4f1c5a3f63cbdbcdd59049dc32f821a2 production ascend_yearly -
subscription_billing_issue 59367b95fafd5fcfd8c1bc23940511bb production ascend_yearly -
subscription_renewed 7d59fc77ee4a10b96065d0b403d0d98f production ascend_yearly -
subscription_cancelled a8cd910ec96903cc8faa7677bc10c0e7 production ascend_yearly -
subscription_expired c4330ce9a3ed0da7c14cca158c36649c production ascend_yearly -
subscription_product_changed ce394b693f7ac904244976554475a07c production ascend_yearly ascend_monthly
subscription_refunded e3753068375889f1e26225a4172a8418 production ascend_yearly -

[PASS] Mixpanel received exactly one accepted import per real transition (11 accepted, 11 rejected+retried)
[PASS] every import is routed to the mapped project (project_id=4051100, strict=1)
[PASS] every import carries the client-equivalent envelope
[PASS] the retried import reused its stable $insert_id
```
</details>
<details>
<summary>Evidence: Replay, retry, and webhook-decoupling summary (production run)</summary>

```text
── 3. RevenueCat replays every delivery five more times ──────────────
12 events x 5 replays -> 200 duplicate
outbox rows before replays: 11 after: 11
[PASS] replayed deliveries created no extra outbox rows (11 rows)

── 4. Webhook ingress never talks to Mixpanel ────────────────────────
Mixpanel requests made while answering every webhook delivery: 0
[PASS] analytics delivery cannot decide or delay the webhook response

── 5. A transient Mixpanel outage retries until it delivers ──────────
worker run 1 (Mixpanel answering 503): {"claimedCount":11,"deliveredCount":0,"retriedCount":11,"failedCount":0,"deferredCount":0}
rows back in the queue: 11, attemptCount=1, lastErrorCode=http_503, readyAt=+60s (bounded exponential backoff)
worker run 2 (Mixpanel healthy): {"claimedCount":11,"deliveredCount":11,"retriedCount":0}
worker run 3 (post-delivery retry): {"claimedCount":0,"deliveredCount":0}
worker run 4 (after webhook replay): {"claimedCount":0,"deliveredCount":0}

── 7. Account deletion removes every UID-bearing outbox row ──────────
outbox rows carrying uid e2e-climber-uid: 11 before deletion, 0 after
cleanup summary: deletedRevenueCatAnalyticsOutbox=11, failures=[]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

- ⚠️ `functions/src/revenueCat/webhook.ts:59` - Analytics destination resolution was placed inside the webhook&#39;s server-configuration gate. If `analyticsEnvironmentForFirebaseProject` throws (Firebase project not in the fixed three-project map, or `admin.app().options.projectId` unset), the webhook returns 500 `server_configuration_error` before authenticating or processing anything, so RevenueCat retries and eventually drops the delivery and entitlement projections stop entirely. The intent requires that analytics &#34;must never determine or delay the webhook response&#34; and that the change must &#34;not change entitlement projection decisions or webhook authentication, deduplication, or environment filtering&#34; - this adds a new analytics-owned pre-auth failure mode on the paid-access critical path, which the runbook describes as &#34;a subscriber lockout rather than a degraded feature&#34;. Suggested resolution: resolve the analytics environment defensively (log and pass `undefined`, skipping outbox writes) rather than failing the webhook, keeping entitlement enforcement independent of the analytics map.
- ⚠️ `functions/src/revenueCat/analyticsEvent.ts:99` - One Apple refund emits two RevenueCat webhooks - `CANCELLATION` with `cancel_reason: CUSTOMER_SUPPORT` and `EXPIRATION` with `expiration_reason: CUSTOMER_SUPPORT`. `EXPIRATION` maps unconditionally to `subscription_refunded` (line 99-100) and `CANCELLATION` maps to `subscription_refunded` whenever fresh truth already shows access removed (line 91-93), which is the normal case for a refund because RevenueCat revokes immediately. The two webhooks carry different event IDs, so the insert-ID dedupe does not collapse them and Mixpanel records two `subscription_refunded` events for one refund. This is the exact double-count the author explicitly guarded against for `CANCELLATION(billing_error)` vs `BILLING_ISSUE` at line 86-90, and it contradicts the intent&#39;s requirement that repeated deliveries &#34;yield exactly one analytics event per real transition&#34;. Decide which of the two webhook types owns `subscription_refunded` and suppress the other.
- ⚠️ `functions/src/revenueCat/firestoreStore.ts:339` - `serializeAnalyticsOutboxEvent` writes no retention stamp, and `firestore.indexes.json` adds no TTL field override for `_revenuecat_analytics_outbox` (the only existing TTL override is `_revenuecat_webhook_events.retainUntil`). Delivered rows therefore persist forever, each holding a Firebase UID in `distinctId`, so the collection grows without bound and retains UID-bearing records indefinitely - directly contrary to the minimal-retention posture the sibling ledger establishes and that `docs/revenuecat-server-entitlement-enforcement.md` documents. Only ~30 days of retention is needed (the dedupe must outlive RevenueCat&#39;s ~155-minute retry ladder and the ledger&#39;s own 30-day TTL). Mirror the ledger: add `retainUntil` to the serialized row and a matching TTL `fieldOverrides` entry, then note the TTL policy in the rollout doc.
- ⚠️ `functions/src/revenueCat/analyticsOutboxProcessor.ts:35` - `claimDue` moves all 25 rows to `processing` in one pass before any delivery begins, then `processAnalyticsOutbox` sends them sequentially with a 10s per-request timeout (`analyticsMixpanelClient.ts:9`), on top of up to 25 reclaim transactions. Worst case exceeds the 250s mark against the worker&#39;s `timeoutSeconds: 120` (`analyticsExporter.ts:24`). When the invocation is killed mid-loop, every unattempted claimed row is stranded in `processing` until `reclaimStale` picks it up 15 minutes later, and the next minute&#39;s run claims 25 more, so sustained Mixpanel latency compounds the backlog instead of draining it. Make the loop deadline-aware (stop claiming/sending once elapsed time nears the timeout), or claim lazily one row at a time, or size the batch to the timeout.
- ⚠️ `functions/src/revenueCat/analyticsOutboxProcessor.ts:77` - A Mixpanel 400 is mapped to non-retryable `validation_failed` (`analyticsMixpanelClient.ts:50-54`) and the row is terminally `markFailed`. Because `strict=1` validation is systemic, a single payload-schema mistake makes every event 400 and be permanently discarded; the only signal is `failedCount` inside one `console.log` info line at `analyticsExporter.ts:42`, which no alert will fire on. The same applies to `environment_mismatch` rows. Emit a `console.error` per permanently-failed row including `outboxId`, `eventName` and `lastErrorCode` (all non-sensitive) so a dead server lifecycle stream is detectable rather than silent.
- ℹ️ `functions/src/revenueCat/firestoreStore.ts:14` - `ANALYTICS_OUTBOX_COLLECTION` is exported from the entitlement store module, so both `analyticsFirestoreOutbox.ts` and `accountCleanup.ts` import the RevenueCat entitlement store just to read a collection name. The constant belongs beside the analytics outbox code (e.g. `analyticsTypes.ts` or `analyticsFirestoreOutbox.ts`), which keeps the dependency direction analytics-to-store rather than cleanup-to-entitlement-store.

🔧 Fix: decouple analytics from webhook ingress and bound outbox delivery
3 issues (1 warning, 2 infos) still open:
- ⚠️ `functions/src/revenueCat/analyticsEvent.ts:99` - The refund dedupe removed the double-count but made `subscription_refunded` conditional on the CANCELLATION branch classifying it, which it does only when `!projection.isActive` (line 91-93). `EXPIRATION` + `customer_support` is now unconditionally `null`. When a refund leaves access in place until period end - which RevenueCat&#39;s own CANCELLATION semantics explicitly allow, and which the intent restates as &#34;cancellation ... may retain active access through the paid period&#34; - the CANCELLATION webhook emits `subscription_cancelled`, and the later EXPIRATION(customer_support) that actually removes access emits nothing. The same total loss occurs if an EXPIRATION(customer_support) ever arrives without a paired CANCELLATION(customer_support). The intent requires a distinct event for &#34;refunded or revoked when fresh RevenueCat truth removes access&#34;; in that path no refund, revoke, or expiration event is exported at all. Consider moving `subscription_refunded` onto the EXPIRATION(customer_support) side (the transition where fresh truth actually removes access) and always mapping CANCELLATION(customer_support) to `subscription_cancelled`, or keying the refund outbox row on uid + refund rather than uid + event id so either webhook can mint it exactly once.
- ℹ️ `functions/src/revenueCat/analyticsOutboxProcessor.ts:57` - `claimDue` increments `attemptCount` at claim time (`analyticsFirestoreOutbox.ts:173`), but a claim released by the run-budget check was never sent. Two consequences: `retryDelayMs(claim.attemptCount)` on the row&#39;s first real transient failure backs off as if it had already failed that many times (six deferrals put it straight at the one-hour cap instead of one minute), which slows the drain exactly when a backlog is what caused the deferrals; and the row is left with `lastErrorCode: &#34;run_deadline_reached&#34;`, which reads as a delivery error for a delivery that never happened. Track deferrals separately from delivery attempts - e.g. pass a flag through `requeue` so a deadline release restores `attemptCount`, or drive the backoff off a distinct `deliveryAttemptCount` field.
- ℹ️ `functions/src/revenueCat/analyticsFirestoreOutbox.ts:228` - `retainUntil` is stamped once in `serializeAnalyticsOutboxEvent` and never touched by `requeue`, `markDelivered`, or `markFailed`, so the 30-day TTL is measured from row creation regardless of delivery state. A row still retrying at day 30 - a rotated Mixpanel credential yields `http_401`, which is classified retryable at `analyticsMixpanelClient.ts:50-54` and so requeues indefinitely - is deleted by the TTL with no `console.error`, since `reportPermanentFailure` only fires on `markFailed`. That silently ends the intent&#39;s &#34;retry until delivery&#34; guarantee for the one failure mode that would trigger it. Refresh `retainUntil` on each `requeue` so the 30-day bound applies to the settled record rather than to the retry window, or emit an error-level signal for rows that are still queued as they approach retention.

🔧 Fix: keep refund transitions distinct and bound outbox retention
1 warning still open:
- ⚠️ `functions/src/revenueCat/analyticsExporter.ts:22` - `processRevenueCatAnalyticsOutbox` binds `secrets: [mixpanelServerConfig]`. `.github/workflows/deploy-staging.yml` fires on any push to `develop` touching `functions/**` and runs `firebase deploy --project ascend-staging-fa7d5 --only functions --non-interactive --force`, which fails when a bound secret does not exist in Secret Manager - and it fails the whole `--only functions` deploy, not just the new worker, so `revenueCatWebhook`, `expireRevenueCatEntitlements`, `cleanupDeletedUserData` and the rest stop updating too. Merging this PR before `MIXPANEL_SERVER_CONFIG` exists in `ascend-staging-fa7d5` therefore breaks the staging backend deploy rather than degrading analytics. The same applies to `ascend-prod-9c8f2` on the production workflow. `docs/revenuecat-server-entitlement-enforcement.md:80` does say &#34;Set both `REVENUECAT_SERVER_CONFIG` and `MIXPANEL_SERVER_CONFIG` before deploying Functions&#34;, but that line sits in the entitlement reference rather than anywhere the merge path surfaces. Confirm the staging secret is created before merging to `develop` (and the production one before the release), or state that it already exists.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`cd functions &amp;&amp; npm test` - 310 unit tests pass, including the 18 new `functions/test/revenueCatAnalytics.test.ts` cases</code>
- <code>`cd functions &amp;&amp; npm run test:emulator` - 34 Firestore-emulator tests pass, including `a transient Mixpanel failure requeues and later delivers`, `a still-retrying row cannot expire before it is delivered`, `a claim released at the run deadline is charged no delivery attempt`, and the replayed `duplicate webhook delivery is durably idempotent`</code>
- <code>`npm run test:firebase-rules` - 115 rules tests pass, including `RevenueCat ledgers, outbox, and inactive status are server-only`</code>
- <code>`npx firebase-tools emulators:exec --only firestore,storage &#34;node --test tests/firebase-rules/paid-access-contract.test.mjs&#34;` - captured the actual PERMISSION_DENIED responses a signed-in paid climber gets when reading or writing `_revenuecat_analytics_outbox`</code>
- <code>E2E harness `node lifecycle-export-e2e.mjs ascend-prod-9c8f2 full` inside the Firestore+Auth emulators: 12 HMAC-signed RevenueCat webhook POSTs through the shipped `handleRevenueCatWebhook`, each verified for webhook status and the exported event name</code>
- <code>E2E: 12 events x 5 RevenueCat replays -&gt; all `200 duplicate`, outbox row count unchanged at 11 (billing-error cancellation deliberately exports nothing)</code>
- <code>E2E: worker run with Mixpanel answering 503 -&gt; 11 rows requeued with `attemptCount=1`, `lastErrorCode=http_503`, `readyAt=+60s`; rerun with Mixpanel healthy -&gt; 11 delivered; two further runs (post-delivery retry, post-delivery webhook replay) claim nothing</code>
- <code>E2E: captured Mixpanel HTTP requests asserted for `strict=1`, mapped `project_id`, Basic service-account auth, unique stable `$insert_id`, and the `app_environment`/`build_config`/`app_version`/`build_number` envelope</code>
- `E2E: stored outbox row asserted to contain no transaction IDs, RevenueCat API key, webhook authorization, signing secret, Mixpanel password, or vendor price payload`
- <code>E2E: `cleanupDeletedUser` with the real admin port removed all 11 outbox rows carrying the deleted uid with no failures</code>
- <code>E2E routing runs `node lifecycle-export-e2e.mjs ascend-staging-fa7d5 routing` and `... ascend-f2e4f routing` - confirmed 4051102/staging and 4032860/dev destinations</code>
- `Reviewed the diff for out-of-scope changes: no Swift/client analytics files touched, and webhook authentication, dedupe, app-id filtering, and entitlement projection logic are unmodified`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `docs/revenuecat-server-entitlement-enforcement.md:63` - The Mixpanel setup guidance creates MIXPANEL_SERVER_CONFIG only in staging and production, but the destination map and the unconditionally exported processRevenueCatAnalyticsOutbox schedule also cover dev (ascend-f2e4f -&gt; 4032860). No documented workflow deploys Functions to dev today, so this is latent rather than broken, but the runbook does not say which answer is intended - create a dev service account and secret, or state that Functions are never deployed to ascend-f2e4f. I left it alone rather than guess at captain-side vendor setup.

🔧 Fix: document dev has no server analytics credential
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
