### PR TITLE
fix(climbs): render the climb detail rank strip only for actual finishers

### DIFF
--- a/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
@@ -139,14 +139,13 @@ final class ClimbDetailViewModel {
     }
 
     var stripOrderText: String? {
-        guard communityCompletedCount > 0 else { return nil }
-
-        if let order = personalFinisherOrder,
-           order <= communityCompletedCount {
-            return "#\(order.formatted())/\(communityCompletedCount.formatted())"
+        guard let order = personalFinisherOrder,
+              communityCompletedCount > 0,
+              order <= communityCompletedCount else {
+            return nil
         }
 
-        return "--/\(communityCompletedCount.formatted())"
+        return "#\(order.formatted())/\(communityCompletedCount.formatted())"
     }
 
     func refresh(modelContext: ModelContext) {

--- a/AscendApp/Features/Climbs/Views/ClimbDetailHeroCardFront.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailHeroCardFront.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct ClimbDetailHeroCardFront<Artwork: View>: View {
+    let climb: Climb
+    let subtitle: String
+    let stripOrderText: String?
+    let artwork: Artwork
+
+    init(
+        climb: Climb,
+        subtitle: String,
+        stripOrderText: String?,
+        @ViewBuilder artwork: () -> Artwork
+    ) {
+        self.climb = climb
+        self.subtitle = subtitle
+        self.stripOrderText = stripOrderText
+        self.artwork = artwork()
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottomLeading) {
+            artwork
+
+            LinearGradient(
+                colors: [
+                    .black.opacity(0.03),
+                    .black.opacity(0.1),
+                    .black.opacity(0.22),
+                    .black.opacity(0.52)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+
+            if let stripOrderText {
+                HStack(spacing: 0) {
+                    UnevenRoundedRectangle(
+                        cornerRadii: .init(
+                            topLeading: 28,
+                            bottomLeading: 28,
+                            bottomTrailing: 0,
+                            topTrailing: 0
+                        ),
+                        style: .continuous
+                    )
+                    .fill(climb.tier.detailStripStyle)
+                    .frame(width: 48)
+                    .overlay {
+                        Text(stripOrderText)
+                            .font(.montserratBold(size: 12))
+                            .foregroundStyle(.white)
+                            .rotationEffect(.degrees(-90))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.74)
+                    }
+
+                    Spacer(minLength: 0)
+                }
+            }
+
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+
+                LinearGradient(
+                    colors: [
+                        .clear,
+                        .black.opacity(0.18),
+                        .black.opacity(0.68),
+                        .black.opacity(0.94)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: 132)
+            }
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(climb.name)
+                    .font(.montserratBold(size: 18))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.72)
+                    .allowsTightening(true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text(subtitle)
+                    .font(.montserratMedium(size: 12))
+                    .foregroundStyle(.white.opacity(0.84))
+                    .lineLimit(1)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .shadow(color: .black.opacity(0.55), radius: 16, x: 0, y: 4)
+            .padding(.leading, stripOrderText == nil ? 20 : 64)
+            .padding(.trailing, 16)
+            .padding(.bottom, 70)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
+        }
+    }
+}

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -577,63 +577,12 @@ struct ClimbDetailView: View {
     }
 
     private var heroCardFront: some View {
-        ZStack(alignment: .bottomLeading) {
+        ClimbDetailHeroCardFront(
+            climb: viewModel.climb,
+            subtitle: viewModel.subtitle,
+            stripOrderText: viewModel.stripOrderText
+        ) {
             ClimbArtworkView(climb: viewModel.climb, variant: .hero)
-
-            LinearGradient(
-                colors: [
-                    .black.opacity(0.03),
-                    .black.opacity(0.1),
-                    .black.opacity(0.22),
-                    .black.opacity(0.52)
-                ],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-
-            if let stripOrderText = viewModel.stripOrderText {
-                HStack(spacing: 0) {
-                    UnevenRoundedRectangle(
-                        cornerRadii: .init(
-                            topLeading: 28,
-                            bottomLeading: 28,
-                            bottomTrailing: 0,
-                            topTrailing: 0
-                        ),
-                        style: .continuous
-                    )
-                        .fill(viewModel.climb.tier.detailStripStyle)
-                        .frame(width: 48)
-                        .overlay {
-                            Text(stripOrderText)
-                                .font(.montserratBold(size: 12))
-                                .foregroundStyle(.white)
-                                .rotationEffect(.degrees(-90))
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.74)
-                        }
-
-                    Spacer(minLength: 0)
-                }
-            }
-
-            VStack(spacing: 0) {
-                Spacer(minLength: 0)
-
-                LinearGradient(
-                    colors: [
-                        .clear,
-                        .black.opacity(0.18),
-                        .black.opacity(0.68),
-                        .black.opacity(0.94)
-                    ],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-                .frame(height: 132)
-            }
-
-            heroTextOverlay
         }
     }
 
@@ -695,29 +644,6 @@ struct ClimbDetailView: View {
             }
             .padding(24)
         }
-    }
-
-    private var heroTextOverlay: some View {
-        VStack(alignment: .leading, spacing: 5) {
-            Text(viewModel.climb.name)
-                .font(.montserratBold(size: 18))
-                .foregroundStyle(.white)
-                .lineLimit(2)
-                .minimumScaleFactor(0.72)
-                .allowsTightening(true)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-            Text(viewModel.subtitle)
-                .font(.montserratMedium(size: 12))
-                .foregroundStyle(.white.opacity(0.84))
-                .lineLimit(1)
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .shadow(color: .black.opacity(0.55), radius: 16, x: 0, y: 4)
-        .padding(.leading, viewModel.stripOrderText == nil ? 20 : 64)
-        .padding(.trailing, 16)
-        .padding(.bottom, 70)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
     }
 
     private var flipCardButton: some View {

--- a/AscendAppTests/ClimbDetailRankStripTests.swift
+++ b/AscendAppTests/ClimbDetailRankStripTests.swift
@@ -1,0 +1,106 @@
+import CoreGraphics
+import SwiftUI
+import Testing
+import UIKit
+@testable import AscendApp
+
+@MainActor
+struct ClimbDetailRankStripTests {
+    @Test("A finisher sees their order among all finishers")
+    func personalFinisherOrderRendersInTheStrip() {
+        let viewModel = makeViewModel(completedCount: 12, personalOrder: 4)
+
+        #expect(viewModel.stripOrderText == "#4/12")
+    }
+
+    @Test("A climber without a finisher order sees no rank strip")
+    func missingPersonalFinisherOrderRendersNothing() {
+        let viewModel = makeViewModel(completedCount: 12, personalOrder: nil)
+
+        #expect(viewModel.stripOrderText == nil)
+    }
+
+    @Test("Artwork fills the hero card when the rank strip is absent")
+    func absentRankStripLeavesNoLeadingGap() throws {
+        let renderer = ImageRenderer(
+            content: ClimbDetailHeroCardFront(
+                climb: .preview,
+                subtitle: Climb.preview.displayLocation,
+                stripOrderText: nil
+            ) {
+                Color.red
+            }
+            .frame(width: 353, height: 390)
+            .clipShape(RoundedRectangle(cornerRadius: 28))
+        )
+        renderer.scale = 2
+
+        let image = try #require(renderer.uiImage, "ImageRenderer produced no hero artwork")
+        let bitmap = try #require(image.cgImage, "The hero render had no bitmap")
+        let pixels = try rgbaPixels(from: bitmap)
+        let y = bitmap.height / 2
+        let inset = 8
+        let sampledX = inset..<(bitmap.width - inset)
+        let artworkPixelCount = sampledX.count(where: { x in
+            let offset = ((y * bitmap.width) + x) * 4
+            return pixels[offset] > 150
+                && pixels[offset + 1] < 30
+                && pixels[offset + 2] < 30
+                && pixels[offset + 3] > 240
+        })
+
+        #expect(
+            Double(artworkPixelCount) / Double(sampledX.count) > 0.98,
+            "The artwork should reach both hero-card edges without a reserved 48pt strip"
+        )
+    }
+
+    private func makeViewModel(
+        completedCount: Int,
+        personalOrder: Int?
+    ) -> ClimbDetailViewModel {
+        let viewModel = ClimbDetailViewModel(climb: .preview)
+        viewModel.leaderboardSummary = LiveReplayLeaderboardSummary(
+            totalClimbers: completedCount,
+            completedCount: completedCount,
+            personalBestDurationSeconds: nil,
+            updatedAt: nil
+        )
+
+        if let personalOrder {
+            viewModel.personalFinisherStatus = LiveReplayFinisherStatus(
+                globalCompletionOrder: personalOrder,
+                firstCompletedAt: nil,
+                bestCompletionDurationSeconds: nil,
+                updatedAt: nil
+            )
+        }
+
+        return viewModel
+    }
+
+    private func rgbaPixels(from bitmap: CGImage) throws -> [UInt8] {
+        var pixels = [UInt8](repeating: 0, count: bitmap.width * bitmap.height * 4)
+
+        try pixels.withUnsafeMutableBytes { bytes in
+            let context = try #require(
+                CGContext(
+                    data: bytes.baseAddress,
+                    width: bitmap.width,
+                    height: bitmap.height,
+                    bitsPerComponent: 8,
+                    bytesPerRow: bitmap.width * 4,
+                    space: CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB(),
+                    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+                ),
+                "Could not create a bitmap context for the hero render"
+            )
+            context.draw(
+                bitmap,
+                in: CGRect(x: 0, y: 0, width: bitmap.width, height: bitmap.height)
+            )
+        }
+
+        return pixels
+    }
+}

--- a/AscendAppTests/ClimbDetailRankStripTests.swift
+++ b/AscendAppTests/ClimbDetailRankStripTests.swift
@@ -22,36 +22,75 @@ struct ClimbDetailRankStripTests {
 
     @Test("Artwork fills the hero card when the rank strip is absent")
     func absentRankStripLeavesNoLeadingGap() throws {
+        let row = try renderHeroMidRow(stripOrderText: nil)
+
+        #expect(
+            row.artworkRatio(fromPoint: 8, toPoint: Self.heroWidth - 8) > 0.98,
+            "The artwork should reach both hero-card edges without a reserved 48pt strip"
+        )
+    }
+
+    @Test("The rank strip covers the leading 48pt of the hero card")
+    func presentRankStripOccupiesTheLeadingStripWidth() throws {
+        let row = try renderHeroMidRow(stripOrderText: "#4/12")
+
+        #expect(
+            row.artworkRatio(fromPoint: 2, toPoint: 46) == 0,
+            "The strip should cover the artwork across the leading 48pt"
+        )
+        #expect(
+            row.artworkRatio(fromPoint: 52, toPoint: Self.heroWidth - 8) > 0.98,
+            "The strip should be exactly 48pt wide, leaving the rest of the hero as artwork"
+        )
+    }
+
+    private static let heroWidth: CGFloat = 353
+    private static let heroHeight: CGFloat = 390
+    private static let renderScale: CGFloat = 2
+
+    private static let artworkMarker = Color(.sRGB, red: 1, green: 0, blue: 0, opacity: 1)
+
+    private struct HeroMidRow {
+        let pixels: [UInt8]
+        let scale: CGFloat
+
+        func artworkRatio(fromPoint: CGFloat, toPoint: CGFloat) -> Double {
+            let sampled = Int(fromPoint * scale)..<Int(toPoint * scale)
+            let artworkPixelCount = sampled.count(where: { x in
+                let offset = x * 4
+                return pixels[offset] > 150
+                    && pixels[offset + 1] < 30
+                    && pixels[offset + 2] < 30
+                    && pixels[offset + 3] > 240
+            })
+
+            return Double(artworkPixelCount) / Double(sampled.count)
+        }
+    }
+
+    private func renderHeroMidRow(stripOrderText: String?) throws -> HeroMidRow {
         let renderer = ImageRenderer(
             content: ClimbDetailHeroCardFront(
                 climb: .preview,
                 subtitle: Climb.preview.displayLocation,
-                stripOrderText: nil
+                stripOrderText: stripOrderText
             ) {
-                Color.red
+                Self.artworkMarker
             }
-            .frame(width: 353, height: 390)
+            .frame(width: Self.heroWidth, height: Self.heroHeight)
             .clipShape(RoundedRectangle(cornerRadius: 28))
         )
-        renderer.scale = 2
+        renderer.scale = Self.renderScale
 
         let image = try #require(renderer.uiImage, "ImageRenderer produced no hero artwork")
         let bitmap = try #require(image.cgImage, "The hero render had no bitmap")
         let pixels = try rgbaPixels(from: bitmap)
         let y = bitmap.height / 2
-        let inset = 8
-        let sampledX = inset..<(bitmap.width - inset)
-        let artworkPixelCount = sampledX.count(where: { x in
-            let offset = ((y * bitmap.width) + x) * 4
-            return pixels[offset] > 150
-                && pixels[offset + 1] < 30
-                && pixels[offset + 2] < 30
-                && pixels[offset + 3] > 240
-        })
+        let rowStart = y * bitmap.width * 4
 
-        #expect(
-            Double(artworkPixelCount) / Double(sampledX.count) > 0.98,
-            "The artwork should reach both hero-card edges without a reserved 48pt strip"
+        return HeroMidRow(
+            pixels: Array(pixels[rowStart..<(rowStart + bitmap.width * 4)]),
+            scale: Self.renderScale
         )
     }
 


