### PR TITLE
docs: define backend and client contract compatibility doctrine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,7 @@ Baseline for every change. If a loaded skill prescribes something more specific,
 - **Clarity over cleverness.** If a future reader won't immediately understand a line, the code is wrong.
 - **Delete before you defend.** Dead code, commented-out experiments, "just in case" abstractions - remove them; a deprecated path may only stay if it carries a written deprecation/removal date. Git history is the backup.
 - **Comments explain WHY, not WHAT.** They earn space only for a non-obvious constraint, workaround, or invariant.
+- **Backend contract compatibility.** Read `docs/backend-contract-compatibility.md` before changing Firestore shapes or rules, callable Function signatures, or Remote Config keys.
 
 ## Tripwires
 

--- a/docs/backend-contract-compatibility.md
+++ b/docs/backend-contract-compatibility.md
@@ -1,0 +1,113 @@
+# Backend and client contract compatibility
+
+Ascend's production backend always serves more than the newest source tree.
+Apple review separates a merge from delivery, and people install updates on their own schedules.
+An app version that shipped weeks or months ago can therefore share the backend with today's version.
+
+The governing invariant is simple: **the production backend must satisfy the union of the contracts required by every live app version.**
+
+## What the contract is
+
+The contract is the backend surface that an installed binary can observe or depend on:
+
+- Firestore collection paths, document shapes, field names, field types, required and optional fields, and field meanings.
+- Firestore and Storage security rules that authorize an operation and accept its payload.
+- Callable Function names, request fields, response fields, types, error behavior, and meanings.
+- Remote Config parameter keys, types, defaults, and meanings.
+
+The client source code is not part of this compatibility contract.
+New source is free to delete old models, repositories, decoders, and feature code when the new app no longer uses them.
+Keeping a released client's source code in the newest app does nothing for the binary already installed on a phone.
+Compatibility comes from preserving the backend behavior that binary calls, not from preserving dead client code in the current branch.
+
+## Additive changes are the default
+
+Every backend contract change is additive until the retirement loop below is complete.
+
+- Add fields, paths, callable parameters, response fields, and Remote Config keys without removing or repurposing existing ones.
+- Make new request fields optional for old callers, or introduce a new callable or document version when the new value is genuinely required.
+- Preserve the type and meaning of every existing field and key because reusing a name for a different concept is a removal hidden inside a rename-free diff.
+- Widen security rules to admit the new valid operation or shape while continuing to admit every valid operation and shape used by a live client.
+- Preserve old required-field sets when widening strict `hasOnly` and `hasAll` validation, so an old client can still write a document that omits the new field.
+- Keep old callable entry points and old Remote Config keys live even after the newest app stops using them.
+
+Changing an optional field to required, narrowing an accepted enum, rejecting a previously accepted document version, changing a callable response type, or changing a Remote Config key's meaning is a narrowing.
+Each one can break a released binary even when the newest source compiles and every current test passes.
+
+### Worked replacement example
+
+Suppose Ascend replaces the cloud-sync format for a completed stair-stepper climb.
+Version 1 writes and reads `users/{uid}/workouts/{workoutId}`, while version 2 will write and read only `users/{uid}/climb_records/{climbId}`.
+
+The safe end-to-end rollout is:
+
+1. Add the `climb_records` model, its rules, its Functions, and any indexes alongside the existing workout backend.
+2. Copy existing workout history into the new model without deleting or rewriting the original workout documents.
+3. If both versions must see climbs created by the other version, deploy an idempotent server-side compatibility projection before version 2 ships.
+4. Ship version 2 with only the new client model and repository, so the current source reads and writes `climb_records` and carries no obsolete version 1 client implementation.
+5. Leave the version 1 path, fields, callable entry points, documents, and rules valid because a climber on version 1 can still finish a workout and sync through that contract.
+6. Keep both backend surfaces until version 1 has completed the retirement loop.
+
+This approach replaces the client subsystem cleanly while the backend serves both generations.
+Deleting the version 1 Swift code is safe because version 1 already contains its own copy, but deleting or narrowing the version 1 backend is not safe while that copy can still run.
+
+## Deploy ordering and the widening asymmetry
+
+Security rules and Functions deploy from the repository and take effect for the whole Firebase project within seconds.
+An App Store binary reaches users days later and then spreads unevenly.
+These timelines make widening and narrowing fundamentally asymmetric.
+
+A widening must reach the backend before or with the first app build that needs it.
+Deploying the app first creates a window in which the new client sends a valid new field or calls a new Function and the old backend rejects it.
+A narrowing has the opposite and larger blast radius because it breaks every live client that needs the removed behavior as soon as the backend deploy completes.
+Waiting to ship a matching new app does not protect the clients already installed.
+
+The standing rule is therefore not "make the backend match the newest app."
+The standing rule is "make the backend accept everything required by all live apps, including the newest one."
+
+### What the current workflows actually do
+
+[Deploy Staging](../.github/workflows/deploy-staging.yml) runs on manual dispatch and on pushes to `develop` that touch one of its listed app, Functions, web, Firebase, rules, scripts, signing, or workflow paths.
+Once triggered, its Firebase job always deploys indexes, waits for them, deploys Functions, verifies Functions, deploys Firestore rules, deploys Storage rules, and deploys Hosting in that order.
+The Firebase job has no dependency on the iOS build and runs in parallel with it, so staging can change before the archive finishes or even when the archive fails.
+The TestFlight upload depends on both jobs, so a successful staging binary is not uploaded until the compatible backend deployment has succeeded.
+
+[Deploy Production](../.github/workflows/deploy-production.yml) runs on manual dispatch and on pushes to `main` that touch one of its listed app, Functions, web, Firebase, rules, scripts, signing, or workflow paths.
+It first checks `PRODUCTION_READY`, then requests the workflow's single protected-environment approval before any build or deploy work begins.
+After approval, it builds the production IPA, deploys indexes, Functions, Firestore rules, Storage rules, and Hosting in dependency order, and only then uploads the IPA to TestFlight.
+The production widening therefore lands after the artifact is built but before that artifact is uploaded.
+
+Both workflows deploy rules when any path in their push allowlist triggers the workflow, not only when a rules file changed.
+A documentation-only push does not trigger either deploy workflow because `docs/**`, `CLAUDE.md`, and its `AGENTS.md` symlink are not in those allowlists.
+
+Remote Config has a separate release path.
+Staging additively publishes new parameters to dev and staging before its archive begins, while no workflow publishes Remote Config to production.
+A new production parameter must be published through the captain-only process in [the production backend rollout runbook](production-backend-rollout-runbook.md) before the production archive preflight will pass.
+
+## Per-version contract snapshots
+
+Every shipped app version should have a checked-in snapshot describing the backend surface that version requires.
+A snapshot should identify the app version and build and record its Firestore paths, operations, accepted document shapes, callable request and response contracts, and Remote Config dependencies.
+It should describe observable requirements rather than preserve or copy the old client source.
+
+CI can consume every non-retired snapshot as a compatibility floor.
+For each proposed backend diff, the gate can verify that current rules still permit the recorded operations and shapes, callable contracts remain compatible, and Remote Config keys retain their recorded types and meanings.
+A removal, newly required field, narrower accepted value set, deleted callable, incompatible response, or missing Remote Config key should fail the pull request when any active snapshot still depends on it.
+
+This document defines the policy but does not build that gate or choose the snapshot format.
+[Issue #421](https://github.com/tpavay/AscendApp/issues/421) owns that implementation.
+
+## The retirement loop
+
+Retirement is the only supported exit from additive-only compatibility.
+
+1. Measure adoption until the versions that depend on the old contract are understood and the intended cutoff is acceptable.
+2. Raise the minimum supported app version to the first version that no longer needs the old contract.
+3. Verify that older builds can no longer continue into backend-dependent product behavior.
+4. Narrow the backend contract, remove the retired data or compatibility projection, and delete only the snapshots below the enforced minimum.
+
+[Issue #319](https://github.com/tpavay/AscendApp/issues/319) owns the minimum-supported-version lever required for this loop.
+Until that lever exists and has been used for the retiring versions, their backend contracts remain live.
+
+Without this loop, old fields, rules, callables, keys, data, and snapshots accumulate forever.
+That accumulation is the deliberate cost of continuing to support old clients, not permission to guess that nobody still runs them.

--- a/docs/backend-contract-compatibility.md
+++ b/docs/backend-contract-compatibility.md
@@ -30,9 +30,19 @@ Every backend contract change is additive until the retirement loop below is com
 - Widen security rules to admit the new valid operation or shape while continuing to admit every valid operation and shape used by a live client.
 - Preserve old required-field sets when widening strict `hasOnly` and `hasAll` validation, so an old client can still write a document that omits the new field.
 - Keep old callable entry points and old Remote Config keys live even after the newest app stops using them.
+- Keep a callable that any shipped client still needs exported from `functions/src/index.ts`, and keep it accepting its old request signature and returning its old response contract, because `scripts/verify-deployed-functions.mjs` reconciles the deployed function set exactly against this ref's exports and both deploy workflows run it.
 
 Changing an optional field to required, narrowing an accepted enum, rejecting a previously accepted document version, changing a callable response type, or changing a Remote Config key's meaning is a narrowing.
 Each one can break a released binary even when the newest source compiles and every current test passes.
+
+### Security rules are the one surface where additive checks are not free
+
+Cloud Firestore Security Rules currently limit a request to 1,000 expressions evaluated, and exceeding that limit denies the request.
+This repository observes that abort as a bare `PERMISSION_DENIED`, which is indistinguishable from a rule that deliberately refused the write, so an over-budget rule reads as a correct denial and can go undiagnosed.
+Every widening that adds validation therefore has to be measured, not assumed, with `tests/firebase-rules/workout-expression-budget.test.mjs` as the pattern to follow.
+Measure every maximum valid document shape the affected rule can be asked to evaluate, including the largest shape each live client version can legitimately build, because a rule that still accepts small documents can already be refusing large ones.
+If the additive validation cannot fit inside the budget, the change must move the new contract to a separately matched path or document version with its own evaluation budget, or complete the retirement loop below before narrowing the old contract.
+Never break an active snapshot to buy room, and never assume checks can accumulate on a single matched path without cost.
 
 ### Worked replacement example
 
@@ -76,6 +86,7 @@ The TestFlight upload depends on both jobs, so a successful staging binary is no
 It first checks `PRODUCTION_READY`, then requests the workflow's single protected-environment approval before any build or deploy work begins.
 After approval, it builds the production IPA, deploys indexes, Functions, Firestore rules, Storage rules, and Hosting in dependency order, and only then uploads the IPA to TestFlight.
 The production widening therefore lands after the artifact is built but before that artifact is uploaded.
+The summary above is deliberately short, and [the production backend rollout runbook](production-backend-rollout-runbook.md) is the authoritative deploy procedure with the full step-by-step ordering.
 
 Both workflows deploy rules when any path in their push allowlist triggers the workflow, not only when a rules file changed.
 A documentation-only push does not trigger either deploy workflow because `docs/**`, `CLAUDE.md`, and its `AGENTS.md` symlink are not in those allowlists.

--- a/docs/backend-contract-compatibility.md
+++ b/docs/backend-contract-compatibility.md
@@ -37,8 +37,8 @@ Each one can break a released binary even when the newest source compiles and ev
 
 ### Security rules are the one surface where additive checks are not free
 
-Cloud Firestore Security Rules currently limit a request to 1,000 expressions evaluated, and exceeding that limit denies the request.
-This repository observes that abort as a bare `PERMISSION_DENIED`, which is indistinguishable from a rule that deliberately refused the write, so an over-budget rule reads as a correct denial and can go undiagnosed.
+Firestore aborts rule evaluation once a request exceeds its expression budget, and the abort arrives as a bare `PERMISSION_DENIED` that is indistinguishable from a rule which deliberately refused the write, so an over-budget rule reads as a correct denial and can go undiagnosed.
+The [`ascend-firebase-data` skill](../.claude/skills/ascend-firebase-data/SKILL.md) owns that budget, its measured per-check costs, and the hoisting rules that keep a validator affordable.
 Every widening that adds validation therefore has to be measured, not assumed, with `tests/firebase-rules/workout-expression-budget.test.mjs` as the pattern to follow.
 Measure every maximum valid document shape the affected rule can be asked to evaluate, including the largest shape each live client version can legitimately build, because a rule that still accepts small documents can already be refusing large ones.
 If the additive validation cannot fit inside the budget, the change must move the new contract to a separately matched path or document version with its own evaluation budget, or complete the retirement loop below before narrowing the old contract.
@@ -80,6 +80,7 @@ The standing rule is "make the backend accept everything required by all live ap
 [Deploy Staging](../.github/workflows/deploy-staging.yml) runs on manual dispatch and on pushes to `develop` that touch one of its listed app, Functions, web, Firebase, rules, scripts, signing, or workflow paths.
 Once triggered, its Firebase job always deploys indexes, waits for them, deploys Functions, verifies Functions, deploys Firestore rules, deploys Storage rules, and deploys Hosting in that order.
 The Firebase job has no dependency on the iOS build and runs in parallel with it, so staging can change before the archive finishes or even when the archive fails.
+That parallelism is a known CI safety gap tracked by [issue #202](https://github.com/tpavay/AscendApp/issues/202) rather than settled design, and the `ascend-deploy` skill owns the job graph it belongs to.
 The TestFlight upload depends on both jobs, so a successful staging binary is not uploaded until the compatible backend deployment has succeeded.
 
 [Deploy Production](../.github/workflows/deploy-production.yml) runs on manual dispatch and on pushes to `main` that touch one of its listed app, Functions, web, Firebase, rules, scripts, signing, or workflow paths.


### PR DESCRIPTION
## Intent

Write and commit Ascend backend and client contract compatibility doctrine as repository documentation, then link it from AGENTS.md through its canonical CLAUDE.md target. Define the contract as Firestore shapes and fields, security rules, callable Function signatures, and Remote Config keys, while stating plainly that current client source is free to change. Require additive backend evolution, include a concrete end-to-end subsystem replacement example, explain the union-of-live-clients invariant and widening versus narrowing deploy asymmetry, and describe per-version contract snapshots conceptually without building the CI gate tracked by issue #421. Document the retirement loop through adoption monitoring and the minimum-supported-version gate tracked by issue #319, and state that old contracts accumulate forever without retirement. Verify all deployment claims against deploy-staging.yml and deploy-production.yml, including path triggers, staging parallelism, production approval placement, Firebase ordering, TestFlight ordering, and the separate production Remote Config process. Keep the change documentation-only: do not modify rules, workflows, app code, the #421 CI gate, or the #319 version gate. Use one full sentence per Markdown line and plain dashes instead of em dashes. Target develop and create a PR whose body contains Closes #423.

## What Changed

- Adds `docs/backend-contract-compatibility.md`, defining the backend contract as Firestore paths/shapes/fields, security rules, callable Function signatures, and Remote Config keys, and stating that current client source is free to change. It requires additive-only backend evolution, walks a worked end-to-end subsystem replacement (workouts to `climb_records`), and explains the union-of-live-clients invariant plus the widening-versus-narrowing deploy asymmetry.
- Carves out security rules as the one surface where additive checks are not free, pointing at the `ascend-firebase-data` skill for the expression budget and `tests/firebase-rules/workout-expression-budget.test.mjs` as the measurement pattern, and notes that a retained callable must stay exported from `functions/src/index.ts` because `scripts/verify-deployed-functions.mjs` reconciles the deployed set against those exports.
- Describes per-version contract snapshots conceptually and the retirement loop through adoption monitoring and a minimum-supported-version gate, deferring the CI gate to issue #421 and the version lever to issue #319; the deploy section restates trigger paths, staging parallelism, production approval placement, Firebase and TestFlight ordering, and the separate production Remote Config path from `deploy-staging.yml` and `deploy-production.yml`, linking the production runbook as authoritative. `CLAUDE.md` (and `AGENTS.md` through the symlink) gains one engineering-principles line pointing at the doc.

No rules, workflows, app code, or CI gates were touched. Review flagged three doc gaps (rules expression budget, callable retention, runbook cross-link) and those were folded in; the test step ran the full `scripts/test` suite and a 66-claim harness validating every deployment assertion against the two workflow files, all passing.

## Risk Assessment

✅ Low: The change is documentation-only - one new doc plus a single pointer line in CLAUDE.md - every factual claim in it verified against the workflows, scripts, tests, and runbook it cites, with all three prior review findings now correctly applied and no code, rules, or workflow modifications.

## Testing

Because this is a doctrine document, the failure mode that matters is a claim that does not match the repo, so I built a 66-claim harness that parses both deploy workflows as YAML and proves each doc assertion against the actual job graph - triggers, Firebase step order, staging parallelism, the single production approval placed before any work, production Firebase-then-TestFlight ordering, and the fact that no workflow publishes Remote Config to production. All 66 pass, and a negative control run against a shadow copy with an injected workflow-ordering defect and an injected em-dash/two-sentence line correctly failed those exact checks, so the green result has teeth. I also ran the CI job this change genuinely triggers (CLAUDE.md sits in ci.yml's `scripts` filter): the full `node --test scripts/test/*.test.mjs` suite passes 493/493, including the two suites that read CLAUDE.md/AGENTS.md. For reviewer-visible evidence I rendered the doc through GitHub's own GFM API and captured a full-page screenshot, which shows the complete end-user surface a contributor or agent reads. Two things remain unexercised and are recorded as informational: the branch is not yet pushed so the `Closes #423` PR body could not be checked (the base commit is confirmed on origin/develop), and the gitignored scripts/node_modules from the test install could not be deleted because the removal was permission-blocked - it cannot be committed or pushed.

- Evidence: Rendered doc (GitHub GFM), full page - the surface a contributor actually reads (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZEC9R2AGMKZ681EEQFTC90Y/doc-rendered-full.png</code>)
<details>
<summary>Evidence: Rendered doc HTML (GitHub GFM output, GitHub-styled)</summary>

```text
<!doctype html><html><head><meta charset="utf-8">
<title>docs/backend-contract-compatibility.md</title>
<style>
:root{--fg:#1f2328;--muted:#59636e;--border:#d1d9e0;--bg:#fff;--code-bg:#eff1f3;--link:#0969da}
body{margin:0;background:#f6f8fa;font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif;color:var(--fg)}
.wrap{max-width:1012px;margin:24px auto;padding:0 16px}
.filehdr{display:flex;align-items:center;gap:8px;background:var(--bg);border:1px solid var(--border);border-bottom:0;border-radius:6px 6px 0 0;padding:8px 16px;font-size:14px;color:var(--muted)}
.filehdr strong{color:var(--fg);font-weight:600}
.badge{margin-left:auto;font-size:12px;background:#dafbe1;color:#1a7f37;border:1px solid #1a7f3733;border-radius:2em;padding:1px 8px}
.md{background:var(--bg);border:1px solid var(--border);border-radius:0 0 6px 6px;padding:32px 40px}
.md h1{font-size:2em;font-weight:600;padding-bottom:.3em;border-bottom:1px solid var(--border);margin:0 0 16px}
.md h2{font-size:1.5em;font-weight:600;padding-bottom:.3em;border-bottom:1px solid var(--border);margin:24px 0 16px}
.md h3{font-size:1.25em;font-weight:600;margin:24px 0 16px}
.md p,.md ul,.md ol{margin:0 0 16px}
.md li{margin-top:.25em}
.md a{color:var(--link);text-decoration:none}.md a:hover{text-decoration:underline}
.md code{background:var(--code-bg);border-radius:6px;padding:.2em .4em;font-size:85%;font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
.md strong{font-weight:600}
</style></head><body><div class="wrap">
<div class="filehdr">📄 <strong>docs/backend-contract-compatibility.md</strong> · 124 lines · new file
<span class="badge">66/66 claims verified against the repo</span></div>
<article class="md">
<h1 dir="auto">Backend and client contract compatibility</h1>
<p dir="auto">Ascend's production backend always serves more than the newest source tree.<br>
Apple review separates a merge from delivery, and people install updates on their own schedules.<br>
An app version that shipped weeks or months ago can therefore share the backend with today's version.</p>
<p dir="auto">The governing invariant is simple: <strong>the production backend must satisfy the union of the contracts required by every live app version.</strong></p>
<h2 dir="auto">What the contract is</h2>
<p dir="auto">The contract is the backend surface that an installed binary can observe or depend on:</p>
<ul dir="auto">
<li>Firestore collection paths, document shapes, field names, field types, required and optional fields, and field meanings.</li>
<li>Firestore and Storage security rules that authorize an operation and accept its payload.</li>
<li>Callable Function names, request fields, response fields, types, error behavior, and meanings.</li>
<li>Remote Config parameter keys, types, defaults, and meanings.</li>
</ul>
<p dir="auto">The client source code is not part of this compatibility contract.<br>
New source is free to delete old models, repositories, decoders, and feature code when the new app no longer uses them.<br>
Keeping a released client's source code in the newest app does nothing for the binary already installed on a phone.<br>
Compatibility comes from preserving the backend behavior that binary calls, not from preserving dead client code in the current branch.</p>
<h2 dir="auto">Additive changes are the default</h2>
<p dir="auto">Every backend contract change is additive until the retirement loop below is complete.</p>
<ul dir="auto">
<li>Add fields, paths, callable parameters, response fields, and Remote Config keys without removing or repurposing existing ones.</li>
<li>Make new request fields optional for old callers, or introduce a new callable or document version when the new value is genuinely required.</li>
<li>Preserve the type and meaning of every existing field and key because reusing a name for a different concept is a removal hidden inside a rename-free diff.</li>
<li>Widen security rules to admit the new valid operation or shape while continuing to admit every valid operation and shape used by a live client.</li>
<li>Preserve old required-field sets when widening strict <code class="notranslate">hasOnly</code> and <code class="notranslate">hasAll</code> validation, so an old client can still write a document that omits the new field.</li>
<li>Keep old callable entry points and old Remote Config keys live even after the newest app stops using them.</li>
<li>Keep a callable that any shipped client still needs exported from <code class="notranslate">functions/src/index.ts</code>, and keep it accepting its old request signature and returning its old response contract, because <code class="notranslate">scripts/verify-deployed-functions.mjs</code> reconciles the deployed function set exactly against this ref's exports and both deploy workflows run it.</li>
</ul>
<p dir="auto">Changing an optional field to required, narrowing an accepted enum, rejecting a previously accepted document version, changing a callable response type, or changing a Remote Config key's meaning is a narrowing.<br>
Each one can break a released binary even when the newest source compiles and every current test passes.</p>
<h3 dir="auto">Security rules are the one surface where additive checks are not free</h3>
<p dir="auto">Cloud Firestore Security Rules currently limit a request to 1,000 expressions evaluated, and exceeding that limit denies the request.<br>
This repository observes that abort as a bare <code class="notranslate">PERMISSION_DENIED</code>, which is indistinguishable from a rule that deliberately refused the write, so an over-budget rule reads as a correct denial and can go undiagnosed.<br>
Every widening that adds validation therefore has to be measured, not assumed, with <code class="notranslate">tests/firebase-rules/workout-expression-budget.test.mjs</code> as the pattern to follow.<br>
Measure every maximum valid document shape the affected rule can be asked to evaluate, including the largest shape each live client version can legitimately build, because a rule that still accepts small documents can already be refusing large ones.<br>
If the additive validation cannot fit inside the budget, the change must move the new contract to a separately matched path or document version with its own evaluation budget, or complete the retirement loop below before narrowing the old contract.<br>
Never break an active snapshot to buy room, and never assume checks can accumulate on a single matched path without cost.</p>
<h3 dir="auto">Worked replacement example</h3>
<p dir="auto">Suppose Ascend replaces the cloud-sync format for a completed stair-stepper climb.<br>
Version 1 writes and reads <code class="notranslate">users/{uid}/workouts/{workoutId}</code>, while version 2 will write and read only <code class="notranslate">users/{uid}/climb_records/{climbId}</code>.</p>
<p dir="auto">The safe end-to-end rollout is:</p>
<ol dir="auto">
<li>Add the <code class="notranslate">climb_records</code> model, its rules, its Functions, and any indexes alongside the existing workout backend.</li>
<li>Copy existing workout history into the new model without deleting or rewriting the original workout documents.</li>
<li>If both versions must see climbs created by the other version, deploy an idempotent server-side compatibility projection before version 2 ships.</li>
<li>Ship version 2 with only the new client model and repository, so the current source reads and writes <code class="notranslate">climb_records</code> and carries no obsolete version 1 client implementation.</li>
<li>Leave the version 1 path, fields, callable entry points, documents, and rules valid because a climber on version 1 can still finish a workout and sync through that contract.</li>
<li>Keep both backend surfaces until version 1 has completed the retirement loop.</li>
</ol>
<p dir="auto">This approach replaces the client subsystem cleanly while the backend serves both generations.<br>
Deleting the version 1 Swift code is safe because version 1 already contains its own copy, but deleting or narrowing the version 1 backend is not safe while that copy can still run.</p>
<h2 dir="auto">Deploy ordering and the widening asymmetry</h2>
<p dir="auto">Security rules and Functions deploy from the repository and take effect for the whole Firebase project within seconds.<br>
An App Store binary reaches users days later and then spreads unevenly.<br>
These timelines make widening and narrowing fundamentally asymmetric.</p>
<p dir="auto">A widening must reach the backend before or with the first app build that needs it.<br>
Deploying the app first creates a window in which the new client sends a valid new field or calls a new Function and the old backend rejects it.<br>
A narrowing has the opposite and larger blast radius because it breaks every live client that needs the removed behavior as soon as the backend deploy completes.<br>
Waiting to ship a matching new app does not protect the clients already installed.</p>
<p dir="auto">The standing rule is therefore not "make the backend match the newest app."<br>
The standing rule is "make the backend accept everything required by all live apps, including the newest one."</p>
<h3 dir="auto">What the current workflows actually do</h3>
<p dir="auto"><a href="../.github/workflows/deploy-staging.yml">Deploy Staging</a> runs on manual dispatch and on pushes to <code class="notranslate">develop</code> that touch one of its listed app, Functions, web, Firebase, rules, scripts, signing, or workflow paths.<br>
Once triggered, its Firebase job always deploys indexes, waits for them, deploys Functions, verifies Functions, deploys Firestore rules, deploys Storage rules, and deploys Hosting in that order.<br>
The Firebase job has no dependency on the iOS build and runs in parallel with it, so staging can change before the archive finishes or even when the archive fails.<br>
The TestFlight upload depends on both jobs, so a successful staging binary is not uploaded until the compatible backend deployment has succeeded.</p>
<p dir="auto"><a href="../.github/workflows/deploy-production.yml">Deploy Production</a> runs on manual dispatch and on pushes to <code class="notranslate">main</code> that touch one of its listed app, Functions, web, Firebase, rules, scripts, signing, or workflow paths.<br>
It first checks <code class="notranslate">PRODUCTION_READY</code>, then requests the workflow's single protected-environment approval before any build or deploy work begins.<br>
After approval, it builds the production IPA, deploys indexes, Functions, Firestore rules, Storage rules, and Hosting in dependency order, and only then uploads the IPA to TestFlight.<br>
The production widening therefore lands after the artifact is built but before that artifact is uploaded.<br>
The summary above is deliberately short, and <a href="production-backend-rollout-runbook.md">the production backend rollout runbook</a> is the authoritative deploy procedure with the full step-by-step ordering.</p>
<p dir="auto">Both workflows deploy rules when any path in their push allowlist triggers the workflow, not only when a rules file changed.<br>
A documentation-only push does not trigger either deploy workflow because <code class="notranslate">docs/**</code>, <code class="notranslate">CLAUDE.md</code>, and its <code class="notranslate">AGENTS.md</code> symlink are not in those allowlists.</p>
<p dir="auto">Remote Config has a separate release path.<br>
Staging additively publishes new parameters to dev and staging before its archive begins, while no workflow publishes Remote Config to production.<br>
A new production parameter must be published through the captain-only process in <a href="production-backend-rollout-runbook.md">the production backend rollout runbook</a> before the production archive preflight will pass.</p>
<h2 dir="auto">Per-version contract snapshots</h2>
<p dir="auto">Every shipped app version should have a checked-in snapshot describing the backend surface that version requires.<br>
A snapshot should identify the app version and build and record its Firestore paths, operations, accepted document shapes, callable request and response contracts, and Remote Config dependencies.<br>
It should describe observable requirements rather than preserve or copy the old client source.</p>
<p dir="auto">CI can consume every non-retired snapshot as a compatibility floor.<br>
For each proposed backend diff, the gate can verify that current rules still permit the recorded operations and shapes, callable contracts remain compatible, and Remote Config keys retain their recorded types and meanings.<br>
A removal, newly required field, narrower accepted value set, deleted callable, incompatible response, or missing Remote Config key should fail the pull request when any active snapshot still depends on it.</p>
<p dir="auto">This document defines the policy but does not build that gate or choose the snapshot format.<br>
<a href="https://github.com/tpavay/AscendApp/issues/421" data-hovercard-type="issue" data-hovercard-url="/tpavay/AscendApp/issues/421/hovercard">Issue #421</a> owns that implementation.</p>
<h2 dir="auto">The retirement loop</h2>
<p dir="auto">Retirement is the only supported exit from additive-only compatibility.</p>
<ol dir="auto">
<li>Measure adoption until the versions that depend on the old contract are understood and the intended cutoff is acceptable.</li>
<li>Raise the minimum supported app version to the first version that no longer needs the old contract.</li>
<li>Verify that older builds can no longer continue into backend-dependent product behavior.</li>
<li>Narrow the backend contract, remove the retired data or compatibility projection, and delete only the snapshots below the enforced minimum.</li>
</ol>
<p dir="auto"><a href="https://github.com/tpavay/AscendApp/issues/319" data-hovercard-type="issue" data-hovercard-url="/tpavay/AscendApp/issues/319/hovercard">Issue #319</a> owns the minimum-supported-version lever required for this loop.<br>
Until that lever exists and has been used for the retiring versions, their backend contracts remain live.</p>
<p dir="auto">Without this loop, old fields, rules, callables, keys, data, and snapshots accumulate forever.<br>
That accumulation is the deliberate cost of continuing to support old clients, not permission to guess that nobody still runs them.</p></article></div></body></html>
```
</details>
<details>
<summary>Evidence: Deployment-claim verification: doc assertions vs. deploy-staging.yml / deploy-production.yml (66/66)</summary>

<code>Claim: deploy-staging.yml&#10;[PASS] triggers on workflow_dispatch&#10;[PASS] triggers on pushes to develop&#10;[PASS] push allowlist excludes docs/**, CLAUDE.md and AGENTS.md&#10;[PASS] Firebase job order: indexes, wait, Functions, verify, Firestore rules, Storage rules, Hosting&#10;[PASS] Firebase job has no dependency on the iOS build (runs in parallel)&#10;[PASS] TestFlight upload depends on BOTH build-ios and deploy-firebase&#10;&#10;Claim: deploy-production.yml&#10;[PASS] production-gate checks PRODUCTION_READY first and has no needs&#10;[PASS] exactly one protected-environment approval job&#10;[PASS] approval job depends only on production-gate (requested before any work)&#10;[PASS] approval job performs no build or deploy work&#10;[PASS] Firebase deploy happens AFTER the IPA build&#10;[PASS] TestFlight upload happens AFTER the Firebase deploy&#10;[PASS] Firebase job order: indexes, Functions, Firestore rules, Storage rules, Hosting&#10;&#10;Claim: Remote Config release path&#10;[PASS] staging workflow publishes new parameters to dev and staging&#10;[PASS] that publish runs before the staging archive begins&#10;[PASS] NO workflow publishes Remote Config to production&#10;[PASS] production archive preflight asserts prod Remote Config is already published&#10;&#10;===&#10;66/66 claims verified against the repository.&#10;===</code>

```text
================================================================================================
BACKEND CONTRACT COMPATIBILITY DOC - CLAIM VERIFICATION
repo: /Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZEC9R2AGMKZ681EEQFTC90Y
doc:  docs/backend-contract-compatibility.md  (124 lines)
================================================================================================

Scope: documentation-only
  [PASS] diff touches only CLAUDE.md and the new doc
  [PASS] no rules, workflow, or app-code file modified

Linkage: AGENTS.md -> CLAUDE.md -> doc
  [PASS] AGENTS.md is a symlink to CLAUDE.md
  [PASS] CLAUDE.md references docs/backend-contract-compatibility.md
  [PASS] the same reference is readable through AGENTS.md

Style: house Markdown rules
  [PASS] no em dash anywhere in the doc
  [PASS] no em dash in the CLAUDE.md line added
  [PASS] one full sentence per Markdown line

References resolve on disk
  [PASS] link target exists: ../.github/workflows/deploy-staging.yml
  [PASS] link target exists: ../.github/workflows/deploy-production.yml
  [PASS] link target exists: production-backend-rollout-runbook.md
  [PASS] link target exists: production-backend-rollout-runbook.md
  [PASS] inline code path exists: tests/firebase-rules/workout-expression-budget.test.mjs
  [PASS] inline code path exists: scripts/verify-deployed-functions.mjs
  [PASS] inline code path exists: functions/src/index.ts

Deferred-work issue references
  [PASS] #421 named as owner of the un-built CI gate
  [PASS] #319 named as owner of the minimum-supported-version lever
  [PASS] unbounded accumulation without retirement is stated

Claim: deploy-staging.yml
  [PASS] triggers on workflow_dispatch
  [PASS] triggers on pushes to develop
  [PASS] push allowlist covers app (AscendApp/**)
  [PASS] push allowlist covers Functions (functions/**)
  [PASS] push allowlist covers web (web/**)
  [PASS] push allowlist covers Firebase (firebase.json)
  [PASS] push allowlist covers rules (firestore.rules)
  [PASS] push allowlist covers scripts (scripts/**)
  [PASS] push allowlist covers signing (fastlane/**)
  [PASS] push allowlist covers workflow (.github/workflows/deploy-staging.yml)
  [PASS] push allowlist excludes docs/**, CLAUDE.md and AGENTS.md
  [PASS] Firebase job order: indexes, wait, Functions, verify, Firestore rules, Storage rules, Hosting
  [PASS] Firebase job has no dependency on the iOS build (runs in parallel)
  [PASS] TestFlight upload depends on BOTH build-ios and deploy-firebase
  [PASS] Firebase deploy steps are unconditional (rules deploy on any allowlisted trigger)

Claim: deploy-production.yml
  [PASS] triggers on workflow_dispatch
  [PASS] triggers on pushes to main
  [PASS] push allowlist excludes docs/**, CLAUDE.md and AGENTS.md
  [PASS] production-gate checks PRODUCTION_READY first and has no needs
  [PASS] exactly one protected-environment approval job
  [PASS] approval job depends only on production-gate (requested before any work)
  [PASS] approval job performs no build or deploy work
  [PASS] build-ios is gated behind production-approval
  [PASS] deploy-firebase is gated behind production-approval
  [PASS] upload-testflight is gated behind production-approval
  [PASS] Firebase deploy happens AFTER the IPA build
  [PASS] TestFlight upload happens AFTER the Firebase deploy
  [PASS] Firebase job order: indexes, Functions, Firestore rules, Storage rules, Hosting

Claim: cross-workflow
  [PASS] both deploy workflows run scripts/verify-deployed-functions.mjs

Claim: Remote Config release path
  [PASS] staging workflow publishes new parameters to dev and staging
  [PASS] that publish runs before the staging archive begins
  [PASS] NO workflow publishes Remote Config to production
  [PASS] production archive preflight asserts prod Remote Config is already published
  [PASS] runbook named as the captain-only production publish process

Claim: rules expression budget
  [PASS] doc states the 1,000-expression limit
  [PASS] cited budget test really measures the expression budget
  [PASS] doc states the abort is observed as a bare PERMISSION_DENIED

Required content from the intent
  [PASS] contract = Firestore shapes/fields
  [PASS] contract = security rules
  [PASS] contract = callable Function signatures
  [PASS] contract = Remote Config keys
  [PASS] client source is free to change
  [PASS] additive evolution required
  [PASS] union-of-live-clients invariant
  [PASS] widening vs narrowing asymmetry
  [PASS] end-to-end replacement example
  [PASS] per-version snapshots described conceptually
  [PASS] adoption monitoring in the retirement loop

================================================================================================
66/66 claims verified against the repository.
================================================================================================
```
</details>
<details>
<summary>Evidence: Negative control - same harness catches injected defects (not vacuous)</summary>

<code>MUTATION 1 (workflow): removed &#39;build-ios&#39; from deploy-production.yml&#39;s deploy-firebase &#39;needs:&#39;&#10;MUTATION 2 (doc): replaced one line with an em-dash line carrying two sentences&#10;&#10;62/66 claims verified against the repository.&#10;4 FAILED:&#10;- [Style: house Markdown rules] no em dash anywhere in the doc&#10;- [Style: house Markdown rules] one full sentence per Markdown line offending lines=[113]&#10;- [Claim: deploy-production.yml] Firebase deploy happens AFTER the IPA build&#10;(the 4th failure is a symlink artifact of the shadow directory, not an injected defect)</code>

```text
NEGATIVE CONTROL - proves verify_contract_doc_claims.py is not vacuous.
The same harness was run against a shadow copy of the repo with two deliberate defects injected:
  MUTATION 1 (workflow): removed 'build-ios' from deploy-production.yml's deploy-firebase 'needs:'
  MUTATION 2 (doc):      replaced one line with an em-dash line carrying two sentences
(The AGENTS.md failure is an artifact of the shadow directory's symlink layout, not an injected defect.)

  [PASS] end-to-end replacement example
  [PASS] per-version snapshots described conceptually
  [PASS] adoption monitoring in the retirement loop

================================================================================================
62/66 claims verified against the repository.
4 FAILED:
  - [Linkage: AGENTS.md -> CLAUDE.md -> doc] AGENTS.md is a symlink to CLAUDE.md target=/Users/tylerpavay/.no-mistakes/worktrees/fe7dc569e94d/01KZEC9R2AGMKZ681EEQFTC90Y/AGENTS.md
  - [Style: house Markdown rules] no em dash anywhere in the doc 
  - [Style: house Markdown rules] one full sentence per Markdown line offending lines=[113]
  - [Claim: deploy-production.yml] Firebase deploy happens AFTER the IPA build 
================================================================================================
```
</details>
- Evidence: Claim-verification harness source (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZEC9R2AGMKZ681EEQFTC90Y/verify_contract_doc_claims.py</code>)
<details>
<summary>Evidence: scripts-verify suite (the CI job this change triggers via CLAUDE.md)</summary>

```text
$ node --test scripts/test/*.test.mjs
ℹ tests 493
ℹ pass 493
ℹ fail 0
ℹ duration_ms 7991.2

$ node --test scripts/test/ci-required-check-routing.test.mjs scripts/test/subscription-launch-offer.test.mjs
✔ the allowlist never overrides the CI trigger
✔ unclassified paths fail closed
✔ CI reruns the contract for every repository-controlled launch surface
ℹ tests 25 pass 25 fail 0
```
</details>
- Outcome: ⚠️ 2 infos across 1 run (7m32s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `docs/backend-contract-compatibility.md:31` - The additive-only doctrine tells authors to preserve old required-field sets when widening strict `hasOnly`/`hasAll` validation, but never mentions that firestore.rules has a hard 1000-expression evaluation budget. Exceeding it is indistinguishable from a deliberate denial (bare PERMISSION_DENIED) and has already caused a real four-day outage for one climber (ASCEND-IOS-1J); `tests/firebase-rules/workout-expression-budget.test.mjs` exists precisely to pin that ceiling. Rules widening is the one place where &#39;accumulate additively forever&#39; is false in this repo, and a doctrine document that omits it will lead someone to widen the workout rule past the abort threshold while believing they followed policy.
- ℹ️ `docs/backend-contract-compatibility.md:32` - The doc says to keep old callable entry points live even after the newest app stops using them, and separately (correctly) says client source is free to delete unused code. It does not say that a retained callable must stay exported from `functions/src/index.ts`: `scripts/verify-deployed-functions.mjs` asserts the project holds exactly what the ref exports, &#39;no more, no fewer&#39;, and both deploy workflows run it. Deleting a now-unused Cloud Function from source under the repo&#39;s &#39;Delete before you defend&#39; principle would both remove it from the backend and fail the reconciliation step. One sentence stating that backend source retention is what keeps an old callable live would close the gap.
- ℹ️ `docs/backend-contract-compatibility.md:77` - The production deploy sequence (readiness gate, single approval, build IPA, indexes, Functions, Firestore rules, Storage rules, Hosting, then TestFlight upload) is restated here while `docs/production-backend-rollout-runbook.md:105-118` already owns it authoritatively in more detail. The doc correctly links that runbook for Remote Config at line 85 but not for the ordering, so the two copies can drift the next time the workflow changes - exactly the failure mode CLAUDE.md&#39;s &#39;prefer a pointer to the authoritative file&#39; guidance targets. Adding a cross-link to the runbook alongside the summary would keep this section honest.

🔧 Fix: Document rules expression budget, callable retention, runbook link
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 2 infos</summary>

- ℹ️ PR-body verification is deferred: branch fm/write-contract-compatibility-doc is not pushed and no PR exists yet, so the intent constraints &#39;target develop&#39; and &#39;PR body contains Closes #423&#39; could not be exercised at this step. The base commit bbba484 is confirmed to be on origin/develop, so the branch point is correct. These should be confirmed when the push/PR step runs.
- ℹ️ scripts/node_modules (from `npm --prefix scripts ci`, required to run the scripts-verify suite) remains in the worktree. Two attempts to delete it were blocked by tool permissions. It is gitignored (.gitignore:84) and `git status --untracked-files=all` reports clean, so it cannot be committed or pushed; delete it manually if a pristine worktree is wanted.
- <code>`python3 verify_contract_doc_claims.py &lt;repo&gt;` - 66-claim harness parsing deploy-staging.yml and deploy-production.yml with PyYAML, asserting each doc assertion about triggers, job graph, step order, approval placement, and Remote Config against the real workflow structure (66/66 pass)</code>
- <code>Negative control: same harness re-run against a shadow repo copy with two injected defects (removed `build-ios` from production deploy-firebase `needs:`; replaced a doc line with an em-dash line carrying two sentences) - correctly dropped to 62/66 and named exactly those defects, proving the harness is not vacuous</code>
- <code>`node --test scripts/test/*.test.mjs` - the full scripts-verify suite, which is the CI job this change triggers because CLAUDE.md is in ci.yml&#39;s `scripts` paths-filter (493/493 pass)</code>
- <code>`node --test scripts/test/ci-required-check-routing.test.mjs scripts/test/subscription-launch-offer.test.mjs` - the two suites that read CLAUDE.md/AGENTS.md directly (25/25 pass)</code>
- <code>`gh api -X POST /markdown --mode gfm` - rendered the doc through GitHub&#39;s own GFM renderer, then captured a full-page screenshot via `chrome-devtools-axi screenshot --full-page` over a local HTTP server (Chrome refused to screenshot the file:// page)</code>
- <code>`git diff --name-only bbba484..HEAD` - confirmed only CLAUDE.md and docs/backend-contract-compatibility.md changed</code>
- `Manual check that AGENTS.md is a symlink to CLAUDE.md and that the new doc reference resolves identically when read through AGENTS.md`
- `Manual verification that every relative link target and inline code path in the doc exists on disk (deploy-staging.yml, deploy-production.yml, production-backend-rollout-runbook.md, workout-expression-budget.test.mjs, verify-deployed-functions.mjs, functions/src/index.ts)`
- <code>`git status --porcelain --untracked-files=all` - confirmed worktree clean after testing</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
