### PR TITLE
feat(onboarding): collect first and last name and render the real climber name

### DIFF
--- a/.claude/skills/ascend-onboarding/SKILL.md
+++ b/.claude/skills/ascend-onboarding/SKILL.md
@@ -23,7 +23,9 @@ The planned onboarding sequence, in order:
 This sequence will evolve as we learn from SuperWall and RevenueCat funnel analytics. Treat it as the current plan, not a permanent contract.
 
 ## Required profile capture
-- Post-auth onboarding must collect the required profile fields before the user reaches the main app: display name plus declared demographics when that stage is enabled. `ascend-profile` owns the full demographics contract - the stored birthday, the derived age and its bounds, and the gender raw values.
+- Post-auth onboarding must collect separate required first-name and last-name fields before the user reaches the main app, plus declared demographics when that stage is enabled.
+  The public board name is composed from both fields, never split or inferred from a single name input.
+  `ascend-profile` owns the full demographics contract - the stored birthday, the derived age and its bounds, and the gender raw values.
 
 ## Routing & resolver
 - Sign-in is a routing transition, not a sheet dismissal - auth screens should not dismiss themselves after provider sign-in; the auth surface is replaced by the authenticated root.

--- a/.claude/skills/ascend-onboarding/SKILL.md
+++ b/.claude/skills/ascend-onboarding/SKILL.md
@@ -58,7 +58,7 @@ This sequence will evolve as we learn from SuperWall and RevenueCat funnel analy
 - Copy and empty-state voice: `ascend-brand-voice` and the `product-design-playbook` skill.
 
 ## Reference
-- `docs/onboarding-design-guide.md` (1270 lines) - the full onboarding design guide. Read it when working on onboarding screens; never inline it.
+- `docs/onboarding-design-guide.md` - the full onboarding design guide, screen by screen. Read it when working on onboarding screens; never inline it.
 - `docs/superwall-paywall-setup.md` - the authoritative launch subscription offer (products, entitlement, offering, paywall plan states), the per-environment RevenueCat/SuperWall split, and the audited Superwall IDs.
   `Staging` and `Release` require an active `app_access` entitlement and audit their environment-specific launch products.
   `Debug` ships unset vendor keys and allows unentitled access for local convenience, with the existing force-paywall control available to exercise the gate.

--- a/.claude/skills/ascend-profile/SKILL.md
+++ b/.claude/skills/ascend-profile/SKILL.md
@@ -22,6 +22,8 @@ description: Use when working on Ascend profiles - own vs other-user profile sur
 - Custom display names and profile photos are public account identity only while App Review Guideline 1.2 moderation remains enforced.
   `PublicClimberIdentity` (`AscendApp/Shared/Models/`) resolves account-authored identity, a stable UID-derived fallback, synthetic fixture identity, and the deleted-account `Anonymous Climber` sentinel.
   Every cross-user view must pass that presentation through `ResolvedUserIdentity.Resolver`, which replaces only a blocked climber's name and photo while preserving rank, metrics, and demographics.
+  The signed-in climber is not an exception: their own row renders the same resolved name and derived initials as every other climber's, falling back to the same stable placeholder identity when the account has no name yet, and a `YOU` chip beside the name is the only marker of whose row it is.
+  Never substitute the literal string `You` for a name or `YOU` for an avatar token.
   Public profile, leaderboard, Live Replay, finisher, and First Ascent mirrors store validated identity, and the server propagation trigger keeps existing projections current.
   Production has no identity backfill to run: the propagation trigger and its indexes must be deployed before the binary that publishes identity. Rollout order: `docs/production-backend-rollout-runbook.md`.
   Dev and staging do hold pre-policy rows, and the only sanctioned repair writes the public profile mirror and lets that same trigger fan it out - never `leaderboard_stats` directly, which rules make server-owned outright. See `ascend-dev-fixtures`.

--- a/.claude/skills/ascend-profile/SKILL.md
+++ b/.claude/skills/ascend-profile/SKILL.md
@@ -6,7 +6,10 @@ description: Use when working on Ascend profiles - own vs other-user profile sur
 # Profile
 
 ## Profile Demographics
-- Post-auth onboarding captures display name and declared demographics on `users/{uid}`. Gender must use the `ProfileGender` raw values: `woman`, `man`, `non_binary`, or `prefer_not_to_say`.
+- Post-auth onboarding captures separate required `firstName` and `lastName` fields plus declared demographics on `users/{uid}`.
+  Public identity composes both fields into `displayName` at the validated publication boundary.
+  A legacy record with only `displayName` remains untouched until the climber supplies both parts in Edit Profile - never split, infer, or backfill it.
+  Gender must use the `ProfileGender` raw values: `woman`, `man`, `non_binary`, or `prefer_not_to_say`.
 - **Age is derived, never stored fresh.**
   The stored field is `birth_date`, a private `YYYY-MM-DD` calendar string on `users/{uid}`, bounded so the derived age lands between 13 and 120.
   `ProfileBirthday` (`AscendApp/Shared/Models/`) parses it and computes age on device, and `functions/src/leaderboardStats.ts` derives the same number server-side for board demographics.

--- a/AscendApp/Features/Authentication/AuthenticationViewModel.swift
+++ b/AscendApp/Features/Authentication/AuthenticationViewModel.swift
@@ -527,49 +527,6 @@ extension AuthenticationViewModel {
     }
     
     @discardableResult
-    func updateDisplayName(_ newDisplayName: String) async -> Bool {
-        errorMessage = nil
-        
-        guard let user = user else {
-            errorMessage = "User not authenticated"
-            return false
-        }
-        
-        let previousDisplayName = displayName
-
-        do {
-            let validatedDisplayName = try DisplayNamePolicy.validated(
-                newDisplayName
-            )
-
-            // Update local state immediately for responsive UI
-            displayName = validatedDisplayName
-
-            try await authenticationService.updateUserDisplayName(
-                displayName: validatedDisplayName
-            )
-            
-            // Save to Firestore user document
-            try await UserDataRepository.shared.updateDisplayName(
-                userId: user.uid,
-                email: user.email,
-                displayName: validatedDisplayName
-            )
-            hasRemoteDisplayName = true
-
-            return true
-            
-        } catch {
-            displayName = previousDisplayName
-            errorMessage = profileUpdateFailureMessage(
-                error,
-                fallback: "Failed to update display name"
-            )
-            return false
-        }
-    }
-
-    @discardableResult
     func updateProfileName(firstName: String, lastName: String) async -> Bool {
         errorMessage = nil
 

--- a/AscendApp/Features/Authentication/UserDataRepository.swift
+++ b/AscendApp/Features/Authentication/UserDataRepository.swift
@@ -80,6 +80,23 @@ struct UserDisplayNameData: Sendable {
         }
         return legacyAge
     }
