### PR TITLE
test(functions): cover RevenueCat webhook HTTP delivery and correct HMAC setup docs

### DIFF
--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -28,8 +28,14 @@ Set the production destination to `https://us-central1-ascend-prod-9c8f2.cloudfu
 Save each webhook integration, then reopen its detail page.
 The HMAC control is not part of the New Webhook form.
 On the saved integration's detail page, toggle **HMAC webhook signing**, then immediately copy the signing secret RevenueCat shows once and store it in that destination's Firebase secret configuration.
-If the one-time value is lost, use **Rotate secret** on that detail page and replace the Firebase value before sending another webhook.
-[RevenueCat's current webhook documentation](https://www.revenuecat.com/docs/integrations/webhooks#webhook-signature-verification-hmac) specifies this post-creation location and the `X-RevenueCat-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex>` delivery header.
+RevenueCat shows the secret only at creation or rotation and cannot retrieve it later, so if the one-time value is lost, use **Rotate secret** on that detail page to mint a new one.
+Rotation invalidates the old secret immediately, and RevenueCat, not the captain, decides when the next delivery arrives.
+Every genuine lifecycle event between the rotation click and the deployed replacement is therefore rejected with HTTP 401.
+That window is unavoidable; only its length is controllable.
+Minimize it by rotating only when the current value is genuinely lost, staging the full new `REVENUECAT_SERVER_CONFIG` JSON before clicking **Rotate secret**, then setting the Firebase secret and redeploying Functions immediately, and finally sending the dashboard test webhook and requiring HTTP 200 before considering the rotation done.
+[RevenueCat's current webhook documentation](https://www.revenuecat.com/docs/integrations/webhooks#webhook-signature-verification-hmac) specifies this post-creation location, the show-once-or-rotate secret, the immediate invalidation of the old secret, and the `X-RevenueCat-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex>` delivery header.
+The same page treats any non-2xx response as a failure and retries a failed delivery up to five times after 5, 10, 20, 40, and 80 minutes.
+A window closed inside roughly 155 minutes therefore self-heals with no lost events, while a longer one permanently drops every delivery whose retries expired unless each failed event is resent by hand with **Retry** from the integration's event table.
 The function requires both credentials on every request.
 6. After the matching Firebase function is deployed, send RevenueCat's test webhook to each destination and require HTTP 200.
 A test event with no real Firebase UID is expected to complete with zero affected users.

--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -25,17 +25,19 @@ Do not enable Paywall UI or virtual-currency events because they create subscrib
 4. Set the staging destination to `https://us-central1-ascend-staging-fa7d5.cloudfunctions.net/revenueCatWebhook`.
 Set the production destination to `https://us-central1-ascend-prod-9c8f2.cloudfunctions.net/revenueCatWebhook`.
 5. Configure a different high-entropy `Authorization` header value for each destination.
-Save each webhook integration, then reopen its detail page.
-The HMAC control is not part of the New Webhook form.
-On the saved integration's detail page, toggle **HMAC webhook signing**, then immediately copy the signing secret RevenueCat shows once and store it in that destination's Firebase secret configuration.
-RevenueCat shows the secret only at creation or rotation and cannot retrieve it later, so if the one-time value is lost, use **Rotate secret** on that detail page to mint a new one.
+HMAC signing is offered only on a saved integration's detail page, never on the New Webhook form, so the ordering is fixed: create the integration with its URL, `Authorization` value, environment, and app filter, save it, then reopen its detail page.
+On that detail page, toggle **HMAC webhook signing** and copy the signing secret immediately, because RevenueCat shows it only at creation or rotation and cannot retrieve it later.
+Only then assemble that destination's complete `REVENUECAT_SERVER_CONFIG` JSON, write the whole secret to Firebase, and deploy Functions.
+All six configuration fields below are required and the parser refuses a partial value, so there is never a valid intermediate write that carries the new signing secret alone.
+If the one-time value is lost, use **Rotate secret** on that detail page to mint a new one.
 Rotation invalidates the old secret immediately, and RevenueCat, not the captain, decides when the next delivery arrives.
 Every genuine lifecycle event between the rotation click and the deployed replacement is therefore rejected with HTTP 401.
 That window is unavoidable; only its length is controllable.
