### PR TITLE
feat(climbs): activate 28 Towerrunning World Tour venues

### DIFF
--- a/.claude/skills/live-climb-content/SKILL.md
+++ b/.claude/skills/live-climb-content/SKILL.md
@@ -83,6 +83,9 @@ Hidden means not raceable, never that earned history disappears. A climber's hel
 
 If images are missing or uncertain, default new climbs to `comingSoon` or `hidden`, not `available`.
 
+A climb only reaches `available` once its race distance is published in `realStairCount`.
+Without one it ranks climbers against `round(totalHeightMeters * 5.5)`, a height fact nobody raced, so `AscendAppTests/ClimbCatalogStairCountTests.swift` fails any `available` climb with a null count.
+
 ## Tier Rules
 
 Set `tier` from the climb's reference step count:
@@ -149,6 +152,8 @@ node scripts/sync-climb-images.mjs sync --from staging --to production --confirm
 ```
 
 Writes to production require `--confirm-production`. Sync copies only missing/changed objects (md5 compare) and never deletes. When adding a climb: upload images to dev/staging first, validate in-app, then sync to production alongside (or before) the catalog deploy that references them.
+
+`releaseState` is not per-environment: one catalogue file deploys to dev, staging, and production, so promoting a climb to `available` commits every environment to having its artwork. Audit the production bucket before that deploy, not after it.
 
 ## Workflow
 

--- a/AscendApp/Features/Climbs/Resources/climbs.json
+++ b/AscendApp/Features/Climbs/Resources/climbs.json
@@ -1615,7 +1615,7 @@
     "tags": ["mixed use", "changsha", "world tour"],
     "funFact": "The complex pairs a seven-storey mall with a 328-metre supertower, the tallest in western Changsha.",
     "sourceURL": "https://www.capitaland.com/en/find-a-property/global-property-listing/retail/capitamall-one.html",
-    "releaseState": "available"
+    "releaseState": "comingSoon"
   },
   {
     "id": "central-plaza-hong-kong",

--- a/AscendApp/Features/Climbs/Resources/climbs.json
+++ b/AscendApp/Features/Climbs/Resources/climbs.json
@@ -1527,7 +1527,7 @@
     "tags": ["supertall", "shenzhen", "world tour"],
     "funFact": "The race climbs 116 floors and 3,201 stairs over 541 vertical metres.",
     "sourceURL": "https://www.towerrunning.com/2026/01/10/tea-faber-wai-ching-soh-pingan-champions/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "ctf-finance-centre-guangzhou",
@@ -1549,7 +1549,7 @@
     "tags": ["supertall", "guangzhou", "world tour"],
     "funFact": "The Guangzhou race climbs 109 floors and 3,160 stairs.",
     "sourceURL": "https://www.towerrunning.com/races/r3103/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "shanghai-world-financial-center",
@@ -1571,7 +1571,7 @@
     "tags": ["observation deck", "shanghai", "world tour"],
     "funFact": "The Sky Marathon finishes after 100 floors and 2,726 stairs.",
     "sourceURL": "https://www.towerrunning.com/races/r2854/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "sommerbergbahn-stair",
@@ -1593,7 +1593,7 @@
     "tags": ["outdoor stairs", "black forest", "world tour"],
     "funFact": "Germany's longest staircase runs 720 metres beside the Sommerbergbahn and pitches up to 52 percent.",
     "sourceURL": "https://calw.wlv-sport.de/home/details/news/17-bad-wildbader-staeffeleslauf-entlang-der-bergbahntrasse-am-freitag-19-juni-2026-auf-deutschland-laengster-treppe",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "capitamall-one",
@@ -1615,7 +1615,7 @@
     "tags": ["mixed use", "changsha", "world tour"],
     "funFact": "The complex pairs a seven-storey mall with a 328-metre supertower, the tallest in western Changsha.",
     "sourceURL": "https://www.capitaland.com/en/find-a-property/global-property-listing/retail/capitamall-one.html",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "central-plaza-hong-kong",
@@ -1637,7 +1637,7 @@
     "tags": ["harbour skyline", "hong kong", "world tour"],
     "funFact": "Hong Chi's full course climbs from ground level to the 75th floor.",
     "sourceURL": "https://www.hongchi.org.hk/en/climbathon/page/competition-details",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "875-north-michigan-avenue",
@@ -1660,7 +1660,7 @@
     "tags": ["x-braced", "chicago", "world tour"],
     "funFact": "Chicago still knows the 100-storey X-braced landmark by its former John Hancock Center name.",
     "sourceURL": "https://www.towerrunning.com/races/r3137/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "dc-tower-1",
@@ -1682,7 +1682,7 @@
     "tags": ["danube skyline", "vienna", "world tour"],
     "funFact": "The race runs from the lobby to floor 58 over a 210-metre ascent.",
     "sourceURL": "https://www.towerrunning.com/races/r3181/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "yingkai-square",
@@ -1704,7 +1704,7 @@
     "tags": ["bamboo facade", "guangzhou", "world tour"],
     "funFact": "Its segmented facade was inspired by the joints of Chinese bamboo.",
     "sourceURL": "https://www.towerrunning.com/races/r3278/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "tk-elevator-test-tower",
@@ -1726,7 +1726,7 @@
     "tags": ["test tower", "rottweil", "world tour"],
     "funFact": "Its 12 test shafts can run elevators at speeds up to 18 metres per second.",
     "sourceURL": "https://www.towerrunning.com/races/r2703/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "varso-tower",
@@ -1748,7 +1748,7 @@
     "tags": ["observation deck", "warsaw", "world tour"],
     "funFact": "Its 310-metre spire makes it the European Union's tallest building.",
     "sourceURL": "https://www.towerrunning.com/races/r2704/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "tianjin-tv-tower",
@@ -1770,7 +1770,7 @@
     "tags": ["broadcast tower", "tianjin", "world tour"],
     "funFact": "The New Year course circles the tower base before climbing 253 vertical metres to the observation hall.",
     "sourceURL": "https://www.sohu.com/a/844232355_267106",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "macau-tower",
@@ -1792,7 +1792,7 @@
     "tags": ["observation deck", "macau", "world tour"],
     "funFact": "The full Oxfam course climbs 61 floors to the observation deck.",
     "sourceURL": "https://www.towerrunning.com/races/r2806/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "frasers-tower",
@@ -1814,7 +1814,7 @@
     "tags": ["green tower", "singapore", "world tour"],
     "funFact": "The 235-metre office tower rises from a three-storey cascading retail podium.",
     "sourceURL": "https://www.towerrunning.com/races/r3037/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "torre-reforma",
@@ -1836,7 +1836,7 @@
     "tags": ["concrete walls", "mexico city", "firefighter race"],
     "funFact": "The 2024 firefighter race extended the course to 56 floors and 1,487 stairs.",
     "sourceURL": "https://www.publimetro.com.mx/noticias/2024/09/21/esto-es-lo-que-tienes-que-saber-de-la-carrera-vertical-del-cuerpo-de-bomberos-de-la-cdmx/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "messeturm-frankfurt",
@@ -1858,7 +1858,7 @@
     "tags": ["pyramid crown", "frankfurt", "world tour"],
     "funFact": "A pyramid crown tops the red-granite tower above Frankfurt's trade-fair grounds.",
     "sourceURL": "https://www.towerrunning.com/races/r3182/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "sky-tower-wroclaw",
@@ -1880,7 +1880,7 @@
     "tags": ["mixed use", "wroclaw", "world tour"],
     "funFact": "The race starts five levels below ground before climbing 49 floors.",
     "sourceURL": "https://www.towerrunning.com/races/r2714/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "gran-hotel-bali",
@@ -1902,7 +1902,7 @@
     "tags": ["hotel", "benidorm", "world tour"],
     "funFact": "The race finishes 180 metres above Benidorm after 52 floors.",
     "sourceURL": "https://www.towerrunning.com/races/r3068/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "tallinn-tv-tower",
@@ -1924,7 +1924,7 @@
     "tags": ["broadcast tower", "tallinn", "world tour"],
     "funFact": "The race climbs 870 stairs inside Estonia's tallest building.",
     "sourceURL": "https://www.towerrunning.com/races/r2433/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "rondo-1",
@@ -1946,7 +1946,7 @@
     "tags": ["left-turn stairs", "warsaw", "world tour"],
     "funFact": "The race's left-turn staircase gains 142 metres over 38 floors.",
     "sourceURL": "https://www.towerrunning.com/2026/02/02/announcement-towerrunning-120-bieg-na-szczyt-rondo-1-warsaw-march-28-2026/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "post-tower",
@@ -1968,7 +1968,7 @@
     "tags": ["headquarters", "bonn", "world tour"],
     "funFact": "The race climbs 41 floors inside Deutsche Post's Bonn headquarters.",
     "sourceURL": "https://www.towerrunning.com/races/r3207/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "sky-tower-bucharest",
@@ -1990,7 +1990,7 @@
     "tags": ["observation deck", "bucharest", "world tour"],
     "funFact": "The 36-floor course gains 126 metres to the observation deck.",
     "sourceURL": "https://www.towerrunning.com/races/r2937/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "koelnturm",
@@ -2012,7 +2012,7 @@
     "tags": ["office tower", "cologne", "world tour"],
     "funFact": "Germany's championship course climbs from ground level to the 40th floor.",
     "sourceURL": "https://www.koelner-treppenlauf.de/infos_en/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "torre-glories",
@@ -2034,7 +2034,7 @@
     "tags": ["observation deck", "barcelona", "world tour"],
     "funFact": "The night race climbs 34 floors to the tower's observation deck.",
     "sourceURL": "https://www.towerrunning.com/2025/11/26/announcement-towerrunning-120-cupra-barcelona-tower-running-challenge-barcelona-fanuary-17-2026/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "az-tower",
@@ -2056,7 +2056,7 @@
     "tags": ["rooftop finish", "brno", "world tour"],
     "funFact": "The current course reaches the roof after 29 floors.",
     "sourceURL": "https://www.towerrunning.com/races/r2867/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "hyatt-regency-barcelona-tower",
@@ -2078,7 +2078,7 @@
     "tags": ["outdoor stairs", "barcelona", "world tour"],
     "funFact": "The outdoor staircase rises 105 metres to the glass dome.",
     "sourceURL": "https://metropolitanskyrun.com/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "messeturm-basel",
@@ -2100,7 +2100,7 @@
     "tags": ["green glass", "basel", "world tour"],
     "funFact": "The green-glass slab was Switzerland's tallest building when it opened in 2003.",
     "sourceURL": "https://www.towerrunning.com/races/r3024/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "pyramidenkogel",
@@ -2122,7 +2122,7 @@
     "tags": ["wooden tower", "carinthia", "world tour"],
     "funFact": "Its 71-metre finish platform sits inside the world's tallest wooden observation tower.",
     "sourceURL": "https://www.towerrunning.com/2025/07/27/announcement-towerrunning-120-pyramidenkogel-turmlauf-september-14/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "ufo-tower-bratislava",
@@ -2144,6 +2144,6 @@
     "tags": ["bridge pylon", "bratislava", "world tour"],
     "funFact": "The race climbs a steep, slanted stair inside one bridge pylon before finishing on the roof.",
     "sourceURL": "https://www.towerrunning.com/races/r3235/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   }
 ]

--- a/AscendAppTests/ClimbCatalogCurationTests.swift
+++ b/AscendAppTests/ClimbCatalogCurationTests.swift
@@ -34,22 +34,16 @@ struct ClimbCatalogCurationTests {
         #expect(Self.comingSoonClimbIDs.isSubset(of: Set(snapshot.visibleClimbs.map(\.id))))
     }
 
-    @Test("The curated catalogue ships the approved 59/21/7 distribution", .bug(id: 465))
+    @Test("The curated catalogue ships the approved 58/21/8 distribution", .bug(id: 465))
     func curatedCatalogueCounts() throws {
         let snapshot = try Self.bundledSnapshot()
         let hiddenCount = snapshot.climbs.count(where: { $0.releaseState == .hidden })
 
         #expect(snapshot.climbs.count == 87)
-        #expect(snapshot.availableClimbs.count == 59)
+        #expect(snapshot.availableClimbs.count == 58)
         #expect(hiddenCount == 21)
-        #expect(snapshot.comingSoonClimbs.count == 7)
+        #expect(snapshot.comingSoonClimbs.count == 8)
         #expect(snapshot.climbs.allSatisfy { $0.releaseState != .disabled })
-        #expect(
-            snapshot.availableClimbs.count + snapshot.comingSoonClimbs.count + hiddenCount
-                == snapshot.climbs.count
-        )
-        #expect(hiddenCount == Self.hiddenMountainIDs.count)
-        #expect(snapshot.comingSoonClimbs.count == Self.comingSoonClimbIDs.count)
         #expect(Set(snapshot.climbs.map(\.id)).count == snapshot.climbs.count)
     }
 
@@ -130,6 +124,9 @@ struct ClimbCatalogCurationTests {
     ]
 
     private static let comingSoonClimbIDs: Set<String> = [
+        // CapitaMall ONE has no published course distance, so racing it would set
+        // every time against round(totalHeightMeters * 5.5) rather than a route.
+        "capitamall-one",
         "marina-bay-sands",
         "n-seoul-tower",
         "osaka-castle",

--- a/AscendAppTests/ClimbCatalogCurationTests.swift
+++ b/AscendAppTests/ClimbCatalogCurationTests.swift
@@ -23,34 +23,33 @@ struct ClimbCatalogCurationTests {
         #expect(Self.hiddenMountainIDs.isDisjoint(with: raceableIDs))
     }
 
-    @Test("Unverified stair routes remain visible but cannot start a race", .bug(id: 440))
+    @Test("Unverified stair routes remain visible but cannot start a race", .bug(id: 465))
     func comingSoonClimbsAreNotRaceable() throws {
         let snapshot = try Self.bundledSnapshot()
         let comingSoonIDs = Set(snapshot.comingSoonClimbs.map(\.id))
         let raceableIDs = Set(snapshot.availableClimbs.map(\.id))
 
-        // A subset, not equality: the World Tour venues from #453 wait for their
-        // artwork in the same state, and promoting them must not fail this test.
-        #expect(Self.comingSoonClimbIDs.isSubset(of: comingSoonIDs))
+        #expect(comingSoonIDs == Self.comingSoonClimbIDs)
         #expect(Self.comingSoonClimbIDs.isDisjoint(with: raceableIDs))
         #expect(Self.comingSoonClimbIDs.isSubset(of: Set(snapshot.visibleClimbs.map(\.id))))
     }
 
-    @Test("The curated catalogue ships only the approved racing states", .bug(id: 440))
+    @Test("The curated catalogue ships the approved 59/21/7 distribution", .bug(id: 465))
     func curatedCatalogueCounts() throws {
         let snapshot = try Self.bundledSnapshot()
         let hiddenCount = snapshot.climbs.count(where: { $0.releaseState == .hidden })
 
-        // Counts are derived, never pinned: the raceable total moves the moment
-        // the pending artwork uploads promote the World Tour venues (issue #452).
+        #expect(snapshot.climbs.count == 87)
+        #expect(snapshot.availableClimbs.count == 59)
+        #expect(hiddenCount == 21)
+        #expect(snapshot.comingSoonClimbs.count == 7)
         #expect(snapshot.climbs.allSatisfy { $0.releaseState != .disabled })
         #expect(
             snapshot.availableClimbs.count + snapshot.comingSoonClimbs.count + hiddenCount
                 == snapshot.climbs.count
         )
-        #expect(snapshot.availableClimbs.count > 0)
         #expect(hiddenCount == Self.hiddenMountainIDs.count)
-        #expect(snapshot.comingSoonClimbs.count >= Self.comingSoonClimbIDs.count)
+        #expect(snapshot.comingSoonClimbs.count == Self.comingSoonClimbIDs.count)
         #expect(Set(snapshot.climbs.map(\.id)).count == snapshot.climbs.count)
     }
 

--- a/AscendAppTests/ClimbCatalogStairCountTests.swift
+++ b/AscendAppTests/ClimbCatalogStairCountTests.swift
@@ -88,7 +88,7 @@ struct ClimbCatalogStairCountTests {
     }
 
     @Test
-    func worldTour2026AdditionsDecodeWithRaceableReleaseAndHonestTierData() throws {
+    func worldTour2026AdditionsRaceOnlyWhereACourseDistanceIsPublished() throws {
         let expectedIDs: Set<String> = [
             "ping-an-finance-centre", "ctf-finance-centre-guangzhou",
             "shanghai-world-financial-center",
@@ -105,12 +105,17 @@ struct ClimbCatalogStairCountTests {
 
         #expect(Set(additions.map(\.id)) == expectedIDs)
         #expect(additions.count == 29)
-        #expect(additions.allSatisfy { $0.releaseState == .available })
         #expect(additions.allSatisfy { $0.tier == ClimbTier(steps: $0.referenceStepCount) })
 
+        // A raceable climb races against a published route, never against
+        // round(totalHeightMeters * 5.5), so the one venue with no verified
+        // count stays a visible teaser instead of a fabricated target.
         let capitaMall = try #require(additions.first { $0.id == "capitamall-one" })
         #expect(capitaMall.realStairCount == nil)
         #expect(capitaMall.referenceStepCount == capitaMall.totalSteps)
+        #expect(capitaMall.releaseState == .comingSoon)
+
+        #expect(additions.count(where: { $0.releaseState == .available }) == 28)
     }
 
     @Test
@@ -179,6 +184,24 @@ struct ClimbCatalogStairCountTests {
         let unverified = climbs.filter { $0.realStairCount == nil }
 
         #expect(unverified.isEmpty == false)
+    }
+
+    @Test
+    func noRaceableClimbSetsItsTimesAgainstAHeightDerivedDistance() throws {
+        // Racing is the product, so a raceable climb's target is a published
+        // route. Without one the only number left is round(height * 5.5), and a
+        // leaderboard built on it ranks climbers against a fabricated distance.
+        let climbs = try Self.bundledCatalog()
+
+        let fabricated = climbs.filter { $0.releaseState == .available && $0.realStairCount == nil }
+
+        #expect(
+            fabricated.isEmpty,
+            """
+            A climb with no published course distance stays comingSoon: \
+            \(fabricated.map(\.id))
+            """
+        )
     }
 
     @Test

--- a/AscendAppTests/ClimbCatalogStairCountTests.swift
+++ b/AscendAppTests/ClimbCatalogStairCountTests.swift
@@ -88,7 +88,7 @@ struct ClimbCatalogStairCountTests {
     }
 
     @Test
-    func worldTour2026AdditionsDecodeWithHonestReleaseAndTierData() throws {
+    func worldTour2026AdditionsDecodeWithRaceableReleaseAndHonestTierData() throws {
         let expectedIDs: Set<String> = [
             "ping-an-finance-centre", "ctf-finance-centre-guangzhou",
             "shanghai-world-financial-center",
@@ -105,7 +105,7 @@ struct ClimbCatalogStairCountTests {
 
         #expect(Set(additions.map(\.id)) == expectedIDs)
         #expect(additions.count == 29)
-        #expect(additions.allSatisfy { $0.releaseState == .comingSoon })
+        #expect(additions.allSatisfy { $0.releaseState == .available })
         #expect(additions.allSatisfy { $0.tier == ClimbTier(steps: $0.referenceStepCount) })
 
         let capitaMall = try #require(additions.first { $0.id == "capitamall-one" })

--- a/AscendAppTests/ClimbCurationSurfaceEvidenceTests.swift
+++ b/AscendAppTests/ClimbCurationSurfaceEvidenceTests.swift
@@ -97,6 +97,38 @@ struct ClimbCurationSurfaceEvidenceTests {
         #expect(text.contains("start live climb"), "expected the race CTA in: \(text)")
     }
 
+    @Test("An activated World Tour venue offers the race on its detail screen", .bug(id: 465))
+    func activatedWorldTourVenueDetailStartsTheRace() async throws {
+        let torreReforma = try #require(
+            try Self.bundledCatalogService.loadAllClimbs().first { $0.id == "torre-reforma" }
+        )
+        #expect(torreReforma.releaseState == .available)
+
+        let text = try await captureDetail(
+            for: torreReforma,
+            named: "climb-detail-available-torre-reforma"
+        )
+
+        #expect(text.contains("start live climb"), "expected the race CTA in: \(text)")
+        #expect(!text.contains("coming soon"))
+    }
+
+    @Test("The World Tour venue with no published course distance stays locked", .bug(id: 465))
+    func heldBackWorldTourVenueDetailStillReadsComingSoon() async throws {
+        let capitaMall = try #require(
+            try Self.bundledCatalogService.loadAllClimbs().first { $0.id == "capitamall-one" }
+        )
+        #expect(capitaMall.releaseState == .comingSoon)
+
+        let text = try await captureDetail(
+            for: capitaMall,
+            named: "climb-detail-coming-soon-capitamall-one"
+        )
+
+        #expect(text.contains("coming soon"), "expected the pending state in: \(text)")
+        #expect(!text.contains("start live climb"))
+    }
+
     @Test("An unverified stair route still reads Coming Soon", .bug(id: 440))
     func comingSoonClimbDetailStillReadsComingSoon() async throws {
         let shard = try #require(

--- a/AscendAppTests/WorldTour2026CatalogueEvidenceTests.swift
+++ b/AscendAppTests/WorldTour2026CatalogueEvidenceTests.swift
@@ -7,27 +7,42 @@ import Vision
 /// Reviewer-facing visual evidence for the 2026 World Tour catalogue additions.
 ///
 /// The catalogue is data, but a climber meets it as pixels: a raceable preview card
-/// when they tap a pin on the globe, plus a category placeholder whenever artwork is
-/// unavailable. These tests render the shipped views against the shipped catalogue
+/// when they tap a pin on the globe, a locked "Coming Soon" card for the venue whose
+/// course distance is still unpublished, and a category placeholder whenever artwork
+/// is unavailable. These tests render the shipped views against the shipped catalogue
 /// file, read the rendered text back with Vision, and write reviewable proof sheets.
 @MainActor
 struct WorldTour2026CatalogueEvidenceTests {
     @Test
-    func newVenuesRenderAsRaceableCardsOnTheGlobe() async throws {
+    func newVenuesRenderTheReleaseStateTheCatalogueShipsThemAt() async throws {
         let showcase = try Self.showcase()
 
         for climb in showcase {
             let card = try renderCard(for: climb)
             let text = try await recognizedText(in: card)
 
-            #expect(text.contains("coming soon") == false, "\(climb.id) still read as coming soon")
             #expect(text.contains(climb.city.lowercased()), "\(climb.id) lost its location")
-            #expect(text.contains("steps"), "\(climb.id) did not expose its race distance")
+
+            if climb.releaseState == .available {
+                #expect(
+                    text.contains("coming soon") == false,
+                    "\(climb.id) still read as coming soon"
+                )
+                #expect(text.contains("steps"), "\(climb.id) did not expose its race distance")
+            } else {
+                // A venue with no published course distance announces itself as
+                // locked, never as a climbable distance.
+                #expect(text.contains("coming soon"), "\(climb.id) did not read as coming soon")
+                #expect(
+                    text.contains("steps") == false,
+                    "\(climb.id) offered a distance it can't be raced at"
+                )
+            }
         }
 
         try writeEvidence(
-            image: try renderSheet(AvailablePreviewProof(climbs: showcase)),
-            named: "world-tour-2026-available-cards.png"
+            image: try renderSheet(PreviewCardProof(climbs: showcase)),
+            named: "world-tour-2026-preview-cards.png"
         )
     }
 
@@ -59,6 +74,7 @@ struct WorldTour2026CatalogueEvidenceTests {
     func theWholeAdditionSetRendersItsTierAndStepReadout() async throws {
         let additions = try Self.additions()
         #expect(additions.count == 29)
+        #expect(additions.count(where: { $0.releaseState == .available }) == 28)
 
         let sheet = try renderSheet(AdditionRosterProof(climbs: additions))
         let text = try await recognizedText(in: sheet)
@@ -237,9 +253,20 @@ private struct MissingArtworkRepository: ClimbImageRepository {
     func resolveImageURL(for climb: Climb, variant: ClimbImageVariant) async -> URL? { nil }
 }
 
+private extension ClimbReleaseState {
+    var evidenceLabel: String {
+        switch self {
+        case .available: "AVAILABLE"
+        case .comingSoon: "COMING SOON"
+        case .hidden: "HIDDEN"
+        case .disabled: "DISABLED"
+        }
+    }
+}
+
 // MARK: - Proof sheets
 
-private struct AvailablePreviewProof: View {
+private struct PreviewCardProof: View {
     let climbs: [Climb]
 
     var body: some View {
@@ -320,11 +347,11 @@ private struct AdditionRosterProof: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("Towerrunning World Tour 2026 · 29 venues added")
+            Text("Towerrunning World Tour 2026 · 29 venues, 28 raceable")
                 .font(.montserratBold(size: 20))
                 .foregroundStyle(.white)
 
-            Text("Each row shows the shipped race distance and the tier it derives.")
+            Text("Each row shows the shipped race distance, its tier, and its release state.")
                 .font(.montserratRegular(size: 12))
                 .foregroundStyle(.white.opacity(0.6))
 
@@ -361,7 +388,7 @@ private struct AdditionRosterProof: View {
                             .foregroundStyle(climb.tier.color)
                             .frame(width: 78, alignment: .leading)
 
-                        Text("AVAILABLE")
+                        Text(climb.releaseState.evidenceLabel)
                             .font(.montserratBold(size: 9))
                             .tracking(1)
                             .foregroundStyle(.white.opacity(0.5))

--- a/AscendAppTests/WorldTour2026CatalogueEvidenceTests.swift
+++ b/AscendAppTests/WorldTour2026CatalogueEvidenceTests.swift
@@ -6,30 +6,28 @@ import Vision
 
 /// Reviewer-facing visual evidence for the 2026 World Tour catalogue additions.
 ///
-/// The catalogue is data, but a climber meets it as pixels: a locked "Coming Soon"
-/// preview card when they tap the new pin on the globe, and - until the artwork is
-/// uploaded to Storage - a category placeholder behind it. These tests render the
-/// shipped views against the shipped catalogue file, read the rendered text back with
-/// Vision, and write the sheets a reviewer can look at.
+/// The catalogue is data, but a climber meets it as pixels: a raceable preview card
+/// when they tap a pin on the globe, plus a category placeholder whenever artwork is
+/// unavailable. These tests render the shipped views against the shipped catalogue
+/// file, read the rendered text back with Vision, and write reviewable proof sheets.
 @MainActor
 struct WorldTour2026CatalogueEvidenceTests {
     @Test
-    func newVenuesRenderAsLockedComingSoonCardsOnTheGlobe() async throws {
+    func newVenuesRenderAsRaceableCardsOnTheGlobe() async throws {
         let showcase = try Self.showcase()
 
         for climb in showcase {
             let card = try renderCard(for: climb)
             let text = try await recognizedText(in: card)
 
-            // A new venue announces itself as locked, never as a climbable distance.
-            #expect(text.contains("coming soon"), "\(climb.id) did not read as coming soon")
+            #expect(text.contains("coming soon") == false, "\(climb.id) still read as coming soon")
             #expect(text.contains(climb.city.lowercased()), "\(climb.id) lost its location")
-            #expect(!text.contains("steps"), "\(climb.id) offered a distance it can't be raced at")
+            #expect(text.contains("steps"), "\(climb.id) did not expose its race distance")
         }
 
         try writeEvidence(
-            image: try renderSheet(ComingSoonPreviewProof(climbs: showcase)),
-            named: "world-tour-2026-coming-soon-cards.png"
+            image: try renderSheet(AvailablePreviewProof(climbs: showcase)),
+            named: "world-tour-2026-available-cards.png"
         )
     }
 
@@ -100,7 +98,7 @@ struct WorldTour2026CatalogueEvidenceTests {
             content: ClimbArtworkView(
                 climb: climb,
                 variant: .hero,
-                imageRepository: UnuploadedArtworkRepository()
+                imageRepository: MissingArtworkRepository()
             )
             .frame(width: 200, height: 200)
             .environment(\.colorScheme, .dark)
@@ -234,15 +232,14 @@ private extension Climb {
     }
 }
 
-/// Artwork for these climbs is not in Storage yet, so the shipped resolver returns no
-/// URL and the placeholder is what a climber actually sees today.
-private struct UnuploadedArtworkRepository: ClimbImageRepository {
+/// Simulates an unavailable image so the category placeholder remains covered.
+private struct MissingArtworkRepository: ClimbImageRepository {
     func resolveImageURL(for climb: Climb, variant: ClimbImageVariant) async -> URL? { nil }
 }
 
 // MARK: - Proof sheets
 
-private struct ComingSoonPreviewProof: View {
+private struct AvailablePreviewProof: View {
     let climbs: [Climb]
 
     var body: some View {
@@ -282,7 +279,7 @@ private struct StaircasePlaceholderProof: View {
                 .font(.montserratBold(size: 19))
                 .foregroundStyle(.white)
 
-            Text("Until the images land in Storage, the category symbol is the artwork.")
+            Text("When artwork is unavailable, the category symbol is the fallback.")
                 .font(.montserratRegular(size: 13))
                 .foregroundStyle(.white.opacity(0.62))
 
@@ -305,7 +302,7 @@ private struct StaircasePlaceholderProof: View {
             ClimbArtworkView(
                 climb: staircase,
                 variant: variant,
-                imageRepository: UnuploadedArtworkRepository()
+                imageRepository: MissingArtworkRepository()
             )
             .frame(width: size.width, height: size.height)
             .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
@@ -364,7 +361,7 @@ private struct AdditionRosterProof: View {
                             .foregroundStyle(climb.tier.color)
                             .frame(width: 78, alignment: .leading)
 
-                        Text("COMING SOON")
+                        Text("AVAILABLE")
                             .font(.montserratBold(size: 9))
                             .tracking(1)
                             .foregroundStyle(.white.opacity(0.5))

--- a/docs/climb-real-stair-counts.md
+++ b/docs/climb-real-stair-counts.md
@@ -286,6 +286,7 @@ These ship as `comingSoon`, so nobody races an unverified distance.
 
 **Announced race with no published course distance yet (1).**
 CapitaMall ONE is scheduled for December 2026, but the venue and Towerrunning World Tour material publish no defensible stair count yet.
+It is held at `comingSoon` while the other 28 Towerrunning World Tour venues added beside it race, because a raceable climb ranks against a published route and the only number left here is the height derivation.
 
 **Not a stair ascent (21).**
 The 21 mountains and volcanoes, which ship as `hidden` for a future endurance ladder.

--- a/docs/climb-real-stair-counts.md
+++ b/docs/climb-real-stair-counts.md
@@ -158,7 +158,7 @@ Every climb carrying a `realStairCount` now takes its floor count from one of tw
 1. **The route's published storey count**, where a source in the tables above states one.
 2. **`round(referenceStepCount / 19.8)`** otherwise.
 
-19.8 is the ratio the height derivation already implied (`5.5` steps per metre over `3.6` metres per floor), so the 43 climbs with no verified stair count keep the floor counts they had - their reference count is still `totalSteps`, and the two rules agree there.
+19.8 is the ratio the height derivation already implied (`5.5` steps per metre over `3.6` metres per floor), so the 29 climbs the catalogue currently ships with a null `realStairCount` - the ones enumerated under [Climbs deliberately left null](#climbs-deliberately-left-null) - keep the floor counts they had, because their reference count is still `totalSteps` and the two rules agree there.
 
 A published **flight** count is not a storey count and is not used as one, unless a second independent source states the same figure as storeys.
 A flight is a run of stairs between landings; a tower can have several per storey, or none at all.

--- a/web/public/climbs/catalog-v1.json
+++ b/web/public/climbs/catalog-v1.json
@@ -1615,7 +1615,7 @@
     "tags": ["mixed use", "changsha", "world tour"],
     "funFact": "The complex pairs a seven-storey mall with a 328-metre supertower, the tallest in western Changsha.",
     "sourceURL": "https://www.capitaland.com/en/find-a-property/global-property-listing/retail/capitamall-one.html",
-    "releaseState": "available"
+    "releaseState": "comingSoon"
   },
   {
     "id": "central-plaza-hong-kong",

--- a/web/public/climbs/catalog-v1.json
+++ b/web/public/climbs/catalog-v1.json
@@ -1527,7 +1527,7 @@
     "tags": ["supertall", "shenzhen", "world tour"],
     "funFact": "The race climbs 116 floors and 3,201 stairs over 541 vertical metres.",
     "sourceURL": "https://www.towerrunning.com/2026/01/10/tea-faber-wai-ching-soh-pingan-champions/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "ctf-finance-centre-guangzhou",
@@ -1549,7 +1549,7 @@
     "tags": ["supertall", "guangzhou", "world tour"],
     "funFact": "The Guangzhou race climbs 109 floors and 3,160 stairs.",
     "sourceURL": "https://www.towerrunning.com/races/r3103/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "shanghai-world-financial-center",
@@ -1571,7 +1571,7 @@
     "tags": ["observation deck", "shanghai", "world tour"],
     "funFact": "The Sky Marathon finishes after 100 floors and 2,726 stairs.",
     "sourceURL": "https://www.towerrunning.com/races/r2854/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "sommerbergbahn-stair",
@@ -1593,7 +1593,7 @@
     "tags": ["outdoor stairs", "black forest", "world tour"],
     "funFact": "Germany's longest staircase runs 720 metres beside the Sommerbergbahn and pitches up to 52 percent.",
     "sourceURL": "https://calw.wlv-sport.de/home/details/news/17-bad-wildbader-staeffeleslauf-entlang-der-bergbahntrasse-am-freitag-19-juni-2026-auf-deutschland-laengster-treppe",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "capitamall-one",
@@ -1615,7 +1615,7 @@
     "tags": ["mixed use", "changsha", "world tour"],
     "funFact": "The complex pairs a seven-storey mall with a 328-metre supertower, the tallest in western Changsha.",
     "sourceURL": "https://www.capitaland.com/en/find-a-property/global-property-listing/retail/capitamall-one.html",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "central-plaza-hong-kong",
@@ -1637,7 +1637,7 @@
     "tags": ["harbour skyline", "hong kong", "world tour"],
     "funFact": "Hong Chi's full course climbs from ground level to the 75th floor.",
     "sourceURL": "https://www.hongchi.org.hk/en/climbathon/page/competition-details",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "875-north-michigan-avenue",
@@ -1660,7 +1660,7 @@
     "tags": ["x-braced", "chicago", "world tour"],
     "funFact": "Chicago still knows the 100-storey X-braced landmark by its former John Hancock Center name.",
     "sourceURL": "https://www.towerrunning.com/races/r3137/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "dc-tower-1",
@@ -1682,7 +1682,7 @@
     "tags": ["danube skyline", "vienna", "world tour"],
     "funFact": "The race runs from the lobby to floor 58 over a 210-metre ascent.",
     "sourceURL": "https://www.towerrunning.com/races/r3181/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "yingkai-square",
@@ -1704,7 +1704,7 @@
     "tags": ["bamboo facade", "guangzhou", "world tour"],
     "funFact": "Its segmented facade was inspired by the joints of Chinese bamboo.",
     "sourceURL": "https://www.towerrunning.com/races/r3278/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "tk-elevator-test-tower",
@@ -1726,7 +1726,7 @@
     "tags": ["test tower", "rottweil", "world tour"],
     "funFact": "Its 12 test shafts can run elevators at speeds up to 18 metres per second.",
     "sourceURL": "https://www.towerrunning.com/races/r2703/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "varso-tower",
@@ -1748,7 +1748,7 @@
     "tags": ["observation deck", "warsaw", "world tour"],
     "funFact": "Its 310-metre spire makes it the European Union's tallest building.",
     "sourceURL": "https://www.towerrunning.com/races/r2704/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "tianjin-tv-tower",
@@ -1770,7 +1770,7 @@
     "tags": ["broadcast tower", "tianjin", "world tour"],
     "funFact": "The New Year course circles the tower base before climbing 253 vertical metres to the observation hall.",
     "sourceURL": "https://www.sohu.com/a/844232355_267106",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "macau-tower",
@@ -1792,7 +1792,7 @@
     "tags": ["observation deck", "macau", "world tour"],
     "funFact": "The full Oxfam course climbs 61 floors to the observation deck.",
     "sourceURL": "https://www.towerrunning.com/races/r2806/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "frasers-tower",
@@ -1814,7 +1814,7 @@
     "tags": ["green tower", "singapore", "world tour"],
     "funFact": "The 235-metre office tower rises from a three-storey cascading retail podium.",
     "sourceURL": "https://www.towerrunning.com/races/r3037/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "torre-reforma",
@@ -1836,7 +1836,7 @@
     "tags": ["concrete walls", "mexico city", "firefighter race"],
     "funFact": "The 2024 firefighter race extended the course to 56 floors and 1,487 stairs.",
     "sourceURL": "https://www.publimetro.com.mx/noticias/2024/09/21/esto-es-lo-que-tienes-que-saber-de-la-carrera-vertical-del-cuerpo-de-bomberos-de-la-cdmx/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "messeturm-frankfurt",
@@ -1858,7 +1858,7 @@
     "tags": ["pyramid crown", "frankfurt", "world tour"],
     "funFact": "A pyramid crown tops the red-granite tower above Frankfurt's trade-fair grounds.",
     "sourceURL": "https://www.towerrunning.com/races/r3182/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "sky-tower-wroclaw",
@@ -1880,7 +1880,7 @@
     "tags": ["mixed use", "wroclaw", "world tour"],
     "funFact": "The race starts five levels below ground before climbing 49 floors.",
     "sourceURL": "https://www.towerrunning.com/races/r2714/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "gran-hotel-bali",
@@ -1902,7 +1902,7 @@
     "tags": ["hotel", "benidorm", "world tour"],
     "funFact": "The race finishes 180 metres above Benidorm after 52 floors.",
     "sourceURL": "https://www.towerrunning.com/races/r3068/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "tallinn-tv-tower",
@@ -1924,7 +1924,7 @@
     "tags": ["broadcast tower", "tallinn", "world tour"],
     "funFact": "The race climbs 870 stairs inside Estonia's tallest building.",
     "sourceURL": "https://www.towerrunning.com/races/r2433/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "rondo-1",
@@ -1946,7 +1946,7 @@
     "tags": ["left-turn stairs", "warsaw", "world tour"],
     "funFact": "The race's left-turn staircase gains 142 metres over 38 floors.",
     "sourceURL": "https://www.towerrunning.com/2026/02/02/announcement-towerrunning-120-bieg-na-szczyt-rondo-1-warsaw-march-28-2026/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "post-tower",
@@ -1968,7 +1968,7 @@
     "tags": ["headquarters", "bonn", "world tour"],
     "funFact": "The race climbs 41 floors inside Deutsche Post's Bonn headquarters.",
     "sourceURL": "https://www.towerrunning.com/races/r3207/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "sky-tower-bucharest",
@@ -1990,7 +1990,7 @@
     "tags": ["observation deck", "bucharest", "world tour"],
     "funFact": "The 36-floor course gains 126 metres to the observation deck.",
     "sourceURL": "https://www.towerrunning.com/races/r2937/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "koelnturm",
@@ -2012,7 +2012,7 @@
     "tags": ["office tower", "cologne", "world tour"],
     "funFact": "Germany's championship course climbs from ground level to the 40th floor.",
     "sourceURL": "https://www.koelner-treppenlauf.de/infos_en/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "torre-glories",
@@ -2034,7 +2034,7 @@
     "tags": ["observation deck", "barcelona", "world tour"],
     "funFact": "The night race climbs 34 floors to the tower's observation deck.",
     "sourceURL": "https://www.towerrunning.com/2025/11/26/announcement-towerrunning-120-cupra-barcelona-tower-running-challenge-barcelona-fanuary-17-2026/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "az-tower",
@@ -2056,7 +2056,7 @@
     "tags": ["rooftop finish", "brno", "world tour"],
     "funFact": "The current course reaches the roof after 29 floors.",
     "sourceURL": "https://www.towerrunning.com/races/r2867/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "hyatt-regency-barcelona-tower",
@@ -2078,7 +2078,7 @@
     "tags": ["outdoor stairs", "barcelona", "world tour"],
     "funFact": "The outdoor staircase rises 105 metres to the glass dome.",
     "sourceURL": "https://metropolitanskyrun.com/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "messeturm-basel",
@@ -2100,7 +2100,7 @@
     "tags": ["green glass", "basel", "world tour"],
     "funFact": "The green-glass slab was Switzerland's tallest building when it opened in 2003.",
     "sourceURL": "https://www.towerrunning.com/races/r3024/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "pyramidenkogel",
@@ -2122,7 +2122,7 @@
     "tags": ["wooden tower", "carinthia", "world tour"],
     "funFact": "Its 71-metre finish platform sits inside the world's tallest wooden observation tower.",
     "sourceURL": "https://www.towerrunning.com/2025/07/27/announcement-towerrunning-120-pyramidenkogel-turmlauf-september-14/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   },
   {
     "id": "ufo-tower-bratislava",
@@ -2144,6 +2144,6 @@
     "tags": ["bridge pylon", "bratislava", "world tour"],
     "funFact": "The race climbs a steep, slanted stair inside one bridge pylon before finishing on the roof.",
     "sourceURL": "https://www.towerrunning.com/races/r3235/",
-    "releaseState": "comingSoon"
+    "releaseState": "available"
   }
 ]

--- a/web/public/climbs/manifest.json
+++ b/web/public/climbs/manifest.json
@@ -1,6 +1,6 @@
 {
-  "catalogVersion": 9,
+  "catalogVersion": 10,
   "catalogPath": "/climbs/catalog-v1.json",
   "featuredClimbId": "empire-state-building",
-  "updatedAt": "2026-08-10T00:47:29.000Z"
+  "updatedAt": "2026-08-10T14:36:52.000Z"
 }

--- a/web/public/climbs/manifest.json
+++ b/web/public/climbs/manifest.json
@@ -2,5 +2,5 @@
   "catalogVersion": 10,
   "catalogPath": "/climbs/catalog-v1.json",
   "featuredClimbId": "empire-state-building",
-  "updatedAt": "2026-08-10T14:36:52.000Z"
+  "updatedAt": "2026-08-10T14:56:51.000Z"
 }


### PR DESCRIPTION
## Intent

Make exactly the 29 Towerrunning World Tour venues added by PR #453 available now that all 29 artwork sets are uploaded and audited clean in dev and staging Storage. Derive the set from PR #453 git history and assert it contains exactly 29 before changing anything. In both web/public/climbs/catalog-v1.json and AscendApp/Features/Climbs/Resources/climbs.json, change only releaseState from comingSoon to available for those 29, keep the files byte-identical, and do not change any other climb field. Resolve and preserve these seven unverified climbs as comingSoon: The Shard, Sagrada Familia, Petronas Towers, N Seoul Tower, Marina Bay Sands, Osaka Castle, and Voortrekker Monument. Preserve all 21 hidden mountains and do not change landmark-count copy because issue #452 owns its derived behavior. The final 87-entry catalogue must contain exactly 59 available, 21 hidden, and 7 comingSoon, asserted in a test. Increment catalogVersion and refresh updatedAt in web/public/climbs/manifest.json. Do not upload, sync, or touch any Firebase Storage bucket or production environment. Create and reference dedicated issue #465, target the PR to develop, and include Closes #465. The PR body must state plainly that releaseState is not per-environment: the same catalogue deploys to dev, staging, and production, so the 29 become available in production at the next production deploy even though their artwork is currently only in dev and staging Storage. The PR body must warn that production Storage must be loaded before the next production deploy or the 29 will be raceable without artwork, and identify the captain-owned command scripts/sync-climb-images.mjs sync --from staging --to production --confirm-production without running it. State the 59/21/7 counts in the PR body.

## What Changed

- Flipped `releaseState` from `comingSoon` to `available` for 28 of the 29 Towerrunning World Tour venues added by PR #453, in both `web/public/climbs/catalog-v1.json` and `AscendApp/Features/Climbs/Resources/climbs.json` (kept byte-identical), and bumped `catalogVersion` to 10 with a fresh `updatedAt` in `web/public/climbs/manifest.json`. No other climb field changed. The 87-entry catalogue now ships **58 available / 21 hidden / 8 comingSoon**.
- Held `capitamall-one` at `comingSoon`: it has no published course distance, so racing it would rank climbers against `round(totalHeightMeters * 5.5)`, a height fact nobody climbed. `ClimbCatalogStairCountTests` now fails any `available` climb with a null `realStairCount`, and `ClimbCatalogCurationTests` pins the 58/21/8 distribution plus the seven unverified landmarks (The Shard, Sagrada Familia, Petronas Towers, N Seoul Tower, Marina Bay Sands, Osaka Castle, Voortrekker Monument) that stay `comingSoon`.
- Added `ClimbCurationSurfaceEvidenceTests` cases rendering the real climb-detail screen for an activated venue (Torre Reforma shows "Start Live Climb") and the held-back one (CapitaMall ONE shows a disabled "Coming Soon"), extended `WorldTour2026CatalogueEvidenceTests` to derive its roster labels from the catalogue, and documented the available-state distance rule and the shared-catalogue artwork risk in `live-climb-content` and `docs/climb-real-stair-counts.md`.

**`releaseState` is not per-environment.** The same catalogue file deploys to dev, staging, and production, so these 28 become available in production at the next production deploy even though their artwork currently exists only in dev and staging Storage. Production Storage must be loaded before that deploy or the 28 will be raceable with SF Symbol placeholders instead of artwork (`FirebaseClimbImageRepository.resolveImageURL` returns nil on a missing object, so the failure is silent). The captain-owned command is `scripts/sync-climb-images.mjs sync --from staging --to production --confirm-production`; it was not run here, and no Storage bucket was touched. Tracked in #466.

Closes #465

## Risk Assessment

✅ Low: The change is now a tightly-bounded 28-field data flip verified byte-for-byte against base, every previously-raised concern is either resolved in code or tracked in a dedicated issue, and the accompanying tests were strengthened from pinned counts to a general invariant that no raceable climb races against a height-derived distance.

## Testing

Ran the catalogue, curation, and World Tour evidence suites in the simulator plus the seven adjacent climb suites and the full node scripts suite (533 pass after installing the scripts package CI installs), then verified the data contract directly: the 29 venues re-derived from PR #453 git history match the test set, 28 entries changed on releaseState alone with zero other field edits, the hosted and bundled catalogues remain byte-identical, and the manifest bumped to catalogVersion 10. For product-level proof I added two tests that capture the real climb-detail screen and confirmed visually that Torre Reforma now shows a live "Start Live Climb" CTA with its artwork loading from Storage, while CapitaMall ONE renders a disabled "Coming Soon". Everything passes; the only issue is that the shipped distribution is 58/21/8 rather than the 59/21/7 the intent mandates, because the review commit intentionally held CapitaMall ONE back.

- Evidence: Climb detail - Torre Reforma is now raceable (Start Live Climb) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZP2453WW6CMTD4NPN4YRS0T/climb-detail-available-torre-reforma.png</code>)
- Evidence: Climb detail - CapitaMall ONE held at Coming Soon (CTA disabled) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZP2453WW6CMTD4NPN4YRS0T/climb-detail-coming-soon-capitamall-one.png</code>)
- Evidence: Roster proof sheet - 29 venues, 28 raceable, with per-venue release state (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZP2453WW6CMTD4NPN4YRS0T/world-tour-2026-addition-roster.png</code>)
- Evidence: Globe preview cards - activated venues show steps, CapitaMall ONE shows Coming Soon (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZP2453WW6CMTD4NPN4YRS0T/world-tour-2026-preview-cards.png</code>)
- Evidence: Artwork placeholder fallback proof sheet (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZP2453WW6CMTD4NPN4YRS0T/world-tour-2026-staircase-placeholder.png</code>)
- Evidence: Onboarding landmarks value page (count copy unchanged, owned by #452) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZP2453WW6CMTD4NPN4YRS0T/onboarding-landmarks-value-page.png</code>)
<details>
<summary>Evidence: Catalogue fetch + diff transcript</summary>

<code>$ curl -s http://127.0.0.1:8793/climbs/manifest.json&#10;{&#10;&#34;catalogVersion&#34;: 10,&#10;&#34;catalogPath&#34;: &#34;/climbs/catalog-v1.json&#34;,&#10;&#34;featuredClimbId&#34;: &#34;empire-state-building&#34;,&#10;&#34;updatedAt&#34;: &#34;2026-08-10T14:56:51.000Z&#34;&#10;}&#10;&#10;$ curl -s http://127.0.0.1:8793/climbs/catalog-v1.json | tally releaseState&#10;entries: 87 {&#34;available&#34;:58,&#34;hidden&#34;:21,&#34;comingSoon&#34;:8}&#10;torre-reforma available&#10;ufo-tower-bratislava available&#10;capitamall-one comingSoon&#10;the-shard comingSoon&#10;mount-everest hidden&#10;&#10;# Bundled app catalogue vs hosted catalogue&#10;byte-identical: true (63320 bytes each)&#10;&#10;# Field-level diff of every catalogue entry, base 6080728 -&gt; head f28328d&#10;entries changed on releaseState only: 28&#10;entries changed on any other field: 0&#10;entry order/id set unchanged: true&#10;&#10;# The 29-venue set derived from PR #453 git history&#10;PR #453 added: 29 venues&#10;now available: 28&#10;still comingSoon: capitamall-one (comingSoon)</code>

```text
# Hosted catalogue as a client fetches it (web/public served over HTTP)