### PR DESCRIPTION
## Intent

Fix the Climb Detail rank strip so it renders only when the climber has a personal finisher order for that climb. When present, the label must render as #n/N using the personal order and community finisher count. When no personal order exists, render no strip and reserve no leading width, so the hero artwork remains full-width with no gap or clipping. Cover the rank label, strip-absent state, and full-width artwork layout. Keep the change limited to layout and presentation without changing how finisher order or community counts are computed or fetched.

## What Changed

- `ClimbDetailViewModel.stripOrderText` now returns `nil` unless the climber has a personal finisher order within the community finisher count, dropping the `--/N` placeholder so the strip renders only as `#n/N`; how the order and count are computed or fetched is unchanged.
- Extracted the hero card front out of `ClimbDetailView` into a reusable `ClimbDetailHeroCardFront` view that takes the artwork as a `@ViewBuilder`, keeping the gradients, 48pt tier strip, and the title inset that switches between 20pt and 64pt with the strip's presence.
- Added `ClimbDetailRankStripTests`: label formatting for a finisher, the strip-absent case, and two `ImageRenderer` pixel-sampling tests asserting the artwork runs full-width when the strip is absent and that the strip covers the leading 48pt when present.

## Denominator Invariant

When `personalCurrentCompletionRank` is present, `communityCompletedCount` already resolves as `max(remoteCompletedCount, personalCurrentCompletionRank.completedCount)`, so the denominator cannot fall below the climber’s own recorded count. No clamp, fallback, or new state was added, and the existing `order <= communityCompletedCount` guard remains exactly as written.

