### PR TITLE
fix(account): let unentitled owners complete account deletion

### DIFF
--- a/.claude/skills/ascend-firebase-data/SKILL.md
+++ b/.claude/skills/ascend-firebase-data/SKILL.md
@@ -43,8 +43,14 @@ The paywall is enforced at the backend boundary: `firestore.rules` and `storage.
 `docs/revenuecat-server-entitlement-enforcement.md` owns that system - the webhook contract, the vendor setup, the choke-point list, and the deploy ordering that keeps a missing secret from locking subscribers out.
 What matters while editing rules:
 
-- Use `isPaidOwner(userId)` / `hasPaidAppAccess()` for anything that is the paid product: private workouts, routines and folders, the public projections derived from them, global leaderboards and replay indexes, and workout media in Storage.
+- Gate by operation, not by collection.
+  `isPaidOwner(userId)` / `hasPaidAppAccess()` guards create and update on the paid product, another climber's copy of a public projection, shared paid content like global leaderboards and replay indexes, and the object bytes of workout media in Storage.
+  The per-collection choke-point list lives in the doc named above; read it there rather than inferring it from a summary here.
 - Keep `isOwner(userId)` for deletes and for everything that has to work before purchase and after lapse - onboarding, auth, restore, account management, support and safety, identity publication, and account deletion.
+  That carve-out covers enumerating an owner's own data, not just deleting it.
+  Account deletion sweeps a collection by listing it and deleting what comes back, and Firestore evaluates a list rule against the query rather than against the stored documents, so a paid read gate refuses an unentitled owner's sweep even when the collection is empty.
+  Read on `users/{uid}/workouts`, `routines`, and `routine_folders` and `list` on the `users/{uid}` Storage media prefixes therefore match their owner-gated delete, while `profile_workouts` adds the owner to its paid read gate instead of replacing it.
+  Re-tightening any of those to `isPaidOwner` reintroduces a guideline 5.1.1(v) deletion blocker; `tests/firebase-rules/account-deletion-contract.test.mjs` is the suite that catches it.
   Paid enforcement must never trap a user's data or their exit.
 - `climb-images/` and the Hosting climb catalog deliberately stay open to any signed-in caller: the `firstClimb` onboarding stage runs before the paywall and renders that artwork.
 - `entitlements`, `entitlement_status`, and `entitlement_reconciliations` are `allow read, write: if false`.

--- a/AscendAppTests/AccountDeletionServiceTests.swift
+++ b/AscendAppTests/AccountDeletionServiceTests.swift
@@ -149,6 +149,33 @@ struct AccountDeletionServiceTests {
         #expect(gateway.steps == [.reauthenticate])
     }
 
+    @Test("Storage failure stops deletion before Firestore or Auth cleanup")
+    func storageFailureLeavesTheAccountAuthenticatedAndRetryable() async throws {
+        let gateway = RecordingAccountDeletionGateway()
+        gateway.storageDeletionError = StoragePermissionTestError()
+        let cleanup = RecordingLocalCleanup()
+        let service = AccountDeletionService(gateway: gateway, localCleanup: cleanup)
+        let modelContext = try makeModelContext()
+        modelContext.insert(Routine(name: "Local Routine"))
+        try modelContext.save()
+
+        do {
+            try await service.deleteAccount(modelContext: modelContext)
+            Issue.record("Expected the Storage permission failure to stop account deletion.")
+        } catch let error as AccountDeletionService.DeletionError {
+            #expect(
+                error.errorDescription ==
+                    "Failed to delete stored files: User does not have permission to access stored files."
+            )
+        } catch {
+            Issue.record("Expected DeletionError, received \(error).")
+        }
+
+        #expect(gateway.steps == [.reauthenticate, .deleteAllUserStorage])
+        #expect(cleanup.steps == [.suspendAuthenticatedWork, .resumeAuthenticatedWork])
+        #expect(try modelContext.fetchCount(FetchDescriptor<Routine>()) == 1)
+    }
+
     @Test
     func keepsLocalDataWhenTheAuthDeletionFails() async throws {
         let gateway = RecordingAccountDeletionGateway()
@@ -463,6 +490,12 @@ private enum TestError: Error {
     case remoteFailure
 }
 
+private struct StoragePermissionTestError: LocalizedError {
+    var errorDescription: String? {
+        "User does not have permission to access stored files."
+    }
+}
+
 /// Keeps the tests off the test host's UserDefaults, documents directory, and
 /// shared image cache.
 @MainActor
@@ -554,6 +587,7 @@ private final class RecordingAccountDeletionGateway: AccountDeletionGateway {
     var reauthenticationResult: Result<ReauthenticationResult, Error> =
         .success(ReauthenticationResult(appleAuthorizationCode: nil))
     var revocationError: Error?
+    var storageDeletionError: Error?
     var authDeletionError: Error?
     var cancelTaskAfterAuthDeletion = false
 
@@ -564,6 +598,9 @@ private final class RecordingAccountDeletionGateway: AccountDeletionGateway {
 
     func deleteAllUserStorage(userId: String) async throws {
         steps.append(.deleteAllUserStorage)
+        if let storageDeletionError {
+            throw storageDeletionError
+        }
     }
 
     func deleteWorkoutBackups(userId: String) async throws {

--- a/docs/production-backend-rollout-runbook.md
+++ b/docs/production-backend-rollout-runbook.md
@@ -255,7 +255,8 @@ npx -y firebase-tools@15.22.1 deploy --project production \
 
 Verify the command reports a successful rules release.
 Then use the production-signed smoke account to read and write its allowed private documents and confirm an unauthenticated client cannot read them.
-The smoke account needs a reconciled `users/{uid}/entitlements/app_access` grant for that check: private workouts, routines, and `profile_stats` are paid boundaries, so a signed-in account without a grant is denied by design.
+The smoke account needs a reconciled `users/{uid}/entitlements/app_access` grant for that check: writing private workouts and routines, and reading or writing `profile_stats`, are paid boundaries, so a signed-in account without a grant is denied by design.
+Reading, enumerating, and deleting an owner's own workouts and routines deliberately are not, which is what keeps account deletion working after a lapse; `docs/revenuecat-server-entitlement-enforcement.md` owns the per-operation gate list.
 Also confirm the current `profile_stats` write succeeds before uploading the binary.
 
 Rollback: redeploy only `firestore:rules` from the last known good production SHA.
@@ -270,7 +271,7 @@ npx -y firebase-tools@15.22.1 deploy --project production \
 
 Verify the command reports a successful rules release.
 Using the production-signed smoke account, upload and delete one file beneath that account's `users/{uid}/...` prefix and confirm a second account cannot read or write it.
-Workout media and heart-rate sidecars authorize through a cross-service Firestore read of the same paid grant, so this check fails closed if that IAM role is missing or the smoke account has no grant; owner deletes stay available either way.
+Workout media and heart-rate sidecars authorize their object reads and uploads through a cross-service Firestore read of the same paid grant, so this check fails closed if that IAM role is missing or the smoke account has no grant; listing and deleting an owner's own prefixes stays available either way.
 
 Rollback: redeploy only `storage` from the last known good production SHA.
 

--- a/docs/revenuecat-server-entitlement-enforcement.md
+++ b/docs/revenuecat-server-entitlement-enforcement.md
@@ -208,22 +208,27 @@ The paid check belongs where a modified client reaches durable paid data, paid s
 
 Firestore requires an active grant for:
 
-- Private workouts, user routines, and routine folders on read, create, and update.
+- Private workouts, user routines, and routine folders on create and update.
 - Live Climb publish status and completed-landmark projections.
-- Profile statistics, public workout summaries, and achievements.
+- Profile statistics, achievements, and another climber's public workout summaries.
 - Global leaderboards, published routine templates, Live Replay indexes, and global Live Climb community statistics.
 - The remote share-card template manifest.
 
 Storage requires an active grant for:
 
-- Workout photos, videos, and heart-rate sidecars on read, list, create, and update.
+- Workout photos, videos, and heart-rate sidecars on object read, create, and update.
 - Share-card template assets and Live Replay avatars.
 
 `climb-images/` deliberately stays readable to any signed-in caller.
 The `firstClimb` onboarding stage is the last stage before the paywall and shows the recommended landmark's artwork, so gating that prefix would break the conversion path itself.
 Like the Hosting climb catalog, it is immutable product content with no user data, mutable state, or compute authority.
 
-Owner deletes stay available after lapse so paid enforcement never traps user data.
+Owner deletes stay available after lapse so paid enforcement never traps user data, and so does the enumeration that finds what to delete.
+Account deletion sweeps a collection by listing it and deleting what comes back, and Firestore evaluates a list rule against the query rather than against the stored documents, so a paid read gate refuses an unentitled owner's sweep even when the collection is empty and turns guideline 5.1.1(v) deletion into a permission error the moment a subscription lapses.
+Read on the owner-private collections that sweep enumerates - `users/{uid}/workouts`, `routines`, and `routine_folders` - therefore matches their owner-gated delete, and `list` on the `users/{uid}` Storage media prefixes does the same.
+Splitting `get` from `list` would buy nothing on the Firestore side, because a list returns full document bodies; Storage objects are separable, so their bytes stay paid while enumeration does not.
+`profile_workouts` is the one swept collection any entitled climber may read, so the owner is added to its paid gate rather than replacing it and every other climber still needs an active grant.
+Create and update stay paid throughout, so a lapsed account can enumerate and remove what it already has without being able to add more.
 Account documents, authentication routing, public identity publication, profile-picture management, lifecycle state, communication preferences, notification devices, blocks, reports, feedback, and rate-limit records stay ungated because onboarding, restore, account management, support, and safety must work before purchase and after lapse.
 Public profile identity is moderated public identity rather than paid fitness data.
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1310,8 +1310,18 @@ service cloud.firestore {
         allow read, write: if false;
       }
 
+      // Read is owner-gated, not paid-gated, on every owner-private collection
+      // the account-deletion sweep enumerates (workouts, routines,
+      // routine_folders, profile_workouts). Deleting an account means listing
+      // each collection and deleting what comes back, and Firestore evaluates a
+      // list rule against the query rather than the stored documents - so a
+      // paid gate here refuses an unentitled owner's sweep even when the
+      // collection is empty, and guideline 5.1.1(v) deletion becomes impossible
+      // the moment a subscription lapses. Read therefore matches the delete
+      // gate exactly. Splitting `get` from `list` would buy nothing: a list
+      // returns full document bodies. Create and update stay paid.
       match /workouts/{workoutId} {
-        allow read: if isPaidOwner(userId);
+        allow read: if isOwner(userId);
         allow create: if isPaidOwner(userId) &&
           isValidWorkoutDocument(userId, workoutId);
         // The stored schema version may only move forward. Equality would make
@@ -1333,7 +1343,7 @@ service cloud.firestore {
       // away from the top-level `routine_templates`, which is server-owned
       // published content and must stay read-only to every client.
       match /routines/{routineId} {
-        allow read: if isPaidOwner(userId);
+        allow read: if isOwner(userId);
         allow create: if isPaidOwner(userId) &&
           isValidUserRoutineDocument(userId, routineId);
         // Same forward-only schema version rule as workouts, and for the same
@@ -1349,7 +1359,7 @@ service cloud.firestore {
       }
 
       match /routine_folders/{folderId} {
-        allow read: if isPaidOwner(userId);
+        allow read: if isOwner(userId);
         allow create: if isPaidOwner(userId) &&
           isValidRoutineFolderDocument(userId, folderId);
         allow update: if isPaidOwner(userId) &&
@@ -1396,8 +1406,11 @@ service cloud.firestore {
         allow delete: if isOwner(userId) && docId == "current";
       }
 
+      // Unlike the collections above this one is cross-account readable, so the
+      // paid gate stays for everyone else and the owner is added to it rather
+      // than replacing it.
       match /profile_workouts/{workoutId} {
-        allow read: if hasPaidAppAccess();
+        allow read: if isOwner(userId) || hasPaidAppAccess();
         allow create, update: if isPaidOwner(userId) &&
           isCanonicalWorkoutId(workoutId) &&
           isValidProfileWorkoutSummary();

--- a/storage.rules
+++ b/storage.rules
@@ -53,10 +53,12 @@ service firebase.storage {
         );
     }
 
+    // Owners must be able to enumerate their files for account deletion even
+    // after paid access lapses. Object reads and uploads remain paid features.
     // User workout photos.
     match /users/{userId}/photos/{fileName} {
       allow get: if isPaidOwner(userId) && validFileName(fileName);
-      allow list: if isPaidOwner(userId);
+      allow list: if isOwner(userId);
       allow create, update: if isPaidOwner(userId) &&
         validFileName(fileName) &&
         isImageUpload(15 * 1024 * 1024);
@@ -66,7 +68,7 @@ service firebase.storage {
     // User workout videos.
     match /users/{userId}/videos/{fileName} {
       allow get: if isPaidOwner(userId) && validFileName(fileName);
-      allow list: if isPaidOwner(userId);
+      allow list: if isOwner(userId);
       allow create, update: if isPaidOwner(userId) &&
         validFileName(fileName) &&
         isVideoUpload(200 * 1024 * 1024);
@@ -76,7 +78,7 @@ service firebase.storage {
     // User workout heart-rate sidecars.
     match /users/{userId}/workout_heart_rate/{fileName} {
       allow get: if isPaidOwner(userId) && validWorkoutHeartRateFileName(fileName);
-      allow list: if isPaidOwner(userId);
+      allow list: if isOwner(userId);
       allow create, update: if isPaidOwner(userId) &&
         validWorkoutHeartRateFileName(fileName) &&
         isCompressedHeartRateUpload(5 * 1024 * 1024);

--- a/tests/firebase-rules/account-deletion-contract.test.mjs
+++ b/tests/firebase-rules/account-deletion-contract.test.mjs
@@ -1,0 +1,354 @@
+import { readFileSync } from 'node:fs';
+import { after, before, beforeEach, test } from 'node:test';
+
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+} from '@firebase/rules-unit-testing';
+import { collection, deleteDoc, doc, getDocs, setDoc } from 'firebase/firestore';
+import { seedActiveAppAccess } from './paid-access-fixture.mjs';
+
+// Test files run concurrently against one emulator and `clearFirestore()` wipes a
+// whole project, so this suite owns its own project id.
+const projectId = 'demo-ascendapp-rules-account-deletion';
+const firestoreRules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+
+const entitledOwnerId = 'entitled-owner-123';
+const unentitledOwnerId = 'unentitled-owner-456';
+const emptyUnentitledOwnerId = 'empty-unentitled-owner-789';
+const entitledIntruderId = 'entitled-intruder-012';
+const unentitledIntruderId = 'unentitled-intruder-345';
+const blockedClimberId = 'blocked-climber-678';
+
+const workoutId = '550E8400-E29B-41D4-A716-446655440000';
+const secondWorkoutId = '660E8400-E29B-41D4-A716-446655440000';
+const routineId = '770E8400-E29B-41D4-A716-446655440000';
+const secondRoutineId = '880E8400-E29B-41D4-A716-446655440000';
+const folderId = '990E8400-E29B-41D4-A716-446655440000';
+const secondFolderId = 'AA0E8400-E29B-41D4-A716-446655440000';
+const intervalId = '11111111-1111-1111-1111-111111111111';
+
+/**
+ * Every collection `FirebaseAccountDeletionGateway` enumerates with
+ * `getDocuments()` before batch-deleting what comes back.
+ *
+ * Firestore evaluates a list rule against the *query*, not against the stored
+ * documents, so a paid read gate on any of these refuses an unentitled owner's
+ * sweep even when the collection is empty - and guideline 5.1.1(v) deletion
+ * becomes impossible the moment a subscription lapses.
+ */
+const sweptCollections = [
+  {
+    name: 'workouts',
+    documentId: workoutId,
+    secondDocumentId: secondWorkoutId,
+    makeDocument: makeWorkoutDocument,
+    paidWrites: true,
+    crossAccountReadable: false,
+  },
+  {
+    name: 'routines',
+    documentId: routineId,
+    secondDocumentId: secondRoutineId,
+    makeDocument: makeRoutineDocument,
+    paidWrites: true,
+    crossAccountReadable: false,
+  },
+  {
+    name: 'routine_folders',
+    documentId: folderId,
+    secondDocumentId: secondFolderId,
+    makeDocument: makeFolderDocument,
+    paidWrites: true,
+    crossAccountReadable: false,
+  },
+  {
+    name: 'blocked',
+    documentId: blockedClimberId,
+    makeDocument: makeBlockedClimberDocument,
+    paidWrites: false,
+    crossAccountReadable: false,
+  },
+  {
+    // The one public projection the sweep enumerates: any entitled climber may
+    // read another's, so the owner is added to that gate rather than replacing it.
+    name: 'profile_workouts',
+    documentId: workoutId,
+    secondDocumentId: secondWorkoutId,
+    makeDocument: makeProfileWorkoutSummary,
+    paidWrites: true,
+    crossAccountReadable: true,
+  },
+];
+
+/** Single documents the sweep deletes by path, without listing first. */
+const sweptDocuments = [
+  { path: (ownerId) => `users/${ownerId}/public_profile/current`, makeDocument: makePublicProfileDocument },
+  { path: (ownerId) => `users/${ownerId}/profile_stats/current`, makeDocument: makeProfileStatsDocument },
+  { path: (ownerId) => `users/${ownerId}`, makeDocument: makeUserDocument },
+];
+
+let testEnv;
+
+before(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId,
+    firestore: {
+      rules: firestoreRules,
+      host: '127.0.0.1',
+      port: 8080,
+    },
+  });
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+  await testEnv.withSecurityRulesDisabled(async (adminContext) => {
+    await seedActiveAppAccess(adminContext, [entitledOwnerId, entitledIntruderId]);
+
+    for (const ownerId of [entitledOwnerId, unentitledOwnerId]) {
+      await seedDeletableAccount(adminContext, ownerId);
+    }
+  });
+});
+
+after(async () => {
+  await testEnv.cleanup();
+});
+
+test('an entitled owner can enumerate and delete everything the sweep touches', async () => {
+  await assertAccountSweepSucceeds(entitledOwnerId);
+});
+
+// The launch blocker: a lapsed subscriber tapping Delete Account. The sweep is
+// ordered Storage, then these collections, then Auth, so a refusal here strands
+// the climber with their media already gone and an account they cannot delete.
+test('an unentitled owner can enumerate and delete everything the sweep touches', async () => {
+  await assertAccountSweepSucceeds(unentitledOwnerId);
+});
+
+test('an unentitled owner can enumerate the swept collections with nothing stored', async () => {
+  const context = testEnv.authenticatedContext(emptyUnentitledOwnerId);
+
+  for (const swept of sweptCollections) {
+    await assertSucceeds(getDocs(collection(
+      context.firestore(),
+      `users/${emptyUnentitledOwnerId}/${swept.name}`
+    )));
+  }
+});
+
+test('enumerating for deletion does not unlock paid creates or updates', async () => {
+  const entitled = testEnv.authenticatedContext(entitledOwnerId);
+  const unentitled = testEnv.authenticatedContext(unentitledOwnerId);
+
+  for (const swept of sweptCollections.filter(({ paidWrites }) => paidWrites)) {
+    // A fresh id is a create; the seeded id is an update. The entitled write
+    // proves the payload is valid, so the unentitled refusal can only be the gate.
+    const createPath = (ownerId) => `users/${ownerId}/${swept.name}/${swept.secondDocumentId}`;
+    const updatePath = (ownerId) => `users/${ownerId}/${swept.name}/${swept.documentId}`;
+
+    for (const path of [createPath, updatePath]) {
+      await assertSucceeds(setDoc(
+        doc(entitled.firestore(), path(entitledOwnerId)),
+        swept.makeDocument(entitledOwnerId)
+      ));
+      await assertFails(setDoc(
+        doc(unentitled.firestore(), path(unentitledOwnerId)),
+        swept.makeDocument(unentitledOwnerId)
+      ));
+    }
+  }
+});
+
+test('another climber cannot enumerate or delete an account they do not own', async () => {
+  const context = testEnv.authenticatedContext(entitledIntruderId);
+
+  for (const swept of sweptCollections) {
+    const collectionRef = collection(
+      context.firestore(),
+      `users/${unentitledOwnerId}/${swept.name}`
+    );
+    const documentRef = doc(collectionRef, swept.documentId);
+
+    if (swept.crossAccountReadable) {
+      await assertSucceeds(getDocs(collectionRef));
+    } else {
+      await assertFails(getDocs(collectionRef));
+    }
+
+    await assertFails(deleteDoc(documentRef));
+  }
+
+  for (const swept of sweptDocuments) {
+    await assertFails(deleteDoc(doc(context.firestore(), swept.path(unentitledOwnerId))));
+  }
+});
+
+// The owner clause added to profile_workouts must not become a second way in for
+// everyone else: an unentitled non-owner stays on the paid side of that gate.
+test('an unentitled climber cannot read another climber public workout mirror', async () => {
+  const context = testEnv.authenticatedContext(unentitledIntruderId);
+
+  await assertFails(getDocs(collection(
+    context.firestore(),
+    `users/${entitledOwnerId}/profile_workouts`
+  )));
+});
+
+test('a signed-out client cannot enumerate or delete anything the sweep touches', async () => {
+  const context = testEnv.unauthenticatedContext();
+
+  for (const swept of sweptCollections) {
+    const collectionRef = collection(
+      context.firestore(),
+      `users/${unentitledOwnerId}/${swept.name}`
+    );
+
+    await assertFails(getDocs(collectionRef));
+    await assertFails(deleteDoc(doc(collectionRef, swept.documentId)));
+  }
+
+  for (const swept of sweptDocuments) {
+    await assertFails(deleteDoc(doc(context.firestore(), swept.path(unentitledOwnerId))));
+  }
+});
+
+/** Walks the gateway's sweep in order: list each collection, delete what came back. */
+async function assertAccountSweepSucceeds(ownerId) {
+  const context = testEnv.authenticatedContext(ownerId);
+
+  for (const swept of sweptCollections) {
+    const collectionRef = collection(context.firestore(), `users/${ownerId}/${swept.name}`);
+    const snapshot = await assertSucceeds(getDocs(collectionRef));
+
+    for (const document of snapshot.docs) {
+      await assertSucceeds(deleteDoc(document.ref));
+    }
+  }
+
+  for (const swept of sweptDocuments) {
+    await assertSucceeds(deleteDoc(doc(context.firestore(), swept.path(ownerId))));
+  }
+}
+
+async function seedDeletableAccount(adminContext, ownerId) {
+  for (const swept of sweptCollections) {
+    await setDoc(
+      doc(adminContext.firestore(), `users/${ownerId}/${swept.name}/${swept.documentId}`),
+      swept.makeDocument(ownerId)
+    );
+  }
+
+  for (const swept of sweptDocuments) {
+    await setDoc(
+      doc(adminContext.firestore(), swept.path(ownerId)),
+      swept.makeDocument(ownerId)
+    );
+  }
+}
+
+function makeWorkoutDocument(ownerId) {
+  return {
+    userId: ownerId,
+    schemaVersion: 1,
+    name: 'Morning Stair Session',
+    startedAt: new Date('2026-04-10T06:30:00.000Z'),
+    durationSeconds: 1800,
+    steps: 1200,
+    floors: 75,
+    stepsPerFloor: 16,
+    notes: 'Felt strong',
+    source: 'apple_health',
+    integrityLevel: 'verified',
+    createdAt: new Date('2026-04-10T06:00:00.000Z'),
+    updatedAt: new Date('2026-04-10T07:00:00.000Z'),
+  };
+}
+
+function makeRoutineDocument(ownerId) {
+  return {
+    userId: ownerId,
+    schemaVersion: 1,
+    name: 'Tuesday Pyramid',
+    description: 'Build to level 14, then unwind.',
+    source: 'userCreated',
+    intervals: [{
+      id: intervalId,
+      durationSeconds: 120,
+      intensityType: 'level',
+      intensityValue: 12,
+      order: 0,
+      skipStep: false,
+      backwardStep: false,
+      holdingBars: false,
+    }],
+    isArchived: false,
+    order: 0,
+    completionCount: 3,
+    lastCompletedAt: new Date('2026-04-10T06:30:00.000Z'),
+    createdAt: new Date('2026-04-01T06:00:00.000Z'),
+    updatedAt: new Date('2026-04-10T06:45:00.000Z'),
+  };
+}
+
+function makeFolderDocument(ownerId) {
+  return {
+    userId: ownerId,
+    schemaVersion: 1,
+    name: 'Race prep',
+    order: 0,
+    createdAt: new Date('2026-04-01T06:00:00.000Z'),
+    updatedAt: new Date('2026-04-10T06:45:00.000Z'),
+  };
+}
+
+function makeBlockedClimberDocument() {
+  return {
+    blockedUid: blockedClimberId,
+    createdAt: new Date('2026-04-10T07:00:00.000Z'),
+  };
+}
+
+function makeProfileWorkoutSummary() {
+  return {
+    name: 'Morning Stair Session',
+    startedAt: new Date('2026-04-10T06:30:00.000Z'),
+    durationSeconds: 1800,
+    steps: 1200,
+    source: 'apple_health',
+    lastUpdated: new Date('2026-04-10T07:00:00.000Z'),
+  };
+}
+
+function makePublicProfileDocument(ownerId) {
+  return {
+    userId: ownerId,
+    displayName: 'Climber',
+    photoURL: '',
+    identityPolicyVersion: 1,
+    identityChangedAt: new Date('2026-04-09T12:00:00.000Z'),
+    lastUpdated: new Date('2026-05-18T12:00:00.000Z'),
+  };
+}
+
+function makeProfileStatsDocument(ownerId) {
+  return {
+    userId: ownerId,
+    schemaVersion: 1,
+    totalClimbs: 4,
+    lastUpdated: new Date('2026-05-18T12:00:00.000Z'),
+  };
+}
+
+function makeUserDocument() {
+  return {
+    email: 'climber@example.com',
+    firstName: '',
+    lastName: '',
+    displayName: 'Climber',
+    createdAt: new Date('2026-05-18T12:00:00.000Z'),
+    lastUpdated: new Date('2026-05-18T12:00:00.000Z'),
+  };
+}

--- a/tests/firebase-rules/account-deletion-contract.test.mjs
+++ b/tests/firebase-rules/account-deletion-contract.test.mjs
@@ -9,10 +9,12 @@ import {
 import { collection, deleteDoc, doc, getDocs, setDoc } from 'firebase/firestore';
 import { seedActiveAppAccess } from './paid-access-fixture.mjs';
 
-// `clearFirestore()` wipes a whole project, and this suite deletes the accounts it
-// seeds, so it owns a project id no other suite reads. Files run serially today
-// (`--test-concurrency=1` in package.json); the isolation is what keeps that a
-// scheduling detail rather than a correctness dependency.
+// `clearFirestore()` wipes a whole project and this suite deletes the accounts it
+// seeds, so it owns a Firestore project id no other suite reads. That is data
+// isolation only - it buys no concurrency. The whole rules suite still has to run
+// one file at a time under `--test-concurrency=1`, because the Storage emulator
+// holds a single global ruleset; see `ascend-firebase-data` for why a parallel run
+// turns `assertFails` green for the wrong reason.
 const projectId = 'demo-ascendapp-rules-account-deletion';
 const firestoreRules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 

--- a/tests/firebase-rules/account-deletion-contract.test.mjs
+++ b/tests/firebase-rules/account-deletion-contract.test.mjs
@@ -9,8 +9,10 @@ import {
 import { collection, deleteDoc, doc, getDocs, setDoc } from 'firebase/firestore';
 import { seedActiveAppAccess } from './paid-access-fixture.mjs';
 
-// Test files run concurrently against one emulator and `clearFirestore()` wipes a
-// whole project, so this suite owns its own project id.
+// `clearFirestore()` wipes a whole project, and this suite deletes the accounts it
+// seeds, so it owns a project id no other suite reads. Files run serially today
+// (`--test-concurrency=1` in package.json); the isolation is what keeps that a
+// scheduling detail rather than a correctness dependency.
 const projectId = 'demo-ascendapp-rules-account-deletion';
 const firestoreRules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 

--- a/tests/firebase-rules/workout-media-storage-contract.test.mjs
+++ b/tests/firebase-rules/workout-media-storage-contract.test.mjs
@@ -22,16 +22,54 @@ const storageRules = readFileSync(new URL('../../storage.rules', import.meta.url
 
 const ownerId = 'owner-123';
 const intruderId = 'intruder-456';
+const unentitledOwnerId = 'unentitled-owner-789';
+const emptyUnentitledOwnerId = 'empty-unentitled-owner-012';
 
 // A one-pixel JPEG is enough: the rules only inspect size and content type.
 const jpegBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00, 0xff, 0xd9]);
 const mp4Bytes = new Uint8Array([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]);
+const gzipBytes = new Uint8Array([0x1f, 0x8b, 0x08, 0x00]);
 
 const legacyPhotoPath = 'photos/2B3C4D5E-6F70-4812-9345-A6B7C8D9E0F1.jpg';
 const legacyVideoPath = 'videos/3C4D5E6F-7081-4923-A456-B7C8D9E0F1A2.mov';
 
 const ownedPhotoPath = `users/${ownerId}/photos/5E6F7081-92A3-4B45-C678-D9E0F1A2B3C4.jpg`;
 const ownedVideoPath = `users/${ownerId}/videos/6F708192-A3B4-4C56-D789-E0F1A2B3C4D5.mov`;
+
+const accountDeletionMedia = [
+  {
+    prefix: 'photos',
+    fileName: '7A8192B3-C4D5-4E67-F890-A1B2C3D4E5F6.jpg',
+    bytes: jpegBytes,
+    contentType: 'image/jpeg',
+    paidContent: true,
+  },
+  {
+    prefix: 'videos',
+    fileName: '8B92A3C4-D5E6-4F78-A901-B2C3D4E5F6A7.mov',
+    bytes: mp4Bytes,
+    contentType: 'video/quicktime',
+    paidContent: true,
+  },
+  {
+    prefix: 'profile_pictures',
+    fileName: '9CA3B4D5-E6F7-4089-B012-C3D4E5F6A7B8.jpg',
+    bytes: jpegBytes,
+    contentType: 'image/jpeg',
+    paidContent: false,
+  },
+  {
+    prefix: 'workout_heart_rate',
+    fileName: 'ad4c5e6f-7081-4923-a456-b7c8d9e0f1a2.json.gz',
+    bytes: gzipBytes,
+    contentType: 'application/gzip',
+    paidContent: true,
+  },
+];
+
+function mediaPath(userId, media) {
+  return `users/${userId}/${media.prefix}/${media.fileName}`;
+}
 
 let testEnv;
 
@@ -61,6 +99,15 @@ beforeEach(async () => {
     await uploadBytes(ref(storage, legacyVideoPath), mp4Bytes, { contentType: 'video/quicktime' });
     await uploadBytes(ref(storage, ownedPhotoPath), jpegBytes, { contentType: 'image/jpeg' });
     await uploadBytes(ref(storage, ownedVideoPath), mp4Bytes, { contentType: 'video/quicktime' });
+
+    for (const media of accountDeletionMedia) {
+      await uploadBytes(ref(storage, mediaPath(ownerId, media)), media.bytes, {
+        contentType: media.contentType,
+      });
+      await uploadBytes(ref(storage, mediaPath(unentitledOwnerId, media)), media.bytes, {
+        contentType: media.contentType,
+      });
+    }
   });
 });
 
@@ -159,6 +206,45 @@ test('an owner can read, list, upload, and delete their own workout media', asyn
   await assertSucceeds(deleteObject(ref(storage, ownedVideoPath)));
 });
 
+test('an entitled owner can list and delete every account-deletion Storage prefix', async () => {
+  const storage = testEnv.authenticatedContext(ownerId).storage();
+
+  for (const media of accountDeletionMedia) {
+    await assertSucceeds(listAll(ref(storage, `users/${ownerId}/${media.prefix}`)));
+    await assertSucceeds(deleteObject(ref(storage, mediaPath(ownerId, media))));
+  }
+});
+
+for (const media of accountDeletionMedia) {
+  test(`an unentitled owner can list and delete ${media.prefix} during account deletion`, async () => {
+    const storage = testEnv.authenticatedContext(unentitledOwnerId).storage();
+
+    await assertSucceeds(listAll(ref(storage, `users/${unentitledOwnerId}/${media.prefix}`)));
+    await assertSucceeds(deleteObject(ref(storage, mediaPath(unentitledOwnerId, media))));
+  });
+}
+
+test('an unentitled owner can list every account-deletion prefix when no files exist', async () => {
+  const storage = testEnv.authenticatedContext(emptyUnentitledOwnerId).storage();
+
+  for (const media of accountDeletionMedia) {
+    await assertSucceeds(listAll(ref(storage, `users/${emptyUnentitledOwnerId}/${media.prefix}`)));
+  }
+});
+
+test('listing for account deletion does not unlock paid media reads or uploads', async () => {
+  const storage = testEnv.authenticatedContext(unentitledOwnerId).storage();
+
+  for (const media of accountDeletionMedia.filter(({ paidContent }) => paidContent)) {
+    await assertFails(getBytes(ref(storage, mediaPath(unentitledOwnerId, media))));
+    await assertFails(
+      uploadBytes(ref(storage, mediaPath(unentitledOwnerId, media)), media.bytes, {
+        contentType: media.contentType,
+      })
+    );
+  }
+});
+
 test('another climber cannot read, list, or delete owner-scoped workout media', async () => {
   const storage = testEnv.authenticatedContext(intruderId).storage();
 
@@ -168,4 +254,10 @@ test('another climber cannot read, list, or delete owner-scoped workout media', 
   await assertFails(listAll(ref(storage, `users/${ownerId}/videos`)));
   await assertFails(deleteObject(ref(storage, ownedPhotoPath)));
   await assertFails(deleteObject(ref(storage, ownedVideoPath)));
+
+  for (const media of accountDeletionMedia) {
+    await assertFails(getBytes(ref(storage, mediaPath(unentitledOwnerId, media))));
+    await assertFails(listAll(ref(storage, `users/${unentitledOwnerId}/${media.prefix}`)));
+    await assertFails(deleteObject(ref(storage, mediaPath(unentitledOwnerId, media))));
+  }
 });

--- a/tests/firebase-rules/workout-media-storage-contract.test.mjs
+++ b/tests/firebase-rules/workout-media-storage-contract.test.mjs
@@ -261,3 +261,19 @@ test('another climber cannot read, list, or delete owner-scoped workout media', 
     await assertFails(deleteObject(ref(storage, mediaPath(unentitledOwnerId, media))));
   }
 });
+
+// Relaxing `list` to isOwner is only safe while isOwner still implies signed in.
+// Nothing else drives an anonymous caller at the owner-scoped prefixes, so a
+// predicate that dropped the isSignedIn() conjunct would pass every other test.
+for (const media of accountDeletionMedia) {
+  test(`an unauthenticated visitor cannot list or delete owner-scoped ${media.prefix}`, async () => {
+    const storage = testEnv.unauthenticatedContext().storage();
+
+    await assertFails(getBytes(ref(storage, mediaPath(ownerId, media))));
+    await assertFails(listAll(ref(storage, `users/${ownerId}/${media.prefix}`)));
+    await assertFails(deleteObject(ref(storage, mediaPath(ownerId, media))));
+
+    await assertFails(listAll(ref(storage, `users/${unentitledOwnerId}/${media.prefix}`)));
+    await assertFails(deleteObject(ref(storage, mediaPath(unentitledOwnerId, media))));
+  });
+}


### PR DESCRIPTION
## Intent

Fix the launch blocker where in-app account deletion fails for a signed-in account owner without the RevenueCat app_access entitlement because Firebase Storage list operations are paid-gated. Account deletion must work for entitled and unentitled owners, with or without stored files, across users/{uid}/photos, videos, profile_pictures, and workout_heart_rate. Preserve owner scoping so unauthenticated callers and non-owners cannot list or delete another account files, and keep paid media reads and uploads entitlement-gated. Storage permission failures must remain visible to the user and must stop before Firestore or Auth cleanup so the account remains authenticated and retryable. Reproduce and cover the regression with Firebase emulator rules tests plus the existing account-deletion service test level. Do not move deletion to a Cloud Function, do not mutate or deploy production, target the PR to develop, and state in the PR that production Storage rules must be deployed before real users receive the fix.

## What Changed

- Gate the deletion sweep by operation instead of by collection: Storage `list` on `users/{uid}/photos`, `videos`, and `workout_heart_rate` and Firestore read on `users/{uid}/workouts`, `routines`, and `routine_folders` now use `isOwner(userId)` so they match their owner-gated delete, while `profile_workouts` adds the owner to its paid read gate rather than replacing it. Object reads, uploads, creates, and updates stay entitlement-gated, and owner scoping is unchanged, so non-owners and unauthenticated callers still cannot enumerate or delete another account's data. This was a full sweep failure, not just the Storage step: enumeration is how deletion finds what to delete, and Firestore evaluates a list rule against the query rather than the stored documents, so a paid read gate refused an unentitled owner even with an empty collection.
- Add `tests/firebase-rules/account-deletion-contract.test.mjs` and extend `workout-media-storage-contract.test.mjs` with emulator coverage for the entitled owner, the unentitled owner, the empty-prefix case, non-owners, and unauthenticated callers, plus the paid-gate negatives that must stay denied. `AccountDeletionServiceTests` gains a case asserting a Storage permission failure surfaces its error and halts after `deleteAllUserStorage`, before any Firestore or Auth cleanup, leaving the account authenticated and the deletion retryable.
- Correct the three now-stale paid-boundary claims in `docs/revenuecat-server-entitlement-enforcement.md`, the matching bullets in the `ascend-firebase-data` skill, and the Firestore/Storage smoke-check steps in `docs/production-backend-rollout-runbook.md`, so the choke-point reference an engineer reads before the next rules change does not lead them to re-tighten these gates.

The fix lives entirely in security rules; the shipped client binary is unchanged. **Production Storage rules must be deployed before real users receive this fix**, and `firestore.rules` and `storage.rules` are not independently sufficient. Deploying only Storage lets the sweep destroy media and revoke the Apple grant before Firestore refuses it, which is worse than the current failure. The documented deploy order puts `firestore:rules,storage,hosting` in one step, so the normal CI path is correct; this only matters for a hand-deployed subset. Nothing was deployed and no production project was touched.

## Risk Assessment

✅ Low: The change is complete and internally consistent - owner-scoped reads and lists across every collection and prefix the deletion sweep touches, paid creates/updates and cross-account gates preserved, emulator coverage for entitled, unentitled, empty-account, non-owner and unauthenticated callers, and every guidance file (the entitlement doc, the Firebase data skill, the test header) now matches the shipped rules.

## Testing

I reproduced the launch blocker before fixing evidence: replaying the account-deletion gateway's real sweep order against the Firebase emulator for a signed-in owner without the `app_access` entitlement, the base-commit rules refuse the very first `listAll(users/{uid}/photos)` with PERMISSION_DENIED, deletion stops before any Firestore or Auth cleanup, and the climber sees "Failed to delete stored files: ..." with the account still authenticated and retryable; under this branch's rules the same climber lists and deletes all four Storage prefixes, sweeps every Firestore collection and the user document, and reaches Auth deletion with no error. The full emulator rules suite passes (137 tests), including the new contract files that cover entitled and unentitled owners, empty prefixes, and the negatives that must stay closed - non-owners, unauthenticated callers, paid object reads and uploads, paid creates and updates, and an unentitled non-owner reading another climber's `profile_workouts`. `AccountDeletionServiceTests` passes on both Staging and Debug configurations, including the new test asserting a Storage failure halts at the storage step and leaves local data intact. No screenshot of the in-app Delete Account alert: that surface needs a real signed-in account against a live Firebase project with a lapsed entitlement, which would mean mutating a real environment, so the CLI transcript of the actual sweep and its user-facing error string is the closest end-user-level artifact. One setup fix was needed - the Staging Firebase plist is absent from this worktree and the build script's symlink is denied by user-script sandboxing, so the Staging test run used `ENABLE_USER_SCRIPT_SANDBOXING=NO`; the symlinks and the emulator debug log were removed afterward and the worktree is clean.

<details>
<summary>Evidence: Account-deletion sweep transcript: unentitled owner, before vs after</summary>

<code>=== BEFORE (rules at base commit c162a56) ===&#10;Signed-in owner lapsed-subscriber-001 taps &#34;Delete Account&#34; (no app_access entitlement)&#10;Storage list users/lapsed-subscriber-001/photos -&gt; PERMISSION_DENIED&#10;STOPPED before Auth deletion. Account stays signed in and retryable.&#10;Alert shown to the climber: &#34;Failed to delete stored files: User does not have permission to access users/lapsed-subscriber-001/photos.&#34;&#10;Firestore workouts still present (nothing half-deleted downstream): true&#10;&#10;=== AFTER (rules on fm/fix-account-deletion-storage-list-permission) ===&#10;Signed-in owner lapsed-subscriber-001 taps &#34;Delete Account&#34; (no app_access entitlement)&#10;Storage list users/lapsed-subscriber-001/photos -&gt; OK (1 file(s))&#10;Storage delete users/lapsed-subscriber-001/photos/aa11bb22-cc33-4d44-8e55-ff6677889900.jpg -&gt; OK&#10;Storage list users/lapsed-subscriber-001/videos -&gt; OK (1 file(s))&#10;Storage delete users/lapsed-subscriber-001/videos/bb22cc33-dd44-4e55-9f66-001122334455.mov -&gt; OK&#10;Storage list users/lapsed-subscriber-001/profile_pictures -&gt; OK (1 file(s))&#10;Storage delete users/lapsed-subscriber-001/profile_pictures/cc33dd44-ee55-4f66-a077-112233445566.jpg -&gt; OK&#10;Storage list users/lapsed-subscriber-001/workout_heart_rate -&gt; OK (1 file(s))&#10;Storage delete users/lapsed-subscriber-001/workout_heart_rate/dd44ee55-ff66-4077-b188-223344556677.json.gz -&gt; OK&#10;Firestore list users/lapsed-subscriber-001/workouts -&gt; OK (1 doc(s))&#10;Firestore delete users/lapsed-subscriber-001/workouts/550E8400-E29B-41D4-A716-446655440000 -&gt; OK&#10;Firestore list users/lapsed-subscriber-001/routines -&gt; OK (1 doc(s))&#10;Firestore delete users/lapsed-subscriber-001/routines/550E8400-E29B-41D4-A716-446655440000 -&gt; OK&#10;Firestore list users/lapsed-subscriber-001/routine_folders -&gt; OK (1 doc(s))&#10;Firestore delete users/lapsed-subscriber-001/routine_folders/550E8400-E29B-41D4-A716-446655440000 -&gt; OK&#10;Firestore list users/lapsed-subscriber-001/blocked -&gt; OK (1 doc(s))&#10;Firestore delete users/lapsed-subscriber-001/blocked/550E8400-E29B-41D4-A716-446655440000 -&gt; OK&#10;Firestore list users/lapsed-subscriber-001/profile_workouts -&gt; OK (1 doc(s))&#10;Firestore delete users/lapsed-subscriber-001/profile_workouts/550E8400-E29B-41D4-A716-446655440000 -&gt; OK&#10;Firestore delete users/lapsed-subscriber-001 -&gt; OK&#10;Auth delete currentUser -&gt; OK (account removed)&#10;No error surfaced. Deletion completed for an unentitled owner.&#10;&#10;RESULT: before -&gt; BLOCKED; after -&gt; completed</code>

```text