+
+    var resolvedDisplayName: String? {
+        if let firstName,
+           let lastName,
+           let composedName = try? DisplayNamePolicy.composedBoardName(
+               firstName: firstName,
+               lastName: lastName
+           ) {
+            return composedName
+        }
+
+        guard let displayName = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              displayName.isEmpty == false else {
+            return nil
+        }
+        return displayName
+    }
 }
 
 final class UserDataRepository: Sendable {
@@ -123,7 +140,7 @@ final class UserDataRepository: Sendable {
     func getDisplayName(userId: String) async -> String? {
         do {
             let userData = try await getUserFromFirestore(userId: userId)
-            let displayName = userData.displayName ?? ""
+            let displayName = userData.resolvedDisplayName ?? ""
             if !displayName.isEmpty {
                 cacheDisplayName(displayName)
                 return displayName
@@ -583,7 +600,7 @@ final class UserDataRepository: Sendable {
         let storedProfile = UserDisplayNameData(userData)
         let publicIdentity = PublicClimberIdentity.resolve(
             userId: userId,
-            storedDisplayName: storedProfile.displayName,
+            storedDisplayName: storedProfile.resolvedDisplayName,
             storedPhotoURL: storedProfile.profilePictureURL.flatMap(URL.init(string:))
         )
 

--- a/AscendApp/Features/Authentication/UserDataRepository.swift
+++ b/AscendApp/Features/Authentication/UserDataRepository.swift
@@ -361,18 +361,6 @@ final class UserDataRepository: Sendable {
         return getCachedProfilePictureURL()
     }
     
-    func updateDisplayName(userId: String, email: String? = nil, displayName: String) async throws {
-        let displayName = try DisplayNamePolicy.validated(displayName)
-        try await updateUserAndPublicProfile(
-            userId: userId,
-            email: email,
-            userFields: ["displayName": displayName],
-            alwaysPublish: true
-        )
-
-        cacheDisplayName(displayName)
-    }
-
     func updateProfileName(
         userId: String,
         email: String? = nil,

--- a/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/LiveClimbSessionViewModel.swift
@@ -171,6 +171,10 @@ final class LiveClimbSessionViewModel {
     private let backgroundSessionService: LiveClimbBackgroundSessionService
     private let draftStore: ActiveHeadphoneWorkoutDraftStore
     private let heartRateRecorder: LiveHeartRateRecorder
+    /// Read once per session. `leaderboardRows` is rebuilt on every step and
+    /// elapsed tick, so the climber's name cannot be resolved from the cache
+    /// inside it.
+    private let currentUserDisplayName = UserDataRepository.shared.getCachedDisplayName()
 
     private(set) var phase: LiveClimbSessionPhase = .idle
     private(set) var recordedResult: HeadphoneMotionSessionResult?
@@ -348,14 +352,16 @@ final class LiveClimbSessionViewModel {
             return [
                 LiveReplayLeaderboardRow.currentUser(
                     rank: nil,
-                    steps: totalRecordedSteps
+                    steps: totalRecordedSteps,
+                    displayName: currentUserDisplayName
                 )
             ]
         }
 
         return leaderboardWindow.locallyRankedRows(
             currentSteps: totalRecordedSteps,
-            currentElapsedSeconds: Int(displayedDuration.rounded(.down))
+            currentElapsedSeconds: Int(displayedDuration.rounded(.down)),
+            displayName: currentUserDisplayName
         )
     }
 

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -1153,7 +1153,7 @@ struct ClimbDetailView: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 7) {
-                    Text(row.isCurrentUser ? "You" : row.identity.displayName)
+                    Text(row.identity.displayName)
                         .font(.montserratBold(size: 15))
                         .foregroundStyle(leaderboardPrimaryTextColor)
                         .lineLimit(1)
@@ -1673,7 +1673,7 @@ struct ClimbDetailView: View {
             return authDisplayName
         }
 
-        return "You"
+        return PublicClimberIdentity.systemHandle(for: Auth.auth().currentUser?.uid)
     }
 
     private var currentUserPhotoURL: URL? {
@@ -1721,7 +1721,7 @@ struct ClimbDetailView: View {
                 effectiveColorScheme: effectiveColorScheme
             )
             .accessibilityLabel(
-                avatar.isCurrentUser ? "You" : avatar.identity.displayName
+                avatar.identity.displayName
             )
         }
     }

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -1744,18 +1744,6 @@ struct ClimbDetailView: View {
         effectiveColorScheme == .dark ? .white.opacity(0.62) : .black.opacity(0.58)
     }
 
-    private static func avatarToken(for displayName: String) -> String {
-        let token = displayName
-            .split(separator: " ")
-            .prefix(2)
-            .compactMap(\.first)
-            .map(String.init)
-            .joined()
-            .uppercased()
-
-        return token.isEmpty ? "YOU" : token
-    }
-
     private func historyMetric(value: String, label: String) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             Text(value)

--- a/AscendApp/Features/Home/ViewModels/HomeDashboardViewModel.swift
+++ b/AscendApp/Features/Home/ViewModels/HomeDashboardViewModel.swift
@@ -374,7 +374,7 @@ final class HomeDashboardViewModel {
                 displayName: resolvedDisplayName,
                 photoURL: photoURLString
             ) ?? UnresolvedUserIdentity(
-                displayName: resolvedDisplayName ?? "You",
+                displayName: resolvedDisplayName ?? PublicClimberIdentity.systemHandle(for: userId),
                 photoURL: photoURLString.flatMap(URL.init(string:))
             )
             return FirestoreLeaderboardStats(

--- a/AscendApp/Features/Leaderboards/Models/LeaderboardEntry.swift
+++ b/AscendApp/Features/Leaderboards/Models/LeaderboardEntry.swift
@@ -56,11 +56,14 @@ struct LeaderboardEntry: Identifiable, Equatable, Sendable {
 
     /// A copy carrying a refreshed profile identity. Every ranking field is preserved:
     /// a profile edit must never move the climber's rank or drop their tie marker.
-    func withProfile(displayName: String, photoURL: URL?) -> LeaderboardEntry {
+    /// A nil `displayName` keeps the published identity: the signed-in account
+    /// has no name to offer yet, which is not the same as being renamed to one.
+    func withProfile(displayName: String?, photoURL: URL?) -> LeaderboardEntry {
         LeaderboardEntry(
             userId: userId,
-            displayName: displayName,
-            photoURL: photoURL,
+            unresolvedIdentity: unresolvedIdentity
+                .applyingOverrides(displayName: displayName, photoURL: nil)
+                .replacingPhotoURL(photoURL),
             rank: rank,
             value: value,
             formattedValue: formattedValue,

--- a/AscendApp/Features/Leaderboards/Services/LeaderboardCurrentUserReconciler.swift
+++ b/AscendApp/Features/Leaderboards/Services/LeaderboardCurrentUserReconciler.swift
@@ -4,7 +4,7 @@ enum LeaderboardCurrentUserReconciler {
     static func reconcilePreviewStats(
         _ statsByMetric: [LeaderboardMetric: [FirestoreLeaderboardStats]],
         userId: String,
-        displayName: String,
+        displayName: String?,
         localStats: LeaderboardStats
     ) -> [LeaderboardMetric: [FirestoreLeaderboardStats]] {
         var resolved = statsByMetric
@@ -26,7 +26,7 @@ enum LeaderboardCurrentUserReconciler {
         _ stats: [FirestoreLeaderboardStats],
         metric: LeaderboardMetric,
         userId: String,
-        displayName: String,
+        displayName: String?,
         localStats: LeaderboardStats
     ) -> [FirestoreLeaderboardStats] {
         reconcileStats(
@@ -42,7 +42,7 @@ enum LeaderboardCurrentUserReconciler {
         _ stats: [FirestoreLeaderboardStats],
         metric: LeaderboardMetric,
         userId: String,
-        displayName: String,
+        displayName: String?,
         localStats: LeaderboardStats
     ) -> [FirestoreLeaderboardStats] {
         var resolved = stats
@@ -51,12 +51,18 @@ enum LeaderboardCurrentUserReconciler {
             return resolved
         }
 
+        /// Only a name the climber actually has overrides the published one.
+        /// An empty override is not an edit - a fresh device is signed in
+        /// before the profile fetch lands - and applying it would blank the
+        /// climber's own row down to a system handle.
+        let nameOverride = normalizedOverride(displayName)
+
         if let currentIndex = resolved.firstIndex(where: { $0.userId == userId }) {
             let existing = resolved[currentIndex]
             resolved[currentIndex] = FirestoreLeaderboardStats(
                 userId: existing.userId,
                 unresolvedIdentity: existing.identityApplyingOverrides(
-                    displayName: displayName,
+                    displayName: nameOverride,
                     photoURL: nil
                 ),
                 identityPolicyVersion: existing.identityPolicyVersion,
@@ -81,7 +87,7 @@ enum LeaderboardCurrentUserReconciler {
             resolved.append(
                 FirestoreLeaderboardStats(
                     userId: userId,
-                    displayName: displayName,
+                    displayName: nameOverride ?? PublicClimberIdentity.systemHandle(for: userId),
                     photoURL: nil,
                     timeFrame: localStats.timeFrameEnum.rawValue,
                     schemaVersion: localStats.schemaVersion,
@@ -107,5 +113,13 @@ enum LeaderboardCurrentUserReconciler {
         }
 
         return resolved
+    }
+
+    private static func normalizedOverride(_ displayName: String?) -> String? {
+        guard let trimmed = displayName?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
     }
 }

--- a/AscendApp/Features/Leaderboards/Services/LeaderboardCurrentUserReconciler.swift
+++ b/AscendApp/Features/Leaderboards/Services/LeaderboardCurrentUserReconciler.swift
@@ -4,6 +4,7 @@ enum LeaderboardCurrentUserReconciler {
     static func reconcilePreviewStats(
         _ statsByMetric: [LeaderboardMetric: [FirestoreLeaderboardStats]],
         userId: String,
+        displayName: String,
         localStats: LeaderboardStats
     ) -> [LeaderboardMetric: [FirestoreLeaderboardStats]] {
         var resolved = statsByMetric
@@ -13,6 +14,7 @@ enum LeaderboardCurrentUserReconciler {
                 resolved[metric] ?? [],
                 metric: metric,
                 userId: userId,
+                displayName: displayName,
                 localStats: localStats
             )
         }
@@ -24,12 +26,14 @@ enum LeaderboardCurrentUserReconciler {
         _ stats: [FirestoreLeaderboardStats],
         metric: LeaderboardMetric,
         userId: String,
+        displayName: String,
         localStats: LeaderboardStats
     ) -> [FirestoreLeaderboardStats] {
         reconcileStats(
             stats,
             metric: metric,
             userId: userId,
+            displayName: displayName,
             localStats: localStats
         )
     }
@@ -38,6 +42,7 @@ enum LeaderboardCurrentUserReconciler {
         _ stats: [FirestoreLeaderboardStats],
         metric: LeaderboardMetric,
         userId: String,
+        displayName: String,
         localStats: LeaderboardStats
     ) -> [FirestoreLeaderboardStats] {
         var resolved = stats
@@ -50,7 +55,10 @@ enum LeaderboardCurrentUserReconciler {
             let existing = resolved[currentIndex]
             resolved[currentIndex] = FirestoreLeaderboardStats(
                 userId: existing.userId,
-                unresolvedIdentity: existing.unresolvedIdentity,
+                unresolvedIdentity: existing.identityApplyingOverrides(
+                    displayName: displayName,
+                    photoURL: nil
+                ),
                 identityPolicyVersion: existing.identityPolicyVersion,
                 identityChangedAt: existing.identityChangedAt,
                 timeFrame: existing.timeFrame,
@@ -73,7 +81,7 @@ enum LeaderboardCurrentUserReconciler {
             resolved.append(
                 FirestoreLeaderboardStats(
                     userId: userId,
-                    displayName: "You",
+                    displayName: displayName,
                     photoURL: nil,
                     timeFrame: localStats.timeFrameEnum.rawValue,
                     schemaVersion: localStats.schemaVersion,

--- a/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
+++ b/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
@@ -26,6 +26,7 @@ final class LeaderboardViewModel {
     private let demographicFilterFetchLimit = 1_000
     private(set) var visibleEntryLimit = 25
     private var currentUserId: String?
+    private var currentUserDisplayName = ""
     private var currentUserPhotoURL: URL?
     private var currentUserProfile: LeaderboardProfileSnapshot?
     private var rawLeaderboardStats: [FirestoreLeaderboardStats] = []
@@ -38,8 +39,9 @@ final class LeaderboardViewModel {
         self.service = service
     }
 
-    func configure(userId: String, modelContext: ModelContext) {
+    func configure(userId: String, displayName: String, modelContext: ModelContext) {
         currentUserId = userId
+        currentUserDisplayName = displayName
         service.configure(modelContext: modelContext)
     }
 
@@ -302,19 +304,20 @@ final class LeaderboardViewModel {
         reapplyCurrentStats()
     }
 
-    func updateCurrentUserProfile(userId: String?, photoURL: URL?) {
+    func updateCurrentUserProfile(userId: String?, displayName: String, photoURL: URL?) {
         guard let userId else { return }
+        currentUserDisplayName = displayName
         currentUserPhotoURL = photoURL
 
         if let index = leaderboardEntries.firstIndex(where: { $0.userId == userId }) {
             leaderboardEntries[index] = leaderboardEntries[index].withProfile(
-                displayName: "You",
+                displayName: displayName,
                 photoURL: photoURL
             )
         }
 
         if let entry = userStanding?.rankedEntry, entry.userId == userId {
-            userStanding = .ranked(entry.withProfile(displayName: "You", photoURL: photoURL))
+            userStanding = .ranked(entry.withProfile(displayName: displayName, photoURL: photoURL))
         }
     }
 
@@ -406,6 +409,7 @@ final class LeaderboardViewModel {
             stats,
             metric: selectedMetric,
             userId: userId,
+            displayName: currentUserDisplayName,
             localStats: localStats
         )
         return applyCurrentUserProfile(to: reconciled, userId: userId)

--- a/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
+++ b/AscendApp/Features/Leaderboards/ViewModels/LeaderboardViewModel.swift
@@ -26,7 +26,7 @@ final class LeaderboardViewModel {
     private let demographicFilterFetchLimit = 1_000
     private(set) var visibleEntryLimit = 25
     private var currentUserId: String?
-    private var currentUserDisplayName = ""
+    private var currentUserDisplayName: String?
     private var currentUserPhotoURL: URL?
     private var currentUserProfile: LeaderboardProfileSnapshot?
     private var rawLeaderboardStats: [FirestoreLeaderboardStats] = []
@@ -39,7 +39,7 @@ final class LeaderboardViewModel {
         self.service = service
     }
 
-    func configure(userId: String, displayName: String, modelContext: ModelContext) {
+    func configure(userId: String, displayName: String?, modelContext: ModelContext) {
         currentUserId = userId
         currentUserDisplayName = displayName
         service.configure(modelContext: modelContext)
@@ -304,7 +304,7 @@ final class LeaderboardViewModel {
         reapplyCurrentStats()
     }
 
-    func updateCurrentUserProfile(userId: String?, displayName: String, photoURL: URL?) {
+    func updateCurrentUserProfile(userId: String?, displayName: String?, photoURL: URL?) {
         guard let userId else { return }
         currentUserDisplayName = displayName
         currentUserPhotoURL = photoURL

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardUserRowView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardUserRowView.swift
@@ -16,7 +16,7 @@ struct LeaderboardUserRowView: View {
     /// assemble a row that carries a rank and an unranked treatment at the same time.
     enum Standing {
         case ranked(ModeratedLeaderboardEntry)
-        case unranked(formattedValue: String, photoURL: URL?)
+        case unranked(displayName: String, formattedValue: String, photoURL: URL?)
     }
 
     @Environment(\.colorScheme) private var colorScheme
@@ -37,11 +37,16 @@ struct LeaderboardUserRowView: View {
 
     init(
         unrankedFormattedValue: String,
+        displayName: String,
         photoURL: URL?,
         metric: LeaderboardMetric,
         crownGapText: String? = nil
     ) {
-        self.standing = .unranked(formattedValue: unrankedFormattedValue, photoURL: photoURL)
+        self.standing = .unranked(
+            displayName: displayName,
+            formattedValue: unrankedFormattedValue,
+            photoURL: photoURL
+        )
         self.metric = metric
         self.crownGapText = crownGapText
     }
@@ -50,8 +55,8 @@ struct LeaderboardUserRowView: View {
         switch standing {
         case .ranked(let entry):
             return entry.identity.displayName
-        case .unranked:
-            return "You"
+        case .unranked(let displayName, _, _):
+            return displayName
         }
     }
 
@@ -59,7 +64,7 @@ struct LeaderboardUserRowView: View {
         switch standing {
         case .ranked(let entry):
             return entry.identity.photoURL
-        case .unranked(_, let photoURL):
+        case .unranked(_, _, let photoURL):
             return photoURL
         }
     }
@@ -68,7 +73,7 @@ struct LeaderboardUserRowView: View {
         switch standing {
         case .ranked(let entry):
             return entry.formattedValue
-        case .unranked(let formattedValue, _):
+        case .unranked(_, let formattedValue, _):
             return formattedValue
         }
     }
@@ -250,6 +255,7 @@ struct LeaderboardUserRowView: View {
 #Preview("Unranked") {
     LeaderboardUserRowView(
         unrankedFormattedValue: "0",
+        displayName: "Maya Chen",
         photoURL: nil,
         metric: .climb,
         crownGapText: "48,000 STEPS TO CROWN"

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
@@ -128,6 +128,9 @@ struct LeaderboardView: View {
         .onChange(of: authVM.displayPhotoURL) { _, _ in
             syncCurrentUserEntry()
         }
+        .onChange(of: authVM.displayName) { _, _ in
+            syncCurrentUserEntry()
+        }
     }
 
     private var header: some View {
@@ -482,7 +485,7 @@ struct LeaderboardView: View {
             case .unranked(let value, let formattedValue):
                 LeaderboardUserRowView(
                     unrankedFormattedValue: formattedValue,
-                    displayName: authVM.displayName,
+                    displayName: currentUserDisplayName,
                     photoURL: authVM.displayPhotoURL,
                     metric: viewModel.selectedMetric,
                     crownGapText: crownGapText(
@@ -750,7 +753,7 @@ struct LeaderboardView: View {
         }
         viewModel.configure(
             userId: userId,
-            displayName: authVM.displayName,
+            displayName: currentUserNameOverride,
             modelContext: modelContext
         )
         await loadData()
@@ -785,9 +788,21 @@ struct LeaderboardView: View {
     private func syncCurrentUserEntry() {
         viewModel.updateCurrentUserProfile(
             userId: authVM.user?.uid,
-            displayName: authVM.displayName,
+            displayName: currentUserNameOverride,
             photoURL: authVM.displayPhotoURL
         )
+    }
+
+    /// Nil until the account actually has a name. A fresh device reaches
+    /// `.authenticated` before the profile fetch lands, and an empty override
+    /// would replace the climber's published board name with a system handle.
+    private var currentUserNameOverride: String? {
+        let trimmed = authVM.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var currentUserDisplayName: String {
+        currentUserNameOverride ?? PublicClimberIdentity.systemHandle(for: authVM.user?.uid)
     }
 }
 

--- a/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
+++ b/AscendApp/Features/Leaderboards/Views/LeaderboardView.swift
@@ -482,6 +482,7 @@ struct LeaderboardView: View {
             case .unranked(let value, let formattedValue):
                 LeaderboardUserRowView(
                     unrankedFormattedValue: formattedValue,
+                    displayName: authVM.displayName,
                     photoURL: authVM.displayPhotoURL,
                     metric: viewModel.selectedMetric,
                     crownGapText: crownGapText(
@@ -747,7 +748,11 @@ struct LeaderboardView: View {
         if let lockedMetric {
             viewModel.selectedMetric = lockedMetric
         }
-        viewModel.configure(userId: userId, modelContext: modelContext)
+        viewModel.configure(
+            userId: userId,
+            displayName: authVM.displayName,
+            modelContext: modelContext
+        )
         await loadData()
         syncCurrentUserEntry()
     }
@@ -780,6 +785,7 @@ struct LeaderboardView: View {
     private func syncCurrentUserEntry() {
         viewModel.updateCurrentUserProfile(
             userId: authVM.user?.uid,
+            displayName: authVM.displayName,
             photoURL: authVM.displayPhotoURL
         )
     }

--- a/AscendApp/Features/Moderation/Models/ModeratedIdentityRenderModels.swift
+++ b/AscendApp/Features/Moderation/Models/ModeratedIdentityRenderModels.swift
@@ -71,6 +71,17 @@ struct UnresolvedUserIdentity:
         )
     }
 
+    /// Unlike `applyingOverrides`, a nil photo here clears the photo: removing
+    /// one is an edit the climber can make, so it must survive the round trip.
+    func replacingPhotoURL(_ photoURL: URL?) -> UnresolvedUserIdentity {
+        UnresolvedUserIdentity(
+            displayName: displayName,
+            photoURL: photoURL,
+            avatarToken: avatarToken,
+            isSynthetic: isSynthetic
+        )
+    }
+
     fileprivate func publicationFields() throws -> (
         displayName: String,
         photoURL: URL?

--- a/AscendApp/Features/Moderation/Models/ResolvedUserIdentity.swift
+++ b/AscendApp/Features/Moderation/Models/ResolvedUserIdentity.swift
@@ -74,7 +74,10 @@ struct ResolvedUserIdentity: Equatable, Sendable {
                 userId: userId,
                 displayName: normalizedName(displayName, fallback: "Climber"),
                 photoURL: photoURL,
-                avatarToken: normalizedName(avatarToken, fallback: "CL"),
+                avatarToken: normalizedName(
+                    avatarToken,
+                    fallback: PublicClimberIdentity.fallbackAvatarToken
+                ),
                 isHidden: false
             )
         }

--- a/AscendApp/Features/Moderation/Models/ResolvedUserIdentity.swift
+++ b/AscendApp/Features/Moderation/Models/ResolvedUserIdentity.swift
@@ -42,9 +42,12 @@ struct ResolvedUserIdentity: Equatable, Sendable {
             if isCurrentUser {
                 return ResolvedUserIdentity(
                     userId: userId,
-                    displayName: normalizedName(displayName, fallback: "You"),
+                    displayName: normalizedName(
+                        displayName,
+                        fallback: PublicClimberIdentity.systemHandle(for: userId)
+                    ),
                     photoURL: photoURL,
-                    avatarToken: normalizedName(avatarToken, fallback: "YOU"),
+                    avatarToken: normalizedName(avatarToken, fallback: "CL"),
                     isHidden: false
                 )
             }

--- a/AscendApp/Features/Moderation/Models/ResolvedUserIdentity.swift
+++ b/AscendApp/Features/Moderation/Models/ResolvedUserIdentity.swift
@@ -47,7 +47,10 @@ struct ResolvedUserIdentity: Equatable, Sendable {
                         fallback: PublicClimberIdentity.systemHandle(for: userId)
                     ),
                     photoURL: photoURL,
-                    avatarToken: normalizedName(avatarToken, fallback: "CL"),
+                    avatarToken: normalizedName(
+                        avatarToken,
+                        fallback: PublicClimberIdentity.fallbackAvatarToken
+                    ),
                     isHidden: false
                 )
             }

--- a/AscendApp/Features/Onboarding/Models/PostAuthNameInput.swift
+++ b/AscendApp/Features/Onboarding/Models/PostAuthNameInput.swift
@@ -8,10 +8,37 @@ struct PostAuthNameInput: Equatable, Sendable {
     /// part of it: a composed name that the policy would reject must keep
     /// CONTINUE disabled rather than fail after the tap.
     var canContinue: Bool {
-        DisplayNamePolicy.composesAllowedBoardName(
-            firstName: firstName,
-            lastName: lastName
-        )
+        validationError == nil
+    }
+
+    /// Onboarding shows first and last name fields, so it cannot borrow the
+    /// policy's own copy: that names a single display name field the climber
+    /// is never shown here.
+    var validationMessage: String? {
+        switch validationError {
+        case .none:
+            return nil
+        case .incompleteName:
+            return DisplayNamePolicyError.incompleteName.errorDescription
+        case .invalidLength:
+            return "That name is too long"
+        case .objectionable:
+            return "That name cannot be used"
+        }
+    }
+
+    private var validationError: DisplayNamePolicyError? {
+        do {
+            _ = try DisplayNamePolicy.composedBoardName(
+                firstName: firstName,
+                lastName: lastName
+            )
+            return nil
+        } catch let error as DisplayNamePolicyError {
+            return error
+        } catch {
+            return .objectionable
+        }
     }
 
     var normalizedFirstName: String {

--- a/AscendApp/Features/Onboarding/Models/PostAuthNameInput.swift
+++ b/AscendApp/Features/Onboarding/Models/PostAuthNameInput.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct PostAuthNameInput: Equatable, Sendable {
+    var firstName = ""
+    var lastName = ""
+
+    var canContinue: Bool {
+        normalizedFirstName.isEmpty == false && normalizedLastName.isEmpty == false
+    }
+
+    var normalizedFirstName: String {
+        firstName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var normalizedLastName: String {
+        lastName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func singleLinePart(_ value: String) -> String {
+        let singleLine = value
+            .replacing("\n", with: " ")
+            .replacing("\r", with: " ")
+        return String(singleLine.prefix(DisplayNamePolicy.maximumLength))
+    }
+}

--- a/AscendApp/Features/Onboarding/Models/PostAuthNameInput.swift
+++ b/AscendApp/Features/Onboarding/Models/PostAuthNameInput.swift
@@ -4,8 +4,14 @@ struct PostAuthNameInput: Equatable, Sendable {
     var firstName = ""
     var lastName = ""
 
+    /// The same gate Edit Profile saves behind. Requiring both halves is only
+    /// part of it: a composed name that the policy would reject must keep
+    /// CONTINUE disabled rather than fail after the tap.
     var canContinue: Bool {
-        normalizedFirstName.isEmpty == false && normalizedLastName.isEmpty == false
+        DisplayNamePolicy.composesAllowedBoardName(
+            firstName: firstName,
+            lastName: lastName
+        )
     }
 
     var normalizedFirstName: String {

--- a/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
+++ b/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
@@ -272,10 +272,8 @@ private struct PostAuthDisplayNameScreen: View {
         .onSubmit {
             if field == .firstName {
                 focusedField = .lastName
-            } else if isContinueEnabled {
-                saveName()
             } else {
-                validationMessage = nameInput.validationMessage
+                saveName()
             }
         }
         .accessibilityLabel(field.rawValue)

--- a/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
+++ b/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
@@ -194,7 +194,7 @@ private struct PostAuthDisplayNameScreen: View {
             stage: stage,
             headline: "What's your\nname?",
             primaryTitle: isSaving ? "SAVING..." : "CONTINUE",
-            isContinueEnabled: nameInput.canContinue && !isSaving,
+            isContinueEnabled: isContinueEnabled,
             onBack: handleBack,
             onContinue: saveName
         ) { metrics in
@@ -272,11 +272,17 @@ private struct PostAuthDisplayNameScreen: View {
         .onSubmit {
             if field == .firstName {
                 focusedField = .lastName
-            } else {
+            } else if isContinueEnabled {
                 saveName()
+            } else {
+                validationMessage = nameInput.validationMessage
             }
         }
         .accessibilityLabel(field.rawValue)
+    }
+
+    private var isContinueEnabled: Bool {
+        nameInput.canContinue && !isSaving
     }
 
     private var fieldBorderColor: Color {
@@ -300,16 +306,8 @@ private struct PostAuthDisplayNameScreen: View {
     }
 
     private func saveName() {
-        guard !isSaving else { return }
-
-        do {
-            _ = try DisplayNamePolicy.composedBoardName(
-                firstName: nameInput.firstName,
-                lastName: nameInput.lastName
-            )
-        } catch {
-            validationMessage = (error as? LocalizedError)?.errorDescription
-                ?? "Enter your first and last name to continue."
+        guard isContinueEnabled else {
+            validationMessage = nameInput.validationMessage
             return
         }
 

--- a/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
+++ b/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
@@ -180,49 +180,38 @@ private struct PostAuthFeatureGuideStageScreen: View {
 
 private struct PostAuthDisplayNameScreen: View {
     @Environment(AuthenticationViewModel.self) private var authVM
-    @FocusState private var isNameFocused: Bool
+    @FocusState private var focusedField: ProfileNameField?
 
     let stage: PostAuthOnboardingStage
     let onContinue: () -> Void
 
-    @State private var displayName = ""
+    @State private var nameInput = PostAuthNameInput()
     @State private var isSaving = false
     @State private var validationMessage: String?
 
     var body: some View {
         PostAuthProfileQuestionShell(
             stage: stage,
-            headline: "What should we call\nyou?",
+            headline: "What's your\nname?",
             primaryTitle: isSaving ? "SAVING..." : "CONTINUE",
-            isContinueEnabled: !isContinueDisabled,
+            isContinueEnabled: nameInput.canContinue && !isSaving,
             onBack: handleBack,
-            onContinue: saveDisplayName
+            onContinue: saveName
         ) { metrics in
-            VStack(alignment: .leading, spacing: metrics.height(8)) {
-                TextField(
-                    "",
-                    text: $displayName,
-                    prompt: Text("Enter your name")
-                        .foregroundStyle(.white.opacity(0.48))
+            VStack(alignment: .leading, spacing: metrics.height(12)) {
+                nameField(
+                    field: .firstName,
+                    text: $nameInput.firstName,
+                    submitLabel: .next,
+                    metrics: metrics
                 )
-                .font(.montserratMedium(size: metrics.font(12)))
-                .foregroundStyle(.white)
-                .tint(OnboardingValuePalette.lime)
-                .textInputAutocapitalization(.words)
-                .autocorrectionDisabled()
-                .submitLabel(.continue)
-                .focused($isNameFocused)
-                .padding(.horizontal, metrics.width(14))
-                .frame(width: metrics.width(334), height: metrics.height(52), alignment: .leading)
-                .background(PostAuthProfilePalette.fieldBackground)
-                .clipShape(RoundedRectangle(cornerRadius: metrics.radius(6), style: .continuous))
-                .overlay {
-                    RoundedRectangle(cornerRadius: metrics.radius(6), style: .continuous)
-                        .stroke(fieldBorderColor, lineWidth: 1)
-                }
-                .onSubmit {
-                    saveDisplayName()
-                }
+
+                nameField(
+                    field: .lastName,
+                    text: $nameInput.lastName,
+                    submitLabel: .continue,
+                    metrics: metrics
+                )
 
                 Text("This is the name climbers see on leaderboards.")
                     .font(.montserratMedium(size: metrics.font(11)))
@@ -237,28 +226,57 @@ private struct PostAuthDisplayNameScreen: View {
                 }
             }
             .frame(width: metrics.width(334), alignment: .topLeading)
-            .offset(x: metrics.x(28), y: metrics.y(326))
-            .onAppear {
-                if displayName.isEmpty {
-                    displayName = authVM.displayName
-                }
-            }
-            .onChange(of: displayName) { _, newValue in
+            .offset(x: metrics.x(28), y: metrics.y(294))
+            .onChange(of: nameInput.firstName) { _, newValue in
                 validationMessage = nil
-                normalizeDisplayName(newValue)
+                normalizeNamePart(newValue, field: .firstName)
+            }
+            .onChange(of: nameInput.lastName) { _, newValue in
+                validationMessage = nil
+                normalizeNamePart(newValue, field: .lastName)
             }
         }
         .keyboardDoneToolbar {
-            isNameFocused = false
+            focusedField = nil
         }
     }
 
-    private var trimmedDisplayName: String {
-        displayName.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private var isContinueDisabled: Bool {
-        isSaving || trimmedDisplayName.isEmpty
+    private func nameField(
+        field: ProfileNameField,
+        text: Binding<String>,
+        submitLabel: SubmitLabel,
+        metrics: PostAuthProfileMetrics
+    ) -> some View {
+        TextField(
+            "",
+            text: text,
+            prompt: Text(field.rawValue)
+                .foregroundStyle(.white.opacity(0.48))
+        )
+        .font(.montserratMedium(size: metrics.font(12)))
+        .foregroundStyle(.white)
+        .tint(OnboardingValuePalette.lime)
+        .textContentType(field == .firstName ? .givenName : .familyName)
+        .textInputAutocapitalization(.words)
+        .autocorrectionDisabled()
+        .submitLabel(submitLabel)
+        .focused($focusedField, equals: field)
+        .padding(.horizontal, metrics.width(14))
+        .frame(width: metrics.width(334), height: metrics.height(52), alignment: .leading)
+        .background(PostAuthProfilePalette.fieldBackground)
+        .clipShape(RoundedRectangle(cornerRadius: metrics.radius(6), style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: metrics.radius(6), style: .continuous)
+                .stroke(fieldBorderColor, lineWidth: 1)
+        }
+        .onSubmit {
+            if field == .firstName {
+                focusedField = .lastName
+            } else {
+                saveName()
+            }
+        }
+        .accessibilityLabel(field.rawValue)
     }
 
     private var fieldBorderColor: Color {
@@ -269,29 +287,32 @@ private struct PostAuthDisplayNameScreen: View {
         validationMessage ?? authVM.errorMessage
     }
 
-    private func normalizeDisplayName(_ value: String) {
-        let singleLine = value
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\r", with: " ")
-
-        let normalized = String(singleLine.prefix(80))
+    private func normalizeNamePart(_ value: String, field: ProfileNameField) {
+        let normalized = PostAuthNameInput.singleLinePart(value)
         if normalized != value {
-            displayName = normalized
+            switch field {
+            case .firstName:
+                nameInput.firstName = normalized
+            case .lastName:
+                nameInput.lastName = normalized
+            }
         }
     }
 
-    private func saveDisplayName() {
+    private func saveName() {
         guard !isSaving else { return }
 
-        let name = trimmedDisplayName
-        guard !name.isEmpty else {
-            validationMessage = "Enter a name to continue."
+        guard nameInput.canContinue else {
+            validationMessage = "Enter your first and last name to continue."
             return
         }
 
         Task { @MainActor in
             isSaving = true
-            let didSave = await authVM.updateDisplayName(name)
+            let didSave = await authVM.updateProfileName(
+                firstName: nameInput.normalizedFirstName,
+                lastName: nameInput.normalizedLastName
+            )
             isSaving = false
 
             if didSave {

--- a/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
+++ b/AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift
@@ -302,8 +302,14 @@ private struct PostAuthDisplayNameScreen: View {
     private func saveName() {
         guard !isSaving else { return }
 
-        guard nameInput.canContinue else {
-            validationMessage = "Enter your first and last name to continue."
+        do {
+            _ = try DisplayNamePolicy.composedBoardName(
+                firstName: nameInput.firstName,
+                lastName: nameInput.lastName
+            )
+        } catch {
+            validationMessage = (error as? LocalizedError)?.errorDescription
+                ?? "Enter your first and last name to continue."
             return
         }
 

--- a/AscendApp/Features/Profile/Services/DisplayNamePolicy.swift
+++ b/AscendApp/Features/Profile/Services/DisplayNamePolicy.swift
@@ -74,9 +74,7 @@ enum DisplayNamePolicy {
         guard !blockedTerms.contains(lettersOnly) else {
             throw DisplayNamePolicyError.objectionable
         }
-        guard !blockedTerms.contains(where: {
-            containsObscuredTerm($0, in: normalized)
-        }) else {
+        guard containsObscuredBlockedTerm(in: normalized) == false else {
             throw DisplayNamePolicyError.objectionable
         }
         guard !embeddedBlockedTerms.contains(where: lettersOnly.contains) else {
@@ -186,27 +184,33 @@ enum DisplayNamePolicy {
         }
     }
 
+    /// Screening runs on every keystroke of the onboarding name fields, so the
+    /// patterns are compiled once per process rather than once per check.
+    private static let longASCIILetterRunExpression = try? NSRegularExpression(
+        pattern: #"([a-z])\1{2,}"#
+    )
+
+    private static let obscuredBlockedTermExpressions: [NSRegularExpression] =
+        blockedTerms.compactMap { term in
+            let letters = term.map {
+                NSRegularExpression.escapedPattern(for: String($0))
+            }
+            let pattern = "(^|[^a-z])" +
+                letters.joined(separator: "[^a-z]*") +
+                "([^a-z]|$)"
+            return try? NSRegularExpression(pattern: pattern)
+        }
+
     private static func containsLongASCIILetterRun(_ value: String) -> Bool {
-        value.range(
-            of: #"([a-z])\1{2,}"#,
-            options: .regularExpression
-        ) != nil
+        guard let longASCIILetterRunExpression else { return false }
+        let range = NSRange(value.startIndex..., in: value)
+        return longASCIILetterRunExpression.firstMatch(in: value, range: range) != nil
     }
 
-    private static func containsObscuredTerm(
-        _ term: String,
-        in normalized: String
-    ) -> Bool {
-        let letters = term.map {
-            NSRegularExpression.escapedPattern(for: String($0))
-        }
-        let pattern = "(^|[^a-z])" +
-            letters.joined(separator: "[^a-z]*") +
-            "([^a-z]|$)"
-        guard let expression = try? NSRegularExpression(pattern: pattern) else {
-            return false
-        }
+    private static func containsObscuredBlockedTerm(in normalized: String) -> Bool {
         let range = NSRange(normalized.startIndex..., in: normalized)
-        return expression.firstMatch(in: normalized, range: range) != nil
+        return obscuredBlockedTermExpressions.contains { expression in
+            expression.firstMatch(in: normalized, range: range) != nil
+        }
     }
 }

--- a/AscendApp/Features/Profile/Services/ProfilePublicationService.swift
+++ b/AscendApp/Features/Profile/Services/ProfilePublicationService.swift
@@ -27,7 +27,7 @@ enum ProfilePublicationService {
             let storedPhotoURL = storedProfile.profilePictureURL.flatMap(URL.init(string:))
             let publicIdentity = PublicClimberIdentity.resolve(
                 userId: userId,
-                storedDisplayName: storedProfile.displayName,
+                storedDisplayName: storedProfile.resolvedDisplayName,
                 storedPhotoURL: storedPhotoURL
             )
             let displayName = try DisplayNamePolicy.validated(publicIdentity.displayName)

--- a/AscendApp/Features/Profile/Services/ProfileStandingService.swift
+++ b/AscendApp/Features/Profile/Services/ProfileStandingService.swift
@@ -23,14 +23,20 @@ final class ProfileStandingService: Sendable {
 
     func loadOwnStandings(
         userId: String,
+        displayName: String,
         modelContext: ModelContext
     ) async -> [ProfileStanding] {
         leaderboardService.configure(modelContext: modelContext)
-        return await loadStandings(userId: userId, includesLocalStats: true)
+        return await loadStandings(
+            userId: userId,
+            displayName: displayName,
+            includesLocalStats: true
+        )
     }
 
     private func loadStandings(
         userId: String,
+        displayName: String = "",
         includesLocalStats: Bool = false
     ) async -> [ProfileStanding] {
         var standings: [ProfileStanding] = []
@@ -46,6 +52,7 @@ final class ProfileStandingService: Sendable {
                 let resolvedStats = reconciledStats(
                     stats,
                     userId: userId,
+                    displayName: displayName,
                     timeFrame: timeFrame,
                     includesLocalStats: includesLocalStats
                 )
@@ -53,6 +60,7 @@ final class ProfileStandingService: Sendable {
             } catch {
                 standings.append(fallbackStanding(
                     for: userId,
+                    displayName: displayName,
                     timeFrame: timeFrame,
                     includesLocalStats: includesLocalStats
                 ))
@@ -65,6 +73,7 @@ final class ProfileStandingService: Sendable {
     private func reconciledStats(
         _ stats: [FirestoreLeaderboardStats],
         userId: String,
+        displayName: String,
         timeFrame: LeaderboardTimeFrame,
         includesLocalStats: Bool
     ) -> [FirestoreLeaderboardStats] {
@@ -78,12 +87,14 @@ final class ProfileStandingService: Sendable {
             stats,
             metric: .climb,
             userId: userId,
+            displayName: displayName,
             localStats: localStats
         )
     }
 
     private func fallbackStanding(
         for userId: String,
+        displayName: String,
         timeFrame: LeaderboardTimeFrame,
         includesLocalStats: Bool
     ) -> ProfileStanding {
@@ -94,6 +105,7 @@ final class ProfileStandingService: Sendable {
                 [],
                 metric: .climb,
                 userId: userId,
+                displayName: displayName,
                 localStats: localStats
             )
             return standing(for: userId, timeFrame: timeFrame, stats: localOnlyStats)

--- a/AscendApp/Features/Profile/Services/ProfileStandingService.swift
+++ b/AscendApp/Features/Profile/Services/ProfileStandingService.swift
@@ -23,20 +23,14 @@ final class ProfileStandingService: Sendable {
 
     func loadOwnStandings(
         userId: String,
-        displayName: String,
         modelContext: ModelContext
     ) async -> [ProfileStanding] {
         leaderboardService.configure(modelContext: modelContext)
-        return await loadStandings(
-            userId: userId,
-            displayName: displayName,
-            includesLocalStats: true
-        )
+        return await loadStandings(userId: userId, includesLocalStats: true)
     }
 
     private func loadStandings(
         userId: String,
-        displayName: String = "",
         includesLocalStats: Bool = false
     ) async -> [ProfileStanding] {
         var standings: [ProfileStanding] = []
@@ -52,7 +46,6 @@ final class ProfileStandingService: Sendable {
                 let resolvedStats = reconciledStats(
                     stats,
                     userId: userId,
-                    displayName: displayName,
                     timeFrame: timeFrame,
                     includesLocalStats: includesLocalStats
                 )
@@ -60,7 +53,6 @@ final class ProfileStandingService: Sendable {
             } catch {
                 standings.append(fallbackStanding(
                     for: userId,
-                    displayName: displayName,
                     timeFrame: timeFrame,
                     includesLocalStats: includesLocalStats
                 ))
@@ -73,7 +65,6 @@ final class ProfileStandingService: Sendable {
     private func reconciledStats(
         _ stats: [FirestoreLeaderboardStats],
         userId: String,
-        displayName: String,
         timeFrame: LeaderboardTimeFrame,
         includesLocalStats: Bool
     ) -> [FirestoreLeaderboardStats] {
@@ -87,14 +78,13 @@ final class ProfileStandingService: Sendable {
             stats,
             metric: .climb,
             userId: userId,
-            displayName: displayName,
+            displayName: nil,
             localStats: localStats
         )
     }
 
     private func fallbackStanding(
         for userId: String,
-        displayName: String,
         timeFrame: LeaderboardTimeFrame,
         includesLocalStats: Bool
     ) -> ProfileStanding {
@@ -105,7 +95,7 @@ final class ProfileStandingService: Sendable {
                 [],
                 metric: .climb,
                 userId: userId,
-                displayName: displayName,
+                displayName: nil,
                 localStats: localStats
             )
             return standing(for: userId, timeFrame: timeFrame, stats: localOnlyStats)

--- a/AscendApp/Features/Profile/ViewModels/ProfileScreenViewModel.swift
+++ b/AscendApp/Features/Profile/ViewModels/ProfileScreenViewModel.swift
@@ -66,7 +66,6 @@ final class ProfileScreenViewModel {
 
         standings = await standingService.loadOwnStandings(
             userId: userId,
-            displayName: displayName,
             modelContext: modelContext
         )
         let loadedAchievementSnapshot = await loadedAchievements

--- a/AscendApp/Features/Profile/ViewModels/ProfileScreenViewModel.swift
+++ b/AscendApp/Features/Profile/ViewModels/ProfileScreenViewModel.swift
@@ -66,6 +66,7 @@ final class ProfileScreenViewModel {
 
         standings = await standingService.loadOwnStandings(
             userId: userId,
+            displayName: displayName,
             modelContext: modelContext
         )
         let loadedAchievementSnapshot = await loadedAchievements
@@ -254,7 +255,7 @@ final class ProfileScreenViewModel {
         joinedAt: Date?
     ) async -> ProfileUserIdentity {
         let storedProfile = try? await UserDataRepository.shared.getUserFromFirestore(userId: userId)
-        let storedDisplayName = storedProfile?.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedDisplayName = storedProfile?.resolvedDisplayName
         let resolvedDisplayName: String
         if let storedDisplayName, !storedDisplayName.isEmpty {
             resolvedDisplayName = storedDisplayName

--- a/AscendApp/Features/Profile/Views/OtherUserProfileView.swift
+++ b/AscendApp/Features/Profile/Views/OtherUserProfileView.swift
@@ -39,7 +39,9 @@ struct OtherUserProfileView: View {
         let trimmed = authVM.displayName.trimmingCharacters(
             in: .whitespacesAndNewlines
         )
-        return trimmed.isEmpty ? "You" : trimmed
+        return trimmed.isEmpty
+            ? PublicClimberIdentity.systemHandle(for: authVM.user?.uid)
+            : trimmed
     }
 
     private var viewerSnapshot: ProfileSnapshot {
@@ -245,7 +247,7 @@ private struct ProfileComparisonHeader: View {
             competitor(
                 identity: viewerIdentity,
                 tint: Color.ascendAccent,
-                fallbackName: "You",
+                fallbackName: "Climber",
                 isLoading: isViewerLoading
             )
 

--- a/AscendApp/Features/Routines/ViewModels/ActiveRoutineViewModel.swift
+++ b/AscendApp/Features/Routines/ViewModels/ActiveRoutineViewModel.swift
@@ -16,6 +16,10 @@ final class ActiveRoutineViewModel {
     private let backgroundSessionService: LiveClimbBackgroundSessionService
     private let draftStore: ActiveHeadphoneWorkoutDraftStore
     private let heartRateRecorder: LiveHeartRateRecorder
+    /// Read once per session. `leaderboardRows` is rebuilt on every step and
+    /// elapsed tick, so the climber's name cannot be resolved from the cache
+    /// inside it.
+    private let currentUserDisplayName = UserDataRepository.shared.getCachedDisplayName()
 
     var phase: ActiveRoutinePhase = .countdown
     var countdownValue = 3
@@ -136,14 +140,16 @@ final class ActiveRoutineViewModel {
             return [
                 LiveReplayLeaderboardRow.currentUser(
                     rank: nil,
-                    steps: currentSteps
+                    steps: currentSteps,
+                    displayName: currentUserDisplayName
                 )
             ]
         }
 
         return leaderboardWindow.locallyRankedRows(
             currentSteps: currentSteps,
-            currentElapsedSeconds: Int(timelineElapsed.rounded(.down))
+            currentElapsedSeconds: Int(timelineElapsed.rounded(.down)),
+            displayName: currentUserDisplayName
         )
     }
 

--- a/AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift
+++ b/AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift
@@ -239,7 +239,7 @@ private struct LiveReplayLeaderboardRowView: View {
                                 .padding(.vertical, 3)
                                 .background(
                                     Capsule(style: .continuous)
-                                        .fill(tint)
+                                        .fill(Color.accent)
                                 )
                         }
                     }

--- a/AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift
+++ b/AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift
@@ -224,11 +224,25 @@ private struct LiveReplayLeaderboardRowView: View {
                 avatarView
 
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(row.identity.displayName)
-                        .font(.montserratBold(size: 17))
-                        .foregroundStyle(primaryColor)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.78)
+                    HStack(spacing: 7) {
+                        Text(row.identity.displayName)
+                            .font(.montserratBold(size: 17))
+                            .foregroundStyle(primaryColor)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.78)
+
+                        if row.isCurrentUser {
+                            Text("YOU")
+                                .font(.montserratBold(size: 9))
+                                .foregroundStyle(.black)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 3)
+                                .background(
+                                    Capsule(style: .continuous)
+                                        .fill(tint)
+                                )
+                        }
+                    }
 
                     if let demographicSummaryText = row.demographicSummaryText {
                         Text(demographicSummaryText)

--- a/AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift
+++ b/AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift
@@ -224,7 +224,7 @@ private struct LiveReplayLeaderboardRowView: View {
                 avatarView
 
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(row.isCurrentUser ? "You" : row.identity.displayName)
+                    Text(row.identity.displayName)
                         .font(.montserratBold(size: 17))
                         .foregroundStyle(primaryColor)
                         .lineLimit(1)

--- a/AscendApp/Shared/Components/ReplayLeaderboard/ReplayCompletionLeaderboardView.swift
+++ b/AscendApp/Shared/Components/ReplayLeaderboard/ReplayCompletionLeaderboardView.swift
@@ -417,8 +417,8 @@ private struct ReplayCompletionLeaderboardRowView: View {
                     .font(.system(size: 16, weight: .semibold))
                     .accessibilityHidden(true)
             } else {
-                Text(row.isCurrentUser ? "YOU" : row.identity.avatarToken)
-                    .font(.montserratBold(size: row.isCurrentUser ? 11 : 13))
+                Text(row.identity.avatarToken)
+                    .font(.montserratBold(size: 13))
             }
         }
             .foregroundStyle(row.isCurrentUser ? .black : .white)

--- a/AscendApp/Shared/Components/ReplayLeaderboard/ReplayCompletionLeaderboardView.swift
+++ b/AscendApp/Shared/Components/ReplayLeaderboard/ReplayCompletionLeaderboardView.swift
@@ -233,7 +233,7 @@ private struct ReplayCompletionLeaderboardRowView: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 7) {
-                    Text(row.isCurrentUser ? "You" : row.identity.displayName)
+                    Text(row.identity.displayName)
                         .font(.montserratBold(size: 15))
                         .foregroundStyle(primaryColor)
                         .lineLimit(1)

--- a/AscendApp/Shared/Models/PublicClimberIdentity.swift
+++ b/AscendApp/Shared/Models/PublicClimberIdentity.swift
@@ -22,6 +22,7 @@ enum PublicClimberIdentity {
 
     static let anonymousDisplayName = "Anonymous Climber"
     static let genericAvatarSystemName = "person.fill"
+    static let fallbackAvatarToken = "CL"
 
     /// Every letter here is absent from every screened term, so no six-character
     /// token can spell one. The generator also never repeats a character back to
@@ -164,12 +165,16 @@ enum PublicClimberIdentity {
         return value
     }
 
-    private static func avatarToken(for displayName: String) -> String {
+    /// The one derivation of a climber's initials. Every avatar surface reads it
+    /// here so a name shape the rule does not yet handle cannot render one way
+    /// during a Live Climb and another on the completion screen.
+    static func avatarToken(for displayName: String) -> String {
         let token = displayName
             .split(separator: " ")
             .prefix(2)
             .compactMap(\.first)
 
-        return String(token).uppercased()
+        let derived = String(token).uppercased()
+        return derived.isEmpty ? fallbackAvatarToken : derived
     }
 }

--- a/AscendApp/Shared/Models/PublicClimberIdentity.swift
+++ b/AscendApp/Shared/Models/PublicClimberIdentity.swift
@@ -69,10 +69,11 @@ enum PublicClimberIdentity {
         currentUserPhotoURL: URL? = nil
     ) -> Presentation {
         if isCurrentUser {
+            let name = nonEmpty(storedDisplayName) ?? systemHandle(for: userId)
             return Presentation(
-                displayName: "You",
+                displayName: name,
                 photoURL: currentUserPhotoURL ?? storedPhotoURL,
-                avatarToken: "YOU",
+                avatarToken: avatarToken(for: name),
                 usesGenericAvatar: currentUserPhotoURL == nil && storedPhotoURL == nil
             )
         }

--- a/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
+++ b/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
@@ -389,18 +389,28 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
     static func currentUser(
         rank: Int?,
         steps: Int,
-        avatarToken: String = "YOU",
+        displayName: String? = nil,
+        avatarToken: String? = nil,
         photoURL: URL? = nil,
         isPersonalBest: Bool = false,
         gender: String? = nil,
         age: Int? = nil,
         locationCity: String? = nil
     ) -> LiveReplayLeaderboardRow {
-        LiveReplayLeaderboardRow(
+        let cachedDisplayName = UserDataRepository.shared.getCachedDisplayName()?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedDisplayName = displayName?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty ?? cachedDisplayName?.nilIfEmpty ?? "Climber"
+        let resolvedAvatarToken = avatarToken ?? String(
+            resolvedDisplayName.split(separator: " ").prefix(2).compactMap(\.first)
+        ).uppercased()
+
+        return LiveReplayLeaderboardRow(
             id: "current-user",
             rank: rank,
-            displayName: "You",
-            avatarToken: avatarToken,
+            displayName: resolvedDisplayName,
+            avatarToken: resolvedAvatarToken,
             photoURL: photoURL,
             stepsAtBucket: max(steps, 0),
             finalSteps: max(steps, 0),

--- a/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
+++ b/AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift
@@ -397,14 +397,12 @@ struct LiveReplayLeaderboardRow: Identifiable, Equatable, Sendable {
         age: Int? = nil,
         locationCity: String? = nil
     ) -> LiveReplayLeaderboardRow {
-        let cachedDisplayName = UserDataRepository.shared.getCachedDisplayName()?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedDisplayName = displayName?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-            .nilIfEmpty ?? cachedDisplayName?.nilIfEmpty ?? "Climber"
-        let resolvedAvatarToken = avatarToken ?? String(
-            resolvedDisplayName.split(separator: " ").prefix(2).compactMap(\.first)
-        ).uppercased()
+            .nilIfEmpty ?? "Climber"
+        let resolvedAvatarToken = avatarToken?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty ?? PublicClimberIdentity.avatarToken(for: resolvedDisplayName)
 
         return LiveReplayLeaderboardRow(
             id: "current-user",
@@ -558,9 +556,13 @@ struct LiveReplayLeaderboardWindow: Equatable, Sendable {
         bucketIndex * context.bucketIntervalSeconds
     }
 
+    /// `displayName` is passed down from the session view model rather than
+    /// resolved here: this runs on every step and elapsed tick of a live
+    /// session, so it must not reach a repository.
     func locallyRankedRows(
         currentSteps liveCurrentSteps: Int,
-        currentElapsedSeconds: Int
+        currentElapsedSeconds: Int,
+        displayName: String? = nil
     ) -> [LiveReplayLeaderboardRow] {
         let clampedCurrentSteps = max(liveCurrentSteps, 0)
         let projectedCompetitorRows = rows.map {
@@ -586,7 +588,8 @@ struct LiveReplayLeaderboardWindow: Equatable, Sendable {
         }
         let currentUserRow = LiveReplayLeaderboardRow.currentUser(
             rank: adjustedCurrentRank,
-            steps: clampedCurrentSteps
+            steps: clampedCurrentSteps,
+            displayName: displayName
         )
         let competitorRows = projectedCompetitorRows.map {
             $0.rebased(currentSteps: clampedCurrentSteps)

--- a/AscendAppTests/LeaderboardCurrentUserReconcilerTests.swift
+++ b/AscendAppTests/LeaderboardCurrentUserReconcilerTests.swift
@@ -106,6 +106,66 @@ struct LeaderboardCurrentUserReconcilerTests {
         #expect(climbStats[0].totalSteps == 80)
     }
 
+    @Test("An empty injected name keeps the published board identity", .bug(id: 394))
+    func detailReconciliationKeepsPublishedNameWhenInjectedNameIsEmpty() {
+        let period = LeaderboardTimeFrame.weekly.currentPeriod(referenceDate: utcDate(year: 2026, month: 4, day: 14))
+        let localStats = LeaderboardStats(
+            userId: "me",
+            timeFrame: .weekly,
+            period: period,
+            totalSteps: 200,
+            totalFloors: 10,
+            totalWorkouts: 2,
+            totalDuration: 1_200,
+            stepsPerMinute: 10
+        )
+
+        let original = [
+            makeRemoteStat(userId: "me", displayName: "Maya Chen", steps: 123, period: period)
+        ]
+
+        for injectedName in [nil, "", "   "] as [String?] {
+            let reconciled = LeaderboardCurrentUserReconciler.reconcileDetailStats(
+                original,
+                metric: .climb,
+                userId: "me",
+                displayName: injectedName,
+                localStats: localStats
+            )
+
+            let identity = resolvedIdentity(for: reconciled[0], currentUserId: "me")
+            #expect(identity.displayName == "Maya Chen")
+            #expect(identity.avatarToken == "MC")
+        }
+    }
+
+    @Test("An inserted row without a known name falls back to the system handle", .bug(id: 394))
+    func detailReconciliationFallsBackToSystemHandleForInsertedRow() {
+        let period = LeaderboardTimeFrame.weekly.currentPeriod(referenceDate: utcDate(year: 2026, month: 4, day: 14))
+        let localStats = LeaderboardStats(
+            userId: "me",
+            timeFrame: .weekly,
+            period: period,
+            totalSteps: 80,
+            totalFloors: 8,
+            totalWorkouts: 1,
+            totalDuration: 900,
+            stepsPerMinute: 5.3
+        )
+
+        let reconciled = LeaderboardCurrentUserReconciler.reconcileDetailStats(
+            [],
+            metric: .climb,
+            userId: "me",
+            displayName: nil,
+            localStats: localStats
+        )
+
+        let identity = resolvedIdentity(for: reconciled[0], currentUserId: "me")
+        #expect(identity.displayName == PublicClimberIdentity.systemHandle(for: "me"))
+        #expect(identity.displayName.isEmpty == false)
+    }
+
     private func resolvedIdentity(
         for stats: FirestoreLeaderboardStats,
         currentUserId: String

--- a/AscendAppTests/LeaderboardCurrentUserReconcilerTests.swift
+++ b/AscendAppTests/LeaderboardCurrentUserReconcilerTests.swift
@@ -27,6 +27,7 @@ struct LeaderboardCurrentUserReconcilerTests {
         let reconciled = LeaderboardCurrentUserReconciler.reconcilePreviewStats(
             original,
             userId: "me",
+            displayName: "Maya Chen",
             localStats: localStats
         )
 
@@ -34,7 +35,7 @@ struct LeaderboardCurrentUserReconcilerTests {
         let identity = resolvedIdentity(for: climbStats[0], currentUserId: "me")
         #expect(climbStats.count == 2)
         #expect(climbStats[0].userId == "me")
-        #expect(identity.displayName == "You")
+        #expect(identity.displayName == "Maya Chen")
         #expect(identity.photoURL == nil)
         #expect(climbStats[0].totalSteps == 200)
     }
@@ -62,6 +63,7 @@ struct LeaderboardCurrentUserReconcilerTests {
             original,
             metric: .climb,
             userId: "me",
+            displayName: "Maya Chen",
             localStats: localStats
         )
 
@@ -92,6 +94,7 @@ struct LeaderboardCurrentUserReconcilerTests {
         let reconciled = LeaderboardCurrentUserReconciler.reconcilePreviewStats(
             original,
             userId: "me",
+            displayName: "Maya Chen",
             localStats: localStats
         )
 
@@ -99,7 +102,7 @@ struct LeaderboardCurrentUserReconcilerTests {
         let identity = resolvedIdentity(for: climbStats[0], currentUserId: "me")
         #expect(climbStats.count == 2)
         #expect(climbStats[0].userId == "me")
-        #expect(identity.displayName == "You")
+        #expect(identity.displayName == "Maya Chen")
         #expect(climbStats[0].totalSteps == 80)
     }
 

--- a/AscendAppTests/LeaderboardViewModelTests.swift
+++ b/AscendAppTests/LeaderboardViewModelTests.swift
@@ -102,7 +102,7 @@ struct LeaderboardViewModelTests {
         let stats = [
             makeRemoteStat(userId: "aaa", displayName: "Leader", totalSteps: 9_000),
             makeRemoteStat(userId: "mmm", displayName: "Rival", totalSteps: 5_000),
-            makeRemoteStat(userId: "zzz", displayName: "You", totalSteps: 5_000)
+            makeRemoteStat(userId: "zzz", displayName: "Maya Chen", totalSteps: 5_000)
         ]
         await cache.setDetailEntries(stats, for: .climb, timeFrame: .weekly)
 
@@ -127,13 +127,14 @@ struct LeaderboardViewModelTests {
         let stats = [
             makeRemoteStat(userId: "aaa", displayName: "Leader", totalSteps: 9_000),
             makeRemoteStat(userId: "mmm", displayName: "Rival", totalSteps: 5_000),
-            makeRemoteStat(userId: "zzz", displayName: "You", totalSteps: 5_000)
+            makeRemoteStat(userId: "zzz", displayName: "Maya Chen", totalSteps: 5_000)
         ]
         await cache.setDetailEntries(stats, for: .climb, timeFrame: .weekly)
 
         await viewModel.loadLeaderboard(userId: "zzz")
         viewModel.updateCurrentUserProfile(
             userId: "zzz",
+            displayName: "Maya Chen",
             photoURL: URL(string: "https://example.com/avatar.jpg")
         )
 
@@ -152,7 +153,7 @@ struct LeaderboardViewModelTests {
                 isBlockListHydrated: true
             )
         }
-        #expect(moderatedListEntry?.identity.displayName == "You")
+        #expect(moderatedListEntry?.identity.displayName == "Maya Chen")
         #expect(
             moderatedListEntry?.identity.photoURL ==
                 URL(string: "https://example.com/avatar.jpg")
@@ -162,12 +163,12 @@ struct LeaderboardViewModelTests {
         #expect(listEntry?.isCurrentUser == true)
         #expect(viewModel.userStanding?.rankedEntry?.rank == listEntry?.rank)
         #expect(viewModel.userStanding?.rankedEntry?.isTied == listEntry?.isTied)
-        #expect(moderatedUserEntry?.identity.displayName == "You")
+        #expect(moderatedUserEntry?.identity.displayName == "Maya Chen")
     }
 
     @Test
     func profileSyncLeavesTheSessionCachePopulated() async {
-        // Cached remote stats carry published public identity; "You" and the private
+        // Cached remote stats carry published public identity; the current name and private
         // photo are resolved at build time, so a profile sync must not force a refetch.
         let cache = LeaderboardSessionCache()
 
@@ -181,6 +182,7 @@ struct LeaderboardViewModelTests {
         await viewModel.loadLeaderboard(userId: "zzz")
         viewModel.updateCurrentUserProfile(
             userId: "zzz",
+            displayName: "Maya Chen",
             photoURL: URL(string: "https://example.com/avatar.jpg")
         )
         await Task.yield()
@@ -250,7 +252,11 @@ struct LeaderboardViewModelTests {
         let viewModel = LeaderboardViewModel(sessionCache: cache, service: service)
         viewModel.selectedMetric = .climb
         viewModel.selectedTimeFrame = .weekly
-        viewModel.configure(userId: userId, modelContext: modelContext)
+        viewModel.configure(
+            userId: userId,
+            displayName: "Maya Chen",
+            modelContext: modelContext
+        )
 
         // No workouts at all: every current period rebuilds to zero.
         try service.rebuildCurrentStats(for: userId, workouts: [])
@@ -281,7 +287,11 @@ struct LeaderboardViewModelTests {
         let viewModel = LeaderboardViewModel(sessionCache: cache, service: service)
         viewModel.selectedMetric = .climb
         viewModel.selectedTimeFrame = .weekly
-        viewModel.configure(userId: userId, modelContext: modelContext)
+        viewModel.configure(
+            userId: userId,
+            displayName: "Maya Chen",
+            modelContext: modelContext
+        )
 
         let now = Date()
         let workout = Workout(

--- a/AscendAppTests/PostAuthNameInputTests.swift
+++ b/AscendAppTests/PostAuthNameInputTests.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+import Testing
+import UIKit
+import Vision
+@testable import AscendApp
+
+@Suite(.serialized, .hostsAWindow)
+@MainActor
+struct PostAuthNameInputTests {
+    @Test("Name onboarding renders separate first and last name fields", .bug(id: 394))
+    func nameOnboardingRendersSeparateFields() async throws {
+        let size = CGSize(width: 402, height: 874)
+        let controller = UIHostingController(
+            rootView: PostAuthOnboardingFlowView(
+                stage: .displayName,
+                onBack: {},
+                onContinue: {}
+            )
+            .frame(width: size.width, height: size.height)
+            .environment(AuthenticationViewModel(observesFirebaseAuth: false))
+            .environment(\.colorScheme, .dark)
+        )
+        controller.overrideUserInterfaceStyle = .dark
+        controller.view.frame = CGRect(origin: .zero, size: size)
+
+        let window = UIWindow(frame: controller.view.frame)
+        window.overrideUserInterfaceStyle = .dark
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        for _ in 0..<8 {
+            controller.view.setNeedsLayout()
+            controller.view.layoutIfNeeded()
+            try await Task.sleep(for: .milliseconds(50))
+        }
+
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.scale = 3
+        let image = UIGraphicsImageRenderer(size: size, format: format).image { _ in
+            controller.view.drawHierarchy(
+                in: controller.view.bounds,
+                afterScreenUpdates: true
+            )
+        }
+        let text = try await recognizedText(in: image)
+
+        #expect(text.contains("what's your name"))
+        #expect(text.contains("first name"))
+        #expect(text.contains("last name"))
+
+        try writeEvidence(image: image, named: "onboarding-first-last-name.png")
+    }
+
+    @Test("Continue requires both name fields", .bug(id: 394))
+    func continueRequiresBothNameFields() {
+        #expect(PostAuthNameInput().canContinue == false)
+        #expect(PostAuthNameInput(firstName: "Maya", lastName: "").canContinue == false)
+        #expect(PostAuthNameInput(firstName: "", lastName: "Chen").canContinue == false)
+        #expect(PostAuthNameInput(firstName: "Maya", lastName: "   ").canContinue == false)
+        #expect(PostAuthNameInput(firstName: " Maya ", lastName: " Chen ").canContinue)
+    }
+
+    @Test("Completed onboarding resolves the stored first and last name", .bug(id: 394))
+    func completedOnboardingResolvesStoredName() {
+        let storedProfile = UserDisplayNameData([
+            "firstName": "Maya",
+            "lastName": "Chen",
+            "displayName": "Stale Name"
+        ])
+        let identity = PublicClimberIdentity.resolve(
+            userId: "maya-chen",
+            storedDisplayName: storedProfile.resolvedDisplayName,
+            storedPhotoURL: nil,
+            isCurrentUser: true
+        )
+
+        #expect(storedProfile.resolvedDisplayName == "Maya Chen")
+        #expect(identity.displayName == "Maya Chen")
+        #expect(identity.avatarToken == "MC")
+    }
+
+    @Test("Legacy display names survive without splitting or inference", .bug(id: 394))
+    func legacyDisplayNameSurvivesUnmodified() {
+        let storedProfile = UserDisplayNameData([
+            "displayName": "Legacy Climber"
+        ])
+
+        #expect(storedProfile.firstName == nil)
+        #expect(storedProfile.lastName == nil)
+        #expect(storedProfile.displayName == "Legacy Climber")
+        #expect(storedProfile.resolvedDisplayName == "Legacy Climber")
+    }
+
+    private func recognizedText(in image: UIImage) async throws -> String {
+        let cgImage = try #require(image.cgImage, "UIImage had no CGImage")
+        var request = RecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = false
+
+        let observations = try await request.perform(on: cgImage)
+        return observations
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: " ")
+            .lowercased()
+    }
+
+    private func writeEvidence(image: UIImage, named name: String) throws {
+        let png = try #require(image.pngData(), "UIImage produced no PNG data")
+        let directory = ProcessInfo.processInfo.environment["ASCEND_EVIDENCE_DIR"]
+            ?? NSTemporaryDirectory()
+        let outputURL = URL(filePath: directory).appending(path: name)
+        try png.write(to: outputURL)
+        #expect(png.count > 5_000)
+        print("Rendered onboarding name evidence: \(outputURL.path())")
+    }
+}

--- a/AscendAppTests/PostAuthNameInputTests.swift
+++ b/AscendAppTests/PostAuthNameInputTests.swift
@@ -61,6 +61,19 @@ struct PostAuthNameInputTests {
         #expect(PostAuthNameInput(firstName: " Maya ", lastName: " Chen ").canContinue)
     }
 
+    @Test("Continue gates on the same policy Edit Profile saves behind", .bug(id: 394))
+    func continueGatesOnTheSharedDisplayNamePolicy() {
+        let overlongPart = String(repeating: "Ab", count: DisplayNamePolicy.maximumLength / 2)
+        #expect(
+            PostAuthNameInput(firstName: overlongPart, lastName: overlongPart)
+                .canContinue == false
+        )
+        #expect(
+            PostAuthNameInput(firstName: "Maya", lastName: "Fucker").canContinue == false
+        )
+        #expect(PostAuthNameInput(firstName: "Maya", lastName: "Chen").canContinue)
+    }
+
     @Test("Completed onboarding resolves the stored first and last name", .bug(id: 394))
     func completedOnboardingResolvesStoredName() {
         let storedProfile = UserDisplayNameData([

--- a/AscendAppTests/PostAuthNameInputTests.swift
+++ b/AscendAppTests/PostAuthNameInputTests.swift
@@ -74,6 +74,26 @@ struct PostAuthNameInputTests {
         #expect(PostAuthNameInput(firstName: "Maya", lastName: "Chen").canContinue)
     }
 
+    @Test("Rejected names read in onboarding's own words", .bug(id: 394))
+    func validationMessagesNeverNameTheDisplayNameField() {
+        let overlongPart = String(repeating: "Ab", count: DisplayNamePolicy.maximumLength / 2)
+
+        #expect(PostAuthNameInput().validationMessage == "Enter both a first and last name.")
+        #expect(
+            PostAuthNameInput(firstName: "Maya", lastName: "").validationMessage ==
+                "Enter both a first and last name."
+        )
+        #expect(
+            PostAuthNameInput(firstName: overlongPart, lastName: overlongPart).validationMessage ==
+                "That name is too long"
+        )
+        #expect(
+            PostAuthNameInput(firstName: "Maya", lastName: "Fucker").validationMessage ==
+                "That name cannot be used"
+        )
+        #expect(PostAuthNameInput(firstName: "Maya", lastName: "Chen").validationMessage == nil)
+    }
+
     @Test("Completed onboarding resolves the stored first and last name", .bug(id: 394))
     func completedOnboardingResolvesStoredName() {
         let storedProfile = UserDisplayNameData([

--- a/AscendAppTests/PostAuthNameOnboardingEvidenceTests.swift
+++ b/AscendAppTests/PostAuthNameOnboardingEvidenceTests.swift
@@ -1,0 +1,316 @@
+import SwiftUI
+import Testing
+import UIKit
+import Vision
+@testable import AscendApp
+
+/// End-to-end visual evidence for the two-field name step.
+///
+/// `PostAuthNameInputTests` holds the gate and the resolver in isolation. This
+/// holds what the climber actually sees: CONTINUE stays dead until both fields
+/// carry a name, and the name they type is the one their profile header reads
+/// afterwards - while a legacy account that never supplied two halves keeps
+/// rendering the display name it already ranks under.
+@Suite(.serialized, .hostsAWindow)
+@MainActor
+struct PostAuthNameOnboardingEvidenceTests {
+    private static let canvas = CGSize(width: 402, height: 874)
+
+    @Test("CONTINUE stays dead until both name fields carry a name", .bug(id: 394))
+    func continueUnlocksOnlyAfterBothFieldsAreTyped() async throws {
+        let controller = UIHostingController(
+            rootView: PostAuthOnboardingFlowView(
+                stage: .displayName,
+                onBack: {},
+                onContinue: {}
+            )
+            .frame(width: Self.canvas.width, height: Self.canvas.height)
+            .environment(AuthenticationViewModel(observesFirebaseAuth: false))
+            .environment(\.colorScheme, .dark)
+        )
+        controller.overrideUserInterfaceStyle = .dark
+        controller.view.frame = CGRect(origin: .zero, size: Self.canvas)
+
+        let window = UIWindow(frame: controller.view.frame)
+        window.overrideUserInterfaceStyle = .dark
+        window.rootViewController = controller
+        window.makeKeyAndVisible()
+        defer { window.isHidden = true }
+
+        try await settle(controller)
+        let empty = capture(controller)
+
+        let fields = textFields(in: controller.view)
+        #expect(fields.count == 2, "The name step must show two fields")
+        let firstNameField = try #require(fields.first)
+        let lastNameField = try #require(fields.last)
+
+        firstNameField.becomeFirstResponder()
+        firstNameField.insertText("Maya")
+        try await settle(controller)
+        let firstOnly = capture(controller)
+
+        lastNameField.becomeFirstResponder()
+        lastNameField.insertText("Chen")
+        try await settle(controller)
+        let bothTyped = capture(controller)
+
+        let emptyContinue = continueButtonIntensity(in: empty)
+        let firstOnlyContinue = continueButtonIntensity(in: firstOnly)
+        let bothTypedContinue = continueButtonIntensity(in: bothTyped)
+
+        // A live CONTINUE is the lime fill; a dead one is the same fill dimmed.
+        #expect(bothTypedContinue > emptyContinue * 2)
+        #expect(bothTypedContinue > firstOnlyContinue * 2)
+
+        let typedText = try await recognizedText(in: bothTyped)
+        #expect(typedText.contains("maya"))
+        #expect(typedText.contains("chen"))
+
+        let firstOnlyText = try await recognizedText(in: firstOnly)
+        #expect(firstOnlyText.contains("maya"))
+        #expect(firstOnlyText.contains("last name"), "The unfilled half keeps its prompt")
+
+        try writeEvidence(
+            image: filmstrip(
+                panels: [
+                    ("Nothing typed - CONTINUE dead", empty),
+                    ("First name only - CONTINUE dead", firstOnly),
+                    ("Both names - CONTINUE live", bothTyped)
+                ]
+            ),
+            named: "onboarding-name-continue-gate.png"
+        )
+    }
+
+    @Test("The profile header reads the composed name, not a placeholder", .bug(id: 394))
+    func profileHeaderReadsTheComposedNameAndLeavesLegacyAlone() async throws {
+        let onboarded = UserDisplayNameData([
+            "firstName": "Maya",
+            "lastName": "Chen",
+            "displayName": "Maya Chen"
+        ])
+        let legacy = UserDisplayNameData([
+            "displayName": "Legacy Climber"
+        ])
+
+        #expect(onboarded.resolvedDisplayName == "Maya Chen")
+        #expect(legacy.firstName == nil)
+        #expect(legacy.lastName == nil)
+        #expect(legacy.resolvedDisplayName == "Legacy Climber")
+
+        let image = try render(
+            VStack(spacing: 0) {
+                headerPanel(
+                    caption: "COMPLETED THE NEW NAME STEP",
+                    userId: "maya-chen",
+                    storedProfile: onboarded
+                )
+                headerPanel(
+                    caption: "LEGACY ACCOUNT - NEVER SPLIT OR BACKFILLED",
+                    userId: "legacy-climber",
+                    storedProfile: legacy
+                )
+            }
+            .frame(width: Self.canvas.width)
+            .background(Color.black)
+            .environment(\.colorScheme, .dark)
+        )
+
+        let text = try await recognizedText(in: image)
+        #expect(text.contains("maya chen"))
+        #expect(text.contains("legacy climber"))
+        #expect(text.contains("you") == false, "The placeholder must be gone")
+
+        try writeEvidence(image: image, named: "profile-header-composed-name.png")
+    }
+
+    // MARK: - Rendering helpers
+
+    private func headerPanel(
+        caption: String,
+        userId: String,
+        storedProfile: UserDisplayNameData
+    ) -> some View {
+        let displayName = storedProfile.resolvedDisplayName ?? ""
+        let identity = ResolvedUserIdentity.Resolver.resolve(
+            userId: userId,
+            displayName: displayName,
+            photoURL: nil,
+            avatarToken: PublicClimberIdentity.avatarToken(for: displayName),
+            isCurrentUser: true,
+            blockedUserIds: [],
+            isBlockListHydrated: true
+        )
+
+        return VStack(alignment: .leading, spacing: 8) {
+            Text(caption)
+                .font(.montserratSemiBold(size: 11))
+                .foregroundStyle(Color.ascendAccent)
+                .padding(.horizontal, 16)
+
+            IdentityHeroSection(
+                snapshot: Self.emptySnapshot(userId: userId),
+                identity: identity
+            )
+        }
+        .padding(.vertical, 16)
+    }
+
+    private static func emptySnapshot(userId: String) -> ProfileSnapshot {
+        ProfileSnapshot(
+            demographics: ProfileDemographicsSnapshot(
+                userId: userId,
+                joinedAt: Date(timeIntervalSince1970: 1_754_000_000)
+            ),
+            stats: .empty,
+            standings: [],
+            activityWorkouts: [],
+            collection: ProfileCollectionSummary(
+                collectedCount: 0,
+                catalogCount: 0,
+                previewCards: [],
+                launchedCards: [],
+                comingSoonClimbs: []
+            ),
+            achievements: .zero,
+            achievementRecords: [],
+            firstAscentsHeld: [],
+            openFirstAscents: [],
+            records: ProfileRecordSummary(personalRecords: [], featuredBestEffort: nil),
+            trends: ProfileTrendSummary(currentSteps: 0, previousSteps: 0, daysWithData: 0),
+            recentWorkouts: []
+        )
+    }
+
+    private func render(_ content: some View) throws -> UIImage {
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = 3
+        return try #require(renderer.uiImage, "ImageRenderer produced no image")
+    }
+
+    private func settle(_ controller: UIHostingController<some View>) async throws {
+        for _ in 0..<8 {
+            controller.view.setNeedsLayout()
+            controller.view.layoutIfNeeded()
+            try await Task.sleep(for: .milliseconds(50))
+        }
+    }
+
+    private func capture(_ controller: UIHostingController<some View>) -> UIImage {
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.scale = 3
+        return UIGraphicsImageRenderer(size: Self.canvas, format: format).image { _ in
+            controller.view.drawHierarchy(
+                in: controller.view.bounds,
+                afterScreenUpdates: true
+            )
+        }
+    }
+
+    private func textFields(in view: UIView) -> [UITextField] {
+        var found: [UITextField] = []
+        if let field = view as? UITextField {
+            found.append(field)
+        }
+        for subview in view.subviews {
+            found.append(contentsOf: textFields(in: subview))
+        }
+        return found.sorted {
+            $0.convert($0.bounds, to: nil).minY < $1.convert($1.bounds, to: nil).minY
+        }
+    }
+
+    private func filmstrip(panels: [(String, UIImage)]) -> UIImage {
+        let captionHeight: CGFloat = 26
+        let gutter: CGFloat = 12
+        let panelWidth = Self.canvas.width
+        let size = CGSize(
+            width: panelWidth * CGFloat(panels.count) + gutter * CGFloat(panels.count + 1),
+            height: Self.canvas.height + captionHeight + gutter * 2
+        )
+
+        let format = UIGraphicsImageRendererFormat.preferred()
+        format.scale = 2
+        return UIGraphicsImageRenderer(size: size, format: format).image { context in
+            UIColor.black.setFill()
+            context.fill(CGRect(origin: .zero, size: size))
+
+            for (index, panel) in panels.enumerated() {
+                let originX = gutter + (panelWidth + gutter) * CGFloat(index)
+                (panel.0 as NSString).draw(
+                    at: CGPoint(x: originX, y: gutter),
+                    withAttributes: [
+                        .font: UIFont.systemFont(ofSize: 13, weight: .semibold),
+                        .foregroundColor: UIColor.white
+                    ]
+                )
+                panel.1.draw(
+                    in: CGRect(
+                        x: originX,
+                        y: gutter + captionHeight,
+                        width: panelWidth,
+                        height: Self.canvas.height
+                    )
+                )
+            }
+        }
+    }
+
+    // MARK: - Reading the rendered pixels back
+
+    /// Mean green channel across the CONTINUE button's fill. The button sits at
+    /// a fixed fraction of the screen it owns, so the sample needs no layout
+    /// introspection to find it.
+    private func continueButtonIntensity(in image: UIImage) -> Double {
+        guard let cgImage = image.cgImage else { return 0 }
+        let sample = CGRect(
+            x: Double(cgImage.width) * 0.40,
+            y: Double(cgImage.height) * 0.875,
+            width: Double(cgImage.width) * 0.20,
+            height: Double(cgImage.height) * 0.02
+        )
+        guard let cropped = cgImage.cropping(to: sample) else { return 0 }
+
+        let width = cropped.width
+        let height = cropped.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return 0 }
+        context.draw(cropped, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        let greenTotal = stride(from: 1, to: pixels.count, by: 4)
+            .reduce(0.0) { $0 + Double(pixels[$1]) }
+        return greenTotal / Double(width * height)
+    }
+
+    private func recognizedText(in image: UIImage) async throws -> String {
+        let cgImage = try #require(image.cgImage, "UIImage had no CGImage")
+        var request = RecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = false
+
+        let observations = try await request.perform(on: cgImage)
+        return observations
+            .compactMap { $0.topCandidates(1).first?.string }
+            .joined(separator: " ")
+            .lowercased()
+    }
+
+    private func writeEvidence(image: UIImage, named name: String) throws {
+        let png = try #require(image.pngData(), "UIImage produced no PNG data")
+        let directory = ProcessInfo.processInfo.environment["ASCEND_EVIDENCE_DIR"]
+            ?? NSTemporaryDirectory()
+        let outputURL = URL(filePath: directory).appending(path: name)
+        try png.write(to: outputURL)
+        #expect(png.count > 5_000)
+        print("Rendered onboarding name evidence: \(outputURL.path())")
+    }
+}

--- a/AscendAppTests/PublicClimberIdentityTests.swift
+++ b/AscendAppTests/PublicClimberIdentityTests.swift
@@ -100,7 +100,7 @@ struct PublicClimberIdentityTests {
     }
 
     @Test
-    func currentUserKeepsPrivatePhotoAndYouLabel() {
+    func currentUserKeepsPrivatePhotoAndStoredName() {
         let privatePhoto = URL(string: "https://example.com/private-profile.jpg")
         let identity = PublicClimberIdentity.resolve(
             userId: "user-123",
@@ -110,9 +110,9 @@ struct PublicClimberIdentityTests {
             currentUserPhotoURL: privatePhoto
         )
 
-        #expect(identity.displayName == "You")
+        #expect(identity.displayName == "Private Name")
         #expect(identity.photoURL == privatePhoto)
-        #expect(identity.avatarToken == "YOU")
+        #expect(identity.avatarToken == "PN")
         #expect(identity.usesGenericAvatar == false)
     }
 

--- a/AscendAppTests/TiedRankRenderEvidenceTests.swift
+++ b/AscendAppTests/TiedRankRenderEvidenceTests.swift
@@ -289,6 +289,7 @@ struct TiedRankRenderEvidenceTests {
 
                 LeaderboardUserRowView(
                     unrankedFormattedValue: "0",
+                    displayName: "Maya Chen",
                     photoURL: nil,
                     metric: .climb,
                     crownGapText: "48,000 STEPS TO CROWN"

--- a/docs/app-store-brief.md
+++ b/docs/app-store-brief.md
@@ -93,8 +93,8 @@ Visual rules the chosen template must satisfy:
 - Full-bleed **dark** background, **thin top progress indicator**, **one large product
   hero**, short copy at the bottom, **exactly one CTA per screen**.
 - **No skip affordances. No card chrome or boxed surfaces.**
-- Must collect required profile fields post-auth (display name + demographics: birthday,
-  bounded to ages 13–120, and gender).
+- Must collect required profile fields post-auth (separate required first and last name +
+  demographics: birthday, bounded to ages 13–120, and gender).
 - Notifications opt-in is anchored to a concrete value prop ("never miss a climb drop / get
   24-hour advance notice on new First Ascent opportunities") — never generic "enable
   notifications" housekeeping.

--- a/docs/onboarding-design-guide.md
+++ b/docs/onboarding-design-guide.md
@@ -544,14 +544,20 @@ Visual:
 - Use angular A mark and/or `AscendWordmark`.
 - Keep provider buttons familiar and high contrast.
 
-### 20. Display Name
+### 20. Name
 
 Copy:
 - Eyebrow: `FIRST THINGS FIRST`
-- Headline: `What should we call you?`
-- Placeholder: `Enter your name`
+- Headline: `What's your name?`
+- First field: `First name`
+- Last field: `Last name`
 - Microcopy: `This is the name climbers see on leaderboards.`
 - CTA: `Continue`
+
+Behavior:
+- Both fields are required.
+- Do not split, infer, or backfill either field from a legacy display name.
+- Existing legacy display names remain untouched until the climber supplies both fields in Edit Profile.
 
 ### 21. Required Demographics
 
@@ -1150,7 +1156,7 @@ Verify:
 ### Phase 3 — Required Profile And Permission Serve
 
 Ship:
-- Display name.
+- First name and last name.
 - Gender, birthday, weight, and location capture.
 - Value reveal.
 - Notification opt-in framed around First Ascent drops.
@@ -1219,7 +1225,7 @@ Track analytics by workflow so the dashboard can answer where the app is losing 
 - First-climb detail opened.
 
 ### Profile And Permissions
-- Display name completed.
+- First and last name completed.
 - Demographics completed by field, no raw PII in analytics.
 - Notification pre-prompt shown.
 - Native notification prompt accepted or declined.


### PR DESCRIPTION
## Intent

Replace the post-auth onboarding screen that asks what to call the climber with two distinct required First name and Last name fields, preserving the existing screen order and surrounding flow. Continue must remain disabled until both trimmed fields are non-empty. Save both fields through the established profile name path so completed onboarding produces a profile header with the climber actual composed first and last name instead of the placeholder You. The captain explicitly rejected splitting, inferring, or backfilling a legacy single display name anywhere: existing legacy records must remain untouched and continue rendering their stored displayName until the climber supplies both parts in Edit Profile. Leaderboards and every public identity surface must render the resolved first and last name. Cover required-both validation, completed onboarding resolving a real profile name, legacy preservation, and the rendered two-field screen. Do not change onboarding order or the sibling-owned gender wording. Do not copy, symlink, or work around the machine-wide missing GoogleService-Info-Production.plist. Local Release compilation is skipped only because that plist was never provisioned in the shared directory; CI iOS Verify Release is authoritative and branch-protected before merge. The PR body must state that environment gap plainly and confirm Debug, Staging, and all 1,330 tests are green.

## What Changed

- Replaced the post-auth "What should we call you?" screen with two required **First name** / **Last name** fields backed by a new `PostAuthNameInput`, which gates CONTINUE on the same `DisplayNamePolicy.composedBoardName` check Edit Profile saves behind and surfaces onboarding-native error copy instead of display-name-field wording. The name is written through the established `updateProfileName(firstName:lastName:)` path; stage order and the sibling-owned gender wording are untouched.
- Identity resolution now returns the composed name everywhere: `UserDisplayNameData.resolvedDisplayName` prefers `firstName`/`lastName` and otherwise returns the stored `displayName` verbatim, so legacy records are neither split nor backfilled. `PublicClimberIdentity` and `ResolvedUserIdentity` drop the `"You"` / `"YOU"` placeholders for the resolved name plus a single shared initials derivation (`avatarToken(for:)`, with a centralized `fallbackAvatarToken`), threaded through the leaderboard reconciler, view model and rows, the live replay panel, and the replay completion board - with the current climber marked by an accent-pinned `YOU` chip rather than an avatar token.
- Removed the orphaned `AuthenticationViewModel.updateDisplayName` / `UserDataRepository.updateDisplayName` write path, added `PostAuthNameInputTests` and `PostAuthNameOnboardingEvidenceTests` (hosted two-field screen, gated CONTINUE, composed profile header, legacy header preserved), and updated the onboarding/profile skills and onboarding + App Store docs.

Debug and Staging builds are green and the full Staging suite passes at 1,328 tests across 196 suites with nothing skipped - the intent's 1,330 was an estimate; 1,326 existed before the two new evidence tests. The local Release compile check (`-configuration Release -sdk iphoneos`) is still unrun: it fails inside the Firebase plist-copy build phase under Xcode's user-script sandbox in this worktree, not in Swift compilation, and no plist was copied, symlinked, or otherwise worked around. Branch-protected **CI iOS Verify Release** remains authoritative for that check before merge.

## Risk Assessment

✅ Low: Both round-3 items landed as two minimal, behavior-preserving edits - collapsing the onSubmit branch onto saveName's existing guard and swapping the YOU chip fill to Color.accent - leaving only a cosmetic dedup opportunity on a marker that is now identical across all three ranking surfaces.

## Testing

I ran the full Staging iOS suite the way CI does, with the evidence directory wired in so the render tests wrote real PNGs: 1,328 tests across 196 suites passed with nothing skipped, and the Debug configuration compile check succeeded. Beyond the assertions, I captured reviewer-visible UI: a three-panel filmstrip of the actual hosted onboarding screen showing CONTINUE dead with nothing typed, still dead with only a first name, and lime-live once both fields carry a name; the rendered two-field screen itself; a profile-header comparison where a completed onboarding reads "Maya Chen" while a legacy account still renders its stored "Legacy Climber" with nothing split or backfilled; and leaderboard pinned-row renders showing the resolved climber name rather than a placeholder. Local Release compilation remains unrun - per your instruction I did not attempt to work around the Xcode script sandboxing that blocks it in this worktree, so CI iOS Verify Release stays the authoritative, branch-protected check. The worktree is clean and the only writes outside it were the evidence PNGs and throwaway derived data under /tmp.

- Evidence: Onboarding name step: CONTINUE gate across empty / first-name-only / both-names (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZBT3ZEN46G5JPA1MK5B8NWB/onboarding-name-continue-gate.png</code>)
- Evidence: Rendered two-field first/last name onboarding screen (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZBT3ZEN46G5JPA1MK5B8NWB/onboarding-first-last-name.png</code>)
- Evidence: Profile header: composed &#34;Maya Chen&#34; vs untouched legacy &#34;Legacy Climber&#34; (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZBT3ZEN46G5JPA1MK5B8NWB/profile-header-composed-name.png</code>)
- Evidence: Leaderboard pinned self-row renders the resolved climber name (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZBT3ZEN46G5JPA1MK5B8NWB/global-list-and-pinned-row-after.png</code>)
- Evidence: Unranked pinned row renders &#34;MAYA CHEN&#34; instead of a placeholder (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZBT3ZEN46G5JPA1MK5B8NWB/global-unranked-pinned-row-after.png</code>)
<details>
<summary>Evidence: Staging suite result and Debug compile result</summary>

```text
✔ Test run with 1328 tests in 196 suites passed after 71.092 seconds.
** TEST SUCCEEDED **

(xcodebuild -scheme AscendApp -configuration Debug -destination "platform=iOS Simulator,name=iPhone 16 Pro" build)
** BUILD SUCCEEDED **
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (34m8s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `AscendApp/Features/Leaderboards/Services/LeaderboardCurrentUserReconciler.swift:58` - The reconciler passes a non-optional displayName into identityApplyingOverrides, whose contract (UnresolvedUserIdentity.applyingOverrides: `displayName ?? self.displayName`) treats only nil as &#34;keep the published value&#34;. An empty string is therefore a real override. On an interactive Apple/Google sign-in to an existing account on a fresh device, registerAuthStateHandler sets displayName = &#34;&#34; and goes straight to .authenticated, so LeaderboardView.setupAndLoad calls configure(displayName: &#34;&#34;); reconcileDetailStats then blanks the climber&#39;s own published row identity and the moderation resolver falls back to PublicClimberIdentity.systemHandle(for:), rendering &#34;Climber 4A9F2E&#34; on their own leaderboard row. HomeDashboardViewModel.swift:373 already handles this correctly with `displayName.isEmpty ? nil : displayName`; make the reconciler parameter String? and mirror that.
- ⚠️ `AscendApp/Features/Leaderboards/Views/LeaderboardView.swift:128` - syncCurrentUserEntry() is re-triggered only by onChange(of: authVM.displayPhotoURL). setupAndLoad captures authVM.displayName once, so a name that arrives from the background Firestore fetch after the view configured never reaches LeaderboardViewModel.currentUserDisplayName. Combined with the empty-string clobber above, the wrong name persists for the whole session until the tab is torn down and .task re-runs. Add an onChange(of: authVM.displayName) calling syncCurrentUserEntry().
- ⚠️ `AscendApp/Features/Leaderboards/Views/LeaderboardUserRowView.swift:58` - The .unranked case returns the injected displayName verbatim with no fallback, and LeaderboardView.swift:484 passes authVM.displayName straight in. When that is &#34;&#34; (fresh-device interactive sign-in before the profile fetch), body renders Text(&#34;&#34;.uppercased()) and the pinned &#34;your standing&#34; row shows a rank dash, avatar, and value with no name at all - where &#34;You&#34; used to be. Every other identity surface touched by this change falls back to PublicClimberIdentity.systemHandle(for:); this one should too.
- ⚠️ `AscendApp/Shared/Components/ReplayLeaderboard/ReplayCompletionLeaderboardView.swift:420` - This line still hardcodes Text(row.isCurrentUser ? &#34;YOU&#34; : row.identity.avatarToken) while the sibling surfaces now render name-derived initials: LiveReplayLeaderboardPanel.swift:326 uses row.identity.avatarToken (now &#34;MC&#34; from LiveReplayLeaderboardModels.swift:405) and ClimbDetailView.swift:1347 uses currentUserAvatar.identity.avatarToken (also &#34;MC&#34;). A climber&#39;s avatar therefore reads &#34;MC&#34; during a Live Climb and &#34;YOU&#34; on the completion screen for the same session. All three read &#34;YOU&#34; before this branch, so the divergence is new - confirm which token the current user should carry now that names are real.
- ⚠️ `AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift:400` - LiveReplayLeaderboardRow.currentUser, a model factory in Shared/Services, now reads UserDataRepository.shared.getCachedDisplayName() (a UserDefaults hit) on every call. All three call sites - ActiveRoutineViewModel.swift:137, LiveClimbSessionViewModel.swift:349, LiveReplayLeaderboardModels.swift:587 - sit inside `leaderboardRows` computed properties that SwiftUI re-evaluates on every step/elapsed tick during a live session, so the read plus a split/uppercase runs on the live render path. It also inverts the project&#39;s layering rule (a model resolving identity from a Features/Authentication repository). The view models have the name available; pass it via the new displayName parameter - which no caller currently uses - and drop the singleton read.
- ℹ️ `AscendApp/Features/Profile/Services/ProfileStandingService.swift:39` - displayName is threaded through loadStandings/reconciledStats/fallbackStanding purely to satisfy the reconciler&#39;s new parameter, but standing(for:timeFrame:stats:) reads only userId, rank, and value - the name is discarded, so the four added parameters change nothing observable. The `displayName: String = &#34;&#34;` default also means the other-user loadStandings(userId:) path implicitly supplies the clobbering empty string; harmless today only because includesLocalStats is false there. Making the reconciler parameter String? lets these pass nil explicitly or drop the parameter entirely.
- ℹ️ `AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift:196` - Onboarding gates Continue on nameInput.canContinue (non-empty only) while Edit Profile gates Save on DisplayNamePolicy.composesAllowedBoardName (ProfileNameEditorView.swift:118). Since PostAuthNameInput.singleLinePart caps each field at 80, two full-length fields compose to 161 and composedBoardName throws invalidLength; a blocked term in either half throws objectionable. The climber taps an enabled CONTINUE and gets &#34;Enter a display name from 1 to 80 characters.&#34; instead of the button staying disabled. Using composesAllowedBoardName here still satisfies the required-both-fields criterion, but it tightens a user-facing gate.
- ℹ️ `AscendApp/Shared/Services/LiveReplayLeaderboard/LiveReplayLeaderboardModels.swift:405` - The two-word-initials derivation added here duplicates PublicClimberIdentity.swift:167 (private avatarToken(for:)) exactly, and ClimbDetailView.swift:1747 is a third copy that already has no callers (pre-existing). Promoting PublicClimberIdentity.avatarToken(for:) from private and calling it keeps one definition, so the rule cannot drift when hyphenated surnames or single-word names need handling.

🔧 Fix: preserve published climber identity across leaderboard and replay surfaces
4 infos still open:
- ℹ️ `AscendApp/Features/Moderation/Models/ResolvedUserIdentity.swift:77` - The avatar-token fallback was centralized onto PublicClimberIdentity.fallbackAvatarToken at line 52 (current-user branch) but the other-user branch at line 77 still uses the bare &#34;CL&#34; literal. Changing the constant would move the signed-in climber&#39;s fallback and leave every other climber behind - the exact drift the centralization closed. Point line 77 at PublicClimberIdentity.fallbackAvatarToken too.
- ℹ️ `AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift:331` - The directive to drop the in-avatar YOU rested on &#34;the row already carries the separate YOU label and current-user highlight.&#34; That is true for ReplayCompletionLeaderboardView.swift:243 and ClimbDetailView.swift:1162, which both render a YOU capsule beside the name, but LiveReplayLeaderboardPanel has no YOU/You text anywhere in the file. Mid-climb the climber&#39;s own row is now distinguished only by the accent tint on rank/steps (lines 220, 246), the progress background (line 213), and a 74pt vs 70pt row height - before this branch the panel had both an avatar reading YOU and a name reading You. Confirm the tint-only treatment is the intended read during a live session, or add the YOU chip the sibling surfaces use.
- ℹ️ `AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift:310` - The new catch block passes DisplayNamePolicyError.errorDescription straight to validationMessage, so a screen headlined &#34;What&#39;s your name?&#34; with First name / Last name fields can display &#34;Enter a display name from 1 to 80 characters.&#34; or &#34;Choose a different display name.&#34; - naming a field the climber cannot see. Reachable because onSubmit on the last-name field calls saveName even while CONTINUE is disabled (two 80-char halves compose to 161 and throw invalidLength; a blocked term throws objectionable). Only .incompleteName reads correctly on this screen. Consider mapping the policy errors to onboarding-native copy rather than reusing the Edit-Profile-oriented strings.
- ℹ️ `AscendApp/Features/Onboarding/Models/PostAuthNameInput.swift:10` - canContinue now routes through DisplayNamePolicy.validated, and PostAuthOnboardingFlowView.swift:197 reads it inside body against @State that changes on every character typed. Each evaluation runs `blockedTerms.contains(where: { containsObscuredTerm($0, in: normalized) })`, and containsObscuredTerm does `try? NSRegularExpression(pattern:)` per term with no short-circuit when nothing matches - 38 pattern compilations plus 38 matches on the main thread per keystroke, on top of the containsLongASCIILetterRun regex. ProfileNameEditorView.swift:118 shares the shape but is a settings screen; this is the first-run onboarding path. Hoist the compiled expressions into a static keyed by term so each pattern is built once per process.

🔧 Fix: centralize name validation copy, avatar fallback, and screening regexes
2 infos still open:
- ℹ️ `AscendApp/Features/Onboarding/Views/PostAuthOnboardingFlowView.swift:275` - The onSubmit else-branch (`validationMessage = nameInput.validationMessage`) is byte-for-byte what saveName&#39;s own guard already does, so `else if isContinueEnabled { saveName() } else { ... }` collapses to a plain `else { saveName() }` with identical behavior. Keeping both leaves two places for a future change to the invalid-submit response to land - the duplication the single-validity-decision refactor set out to remove.
- ℹ️ `AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift:242` - The new YOU capsule fills with the row&#39;s `tint` rather than Color.accent as the siblings do (ReplayCompletionLeaderboardView.swift:246, ClimbDetailView.swift:1169). ActiveRoutineView.swift:255 passes `tint: currentIntervalColor`, which runs the RoutineIntervalScale heat ramp from yellow at level 1 to Color(red: 0.9, green: 0, blue: 0) at level 25, so the chip shifts color as intervals advance and the completion screen shows a lime chip for the same session. At level 25 the black 9pt text on deep red is about 4.35:1, just under the 4.5:1 AA bar for small text. Using `tint` is locally coherent - the rank, steps, progress bar and the avatar circle at line 351 (already black-on-tint before this branch) all use it - so this may be the right call; confirm whether the chip should follow the row tint or match the siblings&#39; fixed accent.

🔧 Fix: pin YOU chip to accent, drop duplicate submit guard
1 info still open:
- ℹ️ `AscendApp/Shared/Components/ReplayLeaderboard/LiveReplayLeaderboardPanel.swift:235` - The current-climber YOU capsule is now byte-identical in three files - LiveReplayLeaderboardPanel.swift:235, ReplayCompletionLeaderboardView.swift:243, and ClimbDetailView.swift:1163 - each holding the same nine lines: Text(&#34;YOU&#34;) at montserratBold(9), foregroundStyle(.black), 6/3 padding, Capsule(style: .continuous).fill(Color.accent). Two copies predate this branch and the third was added to match them, so nothing is wrong today, but the next tweak to the marker has to land in three files and missing one reintroduces the cross-surface divergence this round just closed. Shared/Components/ already hosts small shared visual primitives such as LeadingAccentStripe.swift; a CurrentClimberChip there would make the consistency structural rather than conventional.

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ The intent requires the PR body to confirm &#34;all 1,330 tests are green,&#34; but the actual count on the target commit is 1,326 tests in 195 suites (1,328 after the two evidence tests I added). No tests were skipped in either run. The number in the PR body needs correcting before it is published.
- ℹ️ The PR body is required to state that local Release compilation was skipped because GoogleService-Info-Production.plist was never provisioned in the shared directory, but that plist is present now at ~/.config/ascend/firebase/GoogleService-Info-Production.plist (PROJECT_ID ascend-prod-9c8f2). The real local blocker is different: the plist-copy build phase fails under Xcode&#39;s user-script sandbox in this worktree (deny file-write-unlink on the plist link, deny file-read-data on .git). I did not pre-place or symlink the plist, since the intent forbids it, so the Release compile check remains unrun locally and CI iOS Verify Release stays authoritative. The PR body&#39;s stated reason should be reworded to match.
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp-Staging&#34; -configuration Staging -destination &#34;platform=iOS Simulator,name=iPhone 16 Pro&#34; ENABLE_TESTABILITY=YES test` on the target commit - 1,326 tests in 195 suites passed</code>
- <code>Same full-suite command after adding `AscendAppTests/PostAuthNameOnboardingEvidenceTests.swift` - 1,328 tests in 196 suites passed, no skips</code>
- <code>`-only-testing:AscendAppTests/PostAuthNameInputTests` - required-both validation, shared DisplayNamePolicy gate, onboarding-specific error copy, composed-name resolution, and legacy displayName preservation</code>
- <code>New `-only-testing:AscendAppTests/PostAuthNameOnboardingEvidenceTests` - hosts the real `PostAuthOnboardingFlowView(stage: .displayName)` in a UIWindow, types &#34;Maya&#34; then &#34;Chen&#34; through the actual UITextFields, and samples the CONTINUE button fill to prove it stays dead with zero or one field and goes live only with both</code>
- <code>New evidence test also renders `IdentityHeroSection` for a `UserDisplayNameData` document written by the new path (firstName/lastName) and for a legacy displayName-only document, OCR-asserting &#34;Maya Chen&#34;, &#34;Legacy Climber&#34;, and the absence of the &#34;You&#34; placeholder</code>
- <code>Existing `TiedRankRenderEvidenceTests` leaderboard renders re-checked for the pinned-row identity change (&#34;MAYA CHEN&#34; replacing &#34;YOU&#34;)</code>
- <code>Manual diff review confirming `PostAuthOnboardingStage.allCases` order and the gender screen copy are unchanged</code>
- <code>`xcodebuild ... -configuration Release -sdk iphoneos CODE_SIGNING_ALLOWED=NO build` - failed in the Firebase plist-copy build phase under Xcode&#39;s script sandbox, not in Swift compilation; not worked around, per the intent</code>
- <code>`git status --porcelain` - worktree clean apart from the intentional new test file; no Firebase plist created or linked</code>

🔧 Fix: no source fix needed; failures were uninstalled node deps
✅ Re-checked - no issues remain.
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp-Staging&#34; -configuration Staging -destination &#34;platform=iOS Simulator,name=iPhone 16 Pro&#34; ENABLE_TESTABILITY=YES test` with `TEST_RUNNER_ASCEND_EVIDENCE_DIR` set so render tests emit PNGs - 1,328 tests in 196 suites passed, none skipped</code>
- <code>`PostAuthNameOnboardingEvidenceTests.continueUnlocksOnlyAfterBothFieldsAreTyped()` - hosts the real `PostAuthOnboardingFlowView(stage: .displayName)` in a UIWindow, types into the two live UITextFields, and samples the CONTINUE button pixels across empty / first-name-only / both-names states</code>
- <code>`PostAuthNameOnboardingEvidenceTests.profileHeaderReadsTheComposedNameAndLeavesLegacyAlone()` - renders `IdentityHeroSection` for an onboarded account and a legacy account, OCR-asserting &#34;Maya Chen&#34;, &#34;Legacy Climber&#34;, and the absence of the &#34;You&#34; placeholder</code>
- <code>`PostAuthNameInputTests.nameOnboardingRendersSeparateFields()` - OCR of the hosted screen confirming &#34;What&#39;s your name?&#34;, &#34;First name&#34;, &#34;Last name&#34;</code>
- <code>`PostAuthNameInputTests.continueRequiresBothNameFields()`, `continueGatesOnTheSharedDisplayNamePolicy()`, `validationMessagesNeverNameTheDisplayNameField()`, `completedOnboardingResolvesStoredName()`, `legacyDisplayNameSurvivesUnmodified()`</code>
- <code>`TiedRankRenderEvidenceTests` leaderboard render evidence - pinned self-row rendering the resolved climber name on the per-climb and global boards</code>
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp&#34; -configuration Debug -destination &#34;platform=iOS Simulator,name=iPhone 16 Pro&#34; build` - BUILD SUCCEEDED</code>
- `Manual visual inspection of each generated PNG to confirm the rendered surface matches the intent (two fields, gated CONTINUE, composed name, untouched legacy name, leaderboard identity)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ⚠️ `AscendApp/Features/Authentication/AuthenticationViewModel.swift:530` - `AuthenticationViewModel.updateDisplayName(_:)` (AscendApp/Features/Authentication/AuthenticationViewModel.swift:530) lost its last caller when the onboarding name screen switched to `updateProfileName(firstName:lastName:)`; it is now the sole caller of `UserDataRepository.updateDisplayName(userId:email:displayName:)` (UserDataRepository.swift:364), so both are dead. CLAUDE.md&#39;s &#34;Delete before you defend&#34; says they should go, but removing code is outside a documentation/lint pass, so I left them.

🔧 Fix: drop dead updateDisplayName write path
1 info still open:
- ℹ️ `AscendAppTests/PostAuthNameOnboardingEvidenceTests.swift:34` - The two new render-evidence test files (PostAuthNameOnboardingEvidenceTests.swift:34 and PostAuthNameInputTests.swift:26) construct their test host with `UIWindow(frame:)`, which the compiler flags as deprecated in iOS 26.0 in favor of `init(windowScene:)`. This is not a defect introduced by this change so much as adoption of an existing repo-wide convention: 8 other pre-existing AscendAppTests files use the identical pattern, and the suggested replacement requires a live UIWindowScene that these headless unit tests do not have. Converting only these two files would fragment the convention, so migrating the render-evidence test host is a repo-wide change rather than something to fold into a lint pass. No action taken.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
