### PR TITLE
chore(scripts): make dev and staging Firestore wipes rules-derived and reseedable

### DIFF
--- a/.claude/skills/ascend-dev-fixtures/SKILL.md
+++ b/.claude/skills/ascend-dev-fixtures/SKILL.md
@@ -26,7 +26,9 @@ paths:
 - Use server-side seeding (Admin SDK / Cloud Function / CI job) for deterministic multi-user leaderboard fixtures.
 - For local-only iteration, use the Firestore emulator or seed only the authenticated user.
 - Use `scripts/dev-db.mjs` as the central dev/staging database tool for repeatable fixture workflows. It can seed, clear, or reset `profiles`, `leaderboard`, `live-replay`, or `all`, and it must keep refusing production (`ascend-prod-9c8f2`) and unknown Firebase projects.
-- Dev database cleanup should be target-scoped and metadata-driven. Do not hide an unrestricted project wipe behind a friendly `clear all` command; full destructive wipes need an explicit, separately guarded command and a reviewed collection list.
+- Dev database cleanup should be target-scoped and metadata-driven. Do not hide an unrestricted project wipe behind a friendly `clear all` command.
+  Full dev and staging wipes are separate commands with environment-specific confirmations.
+  Their reviewed collection set is derived from direct top-level matches in `firestore.rules`, while `_migrations` is recognized and preserved; any live collection declared in neither place still blocks the wipe.
 - Profile fixture data must include the full public profile contract: display name, age, gender, `weight_kg`, `location_country`, optional `location_region`, `joined_at`, public profile mirror, profile stats, achievements, and public workout summaries.
   Seeded public profile mirrors and leaderboard rows may retain authored fixture identity when they carry the trusted synthetic marker expected by their schema.
   Real-user fixture projections follow the same validated account identity and shared moderation boundary as production data (see `ascend-profile`).

--- a/.claude/skills/ascend-dev-fixtures/SKILL.md
+++ b/.claude/skills/ascend-dev-fixtures/SKILL.md
@@ -27,8 +27,9 @@ paths:
 - For local-only iteration, use the Firestore emulator or seed only the authenticated user.
 - Use `scripts/dev-db.mjs` as the central dev/staging database tool for repeatable fixture workflows. It can seed, clear, or reset `profiles`, `leaderboard`, `live-replay`, or `all`, and it must keep refusing production (`ascend-prod-9c8f2`) and unknown Firebase projects.
 - Dev database cleanup should be target-scoped and metadata-driven. Do not hide an unrestricted project wipe behind a friendly `clear all` command.
-  Full dev and staging wipes are separate commands with environment-specific confirmations.
-  Their reviewed collection set is derived from direct top-level matches in `firestore.rules`, while `_migrations` is recognized and preserved; any live collection declared in neither place still blocks the wipe.
+  Full dev and staging wipes are separate commands carrying environment-specific confirmations - `npm run db:wipe` passes `--confirm-dev-wipe`, `npm run db:wipe:staging` passes `--confirm-staging-wipe` - and neither confirmation authorizes the other project.
+  `scripts/lib/firestore-wipe-policy.mjs` owns the decision: the deletable set is every direct top-level match in `firestore.rules` plus its short named list of retired collections whose producers are gone, `_migrations` is recognized and preserved so migration audit history and rerun protection survive a reset, and any live collection in neither set fails the wipe closed before anything is deleted.
+  A new top-level collection therefore keeps resets working by being declared in the rules, which is the obligation `ascend-firebase-data` states for rules authors.
 - Profile fixture data must include the full public profile contract: display name, age, gender, `weight_kg`, `location_country`, optional `location_region`, `joined_at`, public profile mirror, profile stats, achievements, and public workout summaries.
   Seeded public profile mirrors and leaderboard rows may retain authored fixture identity when they carry the trusted synthetic marker expected by their schema.
   Real-user fixture projections follow the same validated account identity and shared moderation boundary as production data (see `ascend-profile`).