## Risk Assessment

✅ Low: The follow-up commit touches only the test file, both previously reported test defects are correctly fixed with assertions I traced through the actual render, and the unchanged production diff remains a bounded presentational refactor that satisfies every stated acceptance criterion.

## Testing

Ran the committed ClimbDetailRankStripTests (rank label, strip-absent state, strip-present 48pt coverage, full-width artwork) and then the entire iOS test suite on the Staging scheme - 1470 tests across 216 suites passed with no regressions from the hero-card extraction. Because the changed surface is visual, I additionally rendered the real ClimbDetailHeroCardFront through a temporary ImageRenderer harness driven by actual ClimbDetailViewModel state and captured PNGs of the hero card with no personal finisher order (no strip, artwork reaching both card edges) and with order 4 of 12 (gold tier strip reading "#4/12", title inset to 64pt), plus a before/after board that reproduces the old "--/12" strip for contrast; the captures use a synthetic skyline with edge markers because the real ClimbArtworkView streams its image from Firebase Storage and cannot load in a unit-test render. One environment fix was needed: Xcode's user-script sandbox blocked scripts/link-firebase-plists.sh in this worktree, so xcodebuild was run with ENABLE_USER_SCRIPT_SANDBOXING=NO, and the plist symlinks the build phase created were removed afterwards, leaving the worktree clean.