=== BEFORE (rules at base commit c162a56) ===
Signed-in owner lapsed-subscriber-001 taps "Delete Account" (no app_access entitlement)
  Storage  list   users/lapsed-subscriber-001/photos             -> PERMISSION_DENIED
  STOPPED before Auth deletion. Account stays signed in and retryable.
  Alert shown to the climber: "Failed to delete stored files: User does not have permission to access users/lapsed-subscriber-001/photos."
  Firestore workouts still present (nothing half-deleted downstream): true

=== AFTER (rules on fm/fix-account-deletion-storage-list-permission) ===
Signed-in owner lapsed-subscriber-001 taps "Delete Account" (no app_access entitlement)
  Storage  list   users/lapsed-subscriber-001/photos             -> OK (1 file(s))
  Storage  delete users/lapsed-subscriber-001/photos/aa11bb22-cc33-4d44-8e55-ff6677889900.jpg -> OK
  Storage  list   users/lapsed-subscriber-001/videos             -> OK (1 file(s))
  Storage  delete users/lapsed-subscriber-001/videos/bb22cc33-dd44-4e55-9f66-001122334455.mov -> OK
  Storage  list   users/lapsed-subscriber-001/profile_pictures   -> OK (1 file(s))
  Storage  delete users/lapsed-subscriber-001/profile_pictures/cc33dd44-ee55-4f66-a077-112233445566.jpg -> OK
  Storage  list   users/lapsed-subscriber-001/workout_heart_rate -> OK (1 file(s))
  Storage  delete users/lapsed-subscriber-001/workout_heart_rate/dd44ee55-ff66-4077-b188-223344556677.json.gz -> OK
  Firestore list   users/lapsed-subscriber-001/workouts           -> OK (1 doc(s))
  Firestore delete users/lapsed-subscriber-001/workouts/550E8400-E29B-41D4-A716-446655440000 -> OK
  Firestore list   users/lapsed-subscriber-001/routines           -> OK (1 doc(s))
  Firestore delete users/lapsed-subscriber-001/routines/550E8400-E29B-41D4-A716-446655440000 -> OK
  Firestore list   users/lapsed-subscriber-001/routine_folders    -> OK (1 doc(s))
  Firestore delete users/lapsed-subscriber-001/routine_folders/550E8400-E29B-41D4-A716-446655440000 -> OK
  Firestore list   users/lapsed-subscriber-001/blocked            -> OK (1 doc(s))
  Firestore delete users/lapsed-subscriber-001/blocked/550E8400-E29B-41D4-A716-446655440000 -> OK
  Firestore list   users/lapsed-subscriber-001/profile_workouts   -> OK (1 doc(s))
  Firestore delete users/lapsed-subscriber-001/profile_workouts/550E8400-E29B-41D4-A716-446655440000 -> OK
  Firestore delete users/lapsed-subscriber-001 -> OK
  Auth  delete  currentUser -> OK (account removed)
  No error surfaced. Deletion completed for an unentitled owner.