--- a/.claude/skills/ascend-firebase-data/SKILL.md
+++ b/.claude/skills/ascend-firebase-data/SKILL.md
@@ -13,6 +13,8 @@ Load the `vibe-security` skill for any auth/authz/trust-boundary change, and `fi
 
 Server-owned collections are the exception: they are `allow write: if false` and validate no fields, because no client can write them at all. Adding a field to one (for example the `live_replay_leaderboards` subtree, written only by Cloud Functions and Admin SDK scripts) needs no rules change.
 
+A *new* top-level server-owned collection still needs its own `allow read, write: if false` match. The checked-in top-level matches are also the reviewed deletion contract for dev/staging resets, so an undeclared one blocks `npm run db:wipe` fail-closed - see `ascend-dev-fixtures`.
+
 ## Which collections must be server-owned
 
 **Shape validation is not evidence validation.** A rule can prove a document has the right fields, the right types, and the right author, and still have no idea whether the numbers in it happened. Decide by what reads the document, not by who writes it:

--- a/firestore.rules
+++ b/firestore.rules
@@ -1520,6 +1520,14 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    match /notification_devices/{deviceId} {
+      allow read, write: if false;
+    }
+
+    match /notification_campaigns/{campaignId} {
+      allow read, write: if false;
+    }
+
     match /_public_identity_propagation_jobs/{userId} {
       allow read, write: if false;
 

--- a/scripts/audit-seed-data.mjs
+++ b/scripts/audit-seed-data.mjs
@@ -33,6 +33,7 @@ import {
   PROFILE_SEED_PERSONAS,
   publicIdentityMismatchFields,
   publishedPublicIdentity,
+  seedAsOfInstant,
   statsFromWorkoutDocuments,
   validateDocumentKeys,
 } from "./seed/fixtures/profile-fixtures.mjs";
@@ -214,17 +215,21 @@ async function auditProfiles(db, failures) {
 }
 
 async function auditLeaderboard(db, catalog, failures) {
-  const publicIdentities = await readPublishedPublicIdentities(db, failures);
+  const {identities: publicIdentities, joinedAt} = await readPublishedPublicIdentities(db, failures);
   if (publicIdentities.size !== PROFILE_SEED_PERSONAS.length) {
     return "leaderboard: 0 rows checked; public identity prerequisites failed";
   }
 
+  // Period keys are pinned to when the pack was seeded, not to when it is read,
+  // so a seed and the audit that follows it can straddle UTC midnight.
+  const seededAt = seedAsOfInstant(joinedAt) ?? new Date();
   const expectedWrites = buildLeaderboardSeedWrites({
     db,
     catalog,
     Timestamp,
     FieldValue,
     publicIdentities,
+    now: seededAt,
   });
   const expectedIds = new Set(expectedWrites.map((item) => item.ref.id));
   let checked = 0;
@@ -251,7 +256,7 @@ async function auditLeaderboard(db, catalog, failures) {
       failures.push(`${path} schemaVersion must be 2`);
     }
     if (data.timeFrame) {
-      const period = currentPeriod(data.timeFrame);
+      const period = currentPeriod(data.timeFrame, seededAt);
       if (data.periodKey !== period.key) {
         failures.push(`${path} has stale periodKey ${data.periodKey}; expected ${period.key}`);
       }
@@ -266,7 +271,7 @@ async function auditLeaderboard(db, catalog, failures) {
     }
   }
 
-  for (const docId of expectedLeaderboardDocIds()) {
+  for (const docId of expectedLeaderboardDocIds(seededAt)) {
     if (expectedIds.has(docId)) continue;
     const snapshot = await db.collection("leaderboard_stats").doc(docId).get();
     if (snapshot.exists) {
@@ -291,11 +296,12 @@ async function auditLeaderboard(db, catalog, failures) {
     }
   }
 
-  return `leaderboard: ${checked} current persona rows checked`;
+  return `leaderboard: ${checked} persona rows checked, seeded ${seededAt.toISOString()}`;
 }
 
 async function readPublishedPublicIdentities(db, failures) {
   const identities = new Map();
+  const joinedAt = new Map();
   const snapshots = await Promise.all(
     PROFILE_SEED_PERSONAS.map((persona) =>
       db
@@ -317,6 +323,8 @@ async function readPublishedPublicIdentities(db, failures) {
       continue;
     }
 
+    joinedAt.set(userId, snapshot.data()?.joined_at);
+
     try {
       identities.set(
         userId,
@@ -327,7 +335,7 @@ async function readPublishedPublicIdentities(db, failures) {
     }
   }
 
-  return identities;
+  return {identities, joinedAt};
 }
 
 function auditLeaderboardIdentity(data, identity, path, failures) {

--- a/scripts/dev-db.mjs
+++ b/scripts/dev-db.mjs
@@ -844,6 +844,7 @@ async function wipeFirestore(projectId, args) {
 }
 
 function assertWipeConfirmation(projectId, args) {
+  assertSeedableProject(projectId, "wipe");
   if (args.confirmDevWipe && args.confirmStagingWipe) {
     throw new Error("wipe accepts exactly one environment-specific confirmation");
   }

--- a/scripts/dev-db.mjs
+++ b/scripts/dev-db.mjs
@@ -13,6 +13,7 @@
  *   node scripts/dev-db.mjs clear --target profiles,leaderboard --project dev
  *   node scripts/dev-db.mjs reset --target all --project dev
  *   node scripts/dev-db.mjs wipe --project dev --confirm-dev-wipe
+ *   node scripts/dev-db.mjs wipe --project staging --confirm-staging-wipe
  *   node scripts/dev-db.mjs create-auth-user --project staging --email qa@example.com --display-name "QA Tester"
  *   node scripts/dev-db.mjs hydrate-user --project dev --user <uid> --display-name "Tyler P." --age 27 --gender man --height-in 70 --weight-lb 178 --country US --region IL
  *   node scripts/dev-db.mjs seed-demo-user --project staging --email person@example.com
@@ -327,7 +328,7 @@ Options:
   --target <list>                    Comma-separated target list. Defaults to all.
   --dry-run                          Print plans without writing.
   --skip-clear                       Forwarded to seed targets that support it.
-  --confirm-dev-wipe                 Required for wipe without --dry-run.
+  --confirm-dev-wipe                 Required for a dev wipe without --dry-run.
   --confirm-staging-wipe             Required for a staging wipe without --dry-run.
   --source-user <uid>                Forwarded to live-replay seed.
   --avatar-dir <path>                Forwarded to live-replay seed.

--- a/scripts/dev-db.mjs
+++ b/scripts/dev-db.mjs
@@ -27,31 +27,20 @@ import {getAuth} from "firebase-admin/auth";
 import {FieldValue, getFirestore, Timestamp} from "firebase-admin/firestore";
 import {
   DEV_PROJECT_ID,
+  STAGING_PROJECT_ID,
   assertSeedableProject,
   resolveProjectId as resolveFirebaseProjectId,
 } from "./seed/lib/environments.mjs";
+import {
+  classifyWipeCollections,
+  reviewedWipeCollectionIds,
+} from "./lib/firestore-wipe-policy.mjs";
 import {
   assertPublishablePublicIdentity,
 } from "./seed/lib/public-identity-contract.mjs";
 
 const BATCH_TARGET_ORDER = ["profiles", "leaderboard", "live-replay", "routine-templates"];
 const VALID_GENDERS = new Set(["woman", "man", "non_binary", "prefer_not_to_say"]);
-const WIPE_COLLECTION_IDS = [
-  "users",
-  "leaderboard_stats",
-  "live_replay_leaderboards",
-  "live_climb_community_stats",
-  "routine_templates",
-  "feedback",
-  "userRateLimits",
-  "config",
-  "email_jobs",
-  // Retained-data cleanup: nothing writes this any more, but rows written by the
-  // retired public endpoint are hashed requester IPs that need a deletion path.
-  "email_rate_limits",
-  "oauthStates",
-];
-
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 
@@ -115,6 +104,7 @@ function parseArgs(argv) {
     dryRun: false,
     skipClear: false,
     confirmDevWipe: false,
+    confirmStagingWipe: false,
     passthrough: [],
     userId: null,
     password: null,
@@ -160,6 +150,9 @@ function parseArgs(argv) {
         break;
       case "--confirm-dev-wipe":
         args.confirmDevWipe = true;
+        break;
+      case "--confirm-staging-wipe":
+        args.confirmStagingWipe = true;
         break;
       case "--source-user":
       case "--avatar-dir":
@@ -306,6 +299,7 @@ Usage:
   node scripts/dev-db.mjs clear --target profiles,leaderboard --project dev
   node scripts/dev-db.mjs reset --target all --project dev
   node scripts/dev-db.mjs wipe --project dev --confirm-dev-wipe
+  node scripts/dev-db.mjs wipe --project staging --confirm-staging-wipe
   node scripts/dev-db.mjs create-auth-user --project staging --email qa@example.com --display-name "QA Tester"
   node scripts/dev-db.mjs hydrate-user --project dev --user <uid> --display-name "Tyler P." --age 27 --gender man --height-in 70 --weight-lb 178 --country US --region IL
   node scripts/dev-db.mjs seed-demo-user --project staging --email person@example.com
@@ -316,7 +310,7 @@ Commands:
   audit         Read-only validation for one or more seeded targets.
   clear         Clear one or more targets.
   reset         Clear then seed one or more targets.
-  wipe          Delete all reviewed top-level Firestore collections in dev only.
+  wipe          Delete reviewed top-level Firestore collections in dev/staging.
   create-auth-user Create one Firebase Auth email/password user in dev/staging.
   hydrate-user  Merge complete profile identity/demographic fields into one dev/staging user.
   seed-demo-user Seed one real dev/staging Auth user with product-demo data.
@@ -334,6 +328,7 @@ Options:
   --dry-run                          Print plans without writing.
   --skip-clear                       Forwarded to seed targets that support it.
   --confirm-dev-wipe                 Required for wipe without --dry-run.
+  --confirm-staging-wipe             Required for a staging wipe without --dry-run.
   --source-user <uid>                Forwarded to live-replay seed.
   --avatar-dir <path>                Forwarded to live-replay seed.
   --seed-pack <id>                   Forwarded to seed targets that support it.
@@ -383,7 +378,7 @@ async function main() {
   }
 
   if (args.command === "wipe") {
-    await wipeDevFirestore(projectId, args);
+    await wipeFirestore(projectId, args);
     return;
   }
 
@@ -431,6 +426,7 @@ function printPlan() {
   console.log("  node scripts/dev-db.mjs reset --target all --project dev");
   console.log("  node scripts/dev-db.mjs audit --target all --project staging");
   console.log("  node scripts/dev-db.mjs wipe --project dev --confirm-dev-wipe");
+  console.log("  node scripts/dev-db.mjs wipe --project staging --confirm-staging-wipe");
   console.log("  node scripts/dev-db.mjs seed --target profiles,live-replay --project dev --dry-run");
   console.log("  node scripts/dev-db.mjs seed --target routine-templates --project dev");
   console.log("  node scripts/dev-db.mjs clear --target leaderboard --project dev");
@@ -807,45 +803,65 @@ function firebaseAuthErrorMessage(error) {
   return `${code}${error?.message ?? String(error)}`;
 }
 
-async function wipeDevFirestore(projectId, args) {
-  if (projectId !== DEV_PROJECT_ID) {
-    throw new Error(`wipe is dev-only. Refusing to wipe ${projectId}.`);
-  }
-  if (!args.dryRun && !args.confirmDevWipe) {
-    throw new Error("wipe requires --confirm-dev-wipe unless --dry-run is set");
-  }
+async function wipeFirestore(projectId, args) {
+  assertWipeConfirmation(projectId, args);
 
   initializeFirebaseAdmin(projectId);
   const db = getFirestore();
   const existingCollections = await db.listCollections();
   const existingIds = existingCollections.map((collection) => collection.id).sort();
-  const allowedIds = new Set(WIPE_COLLECTION_IDS);
-  const unknownIds = existingIds.filter((collectionId) => !allowedIds.has(collectionId));
-  if (unknownIds.length > 0) {
+  const plan = classifyWipeCollections(
+    existingIds,
+    reviewedWipeCollectionIds(REPO_ROOT)
+  );
+  if (plan.unknownCollections.length > 0) {
     throw new Error(
       "Refusing wipe because Firestore has unreviewed top-level collection(s): " +
-        unknownIds.join(", ")
+        plan.unknownCollections.join(", ")
     );
   }
 
-  const collectionsToDelete = WIPE_COLLECTION_IDS
-    .filter((collectionId) => existingIds.includes(collectionId));
-
   console.log(`Project: ${projectId}`);
   console.log(`Command: wipe${args.dryRun ? " (dry run)" : ""}`);
-  console.log(`Collections: ${collectionsToDelete.length > 0 ? collectionsToDelete.join(", ") : "(none)"}`);
+  console.log(
+    `Protected: ${plan.protectedCollections.length > 0 ? plan.protectedCollections.join(", ") : "(none)"}`
+  );
+  console.log(
+    `Collections: ${plan.collectionsToDelete.length > 0 ? plan.collectionsToDelete.join(", ") : "(none)"}`
+  );
 
   if (args.dryRun) {
     console.log("Dry run only. No Firestore documents were deleted.");
     return;
   }
 
-  for (const collectionId of collectionsToDelete) {
+  for (const collectionId of plan.collectionsToDelete) {
     console.log(`Deleting ${collectionId} recursively...`);
     await db.recursiveDelete(db.collection(collectionId));
   }
 
-  console.log(`Wiped ${collectionsToDelete.length} top-level collection(s) from ${projectId}.`);
+  console.log(`Wiped ${plan.collectionsToDelete.length} top-level collection(s) from ${projectId}.`);
+}
+
+function assertWipeConfirmation(projectId, args) {
+  if (args.confirmDevWipe && args.confirmStagingWipe) {
+    throw new Error("wipe accepts exactly one environment-specific confirmation");
+  }
+  if (args.confirmDevWipe && projectId !== DEV_PROJECT_ID) {
+    throw new Error(`--confirm-dev-wipe cannot authorize a wipe of ${projectId}`);
+  }
+  if (args.confirmStagingWipe && projectId !== STAGING_PROJECT_ID) {
+    throw new Error(`--confirm-staging-wipe cannot authorize a wipe of ${projectId}`);
+  }
+  if (args.dryRun) {
+    return;
+  }
+  if (projectId === DEV_PROJECT_ID && !args.confirmDevWipe) {
+    throw new Error("dev wipe requires --confirm-dev-wipe");
+  }
+  if (projectId === STAGING_PROJECT_ID && !args.confirmStagingWipe) {
+    throw new Error("staging wipe requires --confirm-staging-wipe");
+  }
 }
 
 async function hydrateUser(projectId, args) {

--- a/scripts/lib/firestore-wipe-policy.mjs
+++ b/scripts/lib/firestore-wipe-policy.mjs
@@ -16,21 +16,75 @@ export const LEGACY_DELETABLE_WIPE_COLLECTION_IDS = Object.freeze([
   "oauthStates",
 ]);
 
+// Deleting these fires the Firestore triggers that rederive the public
+// projections, so they have to be deleted before the projections they feed.
+// Deleting a projection first only invites the trigger to write the row back,
+// which leaves rederived standings behind a wipe that reported success.
+export const WIPE_SOURCE_COLLECTION_IDS = Object.freeze([
+  "users",
+]);
+
+const DOCUMENTS_MATCH_PATTERN = /^match\s+\/databases\/\{[^{}]*\}\/documents\s*\{?$/;
+const COLLECTION_MATCH_PATTERN = /^match\s+\/([^/{}\s]+)\/\{[^{}]*\}\s*\{?$/;
+
 /**
  * Reads the direct child collection matches under the Firestore database.
  * Those matches are the reviewed top-level data contract for the app.
+ *
+ * Nesting is resolved from brace depth rather than indentation, so reformatting
+ * the rules cannot silently promote a subcollection into the deletable set.
  * @param {string} source Firestore rules source.
  * @return {string[]} Sorted top-level collection IDs.
  */
 export function topLevelRuleCollectionIds(source) {
   const ids = [];
-  const pattern = /^ {4}match \/([^/{}]+)\/\{[^}]+\} \{$/gm;
+  let depth = 0;
+  let documentsDepth = null;
 
-  for (const match of source.matchAll(pattern)) {
-    ids.push(match[1]);
+  for (const rawLine of source.split("\n")) {
+    const line = rawLine.replace(/\/\/.*$/, "").trim();
+    if (line !== "") {
+      if (documentsDepth === null && DOCUMENTS_MATCH_PATTERN.test(line)) {
+        documentsDepth = depth + 1;
+      } else if (depth === documentsDepth) {
+        const collection = COLLECTION_MATCH_PATTERN.exec(line);
+        if (collection) {
+          ids.push(collection[1]);
+        }
+      }
+
+      depth += braceDepthDelta(line);
+    }
   }
 
   return [...new Set(ids)].sort();
+}
+
+/**
+ * Net block-nesting change one rules line contributes.
+ *
+ * Brace pairs that open and close on the same line - path variables such as
+ * `{userId}` - change no nesting, so they are removed before counting.
+ * @param {string} line One comment-stripped rules line.
+ * @return {number} Net brace depth change.
+ */
+function braceDepthDelta(line) {
+  let remaining = line;
+  let previous = null;
+  while (remaining !== previous) {
+    previous = remaining;
+    remaining = remaining.replace(/\{[^{}]*\}/g, "");
+  }
+
+  let delta = 0;
+  for (const character of remaining) {
+    if (character === "{") {
+      delta += 1;
+    } else if (character === "}") {
+      delta -= 1;
+    }
+  }
+  return delta;
 }
 
 /**
@@ -65,14 +119,30 @@ export function classifyWipeCollections(
   const existing = [...new Set(existingIds)].sort();
 
   return {
-    collectionsToDelete: existing.filter(
+    collectionsToDelete: orderedForDeletion(existing.filter(
       (collectionId) => reviewed.has(collectionId) && !protectedSet.has(collectionId)
-    ),
+    )),
     protectedCollections: existing.filter((collectionId) => protectedSet.has(collectionId)),
     unknownCollections: existing.filter(
       (collectionId) => !reviewed.has(collectionId) && !protectedSet.has(collectionId)
     ),
   };
+}
+
+/**
+ * Orders one deletion set so every trigger source precedes the projections its
+ * triggers rederive. Everything else keeps its stable alphabetical order.
+ * @param {string[]} collectionIds Collections the wipe will delete.
+ * @return {string[]} The same collections in a safe deletion order.
+ */
+function orderedForDeletion(collectionIds) {
+  const sources = WIPE_SOURCE_COLLECTION_IDS.filter(
+    (collectionId) => collectionIds.includes(collectionId)
+  );
+  return [
+    ...sources,
+    ...collectionIds.filter((collectionId) => !sources.includes(collectionId)),
+  ];
 }
 
 /**
@@ -90,7 +160,7 @@ export function sourceDeclaredTopLevelCollectionIds(source) {
   }
 
   const ids = [];
-  const callPattern = /\b(?:db|firestore|this\.firestore)\s*\.collection\(\s*(?:["']([^"']+)["']|([A-Z][A-Z0-9_]*))\s*\)/g;
+  const callPattern = /(?:\b(?:admin\.firestore|getFirestore)\(\s*[^()]*\)|\b(?:db|firestore|this\.firestore))\s*\.collection\(\s*(?:["']([^"']+)["']|([A-Z][A-Z0-9_]*))\s*\)/g;
   for (const match of source.matchAll(callPattern)) {
     const collectionId = match[1] ?? constants.get(match[2]);
     if (collectionId) {

--- a/scripts/lib/firestore-wipe-policy.mjs
+++ b/scripts/lib/firestore-wipe-policy.mjs
@@ -1,0 +1,102 @@
+import {readFileSync} from "node:fs";
+import {resolve} from "node:path";
+
+// Migration history answers whether a repair has already run in an environment.
+// A database reset must not erase that audit trail or cause completed repairs to
+// run again against newly seeded data.
+export const PROTECTED_WIPE_COLLECTION_IDS = Object.freeze([
+  "_migrations",
+]);
+
+// These collections outlived their producers and therefore have no current
+// Firestore rule declaration to act as their reviewed deletion contract.
+// Keeping them here preserves the only cleanup path for their retained data.
+export const LEGACY_DELETABLE_WIPE_COLLECTION_IDS = Object.freeze([
+  "email_rate_limits",
+  "oauthStates",
+]);
+
+/**
+ * Reads the direct child collection matches under the Firestore database.
+ * Those matches are the reviewed top-level data contract for the app.
+ * @param {string} source Firestore rules source.
+ * @return {string[]} Sorted top-level collection IDs.
+ */
+export function topLevelRuleCollectionIds(source) {
+  const ids = [];
+  const pattern = /^ {4}match \/([^/{}]+)\/\{[^}]+\} \{$/gm;
+
+  for (const match of source.matchAll(pattern)) {
+    ids.push(match[1]);
+  }
+
+  return [...new Set(ids)].sort();
+}
+
+/**
+ * Returns every collection the wipe may delete without a second hand-maintained
+ * allowlist. Adding a reviewed top-level rule automatically keeps resets current.
+ * @param {string} repoRoot Repository root.
+ * @return {string[]} Sorted collection IDs.
+ */
+export function reviewedWipeCollectionIds(repoRoot) {
+  const rules = readFileSync(resolve(repoRoot, "firestore.rules"), "utf8");
+  return [...new Set([
+    ...topLevelRuleCollectionIds(rules),
+    ...LEGACY_DELETABLE_WIPE_COLLECTION_IDS,
+  ])].sort();
+}
+
+/**
+ * Classifies live top-level collections before any destructive work begins.
+ * @param {string[]} existingIds Collection IDs currently present in Firestore.
+ * @param {Iterable<string>} reviewedIds Reviewed, deletable collection IDs.
+ * @param {Iterable<string>} protectedIds Recognized collection IDs to preserve.
+ * @return {{collectionsToDelete: string[], protectedCollections: string[], unknownCollections: string[]}}
+ *   The complete wipe decision.
+ */
+export function classifyWipeCollections(
+  existingIds,
+  reviewedIds,
+  protectedIds = PROTECTED_WIPE_COLLECTION_IDS
+) {
+  const reviewed = new Set(reviewedIds);
+  const protectedSet = new Set(protectedIds);
+  const existing = [...new Set(existingIds)].sort();
+
+  return {
+    collectionsToDelete: existing.filter(
+      (collectionId) => reviewed.has(collectionId) && !protectedSet.has(collectionId)
+    ),
+    protectedCollections: existing.filter((collectionId) => protectedSet.has(collectionId)),
+    unknownCollections: existing.filter(
+      (collectionId) => !reviewed.has(collectionId) && !protectedSet.has(collectionId)
+    ),
+  };
+}
+
+/**
+ * Finds literal root collection calls in one JavaScript or TypeScript source.
+ * This is used by regression coverage to ensure server writers declare their
+ * collection in Firestore rules or in the protected set.
+ * @param {string} source JavaScript or TypeScript source.
+ * @return {string[]} Sorted collection IDs.
+ */
+export function sourceDeclaredTopLevelCollectionIds(source) {
+  const constants = new Map();
+  const constantPattern = /\bconst\s+([A-Z][A-Z0-9_]*)\s*(?::[^=;]+)?=\s*["']([^"']+)["']\s*;/g;
+  for (const match of source.matchAll(constantPattern)) {
+    constants.set(match[1], match[2]);
+  }
+
+  const ids = [];
+  const callPattern = /\b(?:db|firestore|this\.firestore)\s*\.collection\(\s*(?:["']([^"']+)["']|([A-Z][A-Z0-9_]*))\s*\)/g;
+  for (const match of source.matchAll(callPattern)) {
+    const collectionId = match[1] ?? constants.get(match[2]);
+    if (collectionId) {
+      ids.push(collectionId);
+    }
+  }
+
+  return [...new Set(ids)].sort();
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -14,6 +14,7 @@
     "db:reset": "node dev-db.mjs reset --project dev",
     "db:reset:staging": "node dev-db.mjs reset --project staging",
     "db:wipe": "node dev-db.mjs wipe --project dev --confirm-dev-wipe",
+    "db:wipe:staging": "node dev-db.mjs wipe --project staging --confirm-staging-wipe",
     "db:create-auth-user": "node dev-db.mjs create-auth-user --project dev",
     "db:create-auth-user:staging": "node dev-db.mjs create-auth-user --project staging",
     "db:hydrate-user": "node dev-db.mjs hydrate-user --project dev",

--- a/scripts/seed-demo-user.mjs
+++ b/scripts/seed-demo-user.mjs
@@ -1195,6 +1195,7 @@ function printPlan(projectId, seedPlan, args) {
     command: `seed-demo-user${args.dryRun ? " (dry run)" : ""}`,
     user: {
       uid: seedPlan.user.uid,
+      email: seedPlan.user.email,
       displayName: seedPlan.user.displayName,
     },
     scenario: args.scenario,

--- a/scripts/seed-demo-user.mjs
+++ b/scripts/seed-demo-user.mjs
@@ -33,6 +33,7 @@ import {
   PUBLIC_IDENTITY_STATE_PUBLISHED,
   firstAscentSeedFields,
 } from "./seed/lib/live-replay-first-ascent.mjs";
+import {buildDemoReplayEntry} from "./seed/lib/demo-replay-entry.mjs";
 
 const DEV_PROJECT_ID = "ascend-f2e4f";
 const STAGING_PROJECT_ID = "ascend-staging-fa7d5";
@@ -808,24 +809,15 @@ async function addReplayWrites(db, writes, deletes, user, liveContexts, args) {
       }
       writes.push([
         entriesRef.doc(context.workoutId),
-        {
-          avatarToken: user.avatarToken,
-          completionDurationSeconds: context.durationSeconds,
-          displayName: user.displayName,
-          finalSteps: context.finalSteps,
-          ...bestForUserField(context),
+        buildDemoReplayEntry({
+          context,
           identityState: PUBLIC_IDENTITY_STATE_PUBLISHED,
-          isPersonalBest: true,
-          isSynthetic: false,
-          photoURL: user.photoURL,
           schemaVersion: REPLAY_SCHEMA_VERSION,
-          splitBucketCount: context.splitSteps.length,
+          splitIndex: index,
           splitIntervalSeconds: SPLIT_INTERVAL_SECONDS,
-          stepsAtBucket: context.splitSteps[index],
           updatedAt: FieldValue.serverTimestamp(),
-          userId: user.uid,
-          workoutId: context.workoutId,
-        },
+          user,
+        }),
       ]);
     }
   }
@@ -857,19 +849,6 @@ async function addCommunityStatsWrites(db, writes, user, liveContexts) {
     statsData.uniqueCompletedUserCount = FieldValue.increment(1);
   }
   writes.push([statsRef, statsData]);
-}
-
-/**
- * Best-per-user flag for a seeded entry, or nothing when the context has none.
- *
- * Only per-climb contexts collapse a climber's repeat completions into one live
- * race row, so only they carry the flag. There is one seeded completion per
- * context, so that completion is the user's best.
- * @param {object} context Seeded replay context.
- * @return {object} Flag field, or an empty object.
- */
-function bestForUserField(context) {
-  return context.contextType === "live_climb" ? {isBestForUser: true} : {};
 }
 
 function liveContextForWorkout(workout) {
@@ -1216,7 +1195,6 @@ function printPlan(projectId, seedPlan, args) {
     command: `seed-demo-user${args.dryRun ? " (dry run)" : ""}`,
     user: {
       uid: seedPlan.user.uid,
-      email: seedPlan.user.email,
       displayName: seedPlan.user.displayName,
     },
     scenario: args.scenario,

--- a/scripts/seed/fixtures/profile-fixtures.mjs
+++ b/scripts/seed/fixtures/profile-fixtures.mjs
@@ -6,6 +6,7 @@ export {PUBLIC_PHOTO_URL_PATTERN};
 export {currentPeriod};
 
 export const PROFILE_SEED_PACK_ID = "v1-profile-test";
+const DEFAULT_JOINED_OFFSET_DAYS = -60;
 export const PROFILE_SEED_SOURCE = "seed-test-users";
 export const PROFILE_SCHEMA_VERSION = 2;
 const PUBLIC_IDENTITY_STATE_PUBLISHED = "published";
@@ -133,7 +134,7 @@ export function buildProfileSeedWrites({
   const writes = [];
 
   for (const persona of PROFILE_SEED_PERSONAS) {
-    const joinedAt = daysFromNow(persona.joinedOffsetDays ?? -60, now);
+    const joinedAt = daysFromNow(persona.joinedOffsetDays ?? DEFAULT_JOINED_OFFSET_DAYS, now);
     const userRef = db.collection("users").doc(persona.id);
     const publicRef = userRef.collection("public_profile").doc("current");
     const statsRef = userRef.collection("profile_stats").doc("current");
@@ -281,13 +282,36 @@ export function expectedProfileUserIds() {
   return PROFILE_SEED_PERSONAS.map((persona) => persona.id);
 }
 
-export function expectedLeaderboardDocIds() {
+export function expectedLeaderboardDocIds(now = new Date()) {
   return PROFILE_SEED_PERSONAS.flatMap((persona) =>
     LEADERBOARD_TIME_FRAMES.map((timeFrame) => {
-      const period = currentPeriod(timeFrame);
+      const period = currentPeriod(timeFrame, now);
       return leaderboardDocId(persona.id, timeFrame, period.key);
     })
   );
+}
+
+/**
+ * Recovers the instant a profile pack was seeded from the data it left behind.
+ *
+ * A leaderboard document id embeds the period that was current when the pack was
+ * written, so rebuilding the expected ids from the reader's own clock reports
+ * every daily row as missing whenever a seed and the audit that follows it
+ * straddle UTC midnight. `joined_at` is a fixed per-persona offset from the
+ * seeding instant, so it carries that instant back exactly.
+ *
+ * @param {Map<string, {toDate?: () => Date}|Date>} joinedAtByUserId Published
+ *   `joined_at` values keyed by persona id.
+ * @returns {Date|null} The seeding instant, or null when no persona published one.
+ */
+export function seedAsOfInstant(joinedAtByUserId) {
+  for (const persona of PROFILE_SEED_PERSONAS) {
+    const joinedAt = joinedAtByUserId.get(persona.id);
+    const joinedAtDate = typeof joinedAt?.toDate === "function" ? joinedAt.toDate() : joinedAt;
+    if (!(joinedAtDate instanceof Date) || Number.isNaN(joinedAtDate.getTime())) continue;
+    return daysFromNow(-(persona.joinedOffsetDays ?? DEFAULT_JOINED_OFFSET_DAYS), joinedAtDate);
+  }
+  return null;
 }
 
 export function legacyLeaderboardDocIds() {

--- a/scripts/seed/lib/demo-replay-entry.mjs
+++ b/scripts/seed/lib/demo-replay-entry.mjs
@@ -1,0 +1,35 @@
+/**
+ * Builds one demo-user replay entry with the server-owned context contract.
+ * @param {object} input Entry inputs.
+ * @return {object} Firestore replay entry fields.
+ */
+export function buildDemoReplayEntry({
+  context,
+  identityState,
+  schemaVersion,
+  splitIndex,
+  splitIntervalSeconds,
+  updatedAt,
+  user,
+}) {
+  return {
+    avatarToken: user.avatarToken,
+    completionDurationSeconds: context.durationSeconds,
+    contextId: context.contextId,
+    contextType: context.contextType,
+    displayName: user.displayName,
+    finalSteps: context.finalSteps,
+    ...(context.contextType === "live_climb" ? {isBestForUser: true} : {}),
+    identityState,
+    isPersonalBest: true,
+    isSynthetic: false,
+    photoURL: user.photoURL,
+    schemaVersion,
+    splitBucketCount: context.splitSteps.length,
+    splitIntervalSeconds,
+    stepsAtBucket: context.splitSteps[splitIndex],
+    updatedAt,
+    userId: user.uid,
+    workoutId: context.workoutId,
+  };
+}

--- a/scripts/test/firestore-wipe-policy.test.mjs
+++ b/scripts/test/firestore-wipe-policy.test.mjs
@@ -22,12 +22,31 @@ test("wipe deletes reviewed data while preserving the migration ledger", () => {
   );
 
   assert.deepEqual(plan.collectionsToDelete, [
+    "users",
     "leaderboard_periods",
     "notification_devices",
-    "users",
   ]);
   assert.deepEqual(plan.protectedCollections, ["_migrations"]);
   assert.deepEqual(plan.unknownCollections, []);
+});
+
+test("records are deleted before the projections their triggers rederive", () => {
+  const plan = classifyWipeCollections(
+    [
+      "live_replay_leaderboards",
+      "leaderboard_stats",
+      "users",
+      "leaderboard_periods",
+    ],
+    reviewedWipeCollectionIds(REPO_ROOT)
+  );
+
+  assert.equal(plan.collectionsToDelete[0], "users");
+  assert.deepEqual(plan.collectionsToDelete.slice(1), [
+    "leaderboard_periods",
+    "leaderboard_stats",
+    "live_replay_leaderboards",
+  ]);
 });
 
 test("a new unreviewed top-level collection still blocks the wipe", () => {
@@ -73,6 +92,44 @@ test("the rules parser returns direct database children only", () => {
   assert.ok(ids.includes("notification_campaigns"));
   assert.ok(!ids.includes("workouts"));
   assert.ok(!ids.includes("entries"));
+});
+
+test("the rules parser reads nesting from braces, not indentation", () => {
+  const reformatted = [
+    "rules_version = '2';",
+    "service cloud.firestore {",
+    "match /databases/{database}/documents {",
+    "    match /users/{userId} {",
+    "    match /workouts/{workoutId} {",
+    "      allow read: if false;",
+    "    }",
+    "    }",
+    "    match /leaderboard_stats/{docId} {",
+    "      allow read: if false;",
+    "    }",
+    "  }",
+    "}",
+    "",
+  ].join("\n");
+
+  assert.deepEqual(topLevelRuleCollectionIds(reformatted), [
+    "leaderboard_stats",
+    "users",
+  ]);
+});
+
+test("a root collection reached through admin.firestore() is still declared", () => {
+  const source = [
+    "const query = admin.firestore()",
+    "  .collection(\"notification_devices\")",
+    "  .where(\"active\", \"==\", true);",
+    "const other = getFirestore().collection(\"leaderboard_periods\");",
+  ].join("\n");
+
+  assert.deepEqual(sourceDeclaredTopLevelCollectionIds(source), [
+    "leaderboard_periods",
+    "notification_devices",
+  ]);
 });
 
 test("staging requires its own confirmation and rejects the dev confirmation", () => {

--- a/scripts/test/firestore-wipe-policy.test.mjs
+++ b/scripts/test/firestore-wipe-policy.test.mjs
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import {spawnSync} from "node:child_process";
+import {readFileSync, readdirSync} from "node:fs";
+import {dirname, extname, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+import {test} from "node:test";
+
+import {
+  PROTECTED_WIPE_COLLECTION_IDS,
+  classifyWipeCollections,
+  reviewedWipeCollectionIds,
+  sourceDeclaredTopLevelCollectionIds,
+  topLevelRuleCollectionIds,
+} from "../lib/firestore-wipe-policy.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+test("wipe deletes reviewed data while preserving the migration ledger", () => {
+  const plan = classifyWipeCollections(
+    ["users", "_migrations", "notification_devices", "leaderboard_periods"],
+    reviewedWipeCollectionIds(REPO_ROOT)
+  );
+
+  assert.deepEqual(plan.collectionsToDelete, [
+    "leaderboard_periods",
+    "notification_devices",
+    "users",
+  ]);
+  assert.deepEqual(plan.protectedCollections, ["_migrations"]);
+  assert.deepEqual(plan.unknownCollections, []);
+});
+
+test("a new unreviewed top-level collection still blocks the wipe", () => {
+  const plan = classifyWipeCollections(
+    ["users", "new_unreviewed_collection"],
+    reviewedWipeCollectionIds(REPO_ROOT)
+  );
+
+  assert.deepEqual(plan.collectionsToDelete, ["users"]);
+  assert.deepEqual(plan.protectedCollections, []);
+  assert.deepEqual(plan.unknownCollections, ["new_unreviewed_collection"]);
+});
+
+test("every source-declared root collection is reviewed or protected", () => {
+  const reviewed = new Set(reviewedWipeCollectionIds(REPO_ROOT));
+  const protectedIds = new Set(PROTECTED_WIPE_COLLECTION_IDS);
+  const declared = new Set();
+
+  for (const path of sourceFiles(resolve(REPO_ROOT, "functions", "src"))) {
+    addDeclaredCollections(declared, path);
+  }
+  for (const path of sourceFiles(resolve(REPO_ROOT, "scripts"), new Set(["test"]))) {
+    addDeclaredCollections(declared, path);
+  }
+
+  const unreviewed = [...declared]
+    .filter((collectionId) => !reviewed.has(collectionId) && !protectedIds.has(collectionId))
+    .sort();
+
+  assert.deepEqual(
+    unreviewed,
+    [],
+    "root collections used by source must have a top-level Firestore rule or explicit protection"
+  );
+});
+
+test("the rules parser returns direct database children only", () => {
+  const rules = readFileSync(resolve(REPO_ROOT, "firestore.rules"), "utf8");
+  const ids = topLevelRuleCollectionIds(rules);
+
+  assert.ok(ids.includes("users"));
+  assert.ok(ids.includes("notification_devices"));
+  assert.ok(ids.includes("notification_campaigns"));
+  assert.ok(!ids.includes("workouts"));
+  assert.ok(!ids.includes("entries"));
+});
+
+test("staging requires its own confirmation and rejects the dev confirmation", () => {
+  const missing = runDevDb("wipe", "--project", "staging");
+  assert.notEqual(missing.status, 0);
+  assert.match(missing.stderr, /staging wipe requires --confirm-staging-wipe/);
+
+  const mismatched = runDevDb(
+    "wipe",
+    "--project",
+    "staging",
+    "--confirm-dev-wipe"
+  );
+  assert.notEqual(mismatched.status, 0);
+  assert.match(mismatched.stderr, /--confirm-dev-wipe cannot authorize/);
+});
+
+test("production is refused before even a wipe dry-run can list collections", () => {
+  const result = runDevDb("wipe", "--project", "production", "--dry-run");
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Refusing to write ascend-prod-9c8f2/);
+});
+
+function addDeclaredCollections(output, path) {
+  const source = readFileSync(path, "utf8");
+  for (const collectionId of sourceDeclaredTopLevelCollectionIds(source)) {
+    output.add(collectionId);
+  }
+}
+
+function sourceFiles(directory, excludedDirectories = new Set()) {
+  const paths = [];
+  for (const entry of readdirSync(directory, {withFileTypes: true})) {
+    if (entry.name === "node_modules" || excludedDirectories.has(entry.name)) {
+      continue;
+    }
+
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      paths.push(...sourceFiles(path, excludedDirectories));
+    } else if ([".js", ".mjs", ".ts"].includes(extname(entry.name))) {
+      paths.push(path);
+    }
+  }
+  return paths;
+}
+
+function runDevDb(...args) {
+  return spawnSync(
+    process.execPath,
+    [resolve(REPO_ROOT, "scripts", "dev-db.mjs"), ...args],
+    {encoding: "utf8"}
+  );
+}

--- a/scripts/test/seed-audit-period-anchor.test.mjs
+++ b/scripts/test/seed-audit-period-anchor.test.mjs
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PROFILE_SEED_PERSONAS,
+  buildLeaderboardSeedWrites,
+  buildProfileSeedWrites,
+  expectedLeaderboardDocIds,
+  seedAsOfInstant,
+} from "../seed/fixtures/profile-fixtures.mjs";
+
+const BEFORE_MIDNIGHT = new Date("2026-08-06T23:59:30.000Z");
+const AFTER_MIDNIGHT = new Date("2026-08-07T00:00:30.000Z");
+
+const Timestamp = {
+  fromDate: (date) => ({toMillis: () => date.getTime(), toDate: () => date}),
+};
+const FieldValue = {serverTimestamp: () => "server-timestamp"};
+
+function fakeSeedFirestore() {
+  const collectionAt = (path) => ({
+    doc: (documentId) => documentAt(`${path}/${documentId}`),
+  });
+  const documentAt = (path) => ({
+    path,
+    collection: (collectionId) => collectionAt(`${path}/${collectionId}`),
+  });
+  return {collection: collectionAt};
+}
+
+function publishedJoinedAt(now) {
+  return new Map(
+    buildProfileSeedWrites({
+      db: fakeSeedFirestore(),
+      catalog: new Map(),
+      Timestamp,
+      FieldValue,
+      now,
+      includeLeaderboardRows: false,
+    })
+      .filter((entry) => entry.shape === "publicProfile")
+      .map((entry) => [entry.data.userId, entry.data.joined_at])
+  );
+}
+
+function seededLeaderboardDocIds(now) {
+  const publicIdentities = new Map(
+    PROFILE_SEED_PERSONAS.map((persona) => [
+      persona.id,
+      {
+        displayName: persona.name,
+        identityChangedAt: "server-timestamp",
+        identityPolicyVersion: 1,
+        photoURL: "",
+        userId: persona.id,
+      },
+    ])
+  );
+
+  return buildLeaderboardSeedWrites({
+    db: fakeSeedFirestore(),
+    catalog: new Map(),
+    Timestamp,
+    FieldValue,
+    publicIdentities,
+    now,
+  }).map((entry) => entry.ref.path.split("/").at(-1));
+}
+
+test("a published pack carries the instant it was seeded", () => {
+  assert.deepEqual(
+    seedAsOfInstant(publishedJoinedAt(BEFORE_MIDNIGHT)),
+    BEFORE_MIDNIGHT
+  );
+});
+
+test("a pack seeded before UTC midnight still audits after it", () => {
+  const seeded = seededLeaderboardDocIds(BEFORE_MIDNIGHT);
+  const recovered = seedAsOfInstant(publishedJoinedAt(BEFORE_MIDNIGHT));
+  const expected = new Set(expectedLeaderboardDocIds(recovered));
+
+  assert.ok(seeded.length > 0);
+  for (const docId of seeded) {
+    assert.ok(expected.has(docId), `${docId} is not an expected seeded row`);
+  }
+
+  // The clock the audit itself runs on is exactly what used to report every
+  // daily row as missing once the day rolled over.
+  const auditClock = new Set(expectedLeaderboardDocIds(AFTER_MIDNIGHT));
+  assert.ok(seeded.some((docId) => !auditClock.has(docId)));
+});
+
+test("a pack with no published identity leaves the anchor unresolved", () => {
+  assert.equal(seedAsOfInstant(new Map()), null);
+});

--- a/scripts/test/seed-demo-user-replay-contract.test.mjs
+++ b/scripts/test/seed-demo-user-replay-contract.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import {test} from "node:test";
+
+import {buildDemoReplayEntry} from "../seed/lib/demo-replay-entry.mjs";
+
+test("demo replay entries carry the server context contract", () => {
+  const updatedAt = {kind: "server-timestamp"};
+  const entry = buildDemoReplayEntry({
+    context: {
+      contextId: "empire-state-building",
+      contextType: "live_climb",
+      durationSeconds: 480,
+      finalSteps: 1_860,
+      splitSteps: [0, 420, 900, 1_400, 1_860],
+      workoutId: "workout-1",
+    },
+    identityState: "published",
+    schemaVersion: 1,
+    splitIndex: 2,
+    splitIntervalSeconds: 120,
+    updatedAt,
+    user: {
+      avatarToken: "TP",
+      displayName: "Test Person",
+      photoURL: "",
+      uid: "user-1",
+    },
+  });
+
+  assert.equal(entry.contextId, "empire-state-building");
+  assert.equal(entry.contextType, "live_climb");
+  assert.equal(entry.stepsAtBucket, 900);
+  assert.equal(entry.updatedAt, updatedAt);
+});


### PR DESCRIPTION
## Intent

Make Ascend's dev and staging Firestore databases safely wipeable and reseedable, resolving issues #314, #370, and #221 in one PR targeting develop. npm run db:wipe must complete for dev and staging without a separate wipe allowlist edit whenever repository-reviewed top-level collections are introduced, while preserving the fail-closed safeguard for any genuinely new unreviewed collection. Preserve _migrations across wipes so migration audit history and rerun protection survive; delete disposable operational collections such as notification_devices and leaderboard_periods; require environment-specific destructive confirmations; and continue to hard-refuse production ascend-prod-9c8f2. Make scripts/seed-demo-user.mjs write contextId and contextType on every replay entry to match the server replayEntryWrite contract and the live-replay seeder. Require regression coverage, including a hypothetical new unreviewed top-level collection and confirmation and production safety, and prove db:audit passes after real fresh full seeds. The explicit judgment is that checked-in top-level Firestore rule matches are the reviewed deletion contract, _migrations is the protected exception, and live collections outside the reviewed and protected contracts still block the wipe. Never touch production. GitHub Actions is degraded by an upstream incident, so queued checks are expected and should be reported as pending on the outage rather than retried or investigated.

## What Changed

- Replaced `dev-db.mjs`'s hand-maintained wipe allowlist with `scripts/lib/firestore-wipe-policy.mjs`, which derives the deletable set from the top-level matches in `firestore.rules` (brace-depth parsed) plus a short list of retired collections, preserves `_migrations`, orders `users` ahead of the projections its triggers rederive, and still fails closed on any live collection in neither set. Added `notification_devices` and `notification_campaigns` rule matches so they are covered.
- Extended `wipe` to staging behind `--confirm-staging-wipe` (new `db:wipe:staging` script), with per-environment confirmations that cannot authorize each other and a retained hard refusal of `ascend-prod-9c8f2`.
- Moved demo replay entry construction into `scripts/seed/lib/demo-replay-entry.mjs` so every entry carries `contextId` and `contextType`, and anchored the seed audit to the pack's seeding instant recovered from `joined_at` instead of the audit's own clock, which had made fresh seeds fail across UTC midnight.
- Added regression coverage for the wipe policy (unreviewed collection, deletion ordering, source-declared root collections, confirmation and production guards), the replay contract, and the audit period anchor; review left three open informational notes about parser and allowlist edge cases.

## Risk Assessment

✅ Low: Every substantive concern from the prior round is resolved and independently verified (the brace parser yields output identical to the old regex on the real rules file, the broadened guard regex still finds zero unreviewed root collections, `users` is provably the only root trigger source, and the destructive function now refuses production on its own), leaving only informational hardening notes on a dev/staging-only tool that remains fail-closed and confirmation-gated.

## Testing

Following the prior-round dev/staging baselines that exposed the UTC-midnight audit rollover, the current branch passed the complete script and Firebase rules suites, fresh full seed-and-audit cycles for both environments, persisted wipe-safety checks, production refusal, and real demo replay seeding; reviewer-visible CLI transcripts were captured and the worktree was cleaned. GitHub Actions remains pending on the supplied upstream outage and was not retried or investigated.

<details>
<summary>Evidence: Dev fresh full seed and audit</summary>

```text
i  emulators: Starting emulators: firestore, storage
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
⚠  Unexpected rules runtime error: WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/Users/tylerpavay/.cache/firebase/emulators/cloud-storage-rules-runtime-v1.1.3.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release