$ curl -s http://127.0.0.1:8793/climbs/manifest.json
{
  "catalogVersion": 10,
  "catalogPath": "/climbs/catalog-v1.json",
  "featuredClimbId": "empire-state-building",
  "updatedAt": "2026-08-10T14:56:51.000Z"
}

$ curl -s http://127.0.0.1:8793/climbs/catalog-v1.json | tally releaseState
entries: 87 {"available":58,"hidden":21,"comingSoon":8}
  torre-reforma           available
  ufo-tower-bratislava    available
  capitamall-one          comingSoon
  the-shard               comingSoon
  mount-everest           hidden

# Bundled app catalogue vs hosted catalogue
byte-identical: true (63320 bytes each)

# Field-level diff of every catalogue entry, base 6080728 -> head f28328d
entries changed on releaseState only: 28
entries changed on any other field: 0
entry order/id set unchanged: true

# The 29-venue set derived from PR #453 git history
PR #453 added: 29 venues
now available: 28
still comingSoon: capitamall-one (comingSoon)
```
</details>
- Outcome: ⚠️ 1 warning across 1 run (10m40s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `web/public/climbs/catalog-v1.json:1530` - releaseState is global, not per-environment, so this flip makes all 29 venues raceable in production the moment the next production build/hosting deploy ships - while their artwork exists only in dev and staging Storage. FirebaseClimbImageRepository.resolveImageURL returns nil on a missing object and every one of the 29 falls back to the SF Symbol category placeholder on the globe, preview card, detail hero, and Live Activity. Nothing guards this: .claude/skills/live-climb-content/SKILL.md:151 documents &#39;sync to production alongside (or before) the catalog deploy that references them&#39;, and `scripts/sync-climb-images.mjs check` exits 1 when an available climb lacks images, but that check is not wired into any workflow under .github/workflows/. Confirm the PR body carries the required warning, the 59/21/7 counts, the note that releaseState is not per-environment, and the captain-owned `scripts/sync-climb-images.mjs sync --from staging --to production --confirm-production` - the commit message body is currently empty and no PR exists yet, so `Closes #465` is also still outstanding.
- ⚠️ `web/public/climbs/catalog-v1.json:1618` - capitamall-one becomes the only raceable climb in the entire 59-climb catalogue with realStairCount == null. Its race distance falls back to totalSteps = 1804, which is round(328 m * 5.5) - the architectural-height derivation the project guide explicitly calls &#39;a height fact, not a race distance&#39;. The change&#39;s own evidence sheet renders it as `no published course distance` in Color.ascendCaution directly beside the AVAILABLE label (AscendAppTests/WorldTour2026CatalogueEvidenceTests.swift:347), and ClimbCatalogStairCountTests:111-113 pins that nullness as a shipped contract. This is the same defect that kept the other seven venues at comingSoon after PR #464&#39;s curation to &#39;defensible stair-stepper races&#39;, so every time recorded on this climb is set against a fabricated target. The intent requires all 29, so flagging rather than changing: confirm capitamall-one should race on a height-derived number, or hold it at comingSoon as a 58/21/8 split.
- ℹ️ `AscendAppTests/WorldTour2026CatalogueEvidenceTests.swift:364` - AdditionRosterProof hardcodes Text(&#34;AVAILABLE&#34;) for every row instead of reading climb.releaseState, the same way it already derives name, location, distance, and tier from the climb. This is a reviewer-facing proof sheet whose entire job is to show what the catalogue actually says, so a hardcoded label makes it capable of asserting AVAILABLE for a row the catalogue holds at comingSoon or hidden - exactly the drift that required editing this literal from COMING SOON in the first place. Render climb.releaseState (uppercased) so the sheet cannot misreport.
- ℹ️ `AscendAppTests/ClimbCatalogCurationTests.swift:47` - curatedCatalogueCounts now pins snapshot.climbs.count == 87, availableClimbs.count == 59, hiddenCount == 21, and comingSoonClimbs.count == 7 at lines 42-45, which makes the three checks that follow tautological: the 59 + 7 + 21 == 87 sum identity at lines 47-50, hiddenCount == hiddenMountainIDs.count at line 51 (already asserted as equal-sets in hiddenMountainsAreNotRaceable), and comingSoonClimbs.count == comingSoonClimbIDs.count at line 52 (already implied by the set equality added at line 32). None can fail without one of the pinned equalities failing first. Dropping them leaves the pinned distribution plus the duplicate-ID check as the meaningful assertions.

🔧 Fix: Hold capitamall-one at comingSoon; catalogue ships 58/21/8
2 infos still open:
- ℹ️ `web/public/climbs/catalog-v1.json:1618` - Recording a deliberate, already-decided divergence rather than re-opening it. The --intent text still reads &#39;Make exactly the 29 ... venues available&#39; and &#39;must contain exactly 59 available, 21 hidden, and 7 comingSoon&#39;, while the change ships 28 activations and 58/21/8 with capitamall-one held at comingSoon. That is not drift: it is the captain&#39;s explicit round-1 instruction (&#39;Leave capitamall-one at comingSoon and activate only the other 28 PR #453 climbs. The final catalogue distribution must be exactly 58 available, 21 hidden, and 8 comingSoon&#39;), issued after this exact tradeoff was raised, and GitHub issue #465 was retitled and rewritten to match. The intent argument text simply predates the decision. No action needed - flagged only so the count mismatch against the original criteria is on the record and not read later as an unnoticed regression.
- ℹ️ `web/public/climbs/manifest.json:2` - The commit message body is empty and no PR exists yet (PR creation is a downstream pipeline step), so the required PR-body content is still unverifiable from the tree: `Closes #465`, a reference to the new dependency issue #466, the statement that releaseState is not per-environment and the same catalogue deploys to dev/staging/production, that artwork currently lives only in dev and staging Storage, and the final 58 available / 21 hidden / 8 comingSoon counts. The underlying production risk itself is now properly captured - #466 names `scripts/sync-climb-images.mjs sync --from staging --to production --confirm-production` and records that FirebaseClimbImageRepository.resolveImageURL returns nil on a missing object, so the failure mode is silent placeholder artwork rather than an error. Noting the outstanding PR-body items so they are not lost when the PR is opened.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ `AscendAppTests/ClimbCatalogCurationTests.swift:37` - The intent requires the final catalogue to be exactly 59 available / 21 hidden / 7 comingSoon, with all 29 PR #453 venues made available. The branch ships 58/21/8: the follow-up commit f28328d deliberately holds `capitamall-one` at comingSoon (it has no published course distance, so racing it would rank climbers against `round(totalHeightMeters * 5.5)`), and the count test was rewritten to assert 58/21/8. Verified end to end: the hosted and bundled catalogues both tally 58/21/8, and CapitaMall ONE&#39;s detail screen renders a disabled &#34;Coming Soon&#34; CTA instead of &#34;Start Live Climb&#34;. The reasoning is sound, but it contradicts the binding numbers, and the intent also requires the PR body to state 59/21/7 - which would then not match the shipped data. The captain needs to decide: accept 58/21/8 (and restate the PR body counts) or activate CapitaMall ONE to reach 59/21/7.
- <code>`xcodebuild -scheme AscendApp-Staging -only-testing:AscendAppTests/WorldTour2026CatalogueEvidenceTests -only-testing:AscendAppTests/ClimbCatalogCurationTests -only-testing:AscendAppTests/ClimbCatalogStairCountTests test` (23 tests, all passed; renders the reviewer proof sheets)</code>
- <code>`xcodebuild ... -only-testing:AscendAppTests/ClimbCurationSurfaceEvidenceTests` plus the adjacent climb suites `ClimbServiceTests`, `GlobeViewModelTests`, `ClimbPreviewCardCopySnapshotTests`, `ClimbCommonNameTests`, `ClimbCompletionRepositoryTests`, `ProfileCollectionSummaryTests`, `ProfileComparisonSummaryTests` - all passed</code>
- <code>Added two evidence tests to `AscendAppTests/ClimbCurationSurfaceEvidenceTests.swift` that render the real climb-detail screen for an activated venue (Torre Reforma -&gt; &#34;Start Live Climb&#34;) and for the held-back one (CapitaMall ONE -&gt; disabled &#34;Coming Soon&#34;)</code>
- <code>`npm --prefix scripts ci &amp;&amp; node --test scripts/test/*.test.mjs` - 533 pass, 0 fail (the initial 3 failures were a missing `firebase-admin` install in this fresh worktree, fixed by running the same install CI does)</code>
- <code>Served `web/public` over HTTP and fetched `/climbs/manifest.json` and `/climbs/catalog-v1.json` the way the client does, tallying releaseState from the response</code>
- <code>Re-derived the 29-venue set from PR #453 (`git show b2d56db~1` vs `b2d56db`) and compared it against the test&#39;s `expectedIDs`</code>
- <code>Field-by-field diff of all 87 catalogue entries between base `6080728` and target `f28328d`; byte-identity check between `web/public/climbs/catalog-v1.json` and `AscendApp/Features/Climbs/Resources/climbs.json`</code>
- <code>Confirmed `scripts/sync-climb-images.mjs` supports the exact `sync --from staging --to production --confirm-production` invocation the PR body must name (did not run it)</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `docs/climb-real-stair-counts.md:161` - docs/climb-real-stair-counts.md:161 says &#34;the 43 climbs with no verified stair count keep the floor counts they had&#34;, but the catalogue now has 29 climbs with a null realStairCount. Left unedited as a judgment call: the sentence reads as a historical statement about the moment the 19.8 floor rule was introduced, and the drift was caused by the #440 deletions and the #453 additions, not by this change. If the number is meant to describe the current catalogue it should read 29; if it is historical it should say so explicitly.

🔧 Fix: state current null-stair-count total in stair count doc
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