- Evidence: Before/after comparison of the climb-detail hero card rank strip (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZPRHZ9GQWMP2ZA8GCWFKWDN/hero-rank-strip-comparison.png</code>)
- Evidence: After - no personal finisher order: no strip, artwork full-width (edge markers visible at both edges) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZPRHZ9GQWMP2ZA8GCWFKWDN/hero-strip-absent-after.png</code>)
- Evidence: After - personal finisher order 4 of 12: strip reads #4/12 across the leading 48pt (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZPRHZ9GQWMP2ZA8GCWFKWDN/hero-strip-present-after.png</code>)
- Evidence: Before - no personal finisher order still rendered a &#34;--/12&#34; strip (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZPRHZ9GQWMP2ZA8GCWFKWDN/hero-strip-before-no-personal-order.png</code>)
<details>
<summary>Evidence: Rank strip test transcript</summary>

<code>PASS Test &#34;Artwork fills the hero card when the rank strip is absent&#34;&#10;PASS Test &#34;The rank strip covers the leading 48pt of the hero card&#34;&#10;PASS Test &#34;A climber without a finisher order sees no rank strip&#34;&#10;PASS Test &#34;A finisher sees their order among all finishers&#34;&#10;Test run with 1470 tests in 216 suites passed after 116.633 seconds.&#10;** TEST SUCCEEDED **</code>