i  Running script: cd scripts && npm run seed:all && npm run audit:all

> seed:all
> node dev-db.mjs seed --target all --project dev

Project: ascend-f2e4f
Command: seed
Targets: profiles, leaderboard, live-replay, routine-templates

> node seed-test-users.mjs seed --project ascend-f2e4f
Project: ascend-f2e4f
Seed pack: v1-profile-test
Command: seed
Personas: 12
Seed plan:
  achievement: 125
  leaderboardStats: 55
  profileStats: 12
  profileWorkout: 160
  publicProfile: 12
  user: 12
  hostedProfileAvatars: 12
Wrote 376 seeded documents.

> node seed-leaderboard.mjs seed --project ascend-f2e4f
Project: ascend-f2e4f
Command: seed
Users: 12
Prepared 55 leaderboard documents.
Note: run the profiles target first when seeding an empty environment.
Seeded 55 documents into "leaderboard_stats".

> node seed-live-replay-leaderboards.mjs seed --project ascend-f2e4f
No --source-user or ASCEND_SEED_SOURCE_USER_ID provided. Using fallback pace samples.
Project: ascend-f2e4f
Seed pack: live-replay-v1-dev
Apple Health step factor: 0.78
Mode: seed
Planned docs: 31 summaries, 555,723 replay entries
ACTIVE | mount-everest             | 89 completed | 89 replay rows | 361 buckets | FA held by Lia P.
ACTIVE | empire-state-building     | 83 completed | 83 replay rows | 326 buckets | FA held by Ari N.
ACTIVE | burj-khalifa              | 59 completed | 59 replay rows | 361 buckets | FA held by Leo S.
ACTIVE | gateway-arch              | 80 completed | 80 replay rows | 169 buckets | FA held by Maya C.
ACTIVE | eiffel-tower              | 69 completed | 69 replay rows | 268 buckets | FA held by Nate R.
ACTIVE | petronas-towers           | 54 completed | 54 replay rows | 361 buckets | FA held by Rae C.
ACTIVE | cn-tower                  | 49 completed | 49 replay rows | 361 buckets | FA held by Cal N.
ACTIVE | statue-of-liberty         | 69 completed | 69 replay rows | 85 buckets | FA held by Jace M.
ACTIVE | tokyo-skytree             | 41 completed | 41 replay rows | 361 buckets | FA held by Cole A.
ACTIVE | marina-bay-sands          | 48 completed | 48 replay rows | 172 buckets | FA held by Cal N.
WARM   | space-needle              | 27 completed | 27 replay rows | 122 buckets | FA held by Lia P.
WARM   | washington-monument       | 28 completed | 28 replay rows | 108 buckets | FA held by Owen B.
WARM   | willis-tower              | 19 completed | 19 replay rows | 361 buckets | FA held by Jules R.
WARM   | one-world-trade-center    | 17 completed | 17 replay rows | 361 buckets | FA held by Leo S.
WARM   | chrysler-building         | 18 completed | 18 replay rows | 216 buckets | FA held by Gia F.
WARM   | the-shard                 | 17 completed | 17 replay rows | 270 buckets | FA held by Mila B.
WARM   | sagrada-familia           | 18 completed | 18 replay rows | 149 buckets | FA held by Zara T.
WARM   | acropolis-of-athens       | 21 completed | 21 replay rows | 101 buckets | FA held by Max W.
WARM   | elizabeth-tower           | 20 completed | 20 replay rows | 63 buckets | FA held by Finn R.
WARM   | tokyo-tower               | 13 completed | 13 replay rows | 271 buckets | FA held by Sean P.
WARM   | shanghai-tower            | 10 completed | 10 replay rows | 309 buckets | FA held by Eva D.
WARM   | taipei-101                | 10 completed | 10 replay rows | 361 buckets | FA held by Skye M.
WARM   | canton-tower              | 9 completed | 9 replay rows | 361 buckets | FA held by Zara T.
WARM   | leaning-tower-of-pisa     | 13 completed | 13 replay rows | 52 buckets | FA held by Marcus T.
WARM   | cairo-tower               | 10 completed | 10 replay rows | 95 buckets | FA held by Iris M.
WARM   | sydney-tower              | 12 completed | 12 replay rows | 182 buckets | FA held by Theo J.
OPEN   | sky-tower-auckland        | 0 completed | 0 replay rows | 0 buckets | FA open
OPEN   | oriental-pearl-tower      | 0 completed | 0 replay rows | 0 buckets | FA open
OPEN   | table-mountain            | 0 completed | 0 replay rows | 0 buckets | FA open
OPEN   | machu-picchu              | 0 completed | 0 replay rows | 0 buckets | FA open
GLOBAL | just-climb-global         | 903 completed | 903 replay rows | 361 buckets
Cleared 775,428 existing seeded replay entries.
Seeded 555,754 Firestore documents into ascend-f2e4f.