RESULT: before -> BLOCKED; after -> completed
```
</details>
<details>
<summary>Evidence: Emulator rules contract results for the account-deletion sweep</summary>

<code>✔ an entitled owner can enumerate and delete everything the sweep touches&#10;✔ an unentitled owner can enumerate and delete everything the sweep touches&#10;✔ an unentitled owner can enumerate the swept collections with nothing stored&#10;✔ enumerating for deletion does not unlock paid creates or updates&#10;✔ another climber cannot enumerate or delete an account they do not own&#10;✔ an unentitled climber cannot read another climber public workout mirror&#10;✔ a signed-out client cannot enumerate or delete anything the sweep touches&#10;✔ an entitled owner can list and delete every account-deletion Storage prefix&#10;✔ an unentitled owner can list and delete photos during account deletion&#10;✔ an unentitled owner can list and delete videos during account deletion&#10;✔ an unentitled owner can list and delete profile_pictures during account deletion&#10;✔ an unentitled owner can list and delete workout_heart_rate during account deletion&#10;✔ an unentitled owner can list every account-deletion prefix when no files exist&#10;✔ listing for account deletion does not unlock paid media reads or uploads&#10;✔ another climber cannot read, list, or delete owner-scoped workout media&#10;✔ an unauthenticated visitor cannot list or delete owner-scoped photos/videos/profile_pictures/workout_heart_rate&#10;ℹ tests 26 ℹ pass 26 ℹ fail 0</code>

```text
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
✔ an entitled owner can enumerate and delete everything the sweep touches (1458.743459ms)
✔ an unentitled owner can enumerate and delete everything the sweep touches (104.482833ms)
✔ an unentitled owner can enumerate the swept collections with nothing stored (67.4925ms)
✔ enumerating for deletion does not unlock paid creates or updates (219.624584ms)
✔ another climber cannot enumerate or delete an account they do not own (95.13275ms)
✔ an unentitled climber cannot read another climber public workout mirror (46.884834ms)
✔ a signed-out client cannot enumerate or delete anything the sweep touches (82.933625ms)
✔ another climber cannot read legacy root workout media (666.194875ms)
✔ another climber cannot delete legacy root workout media (86.657625ms)
✔ no signed-in climber can enumerate the legacy root workout media prefixes (85.483042ms)
✔ the original uploader cannot reach legacy root workout media either (111.955209ms)
✔ no signed-in climber can write to the legacy root workout media prefixes (87.27925ms)
✔ an unauthenticated visitor cannot reach the legacy root prefixes (117.093291ms)
✔ an owner can read, list, upload, and delete their own workout media (250.001584ms)
✔ an entitled owner can list and delete every account-deletion Storage prefix (177.31425ms)
✔ an unentitled owner can list and delete photos during account deletion (80.907708ms)
✔ an unentitled owner can list and delete videos during account deletion (86.175667ms)
✔ an unentitled owner can list and delete profile_pictures during account deletion (84.4825ms)
✔ an unentitled owner can list and delete workout_heart_rate during account deletion (84.283208ms)
✔ an unentitled owner can list every account-deletion prefix when no files exist (114.028375ms)
✔ listing for account deletion does not unlock paid media reads or uploads (246.36675ms)
✔ another climber cannot read, list, or delete owner-scoped workout media (331.454708ms)
✔ an unauthenticated visitor cannot list or delete owner-scoped photos (125.640792ms)
✔ an unauthenticated visitor cannot list or delete owner-scoped videos (122.437542ms)
✔ an unauthenticated visitor cannot list or delete owner-scoped profile_pictures (129.221ms)
✔ an unauthenticated visitor cannot list or delete owner-scoped workout_heart_rate (131.040541ms)
ℹ tests 26
ℹ suites 0
ℹ pass 26
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 5523.631875
✔  Script exited successfully (code 0)
```
</details>
<details>
<summary>Evidence: Pre-fix rules used for the before run (extracted from base commit c162a56)</summary>

```text
rules_version = '2';
service firebase.storage {
  match /b/{bucket}/o {
    function isSignedIn() {
      return request.auth != null;
    }

    function isOwner(userId) {
      return isSignedIn() && request.auth.uid == userId;
    }

    function hasPaidAppAccess() {
      return isSignedIn() && firestore.exists(
        /databases/(default)/documents/users/$(request.auth.uid)/entitlements/app_access
      );
    }

    function isPaidOwner(userId) {
      return isOwner(userId) &&
        firestore.exists(
          /databases/(default)/documents/users/$(request.auth.uid)/entitlements/app_access
        );
    }

    function validFileName(fileName) {
      return fileName.size() > 0 && fileName.size() <= 200;
    }

    function isImageUpload(maxBytes) {
      return request.resource != null &&
        request.resource.size > 0 &&
        request.resource.size <= maxBytes &&
        request.resource.contentType.matches("image/.*");
    }

    function isVideoUpload(maxBytes) {
      return request.resource != null &&
        request.resource.size > 0 &&
        request.resource.size <= maxBytes &&
        request.resource.contentType.matches("video/.*");
    }

    function validWorkoutHeartRateFileName(fileName) {
      return fileName.matches("^[0-9a-fA-F-]{36}\\.json\\.gz$");
    }

    function isCompressedHeartRateUpload(maxBytes) {
      return request.resource != null &&
        request.resource.size > 0 &&
        request.resource.size <= maxBytes &&
        request.resource.contentType.matches(
          "application/(gzip|x-gzip|octet-stream)"
        );
    }

    // User workout photos.
    match /users/{userId}/photos/{fileName} {
      allow get: if isPaidOwner(userId) && validFileName(fileName);
      allow list: if isPaidOwner(userId);
      allow create, update: if isPaidOwner(userId) &&
        validFileName(fileName) &&
        isImageUpload(15 * 1024 * 1024);
      allow delete: if isOwner(userId) && validFileName(fileName);
    }

    // User workout videos.
    match /users/{userId}/videos/{fileName} {
      allow get: if isPaidOwner(userId) && validFileName(fileName);
      allow list: if isPaidOwner(userId);
      allow create, update: if isPaidOwner(userId) &&
        validFileName(fileName) &&
        isVideoUpload(200 * 1024 * 1024);
      allow delete: if isOwner(userId) && validFileName(fileName);
    }

    // User workout heart-rate sidecars.
    match /users/{userId}/workout_heart_rate/{fileName} {
      allow get: if isPaidOwner(userId) && validWorkoutHeartRateFileName(fileName);
      allow list: if isPaidOwner(userId);
      allow create, update: if isPaidOwner(userId) &&
        validWorkoutHeartRateFileName(fileName) &&
        isCompressedHeartRateUpload(5 * 1024 * 1024);
      allow delete: if isOwner(userId) && validWorkoutHeartRateFileName(fileName);
    }

    // User profile pictures.
    match /users/{userId}/profile_pictures/{fileName} {
      allow get: if isOwner(userId) && validFileName(fileName);
      allow list: if isOwner(userId);
      allow create, update: if isOwner(userId) &&
        validFileName(fileName) &&
        isImageUpload(10 * 1024 * 1024);
      allow delete: if isOwner(userId) && validFileName(fileName);
    }

    // ── Legacy flat-path prefixes (pre-migration), closed ───────────
    // Objects uploaded before the user-scoped path migration still sit at the
    // root photos/, videos/, and profile_pictures/ prefixes. A flat path has no
    // owner segment, so no rule here can tell one climber's media from
    // another's: any rule permissive enough to let an owner in lets every
    // signed-in account in. These prefixes are therefore closed to all client
    // access. Nothing shipped depends on them - uploads have written
    // user-scoped paths since the migration, and in-app display fetches the
    // tokenized download URL over plain HTTPS, which never consults these
    // rules. Whatever objects remain are reachable only by the backend.

    match /photos/{fileName} {
      allow read, write: if false;
    }

    match /videos/{fileName} {
      allow read, write: if false;
    }

    match /profile_pictures/{fileName} {
      allow read, write: if false;
    }

    // Remote share-card template assets are read-only from the app.
    match /share-card-templates/{allPaths=**} {
      allow read: if hasPaidAppAccess();
      allow write: if false;
    }

    // Climb landmark images are read-only from the app, and deliberately stay
    // readable before purchase. The `firstClimb` onboarding stage runs before
    // the paywall and shows the recommended landmark's artwork, so gating this
    // prefix would break the conversion path itself. Like the Hosting climb
    // catalog, this is immutable product content with no user data.
    match /climb-images/{allPaths=**} {
      allow read: if isSignedIn();
      allow write: if false;
    }

    // Synthetic live replay avatars are server-owned and read-only from the app.
    match /live-replay-avatars/{allPaths=**} {
      allow read: if hasPaidAppAccess();
      allow write: if false;
    }
  }
}
```
</details>
- Outcome: ⚠️ 1 info across 1 run (18m56s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (3) ✅</summary>

- 🚨 `firestore.rules:1314` - Intent requires: &#34;Account deletion must work for entitled and unentitled owners&#34;. The diff only relaxes Storage `list`; the Firestore collection reads the deletion sweep depends on are still paid-gated, so deletion still fails for an unentitled owner - one step later, and in a worse state. AccountDeletionService.swift:152 `deleteWorkoutBackups` calls `users/{uid}/workouts.getDocuments()` against `allow read: if isPaidOwner(userId)` (firestore.rules:1314); :163 `deleteRoutineBackups` hits `routines` (1336) and `routine_folders` (1352) with the same gate; :181 `deletePublicProfileMirrors` calls `profile_workouts.getDocuments()` against `allow read: if hasPaidAppAccess()` (1400). Firestore evaluates a list rule against the query rather than the documents, and none of these conditions reference `resource`, so the query is denied even when the collection is empty. Failure scenario: a lapsed subscriber (no `users/{uid}/entitlements/app_access` doc) taps Delete Account; reauth succeeds, the Sign in with Apple token is revoked (AccountDeletionService.swift:136), the newly-permitted Storage sweep deletes every photo, video, profile picture and heart-rate sidecar, then step 3 throws `DeletionError.firestoreDeletionFailed` on PERMISSION_DENIED. The climber is left signed in with all their media destroyed, their Apple grant revoked, and an account they still cannot delete - strictly worse than the pre-fix behavior, where the Storage denial aborted before anything was destroyed. Either extend the same owner-scoped carve-out to the deletion reads (e.g. `allow read: if isPaidOwner(userId) || isOwner(userId)` is a no-op - it needs to be `isOwner` for the list path, or the sweep needs to avoid reads), or confirm the intended scope.
- ⚠️ `tests/firebase-rules/workout-media-storage-contract.test.mjs:248` - Intent requires preserving owner scoping &#34;so unauthenticated callers and non-owners cannot list or delete another account files&#34;, covered by emulator rules tests. The new tests cover the non-owner case (the intruder block at :258-262) but there is no unauthenticated assertion against the owner-scoped `users/{uid}/...` prefixes - the only `unauthenticatedContext()` test (:170) targets the legacy flat root prefixes. Failure scenario: a future edit replaces `isOwner(userId)` with a predicate that omits the `isSignedIn()` conjunct (or `list` is loosened to `request.auth == null || ...` while chasing an emulator quirk), and every existing test still passes because no test ever drives `listAll`/`deleteObject` on `users/{uid}/photos` from an unauthenticated context. Add a test asserting `testEnv.unauthenticatedContext().storage()` fails `listAll` and `deleteObject` for each entry in `accountDeletionMedia`.
- ℹ️ `storage.rules:61` - This fix lives entirely in security rules, so it takes effect only when rules are deployed - the shipped client binary is unchanged. Per the intent, the PR must state that production Storage rules have to be deployed before real users receive the fix; per CLAUDE.md the deploy order is indexes, then functions, then `firestore:rules,storage,hosting`. No PR exists on this branch yet, so this is a reminder rather than a defect in the diff.

🔧 Fix: fix(account): let unentitled owners sweep their own Firestore data
3 issues (1 warning, 2 infos) still open:
- ⚠️ `docs/revenuecat-server-entitlement-enforcement.md:211` - The &#34;Backend choke points&#34; section is the authoritative reference for where the paid gate lives, and three of its bullets no longer match the rules after this change. Line 211 still says private workouts, user routines, and routine folders require an active grant &#34;on read, create, and update&#34; - read is now `isOwner` (firestore.rules:1324, 1346, 1362). Line 213 lists &#34;public workout summaries&#34; as paid without qualification - `profile_workouts` read is now `isOwner(userId) || hasPaidAppAccess()` (firestore.rules:1413). Line 219 says workout photos, videos, and heart-rate sidecars are paid &#34;on read, list, create, and update&#34; - `list` is now `isOwner` (storage.rules:61, 71, 81). Failure scenario: an engineer preparing the next rules change (or an auditor answering &#34;is our paywall server-enforced?&#34;) reads line 211, concludes an unentitled client cannot read its own workout history, and either re-tightens the gate - reintroducing the guideline 5.1.1(v) deletion blocker this PR exists to fix - or ships a feature that assumes the read is gated. Line 226 already states the principle this change generalizes (&#34;Owner deletes stay available after lapse so paid enforcement never traps user data&#34;); extend it to cover enumeration and correct the three bullets.
- ℹ️ `tests/firebase-rules/account-deletion-contract.test.mjs:12` - The header comment justifies the suite&#39;s dedicated project id with &#34;Test files run concurrently against one emulator and `clearFirestore()` wipes a whole project&#34;, but `package.json:7` runs the suite as `node --test --test-concurrency=1 tests/firebase-rules/*.test.mjs`, so files execute serially and no cross-file wipe race exists. Failure scenario: the premise is load-bearing-looking but false, so a future reader either trusts it and adds a second isolation mechanism against a race that cannot happen, or discovers it is wrong and removes the dedicated project id along with the comment - losing the isolation that would actually matter the day `--test-concurrency` is raised. Keep the separate project id and restate the reason as forward-looking isolation rather than a description of current harness behavior.
- ℹ️ `firestore.rules:1313` - Materially different from the Storage-only deploy note dismissed in the previous round: the fix now spans two rules files, and they are not independently sufficient. Deploying only `storage.rules` lets an unentitled owner&#39;s sweep past the Storage step and then refuses it at `deleteWorkoutBackups` (AccountDeletionService.swift:152), which is the strictly-worse partial-deletion state - media destroyed, Apple grant already revoked (AccountDeletionService.swift:136), account undeletable. CLAUDE.md&#39;s documented order puts `firestore:rules,storage` in the same final deploy step, so the normal CI path is correct; this only matters if someone hand-deploys a subset. Worth one line in the PR body alongside the production-Storage-rules warning the intent requires.

🔧 Fix: docs(entitlements): record the owner enumeration exception
2 issues (1 warning, 1 info) still open:
- ⚠️ `.claude/skills/ascend-firebase-data/SKILL.md:46` - The same staleness just corrected in docs/revenuecat-server-entitlement-enforcement.md still exists in the skill that CLAUDE.md&#39;s tripwires route to when editing rules. Line 46 directs &#34;Use `isPaidOwner(userId)` / `hasPaidAppAccess()` for anything that is the paid product: private workouts, routines and folders, the public projections derived from them, global leaderboards and replay indexes, and workout media in Storage&#34; with no read/write distinction, but read on `users/{uid}/workouts`, `routines`, and `routine_folders` is now `isOwner` (firestore.rules:1324, 1346, 1362), `profile_workouts` read is `isOwner(userId) || hasPaidAppAccess()` (firestore.rules:1413), and Storage `list` is `isOwner` (storage.rules:61, 71, 81). Line 47&#39;s counterpart bullet says keep `isOwner` &#34;for deletes and for ... account deletion&#34; without mentioning that the enumeration which finds what to delete is now part of that carve-out. Failure scenario: an engineer adds a field to the workout document, loads `ascend-firebase-data` as the tripwire instructs, reads bullet 46 as the operative directive, and re-tightens the workout read gate to `isPaidOwner` - reintroducing the guideline 5.1.1(v) deletion blocker this PR exists to fix, with emulator tests that would catch it living in a suite the engineer has no reason to suspect. CLAUDE.md states the governing rule directly: &#34;Two copies of a rule become two different rules.&#34; Split bullet 46 by operation and extend bullet 47 to name enumeration, or reduce bullet 46 to a pointer at the owning doc.
- ℹ️ `tests/firebase-rules/account-deletion-contract.test.mjs:14` - The rewritten header comment states &#34;Files run serially today (`--test-concurrency=1` in package.json); the isolation is what keeps that a scheduling detail rather than a correctness dependency.&#34; That is true for this suite, which initializes Firestore only (line 95-102) and therefore does get real per-project rule isolation, but it reads as a general statement about the directory and contradicts a documented invariant: `.claude/skills/ascend-firebase-data/SKILL.md:35` says &#34;That command pins `--test-concurrency=1`, and the files must keep running one at a time&#34;, :36-37 explain the Storage emulator holds exactly one global ruleset so a concurrent `initializeTestEnvironment` answers every storage request with a blanket 403, and :38 says outright &#34;Giving each file its own `projectId` does not help; the buckets are separate but the ruleset is not.&#34; Failure scenario: someone speeding up CI reads this comment, concludes the suite no longer depends on serial execution, raises `--test-concurrency`, and `workout-media-storage-contract.test.mjs` plus `paid-access-contract.test.mjs` start passing their `assertFails` security assertions against blanket 403s - a green run that proves nothing about the rules under review. Scope the claim to Firestore and note that Storage suites still require serial execution.

🔧 Fix: docs(skill): gate by operation, not by collection
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ The intent&#39;s PR-level constraints (target `develop`, and state in the PR that production Storage rules must be deployed before real users receive the fix) could not be verified: no pull request exists for `fm/fix-account-deletion-storage-list-permission` yet (`gh-axi pr list --head fm/fix-account-deletion-storage-list-permission` returns 0). Nothing was deployed and no production project was touched during testing.
- <code>`npm run test:firebase-rules` (full emulator rules suite, 137 tests, all pass)</code>
- <code>`firebase emulators:exec ... node --test tests/firebase-rules/account-deletion-contract.test.mjs tests/firebase-rules/workout-media-storage-contract.test.mjs` (26 tests: entitled owner, unentitled owner, empty prefixes, non-owner, unauthenticated, and the paid-gate negatives)</code>
- <code>Manual end-to-end repro: a temporary emulator harness replaying `FirebaseAccountDeletionGateway`&#39;s sweep order (Storage photos/videos/profile_pictures/workout_heart_rate, then workouts/routines/routine_folders/blocked/profile_workouts, then the user doc) for an owner with no `app_access` entitlement, run once against the base-commit rules (`git show c162a56:{firestore,storage}.rules`) and once against the branch rules; harness deleted after the run</code>
- <code>`xcodebuild -scheme AscendApp-Staging -configuration Staging -only-testing:AscendAppTests/AccountDeletionServiceTests test` (26 tests pass, including &#34;Storage failure stops deletion before Firestore or Auth cleanup&#34;)</code>
- <code>`xcodebuild -scheme AscendApp -configuration Debug -only-testing:AscendAppTests/AccountDeletionServiceTests test` (same 26 tests pass)</code>
- <code>`git status --short` after cleanup to confirm no transient artifacts (plist symlinks, emulator debug log, repro harness) remain in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