```text
$ xcodebuild -scheme AscendApp-Staging -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test
◇ Suite ClimbDetailRankStripTests started.
✔ Test "Artwork fills the hero card when the rank strip is absent" passed after 9.742 seconds.
✔ Test "The rank strip covers the leading 48pt of the hero card" passed after 9.742 seconds.
✔ Test "A climber without a finisher order sees no rank strip" passed after 9.742 seconds.
✔ Test "A finisher sees their order among all finishers" passed after 9.742 seconds.
✔ Suite ClimbDetailRankStripTests passed after 9.860 seconds.
✔ Test run with 1470 tests in 216 suites passed after 116.633 seconds.
** TEST SUCCEEDED **
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `AscendAppTests/ClimbDetailRankStripTests.swift:47` - The full-width-artwork assertion can never pass. SwiftUI&#39;s `Color.red` (line 31) is `systemRed`, not pure red - verified directly: components are (1.0, 0.2588, 0.2706), identical to `systemRed`; on iOS light mode #FF3B30 = (255, 59, 48). The hero&#39;s top LinearGradient composites black at ~0.16 alpha over the artwork at mid-height, so the sampled pixel is ~(214, 49, 40). The `&gt; 150` red threshold accounts for that darkening but the `&lt; 30` green/blue thresholds do not - even the gradient&#39;s lightest stop (0.03) leaves G≈57. `artworkPixelCount` is therefore always 0, the ratio is 0.0, and `#expect(... &gt; 0.98)` always fails. Use an explicit pure marker, e.g. `Color(.sRGB, red: 1, green: 0, blue: 0, opacity: 1)`, which composites to ~(214, 0, 0) and satisfies the existing thresholds.
- ⚠️ `AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift:144` - The added `order &lt;= communityCompletedCount` guard hides the strip completely when a real finisher&#39;s order exceeds the community count. `personalFinisherOrder` falls back to the persisted local mirror (`historySummary.globalCompletionOrder`), while `communityCompletedCount` comes from the live completion leaderboard - deleted results or deleted accounts shrink the count without lowering existing orders. A climber who finished 12th against a count that has fallen to 10 now sees no strip at all, where the previous code at least rendered `--/10`. The user intent says the strip renders &#34;only when the climber has a personal finisher order&#34; and then &#34;must render as #n/N&#34; - it does not say what to do when n &gt; N, so confirm that silently dropping the strip (rather than clamping N up to the order, which is what `communityCompletedCount` already does for `personalCurrentCompletionRank`) is the intended handling.
- ℹ️ `AscendAppTests/ClimbDetailRankStripTests.swift:23` - The render test only covers the strip-absent case. Nothing renders `ClimbDetailHeroCardFront` with a non-nil `stripOrderText`, so the `if let stripOrderText` branch and the 64pt leading text padding - the exact code paths this fix exists to protect - would stay green if someone broke them. The same `rgbaPixels` helper supports the inverse assertion: with `stripOrderText: &#34;#4/12&#34;` the leading ~48pt should NOT be artwork-colored, which pins both the strip&#39;s presence and its width.

🔧 Fix: Fix rank strip test marker color, cover strip-present layout
1 info still open:
- ℹ️ `AscendAppTests/ClimbDetailRankStripTests.swift:93` - `HeroMidRow.scale` is passed the requested `Self.renderScale` rather than the scale the bitmap actually came back at, so the point-to-pixel conversion in `artworkRatio` (line 58) is an assumption instead of a measurement. If `ImageRenderer` ever returned a 1x bitmap (353px wide), `Int(345 * 2) = 690` would index past the 353-pixel row and `pixels[offset]` would trap - a crash instead of a readable assertion failure. Deriving it from the render, `scale: CGFloat(bitmap.width) / Self.heroWidth`, removes the duplicated assumption and keeps the sampling windows self-consistent with whatever was rendered.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp-Staging&#34; -configuration Staging -destination &#34;platform=iOS Simulator,name=iPhone 17 Pro&#34; ENABLE_TESTABILITY=YES ENABLE_USER_SCRIPT_SANDBOXING=NO -only-testing:AscendAppTests/ClimbDetailRankStripTests test` - 4/4 passed</code>
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp-Staging&#34; -configuration Staging -destination &#34;platform=iOS Simulator,name=iPhone 17 Pro&#34; ENABLE_TESTABILITY=YES ENABLE_USER_SCRIPT_SANDBOXING=NO test` - full suite, 1470 tests in 216 suites passed</code>
- <code>Temporary `AscendAppTests/ClimbDetailHeroCardEvidenceRenderTests` ImageRenderer harness driving `ClimbDetailHeroCardFront` from real `ClimbDetailViewModel` instances (12 finishers, personal order nil vs 4) to write hero-card PNGs at 353x390 @3x; file deleted after capture</code>
- <code>Visual inspection of the rendered PNGs for strip presence, `#4/12` label, 48pt strip width, title inset, and full-bleed artwork edge markers</code>
- <code>`git status --porcelain` after cleanup - worktree clean, build-created Firebase plist symlinks removed</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>