> node seed-routine-templates.mjs seed --project ascend-f2e4f
Project: ascend-f2e4f
Command: seed
Seed pack: routine-templates-v1-dev
Collection: routine_templates
Fixture: /Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/fixtures/routine-templates.dev.json
Templates: tylers-10-min-heater (published), social-pyramid-20 (published)
Cleared 0 existing routine template document(s).
Seeded 2 routine template document(s).

> audit:all
> node dev-db.mjs audit --target all --project dev


> node audit-seed-data.mjs --project ascend-f2e4f --target all
Project: ascend-f2e4f
Audit targets: profiles, leaderboard, live-replay, routine-templates

Audit summary:
  profiles: 12 users, 196 profile documents checked
  leaderboard: 55 persona rows checked, seeded 2026-08-07T05:10:21.748Z
  live-replay: 31 summaries, 1806 bucket-zero entries checked
  routine-templates: 2 templates checked

Seed audit passed.
✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  firestore: Stopping Firestore Emulator
i  storage: Stopping Storage Emulator
i  hub: Stopping emulator hub
i  logging: Stopping Logging Emulator
```
</details>
<details>
<summary>Evidence: Staging fresh full seed and audit</summary>

```text
i  emulators: Starting emulators: firestore, storage
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
⚠  Unexpected rules runtime error: WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::arrayBaseOffset has been called by com.google.protobuf.UnsafeUtil$MemoryAccessor (file:/Users/tylerpavay/.cache/firebase/emulators/cloud-storage-rules-runtime-v1.1.3.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.protobuf.UnsafeUtil$MemoryAccessor
WARNING: sun.misc.Unsafe::arrayBaseOffset will be removed in a future release

i  Running script: cd scripts && npm run seed:all:staging -- --skip-clear && npm run audit:all:staging

> seed:all:staging
> node dev-db.mjs seed --target all --project staging --skip-clear

Project: ascend-staging-fa7d5
Command: seed
Targets: profiles, leaderboard, live-replay, routine-templates
profiles target does not support --skip-clear; it will replace its seed pack.

> node seed-test-users.mjs seed --project ascend-staging-fa7d5
Project: ascend-staging-fa7d5
Seed pack: v1-profile-test
Command: seed
Personas: 12
Seed plan:
  achievement: 125
  leaderboardStats: 55
  profileStats: 12
  profileWorkout: 160
  publicProfile: 12
  user: 12
  hostedProfileAvatars: 12
Wrote 376 seeded documents.
leaderboard target does not support --skip-clear; it will upsert generated rows.

> node seed-leaderboard.mjs seed --project ascend-staging-fa7d5
Project: ascend-staging-fa7d5
Command: seed
Users: 12
Prepared 55 leaderboard documents.
Note: run the profiles target first when seeding an empty environment.
Seeded 55 documents into "leaderboard_stats".

> node seed-live-replay-leaderboards.mjs seed --project ascend-staging-fa7d5 --skip-clear
No --source-user or ASCEND_SEED_SOURCE_USER_ID provided. Using fallback pace samples.
Project: ascend-staging-fa7d5
Seed pack: live-replay-v1-staging
Apple Health step factor: 0.78
Mode: seed
Planned docs: 31 summaries, 560,644 replay entries
ACTIVE | mount-everest             | 89 completed | 89 replay rows | 361 buckets | FA held by Lia P.
ACTIVE | empire-state-building     | 83 completed | 83 replay rows | 349 buckets | FA held by Ari N.
ACTIVE | burj-khalifa              | 59 completed | 59 replay rows | 361 buckets | FA held by Leo S.
ACTIVE | gateway-arch              | 80 completed | 80 replay rows | 151 buckets | FA held by Maya C.
ACTIVE | eiffel-tower              | 69 completed | 69 replay rows | 310 buckets | FA held by Nate R.
ACTIVE | petronas-towers           | 54 completed | 54 replay rows | 361 buckets | FA held by Rae C.
ACTIVE | cn-tower                  | 49 completed | 49 replay rows | 361 buckets | FA held by Cal N.
ACTIVE | statue-of-liberty         | 69 completed | 69 replay rows | 87 buckets | FA held by Jace M.
ACTIVE | tokyo-skytree             | 41 completed | 41 replay rows | 361 buckets | FA held by Cole A.
ACTIVE | marina-bay-sands          | 48 completed | 48 replay rows | 196 buckets | FA held by Cal N.
WARM   | space-needle              | 27 completed | 27 replay rows | 122 buckets | FA held by Lia P.
WARM   | washington-monument       | 28 completed | 28 replay rows | 107 buckets | FA held by Owen B.
WARM   | willis-tower              | 19 completed | 19 replay rows | 333 buckets | FA held by Jules R.
WARM   | one-world-trade-center    | 17 completed | 17 replay rows | 361 buckets | FA held by Leo S.
WARM   | chrysler-building         | 18 completed | 18 replay rows | 214 buckets | FA held by Gia F.
WARM   | the-shard                 | 17 completed | 17 replay rows | 268 buckets | FA held by Mila B.
WARM   | sagrada-familia           | 18 completed | 18 replay rows | 128 buckets | FA held by Zara T.
WARM   | acropolis-of-athens       | 21 completed | 21 replay rows | 127 buckets | FA held by Max W.
WARM   | elizabeth-tower           | 20 completed | 20 replay rows | 76 buckets | FA held by Finn R.
WARM   | tokyo-tower               | 13 completed | 13 replay rows | 189 buckets | FA held by Sean P.
WARM   | shanghai-tower            | 10 completed | 10 replay rows | 361 buckets | FA held by Eva D.
WARM   | taipei-101                | 10 completed | 10 replay rows | 361 buckets | FA held by Skye M.
WARM   | canton-tower              | 9 completed | 9 replay rows | 361 buckets | FA held by Zara T.
WARM   | leaning-tower-of-pisa     | 13 completed | 13 replay rows | 34 buckets | FA held by Marcus T.
WARM   | cairo-tower               | 10 completed | 10 replay rows | 132 buckets | FA held by Iris M.
WARM   | sydney-tower              | 12 completed | 12 replay rows | 255 buckets | FA held by Theo J.
OPEN   | sky-tower-auckland        | 0 completed | 0 replay rows | 0 buckets | FA open
OPEN   | oriental-pearl-tower      | 0 completed | 0 replay rows | 0 buckets | FA open
OPEN   | table-mountain            | 0 completed | 0 replay rows | 0 buckets | FA open
OPEN   | machu-picchu              | 0 completed | 0 replay rows | 0 buckets | FA open
GLOBAL | just-climb-global         | 903 completed | 903 replay rows | 361 buckets
Seeded 560,675 Firestore documents into ascend-staging-fa7d5.

> node seed-routine-templates.mjs seed --project ascend-staging-fa7d5 --skip-clear
Project: ascend-staging-fa7d5
Command: seed
Seed pack: routine-templates-v1-staging
Collection: routine_templates
Fixture: /Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/fixtures/routine-templates.dev.json
Templates: tylers-10-min-heater (published), social-pyramid-20 (published)
Seeded 2 routine template document(s).

> audit:all:staging
> node dev-db.mjs audit --target all --project staging


> node audit-seed-data.mjs --project ascend-staging-fa7d5 --target all
Project: ascend-staging-fa7d5
Audit targets: profiles, leaderboard, live-replay, routine-templates

Audit summary:
  profiles: 12 users, 196 profile documents checked
  leaderboard: 55 persona rows checked, seeded 2026-08-07T05:39:52.676Z
  live-replay: 31 summaries, 1806 bucket-zero entries checked
  routine-templates: 2 templates checked

Seed audit passed.
✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  firestore: Stopping Firestore Emulator
i  storage: Stopping Storage Emulator
i  hub: Stopping emulator hub
i  logging: Stopping Logging Emulator
```
</details>
<details>
<summary>Evidence: Dev wipe safety and persisted state</summary>

```text
i  emulators: Starting emulators: firestore
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
i  Running script: bash /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZCN1E9VRNT4Q1HN0WSWX1C7/run-firestore-wipe-e2e.sh ascend-f2e4f /Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7
SEEDED _migrations, users, notification_devices, leaderboard_periods, new_unreviewed_collection
Error: dev wipe requires --confirm-dev-wipe
    at assertWipeConfirmation (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:861:11)
    at wipeFirestore (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:807:3)
    at main (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:381:11)
    at file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:1057:3
    at ModuleJob.run (node:internal/modules/esm/module_job:569:25)
    at async node:internal/modules/esm/loader:650:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
VERIFIED expected refusal with exit 1
VERIFIED blocked wipe deleted nothing

> db:wipe
> node dev-db.mjs wipe --project dev --confirm-dev-wipe

Error: Refusing wipe because Firestore has unreviewed top-level collection(s): new_unreviewed_collection
    at wipeFirestore (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:818:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async main (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:381:5)
VERIFIED expected refusal with exit 1
VERIFIED blocked wipe deleted nothing
REMOVED test-only unreviewed collection

> db:wipe
> node dev-db.mjs wipe --project dev --confirm-dev-wipe

Project: ascend-f2e4f
Command: wipe
Protected: _migrations
Collections: users, leaderboard_periods, notification_devices
Deleting users recursively...
Deleting leaderboard_periods recursively...
Deleting notification_devices recursively...
Wiped 3 top-level collection(s) from ascend-f2e4f.
VERIFIED _migrations retained
VERIFIED users, notification_devices, leaderboard_periods deleted
PERSISTED top-level collections: _migrations
✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  firestore: Stopping Firestore Emulator
i  hub: Stopping emulator hub
i  logging: Stopping Logging Emulator
```
</details>
<details>
<summary>Evidence: Staging wipe safety and persisted state</summary>

```text
i  emulators: Starting emulators: firestore
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
i  Running script: bash /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZCN1E9VRNT4Q1HN0WSWX1C7/run-firestore-wipe-e2e.sh ascend-staging-fa7d5 /Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7
SEEDED _migrations, users, notification_devices, leaderboard_periods, new_unreviewed_collection
Error: staging wipe requires --confirm-staging-wipe
    at assertWipeConfirmation (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:864:11)
    at wipeFirestore (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:807:3)
    at main (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:381:11)
    at file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:1057:3
    at ModuleJob.run (node:internal/modules/esm/module_job:569:25)
    at async node:internal/modules/esm/loader:650:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
VERIFIED expected refusal with exit 1
VERIFIED blocked wipe deleted nothing
Error: --confirm-dev-wipe cannot authorize a wipe of ascend-staging-fa7d5
    at assertWipeConfirmation (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:852:11)
    at wipeFirestore (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:807:3)
    at main (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:381:11)
    at file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:1057:3
    at ModuleJob.run (node:internal/modules/esm/module_job:569:25)
    at async node:internal/modules/esm/loader:650:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
VERIFIED expected refusal with exit 1
VERIFIED blocked wipe deleted nothing

> db:wipe:staging
> node dev-db.mjs wipe --project staging --confirm-staging-wipe

Error: Refusing wipe because Firestore has unreviewed top-level collection(s): new_unreviewed_collection
    at wipeFirestore (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:818:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
    at async main (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:381:5)
VERIFIED expected refusal with exit 1
VERIFIED blocked wipe deleted nothing
REMOVED test-only unreviewed collection

> db:wipe:staging
> node dev-db.mjs wipe --project staging --confirm-staging-wipe

Project: ascend-staging-fa7d5
Command: wipe
Protected: _migrations
Collections: users, leaderboard_periods, notification_devices
Deleting users recursively...
Deleting leaderboard_periods recursively...
Deleting notification_devices recursively...
Wiped 3 top-level collection(s) from ascend-staging-fa7d5.
VERIFIED _migrations retained
VERIFIED users, notification_devices, leaderboard_periods deleted
PERSISTED top-level collections: _migrations
✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  firestore: Stopping Firestore Emulator
i  hub: Stopping emulator hub
i  logging: Stopping Logging Emulator
```
</details>
<details>
<summary>Evidence: Production refusal</summary>

```text
Error: Refusing to write ascend-prod-9c8f2. Only ascend-f2e4f and ascend-staging-fa7d5 are allowed.
    at assertSeedableProject (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/seed/lib/environments.mjs:24:11)
    at assertAllowedProject (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:443:3)
    at main (file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:373:3)
    at file:///Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts/dev-db.mjs:1057:3
    at ModuleJob.run (node:internal/modules/esm/module_job:569:25)
    at async node:internal/modules/esm/loader:650:26
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
VERIFIED production hard-refused before database initialization with exit 1
```
</details>
<details>
<summary>Evidence: Demo replay persisted contract</summary>

```text
i  emulators: Starting emulators: auth, firestore
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
i  Running script: node /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZCN1E9VRNT4Q1HN0WSWX1C7/demo-replay-contract-state.mjs create-auth ascend-f2e4f /Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7 && cd /Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7/scripts && node seed-demo-user.mjs seed --project dev --user demo-replay-e2e --display-name 'Demo Climber' --no-first-ascent && node /var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZCN1E9VRNT4Q1HN0WSWX1C7/demo-replay-contract-state.mjs verify ascend-f2e4f /Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZCN1E9VRNT4Q1HN0WSWX1C7
CREATED isolated Auth emulator user demo-replay-e2e
{
  "project": "ascend-f2e4f",
  "command": "seed-demo-user",
  "user": {
    "uid": "demo-replay-e2e",
    "email": "demo-replay-e2e@example.invalid",
    "displayName": "Demo Climber"
  },
  "scenario": "full-showcase",
  "workouts": 11,
  "liveReplayContexts": 9,
  "writes": 1138,
  "staleCaseVariantDeletes": 1094,
  "firstAscentClimb": null,
  "totalClimbsCompleted": 6
}
Seeded demo account demo-replay-e2e with 11 workouts, 9 replay context(s), and 5 leaderboard stat rows.
VERIFIED 1072 persisted demo replay entries
VERIFIED every entry carries non-empty contextId and contextType
PERSISTED entry types: live_climb=829, routine_template=243
✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  firestore: Stopping Firestore Emulator
i  auth: Stopping Authentication Emulator
i  hub: Stopping emulator hub
i  logging: Stopping Logging Emulator
```
</details>
- Outcome: 🔧 1 issue found → auto-fixed ✅ across 2 runs (6h40m22s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ⚠️ `scripts/lib/firestore-wipe-policy.mjs:65` - classifyWipeCollections sorts `existing` alphabetically, so the wipe now deletes `users` LAST (previously WIPE_COLLECTION_IDS put it first). `users/{uid}/workouts/{id}` deletes fire onWorkoutWrittenLeaderboardStats -&gt; reconcileLeaderboardStats, and `users/{uid}` deletes fire onUserDemographicsWrittenLeaderboardStats and cleanupDeletedUserData, all of which write into `leaderboard_stats`, `leaderboard_periods` and `live_replay_leaderboards`. Because those collections sort before `users`, they are already deleted when the triggers land, so a full wipe deterministically leaves rederived leaderboard rows behind and the next `db:audit` can see stale standings. Restore an explicit ordering (users first, derived projections after) rather than relying on sort order.
- ⚠️ `scripts/lib/firestore-wipe-policy.mjs:93` - sourceDeclaredTopLevelCollectionIds only matches `db.`, `firestore.` or `this.firestore.` receivers, so root collection access through `admin.firestore().collection(...)` or `getFirestore().collection(...)` is invisible to the &#34;every source-declared root collection is reviewed or protected&#34; test. functions/src/pushNotifications.ts:378 already uses `admin.firestore().collection(&#34;notification_devices&#34;)` - that root collection is only detected because a different call site happens to use a bare `firestore` receiver. A future function that reaches a brand-new root collection solely via `admin.firestore()` passes CI and then hard-blocks the next dev/staging wipe with no prior signal, which is exactly the failure this test exists to prevent. Broaden the receiver alternation to include `admin.firestore()` / `getFirestore()`.
- ⚠️ `scripts/dev-db.mjs:846` - The old wipeDevFirestore opened with `if (projectId !== DEV_PROJECT_ID) throw`, an unconditional refusal inside the destructive function. assertWipeConfirmation replaces it with per-environment checks that only fire for DEV_PROJECT_ID or STAGING_PROJECT_ID: for any other project id (including ascend-prod-9c8f2) every branch is skipped and the function returns cleanly, so the sole remaining refusal is assertAllowedProject in main(). Today that ordering holds, but the most destructive routine in the repo now has no self-contained project guard - a future caller, refactor, or new entry point that reaches wipeFirestore directly gets an unconfirmed wipe of whatever project id it was handed. Add an assertSeedableProject(projectId, &#34;wipe&#34;) (or an explicit dev/staging membership check) at the top of assertWipeConfirmation.
- ℹ️ `scripts/lib/firestore-wipe-policy.mjs:27` - topLevelRuleCollectionIds keys the entire reviewed deletion contract off a regex requiring exactly four leading spaces and a trailing ` {` on the same line. A rules reformat, a rule wrapped across lines, or a future nested block indented at four spaces silently changes which collections are considered reviewed - in the miss direction the wipe fail-closes (acceptable), but in the false-positive direction a subcollection match indented at four spaces would be treated as a deletable root collection. Consider asserting a known-good subset in the parser test (it currently checks only five names) or parsing brace depth instead of indentation.
- ℹ️ `scripts/seed-demo-user.mjs:1197` - printPlan no longer prints `email` for the target user, though seedPlan.user.email is still populated. `--email` is how an operator targets which account seed-demo-user overwrites, so the dry-run plan is now the only confirmation surface that no longer echoes it back. This removal is unrelated to the stated intent (wipe policy plus contextId/contextType on replay entries) - if it was dropped deliberately for PII hygiene in logs that is reasonable, but it should be a conscious call rather than incidental to this PR.
- ℹ️ `firestore.rules:1539` - Deriving the reviewed set from rules means `_revenuecat_webhook_events` (the webhook idempotency ledger) and `_revenuecat_analytics_outbox` are now deleted by a wipe, where the old hand-maintained list excluded them. This follows directly from the stated judgment that `_migrations` is the only protected exception, and in dev/staging replaying already-processed RevenueCat webhooks is harmless - noting it only so the dedup-ledger reset is a known consequence of the next staging wipe rather than a surprise during entitlement testing.

🔧 Fix: order wipe deletes and harden wipe guards
3 infos still open:
- ℹ️ `scripts/lib/firestore-wipe-policy.mjs:45` - The new brace-depth parser strips comments with `rawLine.replace(/\/\/.*$/, &#34;&#34;)` before counting braces, which also truncates at a `//` inside a string literal. firestore.rules:136 already carries `&#34;^https://firebasestorage\\.googleapis\\.com...&#34;`; it is harmless only because no brace follows on that line (I checked every line - zero currently change delta after stripping). A future rules line that combines a `//`-bearing string with a brace shifts `depth` for the whole rest of the file: eating a `}` leaves depth too high and silently drops reviewed collections (fail-closed, wipe blocks), while eating a `{` leaves depth too low and promotes subcollection matches such as `workouts` or `entries` into the deletable set. Strip comments only outside quotes, or skip lines that do not start with a rules keyword.
- ℹ️ `scripts/lib/firestore-wipe-policy.mjs:23` - WIPE_SOURCE_COLLECTION_IDS is a hand-maintained list of trigger sources with no regression coverage keeping it in sync with functions/src, even though this PR built exactly that kind of guard for the collection allowlist (&#34;every source-declared root collection is reviewed or protected&#34;). It is correct today, but `_public_identity_propagation_jobs/{userId}/kinds/{kind}` is an onDocumentWritten trigger on a non-users root collection that stays safe only because its handler early-returns when `after.data()` is undefined - remove that guard, or add a trigger rooted at any other top-level collection, and the ordering fix silently stops covering it with no test failure. Consider a test that parses the `document:` paths off every `onDocument*` registration and asserts each non-`users` root is either absent or listed here.
- ℹ️ `scripts/dev-db.mjs:838` - Ordering `users` first is the right mitigation but is best-effort: `recursiveDelete` resolves as soon as the documents are gone, while `cleanupDeletedUserData` is declared `retry: true, timeoutSeconds: 540` and the identity-propagation chain runs asynchronously afterwards, so rederived rows can still land in `leaderboard_stats` or `live_replay_leaderboards` seconds to minutes after those collections were deleted. Nothing here is a regression - it matches the pre-change behavior - but a wipe that prints &#34;Wiped N top-level collection(s)&#34; is not proof the projections stayed empty. Re-running `wipe --dry-run` after a wipe is the cheap confirmation, since it lists whatever came back.

</details>

<details>
<summary>🔧 **Test** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `scripts/audit-seed-data.mjs:222` - Fresh full seeds are not reliably auditable across UTC midnight. Independent baseline dev and staging emulator cycles seeded 44 rows before midnight, then the immediately following audits recomputed daily IDs for 2026-08-07 and failed because all 11 new-day rows were absent. Later cycles completed wholly after the rollover and passed, confirming a timing flake. Persist or otherwise derive the fixture pack&#39;s as-of period and audit against that instead of rebuilding expected IDs from a new `Date` at audit time.
- <code>Baseline emulator harnesses `run-dev-cycle.sh` and `run-staging-cycle.sh`: empty database, full seed, audit, confirmation guards, unknown-collection refusal, real wipe, migration/disposable-collection state inspection, reseed, and final audit.</code>
- `node --test scripts/test/firestore-wipe-policy.test.mjs scripts/test/seed-demo-user-replay-contract.test.mjs`
- `npm run test:firebase-rules`
- <code>Production and confirmation guard invocations captured in `safety-guards.log`, including production dry-run refusal before Firebase initialization.</code>
- <code>`npm run db:wipe -- --dry-run` and `npm run db:wipe:staging -- --dry-run` against authenticated dev and staging environments.</code>
- <code>Created `no_mistakes_unreviewed_wipe_probe` in dev, ran `npm run db:wipe`, verified refusal left all collections intact, then removed the probe.</code>
- <code>`npm run db:wipe` followed by an Admin SDK state check proving only the unchanged `_migrations` ledger survived.</code>
- <code>`npm run db:seed` followed by `npm run db:audit` and persisted dev replay/context state inspection.</code>
- <code>`npm run db:wipe:staging` followed by an Admin SDK state check proving only both unchanged `_migrations` documents survived and disposable operational collections were removed.</code>
- <code>`npm run db:seed:staging -- --skip-clear` followed by `npm run db:audit:staging` and persisted staging replay/context state inspection.</code>
- <code>Created a demo replay entry through `scripts/seed/lib/demo-replay-entry.mjs`; the baseline emulator cycle also seeded a real Auth demo user and read replay documents back from Firestore with `contextId` and `contextType`.</code>
- <code>Removed the generated `firestore-debug.log` and verified the worktree was clean. GitHub Actions was not retried or investigated because the supplied upstream outage marks queued checks as expected.</code>

🔧 Fix: anchor seed audit to the pack&#39;s seeding instant
✅ Re-checked - no issues remain.
- `node --test scripts/test/*.test.mjs`
- `npm run test:firebase-rules`
- `npx -y firebase-tools@15.22.1 emulators:exec --project ascend-f2e4f --only firestore,storage "cd scripts && npm run seed:all && npm run audit:all"`
- `npx -y firebase-tools@15.22.1 emulators:exec --project ascend-staging-fa7d5 --only firestore,storage "cd scripts && npm run seed:all:staging -- --skip-clear && npm run audit:all:staging"`
- <code>Dev emulator wipe with missing confirmation, hypothetical unreviewed collection, successful `npm run db:wipe`, and persisted-state verification.</code>
- <code>Staging emulator wipe with missing and mismatched confirmations, hypothetical unreviewed collection, successful `npm run db:wipe:staging`, and persisted-state verification.</code>
- <code>`node scripts/dev-db.mjs wipe --project ascend-prod-9c8f2 --dry-run` with asserted refusal before database initialization.</code>
- <code>Isolated Auth and Firestore emulator execution of `node scripts/seed-demo-user.mjs seed --project dev --user demo-replay-e2e --display-name &#39;Demo Climber&#39; --no-first-ascent`, followed by validation of every persisted replay entry.</code>
- `Removed and verified absence of the disposable dev Auth record created during the initial misconfigured harness attempt; removed generated emulator logs and confirmed a clean worktree.`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