-Minimize it by rotating only when the current value is genuinely lost, staging the full new `REVENUECAT_SERVER_CONFIG` JSON before clicking **Rotate secret**, then setting the Firebase secret and redeploying Functions immediately, and finally sending the dashboard test webhook and requiring HTTP 200 before considering the rotation done.
-[RevenueCat's current webhook documentation](https://www.revenuecat.com/docs/integrations/webhooks#webhook-signature-verification-hmac) specifies this post-creation location, the show-once-or-rotate secret, the immediate invalidation of the old secret, and the `X-RevenueCat-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex>` delivery header.
-The same page treats any non-2xx response as a failure and retries a failed delivery up to five times after 5, 10, 20, 40, and 80 minutes.
-A window closed inside roughly 155 minutes therefore self-heals with no lost events, while a longer one permanently drops every delivery whose retries expired unless each failed event is resent by hand with **Retry** from the integration's event table.
+Rotate only when the current value is genuinely lost, and follow the same ordering without pausing: click **Rotate secret**, copy the new secret, write the complete Firebase secret with it, deploy Functions, then send the dashboard test webhook and require HTTP 200 before considering the rotation done.
+[RevenueCat's current webhook documentation](https://www.revenuecat.com/docs/integrations/webhooks#webhook-signature-verification-hmac) specifies enabling the toggle on an existing webhook integration, the secret shown only once at creation or rotation, the immediate invalidation of the old secret on rotation, and the `X-RevenueCat-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex>` delivery header.
+That the toggle is absent from the New Webhook form is an observation of the current dashboard rather than a documented claim.
+The same page states that the server should return a 200 status code, that any other status code is considered a failure by RevenueCat's backend, that RevenueCat then retries up to five times with increasing delays of 5, 10, 20, 40, and 80 minutes, and that it stops sending after five retries.
+A rejected delivery's last retry therefore lands roughly 155 minutes after its first attempt: a rotation window closed inside that span self-heals for every delivery still retrying, while any delivery whose five retries expired first is lost unless it is resent by hand with **Retry** from the failed-event table, which the same page documents.
 The function requires both credentials on every request.
 6. After the matching Firebase function is deployed, send RevenueCat's test webhook to each destination and require HTTP 200.
 A test event with no real Firebase UID is expected to complete with zero affected users.

--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -25,7 +25,11 @@ Do not enable Paywall UI or virtual-currency events because they create subscrib
 4. Set the staging destination to `https://us-central1-ascend-staging-fa7d5.cloudfunctions.net/revenueCatWebhook`.
 Set the production destination to `https://us-central1-ascend-prod-9c8f2.cloudfunctions.net/revenueCatWebhook`.
 5. Configure a different high-entropy `Authorization` header value for each destination.
-Enable RevenueCat HMAC signing for each destination and capture each signing secret when RevenueCat shows it once.
+Save each webhook integration, then reopen its detail page.
+The HMAC control is not part of the New Webhook form.
+On the saved integration's detail page, toggle **HMAC webhook signing**, then immediately copy the signing secret RevenueCat shows once and store it in that destination's Firebase secret configuration.
+If the one-time value is lost, use **Rotate secret** on that detail page and replace the Firebase value before sending another webhook.
+[RevenueCat's current webhook documentation](https://www.revenuecat.com/docs/integrations/webhooks#webhook-signature-verification-hmac) specifies this post-creation location and the `X-RevenueCat-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex>` delivery header.
 The function requires both credentials on every request.
 6. After the matching Firebase function is deployed, send RevenueCat's test webhook to each destination and require HTTP 200.
 A test event with no real Firebase UID is expected to complete with zero affected users.
@@ -115,7 +119,7 @@ Superwall remains the paywall presentation and conversion layer, while RevenueCa
 
 ## Server flow
 
-1. RevenueCat sends a POST request with the configured Authorization header and HMAC signature.
+1. After HMAC is enabled on the saved integration, RevenueCat sends a POST request with the configured `Authorization` header and an `X-RevenueCat-Webhook-Signature` HMAC header.
 2. `revenueCatWebhook` verifies method, raw-body size, content type, Authorization, signature, five-minute timestamp tolerance, JSON shape, event ID, event timestamp, and expected RevenueCat app ID.
 3. `_revenuecat_webhook_events/{event.id}` is transactionally claimed with a two-minute processing lease.
 First delivery wins: the ledger keeps the digest and event metadata of the delivery that created it, and a redelivery whose bytes differ never overwrites either.

--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -161,9 +161,8 @@ Only a confirmed import marks the row delivered; transient network, rate-limit, 
 This fails closed if an expiration webhook is delayed and a concurrent renewal wins through Firestore transaction retry.
 The sweep pages past documents from any other `entitlements` subcollection until it has spent its budget on real `users/{uid}/entitlements/app_access` grants, because the query is ordered by `accessUntil` and a single foreign document with an ancient timestamp would otherwise sit at the head of a fixed window and starve every real expiry behind it.
 
-Webhook failures return a non-2xx response so RevenueCat retries them.
-RevenueCat currently documents five retries after 5, 10, 20, 40, and 80 minutes.
-The processor is safe after a crash because a failed attempt is reclaimable and an abandoned processing lease expires before RevenueCat's first retry.
+Webhook failures return a non-2xx response so RevenueCat retries them, on the five-retry ladder the dashboard setup step above records.
+The processor is safe after a crash because a failed attempt is reclaimable and an abandoned processing lease expires within two minutes, inside the documented five-minute delay before RevenueCat's first retry.
 Mixpanel delivery failures do not fail or delay the webhook response because delivery starts only from the separately scheduled outbox worker.
 An unresolvable analytics destination is degraded rather than fatal: the webhook logs it, skips outbox enqueueing, and still authenticates, deduplicates, and projects the entitlement, because analytics may never decide paid access.
 Each worker run stops claiming deliveries before its function timeout and immediately returns every unattempted claim to the queue, so provider latency drains instead of stranding rows until the fifteen-minute stale sweep.
@@ -176,7 +175,7 @@ The event ledger stores only event metadata, a payload digest, processing state,
 The analytics outbox stores the affected Firebase UID only as the Mixpanel `distinct_id`; account deletion removes every outbox row that still carries it.
 
 Each ledger entry carries `retainUntil`, an explicit thirty-day future timestamp, and a Firestore TTL field override deletes the entry when it passes.
-The dedupe evidence only has to outlive RevenueCat's roughly 155-minute retry ladder, so thirty days is generous while still bounding the collection.
+The dedupe evidence only has to outlive RevenueCat's five documented retries, whose longest documented delay is 80 minutes and whose total span is unverified, so thirty days is generous while still bounding the collection.
 `receivedAt` cannot carry the policy: it is already in the past when it is written, so every entry would be eligible for deletion the moment it was created.
 Each analytics outbox row carries the same thirty-day `retainUntil` stamp and its own Firestore TTL field override, because a row holds a Firebase UID as its Mixpanel `distinct_id` and may not outlive the delivery it exists to prove.
 Every state change restamps it, so the thirty days run from the row's last movement rather than from its creation: a row still retrying cannot be deleted out from under the retry-until-delivery guarantee, and a delivered or terminally failed row gets exactly one bounded window after it settled.

--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -37,7 +37,8 @@ Rotate only when the current value is genuinely lost, and follow the same orderi
 [RevenueCat's current webhook documentation](https://www.revenuecat.com/docs/integrations/webhooks#webhook-signature-verification-hmac) specifies enabling the toggle on an existing webhook integration, the secret shown only once at creation or rotation, the immediate invalidation of the old secret on rotation, and the `X-RevenueCat-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex>` delivery header.
 That the toggle is absent from the New Webhook form is an observation of the current dashboard rather than a documented claim.
 The same page states that the server should return a 200 status code, that any other status code is considered a failure by RevenueCat's backend, that RevenueCat then retries up to five times with increasing delays of 5, 10, 20, 40, and 80 minutes, and that it stops sending after five retries.
-A rejected delivery's last retry therefore lands roughly 155 minutes after its first attempt: a rotation window closed inside that span self-heals for every delivery still retrying, while any delivery whose five retries expired first is lost unless it is resent by hand with **Retry** from the failed-event table, which the same page documents.
+It does not state whether those delays are intervals between attempts or offsets from the first attempt, so the total retry span, and with it any guaranteed self-healing window for the rotation gap, is unverified and must not be planned against.
+Deliveries rejected during the gap enter that documented retry process, so restore HTTP 200 promptly, then inspect the integration's failed and retrying events and resend whatever still needs it with the **Retry** action the same page documents.
 The function requires both credentials on every request.
 6. After the matching Firebase function is deployed, send RevenueCat's test webhook to each destination and require HTTP 200.
 A test event with no real Firebase UID is expected to complete with zero affected users.
@@ -251,6 +252,8 @@ The processor handles transfer events by re-fetching both sides, but the captain
 - The App Review promotional entitlement's exact `product_identifier` remains unknown.
 It must be explicitly allowlisted if it is not one of the production subscription product IDs.
 - Live webhook destinations and HMAC settings remain unknown until the captain configures and tests them in RevenueCat.
+- RevenueCat documents five retries with increasing delays of 5, 10, 20, 40, and 80 minutes but never says whether those are intervals between attempts or offsets from the first attempt.
+The total retry span is therefore unverified, and no HMAC rotation gap of any particular length can be promised to self-heal.
 
 ## IRREDUCIBLE
 

--- a/functions/src/revenueCat/analyticsFirestoreOutbox.ts
+++ b/functions/src/revenueCat/analyticsFirestoreOutbox.ts
@@ -12,9 +12,9 @@ export const ANALYTICS_OUTBOX_COLLECTION =
 
 // A row carries the affected Firebase UID as its Mixpanel `distinct_id`, so it
 // may not outlive the reason it exists. Delivery dedupe only has to outlive
-// RevenueCat's roughly 155-minute retry ladder; thirty days matches the event
-// ledger and leaves a human-inspectable trail. The Firestore TTL policy on
-// `retainUntil` does the deleting.
+// RevenueCat's five documented retries, whose total span is unverified; thirty
+// days matches the event ledger and leaves a human-inspectable trail. The
+// Firestore TTL policy on `retainUntil` does the deleting.
 //
 // Every state transition restamps it, so the bound measures thirty days from
 // the row's last movement rather than from its creation: a row still retrying

--- a/functions/src/revenueCat/firestoreStore.ts
+++ b/functions/src/revenueCat/firestoreStore.ts
@@ -17,8 +17,10 @@ import type {
 const EVENT_COLLECTION = "_revenuecat_webhook_events";
 const PROCESSING_LEASE_MS = 2 * 60 * 1000;
 
-// RevenueCat currently retries a failed delivery five times over roughly 155
-// minutes, and dedupe only has to outlive that window. Thirty days keeps a
+// RevenueCat documents five retries of a failed delivery, the longest at 80
+// minutes, and dedupe only has to outlive that ladder; the documentation never
+// says whether those delays are intervals or offsets, so the total span is
+// unverified and nothing here may be sized against it. Thirty days keeps a
 // human-inspectable trail of what the server acted on while still bounding the
 // ledger, and the Firestore TTL policy on `retainUntil` does the deleting.
 // `receivedAt` cannot carry the policy: it is already in the past when it is

--- a/functions/src/revenueCat/webhook.ts
+++ b/functions/src/revenueCat/webhook.ts
@@ -18,28 +18,61 @@ import {AdminFirebaseUserVerifier} from "./firebaseUserVerifier";
 import {FirestoreRevenueCatEntitlementStore} from "./firestoreStore";
 import {processRevenueCatWebhookEvent} from "./processor";
 import {HttpRevenueCatSubscriberClient} from "./subscriber";
+import type {RevenueCatAnalyticsEnvironment} from "./analyticsTypes";
+import type {
+  RevenueCatProcessingOutcome,
+  RevenueCatServerConfig,
+  RevenueCatWebhookEvent,
+} from "./types";
 
-interface WebhookHttpRequest {
+export interface WebhookHttpRequest {
   method: string;
   rawBody?: Buffer;
   get(name: string): string | undefined;
 }
 
-interface WebhookHttpResponse {
+export interface WebhookHttpResponse {
   set(field: string, value: string): WebhookHttpResponse;
   status(code: number): WebhookHttpResponse;
   json(body: Record<string, string>): WebhookHttpResponse;
 }
 
+export interface RevenueCatWebhookRuntime {
+  loadConfig(): RevenueCatServerConfig;
+  processEvent(
+    event: RevenueCatWebhookEvent,
+    payloadSha256: string,
+    config: RevenueCatServerConfig,
+    analyticsEnvironment: RevenueCatAnalyticsEnvironment | null
+  ): Promise<RevenueCatProcessingOutcome>;
+  now(): Date;
+}
+
+const deployedRuntime: RevenueCatWebhookRuntime = {
+  loadConfig: getRevenueCatServerConfig,
+  processEvent: (event, payloadSha256, config, analyticsEnvironment) =>
+    processRevenueCatWebhookEvent(event, payloadSha256, {
+      store: new FirestoreRevenueCatEntitlementStore(admin.firestore()),
+      subscriberClient: new HttpRevenueCatSubscriberClient(config.apiKey),
+      userVerifier: new AdminFirebaseUserVerifier(),
+      config,
+      analyticsEnvironment,
+      now: () => new Date(),
+    }),
+  now: () => new Date(),
+};
+
 /**
  * Authenticates and processes one RevenueCat webhook request.
  * @param {WebhookHttpRequest} request - HTTP request
  * @param {WebhookHttpResponse} response - HTTP response
+ * @param {RevenueCatWebhookRuntime} runtime - Deployment-owned collaborators
  * @return {Promise<void>}
  */
 export async function handleRevenueCatWebhook(
   request: WebhookHttpRequest,
-  response: WebhookHttpResponse
+  response: WebhookHttpResponse,
+  runtime: RevenueCatWebhookRuntime = deployedRuntime
 ): Promise<void> {
   response.set("Cache-Control", "no-store");
   if (request.method !== "POST") {
@@ -50,7 +83,7 @@ export async function handleRevenueCatWebhook(
 
   let config;
   try {
-    config = getRevenueCatServerConfig();
+    config = runtime.loadConfig();
   } catch {
     console.error("RevenueCat webhook server configuration is invalid");
     response.status(500).json({status: "server_configuration_error"});
@@ -74,7 +107,7 @@ export async function handleRevenueCatWebhook(
     rawBody,
     config.webhookAuthorization,
     config.webhookSigningSecret,
-    new Date()
+    runtime.now()
   );
   if (authentication !== "authenticated") {
     response.status(401).json({status: "unauthorized"});
@@ -108,17 +141,11 @@ export async function handleRevenueCatWebhook(
   }
 
   try {
-    const outcome = await processRevenueCatWebhookEvent(
+    const outcome = await runtime.processEvent(
       parsed.event,
       parsed.payloadSha256,
-      {
-        store: new FirestoreRevenueCatEntitlementStore(admin.firestore()),
-        subscriberClient: new HttpRevenueCatSubscriberClient(config.apiKey),
-        userVerifier: new AdminFirebaseUserVerifier(),
-        config,
-        analyticsEnvironment,
-        now: () => new Date(),
-      }
+      config,
+      analyticsEnvironment
     );
 
     if (outcome === "busy") {
@@ -146,5 +173,5 @@ export const revenueCatWebhook = onRequest(
     secrets: [revenueCatServerConfig],
     timeoutSeconds: 60,
   },
-  handleRevenueCatWebhook
+  (request, response) => handleRevenueCatWebhook(request, response)
 );

--- a/functions/test/revenueCat.test.ts
+++ b/functions/test/revenueCat.test.ts
@@ -54,27 +54,54 @@ const ANALYTICS_ENVIRONMENT: RevenueCatAnalyticsEnvironment = {
   mixpanelProjectId: "4051100",
 };
 
-test("webhook authentication requires authorization and a current HMAC", () => {
-  const body = Buffer.from("{\"event\":{}}", "utf8");
+test("RevenueCat's documented signed delivery authenticates", () => {
+  const body = eventBody();
   const timestamp = Math.floor(NOW_MS / 1000);
-  const signature = signedHeader(body, timestamp);
+  const request = {
+    method: "POST",
+    headers: {
+      Authorization: AUTHORIZATION,
+      "Content-Type": "application/json",
+      "X-RevenueCat-Webhook-Signature": signedHeader(body, timestamp),
+    },
+    rawBody: body,
+  };
 
   assert.equal(authenticateRevenueCatWebhook(
-    AUTHORIZATION,
-    signature,
-    body,
+    request.headers.Authorization,
+    request.headers["X-RevenueCat-Webhook-Signature"],
+    request.rawBody,
     AUTHORIZATION,
     SIGNING_SECRET,
     NOW
   ), "authenticated");
-  assert.equal(authenticateRevenueCatWebhook(
+});
+
+test("signed deliveries without valid Authorization are rejected", () => {
+  const body = eventBody();
+  const timestamp = Math.floor(NOW_MS / 1000);
+  const signature = signedHeader(body, timestamp);
+
+  for (const authorization of [
+    undefined,
     "Bearer wrong-authorization-secret-1234567890",
-    signature,
-    body,
-    AUTHORIZATION,
-    SIGNING_SECRET,
-    NOW
-  ), "invalid_authorization");
+  ]) {
+    assert.equal(authenticateRevenueCatWebhook(
+      authorization,
+      signature,
+      body,
+      AUTHORIZATION,
+      SIGNING_SECRET,
+      NOW
+    ), "invalid_authorization");
+  }
+});
+
+test("webhook authentication rejects altered bodies and stale HMACs", () => {
+  const body = eventBody();
+  const timestamp = Math.floor(NOW_MS / 1000);
+  const signature = signedHeader(body, timestamp);
+
   assert.equal(authenticateRevenueCatWebhook(
     AUTHORIZATION,
     signature,

--- a/functions/test/revenueCat.test.ts
+++ b/functions/test/revenueCat.test.ts
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
-import {createHmac} from "node:crypto";
+import {createHash, createHmac} from "node:crypto";
 import test from "node:test";
 import {
   authenticateRevenueCatWebhook,
 } from "../src/revenueCat/authentication";
+import {handleRevenueCatWebhook} from "../src/revenueCat/webhook";
+import type {
+  RevenueCatWebhookRuntime,
+} from "../src/revenueCat/webhook";
 import {parseRevenueCatServerConfig} from "../src/revenueCat/config";
 import {
   parseRevenueCatWebhook,
@@ -26,6 +30,7 @@ import type {
   AppAccessProjection,
   FirebaseUserVerifier,
   RevenueCatEntitlementStore,
+  RevenueCatProcessingOutcome,
   RevenueCatServerConfig,
   RevenueCatSubscriberClient,
   RevenueCatSubscriberResponse,
@@ -54,47 +59,135 @@ const ANALYTICS_ENVIRONMENT: RevenueCatAnalyticsEnvironment = {
   mixpanelProjectId: "4051100",
 };
 
-test("RevenueCat's documented signed delivery authenticates", () => {
+test("RevenueCat's documented signed delivery is processed", async () => {
   const body = eventBody();
-  const timestamp = Math.floor(NOW_MS / 1000);
-  const request = {
+  const runtime = new RecordingWebhookRuntime();
+  const response = new FakeWebhookResponse();
+
+  await handleRevenueCatWebhook(new FakeWebhookRequest({
     method: "POST",
     headers: {
-      Authorization: AUTHORIZATION,
-      "Content-Type": "application/json",
-      "X-RevenueCat-Webhook-Signature": signedHeader(body, timestamp),
+      "Authorization": AUTHORIZATION,
+      "Content-Type": "application/json; charset=utf-8",
+      "X-RevenueCat-Webhook-Signature": documentedSignature(body),
     },
     rawBody: body,
-  };
+  }), response, runtime);
 
-  assert.equal(authenticateRevenueCatWebhook(
-    request.headers.Authorization,
-    request.headers["X-RevenueCat-Webhook-Signature"],
-    request.rawBody,
-    AUTHORIZATION,
-    SIGNING_SECRET,
-    NOW
-  ), "authenticated");
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(response.payload, {status: "processed"});
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal(runtime.processedEvents.length, 1);
+  assert.equal(runtime.processedEvents[0].event.id, "event-123");
+  assert.equal(
+    runtime.processedEvents[0].payloadSha256,
+    createHash("sha256").update(body).digest("hex")
+  );
 });
 
-test("signed deliveries without valid Authorization are rejected", () => {
+test("signed deliveries without valid Authorization are rejected", async () => {
   const body = eventBody();
-  const timestamp = Math.floor(NOW_MS / 1000);
-  const signature = signedHeader(body, timestamp);
+  const signature = documentedSignature(body);
 
   for (const authorization of [
     undefined,
     "Bearer wrong-authorization-secret-1234567890",
   ]) {
-    assert.equal(authenticateRevenueCatWebhook(
-      authorization,
-      signature,
-      body,
-      AUTHORIZATION,
-      SIGNING_SECRET,
-      NOW
-    ), "invalid_authorization");
+    const runtime = new RecordingWebhookRuntime();
+    const response = new FakeWebhookResponse();
+
+    await handleRevenueCatWebhook(new FakeWebhookRequest({
+      headers: {
+        ...authorization === undefined ? {} : {Authorization: authorization},
+        "Content-Type": "application/json",
+        "X-RevenueCat-Webhook-Signature": signature,
+      },
+      rawBody: body,
+    }), response, runtime);
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(response.payload, {status: "unauthorized"});
+    assert.equal(runtime.processedEvents.length, 0);
   }
+
+  assert.equal(authenticateRevenueCatWebhook(
+    undefined,
+    signature,
+    body,
+    AUTHORIZATION,
+    SIGNING_SECRET,
+    NOW
+  ), "invalid_authorization");
+});
+
+test("deliveries RevenueCat never sends cannot reach processing", async () => {
+  const body = eventBody();
+  const signature = documentedSignature(body);
+  const runtime = new RecordingWebhookRuntime();
+  const documentedHeaders = {
+    "Authorization": AUTHORIZATION,
+    "Content-Type": "application/json",
+    "X-RevenueCat-Webhook-Signature": signature,
+  };
+
+  const wrongMethod = new FakeWebhookResponse();
+  await handleRevenueCatWebhook(new FakeWebhookRequest({
+    method: "GET",
+    headers: documentedHeaders,
+    rawBody: body,
+  }), wrongMethod, runtime);
+  assert.equal(wrongMethod.statusCode, 405);
+  assert.deepEqual(wrongMethod.payload, {status: "method_not_allowed"});
+  assert.equal(wrongMethod.headers.get("allow"), "POST");
+
+  const wrongContentType = new FakeWebhookResponse();
+  await handleRevenueCatWebhook(new FakeWebhookRequest({
+    headers: {
+      ...documentedHeaders,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    rawBody: body,
+  }), wrongContentType, runtime);
+  assert.equal(wrongContentType.statusCode, 400);
+  assert.deepEqual(wrongContentType.payload, {status: "invalid_request"});
+
+  const tamperedBody = new FakeWebhookResponse();
+  await handleRevenueCatWebhook(new FakeWebhookRequest({
+    headers: documentedHeaders,
+    rawBody: eventBody({product_id: "ascend_monthly"}),
+  }), tamperedBody, runtime);
+  assert.equal(tamperedBody.statusCode, 401);
+  assert.deepEqual(tamperedBody.payload, {status: "unauthorized"});
+
+  const missingBody = new FakeWebhookResponse();
+  await handleRevenueCatWebhook(
+    new FakeWebhookRequest({headers: documentedHeaders}),
+    missingBody,
+    runtime
+  );
+  assert.equal(missingBody.statusCode, 400);
+  assert.deepEqual(missingBody.payload, {status: "invalid_request"});
+
+  assert.equal(runtime.processedEvents.length, 0);
+});
+
+test("a busy processor asks RevenueCat to retry the delivery", async () => {
+  const body = eventBody();
+  const runtime = new RecordingWebhookRuntime("busy");
+  const response = new FakeWebhookResponse();
+
+  await handleRevenueCatWebhook(new FakeWebhookRequest({
+    headers: {
+      "Authorization": AUTHORIZATION,
+      "Content-Type": "application/json",
+      "X-RevenueCat-Webhook-Signature": documentedSignature(body),
+    },
+    rawBody: body,
+  }), response, runtime);
+
+  assert.equal(response.statusCode, 503);
+  assert.deepEqual(response.payload, {status: "retry"});
+  assert.equal(response.headers.get("retry-after"), "300");
 });
 
 test("webhook authentication rejects altered bodies and stale HMACs", () => {
@@ -608,6 +701,80 @@ test("reconciliation cannot move access back to older subscriber truth", async (
     NOW_MS + 2_000
   );
 });
+
+function documentedSignature(body: Buffer): string {
+  return signedHeader(body, Math.floor(NOW_MS / 1000));
+}
+
+class FakeWebhookRequest {
+  readonly method: string;
+  readonly rawBody?: Buffer;
+  private readonly headerValues: Map<string, string>;
+
+  constructor(options: {
+    method?: string;
+    rawBody?: Buffer;
+    headers?: Record<string, string>;
+  }) {
+    this.method = options.method ?? "POST";
+    this.rawBody = options.rawBody;
+    this.headerValues = new Map(Object.entries(options.headers ?? {}).map(
+      ([name, value]) => [name.toLowerCase(), value] as const
+    ));
+  }
+
+  get(name: string): string | undefined {
+    return this.headerValues.get(name.toLowerCase());
+  }
+}
+
+class FakeWebhookResponse {
+  statusCode: number | null = null;
+  payload: Record<string, string> | null = null;
+  readonly headers = new Map<string, string>();
+
+  set(field: string, value: string): this {
+    this.headers.set(field.toLowerCase(), value);
+    return this;
+  }
+
+  status(code: number): this {
+    this.statusCode = code;
+    return this;
+  }
+
+  json(body: Record<string, string>): this {
+    this.payload = body;
+    return this;
+  }
+}
+
+class RecordingWebhookRuntime implements RevenueCatWebhookRuntime {
+  readonly processedEvents: {
+    event: RevenueCatWebhookEvent;
+    payloadSha256: string;
+  }[] = [];
+
+  constructor(
+    private readonly outcome: RevenueCatProcessingOutcome = "processed"
+  ) {}
+
+  loadConfig(): RevenueCatServerConfig {
+    return CONFIG;
+  }
+
+  async processEvent(
+    event: RevenueCatWebhookEvent,
+    payloadSha256: string
+  ): Promise<RevenueCatProcessingOutcome> {
+    this.processedEvents.push({event, payloadSha256});
+    return this.outcome;
+  }
+
+  now(): Date {
+    return NOW;
+  }
+}
 
 function signedHeader(body: Buffer, timestamp: number): string {
   const signature = createHmac("sha256", SIGNING_SECRET)


### PR DESCRIPTION
## Intent

Establish ground truth from current first-party RevenueCat documentation about outgoing webhook authentication, including whether HMAC signing exists after creation on a saved webhook detail page and which header carries it, and cite that source. The verified result is that RevenueCat supports opt-in HMAC signing on the saved integration detail page and sends X-RevenueCat-Webhook-Signature in t=<unix_timestamp>,v1=<hmac_sha256_hex> form. Preserve the existing security contract: the configured Authorization value remains mandatory and constant-time compared, HMAC verification remains mandatory, webhookSigningSecret remains a required strong config field, and unauthorized requests must never be accepted. Correct docs/revenuecat-server-entitlement-enforcement.md so the captain knows the HMAC control is absent from New Webhook, must save and reopen each integration, enable HMAC webhook signing on its detail page, capture the one-time secret or rotate it if lost, and test for HTTP 200. Add tests modeling the documented RevenueCat POST with Authorization, Content-Type application/json, and X-RevenueCat-Webhook-Signature over the exact raw body, proving it authenticates, plus tests proving absent or wrong Authorization is rejected even with a valid HMAC. Do not touch production configuration or data, do not read or expose secrets, and do not change entitlement projection, deduplication, or analytics exporting. The PR body must state plainly that the previous test locally generated the HMAC and called the low-level authenticator directly, so it proved the implementation against its own signing assumptions but did not model the documented HTTP header shape or establish where RevenueCat enables signing. Ship a PR targeting develop after review, tests, lint, and CI pass.

## What Changed

- Added Cloud Functions tests that drive `handleRevenueCatWebhook` end to end with RevenueCat's documented POST shape - `Authorization`, `Content-Type: application/json`, and `X-RevenueCat-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex>` over the exact raw body - proving a documented delivery is processed (200), that a valid HMAC with an absent or wrong `Authorization` is still rejected (401), that a wrong method, wrong content type, tampered body, or missing body never reaches processing, and that a busy processor answers 503 with `Retry-After`. The previous test locally generated the HMAC and called the low-level `authenticateRevenueCatWebhook` directly, so it proved the implementation against its own signing assumptions but did not model the documented HTTP header shape or establish where RevenueCat enables signing.
- Exposed a `RevenueCatWebhookRuntime` seam on `handleRevenueCatWebhook` so config loading, event processing, and the clock can be injected in tests; the deployed entry point keeps the same Firestore store, subscriber client, user verifier, and clock it had before. The authentication, config-strength, projection, dedup, and analytics paths are untouched: `Authorization` remains mandatory and constant-time compared, HMAC verification remains mandatory, and `webhookSigningSecret` remains a required strong config field.
- Corrected `docs/revenuecat-server-entitlement-enforcement.md` against [RevenueCat's current webhook documentation](https://www.revenuecat.com/docs/integrations/webhooks#webhook-signature-verification-hmac): HMAC signing is enabled on a saved integration's detail page rather than the New Webhook form, the secret is shown only at creation or rotation, rotation invalidates the old secret immediately and opens an unavoidable 401 window, and each destination must be tested for HTTP 200. The previously stated "roughly 155-minute" retry span is now marked unverified in the doc and in the `firestoreStore.ts` / `analyticsFirestoreOutbox.ts` retention comments, because the source never says whether the 5/10/20/40/80-minute delays are intervals or offsets.

Pipeline review, test, lint, document, and push checks all pass; `cd functions && npm test` runs 317 tests green.

## Risk Assessment

✅ Low: This round is a four-line documentation-only edit that removes an inferred retry span, marks the interval-vs-offset ambiguity unverified in the doc's existing UNKNOWN section, and leaves functions/ byte-identical to the previous commit, so the handler regression coverage and security contract are untouched and no claim remains that the cited source does not support.

## Testing

<code>Ran the full Cloud Functions suite (317 pass) plus the focused RevenueCat file, then went beyond unit tests: I fetched RevenueCat&#39;s current webhook documentation and confirmed the runbook&#39;s corrected setup ordering, the exact `X-RevenueCat-Webhook-Signature: t=&lt;unix&gt;,v1=&lt;hmac_sha256_hex&gt;` header, the one-time secret and rotation behavior, and the 200-or-retry policy including the undocumented interval-vs-offset ambiguity the doc now flags. For product-level proof I served the real compiled handler over a live HTTP socket and replayed the documented POST shape: the signed delivery returns 200 `processed` with the raw-body SHA-256 intact, while the same body with a valid HMAC but absent or wrong Authorization returns 401 `unauthorized` and never reaches entitlement processing. I also verified the deployed default runtime is genuinely wired (fails closed with 500 on missing config) so the new test seam is not masking the production path, and confirmed authentication, config parsing, projection, dedup, and analytics export are untouched. No screenshot applies: the surfaces here are an HTTP webhook endpoint and a repository markdown runbook, neither of which renders a UI, so the HTTP transcript and the runbook text are the reviewer-visible artifacts. Everything passed and no production configuration, data, or secrets were touched.</code>

<details>
<summary>Evidence: Live HTTP transcript: documented RevenueCat delivery authenticates, unauthorized variants rejected</summary>

<code>Destination under test: http://127.0.0.1:50472/revenueCatWebhook&#10;&#10;--- RevenueCat&#39;s documented signed delivery ---&#10;&gt; POST http://127.0.0.1:50472/revenueCatWebhook&#10;&gt; Content-Type: application/json&#10;&gt; X-RevenueCat-Webhook-Signature: t=1785971912,v1=76cf235b5f28d270a8689eae5e8b16040bf7534deed4b305dc998dc7d39c478d&#10;&gt; Authorization: Bearer harness...&#10;&gt; body: 267 bytes of application/json&#10;&lt; HTTP 200&#10;&lt; cache-control: no-store&#10;&lt; {&#34;status&#34;:&#34;processed&#34;}&#10;entitlement processing invoked: yes&#10;processed event: 8B0C2D91-RENEWAL-0001 (RENEWAL), raw-body sha256 6f36b02ad83f5fe2...&#10;&#10;--- same valid HMAC, Authorization header absent ---&#10;&gt; X-RevenueCat-Webhook-Signature: t=1785971913,v1=644a029955b64db1552682c3afcf26844ff5a49a6b6193a22fa036068ae2a8a0&#10;&gt; Authorization: (header not sent)&#10;&lt; HTTP 401&#10;&lt; {&#34;status&#34;:&#34;unauthorized&#34;}&#10;entitlement processing invoked: no&#10;&#10;--- same valid HMAC, wrong Authorization value ---&#10;&gt; X-RevenueCat-Webhook-Signature: t=1785971913,v1=e1f078bdeec027b8a3a9dc37399de70b045e074cdef0a779d46ca59a3136c394&#10;&gt; Authorization: Bearer attacke...&#10;&lt; HTTP 401&#10;&lt; {&#34;status&#34;:&#34;unauthorized&#34;}&#10;entitlement processing invoked: no&#10;&#10;Total deliveries that reached entitlement processing: 1</code>

```text
Destination under test: http://127.0.0.1:50472/revenueCatWebhook

RevenueCat analytics destination is unresolved { firebaseProjectId: 'unknown' }
--- RevenueCat's documented signed delivery ---
> POST http://127.0.0.1:50472/revenueCatWebhook
> Content-Type: application/json
> X-RevenueCat-Webhook-Signature: t=1785971912,v1=76cf235b5f28d270a8689eae5e8b16040bf7534deed4b305dc998dc7d39c478d
> Authorization: Bearer harness…
> body: 267 bytes of application/json
< HTTP 200
< cache-control: no-store
< {"status":"processed"}
  entitlement processing invoked: yes
  processed event: 8B0C2D91-RENEWAL-0001 (RENEWAL), raw-body sha256 6f36b02ad83f5fe2…

RevenueCat analytics destination is unresolved { firebaseProjectId: 'unknown' }
--- same valid HMAC, Authorization header absent ---
> POST http://127.0.0.1:50472/revenueCatWebhook
> Content-Type: application/json
> X-RevenueCat-Webhook-Signature: t=1785971913,v1=644a029955b64db1552682c3afcf26844ff5a49a6b6193a22fa036068ae2a8a0
> Authorization: (header not sent)
> body: 267 bytes of application/json
< HTTP 401
< cache-control: no-store
< {"status":"unauthorized"}
  entitlement processing invoked: no

RevenueCat analytics destination is unresolved { firebaseProjectId: 'unknown' }
--- same valid HMAC, wrong Authorization value ---
> POST http://127.0.0.1:50472/revenueCatWebhook
> Content-Type: application/json
> X-RevenueCat-Webhook-Signature: t=1785971913,v1=e1f078bdeec027b8a3a9dc37399de70b045e074cdef0a779d46ca59a3136c394
> Authorization: Bearer attacke…
> body: 267 bytes of application/json
< HTTP 401
< cache-control: no-store
< {"status":"unauthorized"}
  entitlement processing invoked: no

Total deliveries that reached entitlement processing: 1
```
</details>
<details>
<summary>Evidence: E2E harness source (serves the real handler over a live socket)</summary>

```text
// End-to-end harness: serves the real revenueCatWebhook handler over a live
// HTTP socket and replays the RevenueCat delivery shape the vendor documents
// at https://www.revenuecat.com/docs/integrations/webhooks
//
//   POST <destination>
//   Authorization: <configured value>
//   Content-Type: application/json
//   X-RevenueCat-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex>
//
// Nothing here touches Firestore, RevenueCat, or any real secret: the config
// and processor are local fakes wired through the handler's runtime seam.

import {createHmac} from "node:crypto";
import {createServer} from "node:http";

const FUNCTIONS = process.argv[2];
const {handleRevenueCatWebhook} = await import(
  `${FUNCTIONS}/lib/src/revenueCat/webhook.js`
);

const AUTHORIZATION = "Bearer harness-authorization-secret-1234567890";
const SIGNING_SECRET = "harness-signing-secret-12345678901234567890";
const CONFIG = {
  apiKey: "harness-api-key-123456789012345678901234",
  webhookAuthorization: AUTHORIZATION,
  webhookSigningSecret: SIGNING_SECRET,
  appId: "app123",
  entitlementId: "app_access",
  allowedProductIds: ["ascend_yearly", "ascend_monthly"],
};

const processed = [];
const runtime = {
  loadConfig: () => CONFIG,
  processEvent: async (event, payloadSha256) => {
    processed.push({id: event.id, type: event.type, payloadSha256});
    return "processed";
  },
  now: () => new Date(),
};

const server = createServer((req, res) => {
  const chunks = [];
  req.on("data", (chunk) => chunks.push(chunk));
  req.on("end", async () => {
    const rawBody = Buffer.concat(chunks);
    await handleRevenueCatWebhook(
      {
        method: req.method,
        rawBody: rawBody.length > 0 ? rawBody : undefined,
        get: (name) => req.headers[name.toLowerCase()],
      },
      {
        set(field, value) {
          res.setHeader(field, value);
          return this;
        },
        status(code) {
          res.statusCode = code;
          return this;
        },
        json(body) {
          res.setHeader("Content-Type", "application/json");
          res.end(JSON.stringify(body));
          return this;
        },
      },
      runtime
    );
  });
});

await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
const {port} = server.address();
const destination = `http://127.0.0.1:${port}/revenueCatWebhook`;

function revenueCatBody() {
  return Buffer.from(JSON.stringify({
    api_version: "1.0",
    event: {
      id: "8B0C2D91-RENEWAL-0001",
      type: "RENEWAL",
      app_id: CONFIG.appId,
      event_timestamp_ms: Date.now(),
      app_user_id: "firebase-user-1",
      product_id: "ascend_yearly",
      store: "APP_STORE",
      period_type: "NORMAL",
      expiration_at_ms: Date.now() + 365 * 24 * 60 * 60 * 1000,
    },
  }), "utf8");
}

// Exactly the header RevenueCat documents sending, over the exact raw bytes.
function revenueCatSignature(rawBody) {
  const t = Math.floor(Date.now() / 1000);
  const v1 = createHmac("sha256", SIGNING_SECRET)
    .update(`${t}.`, "utf8")
    .update(rawBody)
    .digest("hex");
  return `t=${t},v1=${v1}`;
}

const scenarios = [
  {
    name: "RevenueCat's documented signed delivery",
    authorization: AUTHORIZATION,
  },
  {
    name: "same valid HMAC, Authorization header absent",
    authorization: undefined,
  },
  {
    name: "same valid HMAC, wrong Authorization value",
    authorization: "Bearer attacker-authorization-secret-000000",
  },
];

console.log(`Destination under test: ${destination}\n`);

for (const scenario of scenarios) {
  const rawBody = revenueCatBody();
  const signature = revenueCatSignature(rawBody);
  const headers = {
    "Content-Type": "application/json",
    "X-RevenueCat-Webhook-Signature": signature,
    ...(scenario.authorization === undefined ?
      {} :
      {"Authorization": scenario.authorization}),
  };

  const before = processed.length;
  const response = await fetch(destination, {
    method: "POST",
    headers,
    body: rawBody,
  });
  const text = await response.text();

  console.log(`--- ${scenario.name} ---`);
  console.log(`> POST ${destination}`);
  console.log(`> Content-Type: ${headers["Content-Type"]}`);
  console.log(`> X-RevenueCat-Webhook-Signature: ${signature}`);
  console.log(`> Authorization: ${
    scenario.authorization === undefined ?
      "(header not sent)" :
      `${scenario.authorization.slice(0, 14)}…`
  }`);
  console.log(`> body: ${rawBody.length} bytes of application/json`);
  console.log(`< HTTP ${response.status}`);
  console.log(`< cache-control: ${response.headers.get("cache-control")}`);
  console.log(`< ${text}`);
  console.log(`  entitlement processing invoked: ${
    processed.length > before ? "yes" : "no"
  }`);
  if (processed.length > before) {
    const last = processed[processed.length - 1];
    console.log(
      `  processed event: ${last.id} (${last.type}), ` +
      `raw-body sha256 ${last.payloadSha256.slice(0, 16)}…`
    );
  }
  console.log("");
}

console.log(
  `Total deliveries that reached entitlement processing: ${processed.length}`
);
server.close();
```
</details>
<details>
<summary>Evidence: Corrected captain-facing runbook section (docs/revenuecat-server-entitlement-enforcement.md step 5)</summary>

```text
These are the `event.app_id` values, not bundle IDs and not project ID `project-NnEDGL1m`.
3. Create one webhook integration filtered to `Ascend Staging` and one filtered to `Ascend`.
Use both sandbox and production events for each app.
Select Dashboard Test, Subscription Lifecycle Purchases, Transfer, Temporary Entitlement Grant, and Subscriber Alias events.
Do not enable Paywall UI or virtual-currency events because they create subscriber API traffic without changing paid access.
4. Set the staging destination to `https://us-central1-ascend-staging-fa7d5.cloudfunctions.net/revenueCatWebhook`.
Set the production destination to `https://us-central1-ascend-prod-9c8f2.cloudfunctions.net/revenueCatWebhook`.
5. Configure a different high-entropy `Authorization` header value for each destination.
HMAC signing is offered only on a saved integration's detail page, never on the New Webhook form, so the ordering is fixed: create the integration with its URL, `Authorization` value, environment, and app filter, save it, then reopen its detail page.
On that detail page, toggle **HMAC webhook signing** and copy the signing secret immediately, because RevenueCat shows it only at creation or rotation and cannot retrieve it later.
Only then assemble that destination's complete `REVENUECAT_SERVER_CONFIG` JSON, write the whole secret to Firebase, and deploy Functions.
All six configuration fields below are required and the parser refuses a partial value, so there is never a valid intermediate write that carries the new signing secret alone.
If the one-time value is lost, use **Rotate secret** on that detail page to mint a new one.
Rotation invalidates the old secret immediately, and RevenueCat, not the captain, decides when the next delivery arrives.
Every genuine lifecycle event between the rotation click and the deployed replacement is therefore rejected with HTTP 401.
That window is unavoidable; only its length is controllable.
Rotate only when the current value is genuinely lost, and follow the same ordering without pausing: click **Rotate secret**, copy the new secret, write the complete Firebase secret with it, deploy Functions, then send the dashboard test webhook and require HTTP 200 before considering the rotation done.
[RevenueCat's current webhook documentation](https://www.revenuecat.com/docs/integrations/webhooks#webhook-signature-verification-hmac) specifies enabling the toggle on an existing webhook integration, the secret shown only once at creation or rotation, the immediate invalidation of the old secret on rotation, and the `X-RevenueCat-Webhook-Signature: t=<unix_timestamp>,v1=<hmac_sha256_hex>` delivery header.
That the toggle is absent from the New Webhook form is an observation of the current dashboard rather than a documented claim.
The same page states that the server should return a 200 status code, that any other status code is considered a failure by RevenueCat's backend, that RevenueCat then retries up to five times with increasing delays of 5, 10, 20, 40, and 80 minutes, and that it stops sending after five retries.
It does not state whether those delays are intervals between attempts or offsets from the first attempt, so the total retry span, and with it any guaranteed self-healing window for the rotation gap, is unverified and must not be planned against.
Deliveries rejected during the gap enter that documented retry process, so restore HTTP 200 promptly, then inspect the integration's failed and retrying events and resend whatever still needs it with the **Retry** action the same page documents.
The function requires both credentials on every request.
6. After the matching Firebase function is deployed, send RevenueCat's test webhook to each destination and require HTTP 200.
A test event with no real Firebase UID is expected to complete with zero affected users.
7. For every Firebase UID that already has paid access before rules are enabled, cause a fresh RevenueCat lifecycle delivery after the webhook exists and verify that `users/{uid}/entitlements/app_access` exists.
Staging sandbox purchases and the App Review promotional entitlement must be reconciled before their accounts can pass backend rules.
8. If the App Review account uses a RevenueCat promotional entitlement, inspect its subscriber response and add its exact `product_identifier` to production `allowedProductIds`.
Do not allow every promotional identifier as a class.

RevenueCat supports multiple webhook integrations in one project, which is required because production and staging share a project but write to different Firebase projects.
```
</details>
<details>
<summary>Evidence: Deployed default runtime still fails closed without injected fakes</summary>

<code>RevenueCat webhook server configuration is invalid&#10;default (deployed) runtime used, no injected fake:&#10;HTTP 500 {&#34;status&#34;:&#34;server_configuration_error&#34;}</code>

```text
{"severity":"WARNING","message":"No value found for secret parameter \"REVENUECAT_SERVER_CONFIG\". A function can only access a secret if you include the secret in the function's dependency array."}
RevenueCat webhook server configuration is invalid
default (deployed) runtime used, no injected fake:
  HTTP 500 {"status":"server_configuration_error"}
```
</details>
- Evidence: [Cited first-party ground truth: RevenueCat webhook documentation](https://www.revenuecat.com/docs/integrations/webhooks)
- Outcome: ⚠️ 1 info across 1 run (3m25s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed (3) ✅</summary>

- ⚠️ `functions/test/revenueCat.test.ts:60` - The new &#34;documented signed delivery&#34; test builds a request-shaped literal (method POST, Content-Type application/json, X-RevenueCat-Webhook-Signature) but then plucks two values back out of it and calls the low-level authenticateRevenueCatWebhook directly. `method` and `Content-Type` are never read by any assertion, and the exact-case header keys do not match how Node/Express deliver headers (lowercased). handleRevenueCatWebhook (functions/src/revenueCat/webhook.ts:40-134) - the only code that binds the header name `x-revenuecat-webhook-signature` at :73 and enforces the content-type at :84-91 - has no test anywhere in functions/test/. Renaming that header key or deleting the content-type guard leaves the entire suite green while every live RevenueCat delivery 401s and entitlement projection silently stops. The intent requires &#34;tests modeling the documented RevenueCat POST with Authorization, Content-Type application/json, and X-RevenueCat-Webhook-Signature over the exact raw body, proving it authenticates&#34;; the change names those headers but does not exercise them. The WebhookHttpRequest interface at webhook.ts:22-26 is already shaped for a fake request, so routing the test through the handler would close the gap and also cover the 405/400/401 responses.
- ℹ️ `docs/revenuecat-server-entitlement-enforcement.md:31` - The rotation instruction says to replace the Firebase value &#34;before sending another webhook&#34;, but the cited RevenueCat page states the old secret is &#34;immediately invalidated&#34; on rotation. On a live production integration the captain does not control when the next delivery arrives: every genuine lifecycle event between the rotation click and the redeployed REVENUECAT_SERVER_CONFIG fails HMAC and returns 401 (RevenueCat retries, so it is recoverable, but the doc should say the gap is unavoidable and should be minimized rather than implying it can be scheduled).

🔧 Fix: test RevenueCat webhook HTTP edge; document HMAC rotation window
3 infos still open:
- ℹ️ `docs/revenuecat-server-entitlement-enforcement.md:35` - The window-minimizing procedure instructs the operator to stage &#34;the full new REVENUECAT_SERVER_CONFIG JSON before clicking Rotate secret&#34;, but the new webhookSigningSecret does not exist until rotation is performed - RevenueCat shows it only at creation or rotation. An operator following the step literally cannot complete it and will stall mid-rotation, lengthening exactly the 401 window the step exists to minimize. Reword to say: pre-stage every field of the JSON except webhookSigningSecret, so that only that single value is pasted in after clicking Rotate secret.
- ℹ️ `docs/revenuecat-server-entitlement-enforcement.md:37` - The sentence says the cited RevenueCat page &#34;treats any non-2xx response as a failure&#34;. That page actually states: &#34;Your server should return a 200 status code. Any other status code will be considered a failure by our backend.&#34; No current handler path returns a 2xx other than 200 (responses are 200/400/401/405/500/503), so there is no operational impact today, but the paraphrase is looser than the source it explicitly cites, in a change whose stated purpose is source-accurate ground truth. Suggest &#34;any status other than 200&#34;.
- ℹ️ `functions/test/revenueCat.test.ts:764` - handleRevenueCatWebhook resolves the analytics environment at webhook.ts:93-96 via deployedFirebaseProjectId()/optionalAnalyticsEnvironment, outside the injected RevenueCatWebhookRuntime. RecordingWebhookRuntime.processEvent declares only (event, payloadSha256) and discards the config and analyticsEnvironment arguments, so nothing asserts what the handler passes downstream. Additionally, admin.initializeApp() runs only in index.ts, which the test does not import, so admin.app() throws, projectId resolves undefined, and optionalAnalyticsEnvironment emits console.error(&#34;RevenueCat analytics destination is unresolved&#34;) once per handler test - four error lines in otherwise-green CI output that can mask a genuine failure. Either capture and assert the fourth argument in RecordingWebhookRuntime, or move analytics-environment resolution behind the runtime seam. Analytics exporting itself is unchanged, consistent with the intent&#39;s constraint.

🔧 Fix: document exact RevenueCat HMAC setup ordering and retry rule
1 info still open:
- ℹ️ `docs/revenuecat-server-entitlement-enforcement.md:40` - The &#34;roughly 155 minutes&#34; figure is inferred, not documented. The cited RevenueCat page says only &#34;RevenueCat will retry later (up to 5 times) with an increasing delay (5, 10, 20, 40, and 80 minutes)&#34; and never states whether those delays are intervals between attempts or offsets from the first attempt. As intervals they sum to 155 minutes; as offsets the last retry lands at 80 minutes. The doc presents the 155 reading with &#34;therefore&#34;, as though it followed from the quoted schedule, in the very paragraph that otherwise separates documented claims from observations (line 38 correctly marks the New Webhook form absence as an observation rather than a documented claim). Operational consequence: an operator rotating a production secret who believes they have ~155 minutes of self-healing slack could exceed an actual 80-minute budget and permanently lose lifecycle deliveries, each then needing manual Retry. Either state the conservative 80-minute figure, or mark the interval-vs-offset reading unverified the same way line 38 marks its observation.

🔧 Fix: mark RevenueCat total retry span unverified
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ The intent requires the PR body to state that the previous test locally generated the HMAC and called the low-level authenticator directly. No PR exists for branch fm/fix-revenuecat-webhook-signature-requirement yet, so that requirement is not verifiable at test time and must be satisfied when the PR is opened.
- <code>`cd functions &amp;&amp; npm test` - full Cloud Functions suite, 317 tests pass</code>
- <code>`node --test lib/test/revenueCat.test.js` - 25 RevenueCat tests pass, including the new `RevenueCat&#39;s documented signed delivery is processed`, `signed deliveries without valid Authorization are rejected`, `deliveries RevenueCat never sends cannot reach processing`, and `a busy processor asks RevenueCat to retry the delivery`</code>
- <code>Live HTTP end-to-end: served the compiled `handleRevenueCatWebhook` on a real socket and sent three `fetch` POSTs carrying `Authorization`, `Content-Type: application/json`, and `X-RevenueCat-Webhook-Signature: t=&lt;unix&gt;,v1=&lt;hmac_sha256_hex&gt;` over the exact raw bytes - documented delivery -&gt; 200 processed; valid HMAC with no Authorization -&gt; 401; valid HMAC with wrong Authorization -&gt; 401</code>
- <code>Fetched https://www.revenuecat.com/docs/integrations/webhooks and compared it line-by-line against the corrected step 5 of `docs/revenuecat-server-entitlement-enforcement.md` (toggle location, header name and format, one-time secret and rotation, 200 requirement, 5 retries at 5/10/20/40/80 minutes, absence of any interval-vs-offset statement)</code>
- <code>Called `handleRevenueCatWebhook(request, response)` with no injected runtime to confirm the deployed default runtime still resolves `getRevenueCatServerConfig` and fails closed with HTTP 500 `server_configuration_error`</code>
- <code>`git diff --stat HEAD -- functions/src/revenueCat/{config,authentication,processor,analytics*}.ts` - empty, confirming the authentication, config-strength, projection, dedup, and analytics paths are unchanged</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
