### PR TITLE
docs(app-store): replace listing copy and review notes that sell deleted features

### DIFF
--- a/docs/app-store-racing-repositioning-proposal.md
+++ b/docs/app-store-racing-repositioning-proposal.md
@@ -7,6 +7,10 @@ This file is a proposal for issue [#439](https://github.com/tpavay/AscendApp/iss
 Nothing here has been written to App Store Connect.
 Firstmate owns App Store Connect metadata and applies it.
 
+Every claim below was re-verified against build `2026081101` (commit `650acdbc`) on 2026-08-11, after the pre-submission audit found the live description and the live App Review notes both selling manual workout entry and Apple Health workout import - two features [#437](https://github.com/tpavay/AscendApp/issues/437) deleted on 2026-08-08.
+That is Guideline 2.1 and 2.3, so both are submission blockers.
+The claim-by-claim evidence is in [Traceability](#traceability); the replacement review notes are in [App Review notes](#app-review-notes).
+
 The currently-live listing copy is recorded in `data/ascend-support-page-and-product-page-package/app-store-copy.md`.
 That file still describes the tracking product.
 It should be updated to match whatever is actually applied to App Store Connect, and only then, so the repo keeps exactly one record of what is live.
@@ -22,7 +26,7 @@ For that enrichment, Ascend reads exactly two Apple Health types - heart rate an
 It never requests `workoutType()`, so Workouts does not appear in the Health permission sheet, and it never writes to Apple Health.
 `HealthKitAuthorizationClient.readTypes` is the authority for that set; the legal pages, the `Info.plist` usage string, and the App Store data answers all have to match it.
 
-The App Review notes still describe manual logging and must be replaced with the hardware demo-video path before this listing is applied.
+The live App Review notes describe the same two deleted features, so they are replaced wholesale by [App Review notes](#app-review-notes) below.
 
 ## App name
 
@@ -128,7 +132,7 @@ RACE REAL TOWERS
 
 Choose a landmark and attack its actual step count: the Empire State Building, Taipei 101, the Eiffel Tower, Burj Khalifa, and more.
 Motion sensors in compatible AirPods or Beats count your steps in real time.
-Every attempt ever posted on that tower is the field you are racing.
+Every climber who has raced that tower lines up beside you, each running their best attempt.
 Watch your position move while you climb.
 
 CLIMB THE LEADERBOARDS
@@ -153,7 +157,8 @@ TRAIN BETWEEN RACES
 
 Guided routines build structured intervals and changing intensity into a stair session.
 Pair a Bluetooth chest strap for live heart rate and effort zones.
-Every finished routine lands in the same history as your races.
+Or start a Just Climb when you only want the work, with a step goal if you want one.
+Every finished session lands in the same history as your races.
 
 SHARE THE CLIMB
 
@@ -167,13 +172,13 @@ An auto-renewing subscription is required after onboarding.
 Available plans, billing terms, and any eligible trial are shown before purchase.
 Subscriptions can be managed through your Apple Account, and eligible purchases can be restored in Ascend.
 
-Live Climbs and guided routines require compatible motion-equipped AirPods or Beats.
+Every session in Ascend - a tower race, a Just Climb, or a guided routine - is counted by motion sensors in compatible AirPods or Beats, and needs a stair stepper to climb.
 Apple Health is optional and is used only to attach heart rate and active-energy calories recorded while you were climbing in Ascend.
 A Bluetooth heart-rate monitor is optional.
 Ascend is not a medical device and does not provide medical advice.
 ```
 
-2,541 characters of 4,000.
+2,738 characters of 4,000.
 
 ### What changed from the live description, and why
 
@@ -189,9 +194,142 @@ Three other changes carry the repositioning:
 - **Mt. Everest is gone** from the landmark examples, ahead of #440.
 - The Apple Health footnote now says what Apple Health is actually for after #437: attaching heart rate and active-energy calories to a climb performed in Ascend, from an Apple Watch or any wearable that writes to Apple Health.
 
+Three further corrections came out of verifying every sentence against build 2026081101 on 2026-08-11:
+
+- **"Every attempt ever posted on that tower is the field you are racing" was not true.** The replay field carries one entry per climber, their best attempt on that context's own metric, because `reconcileUserBestEntries` in `functions/src/liveReplayLeaderboard.ts` is the authority for the `bestPerUser` flag the board renders. The line now says what the climber actually sees.
+- **Just Climb was missing.** It is one of the three start actions on Home (`HomeStartAction`), it produces a real recorded session, and a description that never mentions it undersells the app rather than overselling it.
+- **The hardware footnote named too few sessions.** Just Climb routes into `LiveClimbSessionView` like a tower race does, so it is gated by the same `HeadphoneMotionReadinessService` check. The footnote now covers all three session types and names the stair stepper, which the old wording left implicit.
+
+### Traceability
+
+Every claim in the description, and where the app makes it true. Checked against build `2026081101` on 2026-08-11.
+
+| Claim | Evidence |
+|---|---|
+| Races real towers by their actual step count | `web/public/climbs/catalog-v1.json` - 58 `available` climbs. Empire State Building, Taipei 101, Eiffel Tower and Burj Khalifa are all `available` and all carry a `realStairCount` sourced in `docs/climb-real-stair-counts.md`. |
+| Steps come from AirPods / Beats motion | `HeadphoneMotionReadinessService` gates every start on `CMHeadphoneMotionManager.isDeviceMotionAvailable`; the supported models are listed in `CompatibleHeadphonesHelpSheet`. |
+| A field of other climbers, live | `LiveReplayLeaderboardPanel` renders the `everyone` field during the session; `functions/src/liveReplayLeaderboard.ts` derives it as each climber's best attempt. |
+| Per-tower rankings on finish time, cadence, steps | `ClimbDetailView`'s Leaderboard tab; the global board's metrics are `LeaderboardMetric` - steps, workouts, duration, steps/min. |
+| First Ascent is permanent | `ProfileAchievementLadder`, `TodayClimbStakeLine`, `Climb`. Locked copy lives in `ascend-brand-voice`. |
+| Best Efforts record book | `BestEffortMetric` - most steps, longest climb, highest average SPM, most steps in a time window, fastest step target. |
+| Guided routines with chest-strap heart rate | `AscendApp/Features/Routines/`; `HeartRateMonitorIntegrationCard` names the Bluetooth chest strap, and `LiveHeartRateSourceKind` ranks it above the watch. |
+| Just Climb, open-ended with an optional goal | `HomeStartAction.justClimb` -> `LiveClimbSessionView(justClimbGoal:)`. |
+| Share card from a race result | `AscendApp/Features/ShareComposer/`. |
+| No manual entry, no import | `WorkoutSource.filterOptions == [.headphoneMotion]`, and `AscendAppTests/ManualLoggingAndImportRemovalEvidenceTests.swift` reads the removal back off rendered pixels. |
+| Apple Health is heart rate and active energy only, over the session's own window | `HealthKitAuthorizationClient.readTypes`; `workoutType()` is never requested and no share types are requested. |
+
+Two claims the description deliberately does **not** make, because the build does not support them:
+
+- **No landmark count.** The catalogue moves with every climb drop, and #440 already took the hard-coded count out of the onboarding paywall for the same reason.
+- **No Mapbox globe.** `ClimbMapboxPrototypeSurface` and `ClimbMapboxPrototypeRenderer` are both wrapped in `#if DEBUG`, and the production `MBXAccessToken` is empty. The browse globe a customer sees is `ClimbMapKitRenderer`, which is MapKit.
+
+## App Review notes
+
+Locale-independent; App Store Connect keeps one set for the version.
+Apple's limit on this field is 4,000 bytes.
+As written below it is **3,810 bytes**, so the bracketed fields have roughly 190 bytes to grow into - enough for real addresses, eight-digit backup codes, a video URL and a contact line, but not much more.
+Count it again after filling them in; a long hosting URL is the one field that can blow the budget.
+
+This text is truthful **only** once the bracketed fields are filled and the checklist below is verified against the production-signed build being submitted.
+Every unbracketed sentence in it was checked against build `2026081101` on 2026-08-11.
+
+```text
+ASCEND - NOTES FOR APP REVIEW
+
+Ascend is a stair stepper racing app. You pick a real tower, such as the Empire
+State Building or Burj Khalifa, and race its real step count on a stair stepper
+while motion sensors in your AirPods or Beats count your steps. Your time is
+ranked on that tower's leaderboard.
+
+1. SIGNING IN
+
+Production offers Sign in with Apple and Sign in with Google only. Please use
+Google, so you never have to sign out of your own Apple ID. Google challenges a
+sign-in from a new device: choose "Try another way", then "Enter one of your
+8-digit backup codes". Each code works once.
+
+Full access, no purchase needed:
+  Email: [REVIEW GOOGLE ADDRESS]
+  Password: [PASSWORD]
+  Backup codes: [CODE] [CODE] [CODE]
+This account already holds the app_access entitlement and goes straight in.
+
+Subscription flow, for reviewing the purchase:
+  Email: [UNENTITLED GOOGLE ADDRESS]
+  Password: [PASSWORD]
+  Backup codes: [CODE] [CODE] [CODE]
+No entitlement. After onboarding it reaches the subscription gate: an annual
+plan with a seven-day free trial, or a monthly plan charged immediately.
+Restore Purchases is on that gate and in Settings > Subscription.
+
+2. THE HARDWARE, AND THE DEMO VIDEO
+
+Demo video: [STABLE HTTPS URL, NO LOGIN]
+
+Recording a session needs two things you will not have at a desk:
+
+- AirPods or Beats that report headphone motion through Core Motion: AirPods 3
+  and later, any AirPods Pro, AirPods Max, Beats Fit Pro, Beats Studio Pro,
+  Beats Solo 4. Ascend counts steps from those sensors; an Apple Watch or the
+  iPhone itself cannot supply them.
+- A stair stepper, stair climber or StairMaster to physically climb.
+
+Without both, the start control refuses with "Connect compatible headphones to
+start this live climb" and no session begins. That is designed behaviour, not a
+failure.
+
+The video was recorded on the submitted build and shows the headphones, the
+machine, a live tower race with splits and leaderboard movement, the finish,
+and a guided routine start to finish. We will ship the hardware on request.
+
+3. WHAT YOU CAN REVIEW WITHOUT THAT HARDWARE
+
+On the full-access account, everything except starting a session:
+
+- Home: today's tower, your weekly standing, recent records.
+- Globe and catalogue: open any tower for its step count, floors, overview,
+  history and per-tower leaderboard.
+- Leaderboard: steps, workouts, duration and steps-per-minute, over weekly,
+  monthly, yearly and all-time windows. Open another climber's profile.
+- Training: browse routines, open a routine's overview, history and
+  leaderboard, and create, edit or delete your own.
+- Profile: lifetime stats, tower collection, achievements, Best Efforts,
+  activity calendar, session history.
+- Settings: profile, units, notifications, integrations, Manage Subscription,
+  Restore Purchases, Terms, Privacy, Contact Us, sign out, Delete Account.
+
+4. THINGS WE WANT TO STATE PLAINLY
+
+- There is no manual entry and no import. Every session is recorded live by
+  Ascend. Typed-in workouts and Apple Health workout import were both removed
+  from the app, and earlier notes that mentioned them were wrong.
+- Apple Health is optional and read-only. Ascend requests exactly two types,
+  heart rate and active energy, and reads them only across the time window of a
+  session Ascend itself recorded, to attach heart rate and calories to it.
+  Ascend never requests workout data and never writes to Health.
+- Bluetooth is used for one thing: an optional heart-rate chest strap.
+- Delete Account sits at the bottom of Settings and is also reachable from the
+  subscription gate, so an account that never subscribed can still delete
+  itself. Deleting it does not cancel an App Store subscription, and the app
+  says so and points to Apple's subscription settings.
+
+Contact: [NAME] [PHONE] [EMAIL]
+```
+
+### Before these notes are pasted into App Store Connect
+
+Each item is a sentence in the notes that this repository cannot prove on its own.
+
+1. **Both accounts exist and are non-expiring, and both sets of Google backup codes are fresh.** Generating a new set invalidates the previous set, and the account must not be in Google's Advanced Protection Program, which disables backup codes entirely.
+2. **The full-access account really opens the app.** Sign in on a device that has never held those credentials and confirm you land on Home rather than the gate. RevenueCat's dashboard reports a grant active whether or not Ascend's own product allowlist accepted it, so the dashboard is not the check - the app is. `app-setup-runbook.md` 4h has the failure mode.
+3. **The unentitled account still sees both products** and can complete an Apple test purchase and a restore.
+4. **The demo video is recorded on the submitted build**, is hosted at a stable HTTPS URL with no login, expiry or geographic restriction, and actually shows every artifact paragraph 2 claims it shows.
+5. **Delete Account is reachable from the subscription gate.** As audited on 2026-08-11 it was not: the gate auto-presents the Superwall paywall, which has no close control, and hides the recovery actions behind it. That is a separate submission blocker. If it is not fixed in the submitted build, delete that clause from the notes - it is the one sentence here that a reviewer can disprove in ten seconds.
+6. **The attached build is 2026081101, or the notes were re-checked against a newer one.** The watchOS target (#471) landed *after* 2026081101 and ships embedded in the iOS bundle. A build carrying it puts a watch app in front of the reviewer whose entire content is "No climb running - start one on your iPhone", which these notes do not mention and Guideline 2.3.1 says should be described.
+7. **The plan wording matches the live products.** The notes describe the plan structure rather than quoting prices, so a price change cannot make them false, but confirm the trial and billing terms still read as written.
+
 ## Out of scope for this proposal
 
-- **App Review notes.** They still tell the reviewer that sessions can be logged manually, which #437 made false on 2026-08-08. Replacing them with the hardware demo-video path is tracked in #437 and #439 and is not proposed here.
 - **Screenshots.** Tracked separately in [#390](https://github.com/tpavay/AscendApp/issues/390).
 - **In-app copy.** Tracked in #437.
 - **The Superwall onboarding paywall** (`web/public/superwall/onboarding-paywall.html`). Resolved by #440: it no longer hard-codes a landmark count, and derives it from the published catalogue instead. `docs/launch-readiness-audit.md` (Promise vs. reality, item 8) owns how that resolution works.

--- a/scripts/seed-demo-user.mjs
+++ b/scripts/seed-demo-user.mjs
@@ -120,6 +120,11 @@ const LIVE_CLIMB_SPECS = [
   {climbId: "statue-of-liberty", daysAgo: 27, spm: 88, finisherOrder: 1},
 ];
 
+// Non-climb sessions, here so Best Efforts and history have depth behind the
+// landmark races. Both are `headphone_motion`: #437 deleted manual entry and
+// Apple Health workout import on 2026-08-08, so seeding a `manual` or
+// `apple_health` row would put a workout in the demo account that the app can
+// no longer produce.
 const EXTRA_WORKOUT_SPECS = [
   {
     key: "record-20-min",
@@ -127,9 +132,9 @@ const EXTRA_WORKOUT_SPECS = [
     daysAgo: 35,
     durationSeconds: 1200,
     steps: 1927,
-    source: "manual",
-    integrityLevel: "unverified",
-    notes: "Demo manual log for best-effort depth.",
+    source: "headphone_motion",
+    integrityLevel: "verified",
+    notes: "Demo session for best-effort depth.",
   },
   {
     key: "long-climb",
@@ -137,9 +142,9 @@ const EXTRA_WORKOUT_SPECS = [
     daysAgo: 42,
     durationSeconds: 4820,
     steps: 6120,
-    source: "apple_health",
+    source: "headphone_motion",
     integrityLevel: "verified",
-    notes: "Demo imported workout for history depth.",
+    notes: "Demo session for history depth.",
   },
 ];
 
@@ -672,7 +677,7 @@ function workoutRecord(input) {
     avgHeartRateBpm: averageHeartRate(input.steps, input.durationSeconds),
     maxHeartRateBpm: averageHeartRate(input.steps, input.durationSeconds) + 24,
     caloriesBurned: Math.round(input.durationSeconds / 60 * 8.4),
-    effortRating: input.source === "manual" ? 4 : 4.5,
+    effortRating: 4.5,
     averageMETs: 8.2,
     deviceModel: "Ascend Demo Seed",
     participations: input.participations,

--- a/scripts/test/outward-racing-copy.test.mjs
+++ b/scripts/test/outward-racing-copy.test.mjs
@@ -13,7 +13,8 @@ const sourcePaths = {
   privacy: pathFromRoot("web/src/pages/privacy.astro"),
   terms: pathFromRoot("web/src/pages/terms.astro"),
   proposal: pathFromRoot("docs/app-store-racing-repositioning-proposal.md"),
-  projectMemory: pathFromRoot("CLAUDE.md")
+  projectMemory: pathFromRoot("CLAUDE.md"),
+  demoSeed: pathFromRoot("scripts/seed-demo-user.mjs")
 };
 
 async function source(name) {
@@ -28,6 +29,15 @@ function sectionBetween(contents, start, end) {
   assert.notEqual(endIndex, -1, `missing section end: ${end}`);
 
   return contents.slice(startIndex, endIndex);
+}
+
+function fencedBlockAfter(contents, heading) {
+  const sectionStart = contents.indexOf(`## ${heading}`);
+  assert.notEqual(sectionStart, -1, `missing proposal heading: ${heading}`);
+
+  const match = contents.slice(sectionStart).match(/```text\n([\s\S]*?)\n```/);
+  assert.ok(match, `missing proposal block: ${heading}`);
+  return match[1];
 }
 
 function textCodeBlockAfter(contents, heading) {
@@ -61,6 +71,82 @@ test("the App Store proposal pins the settled racing metadata", async () => {
     .filter((keyword) => indexedTokens.has(keyword));
 
   assert.deepEqual(repeatedTokens, []);
+});
+
+test("the proposed listing copy sells nothing #437 removed", async () => {
+  const proposal = await source("proposal");
+  const description = fencedBlockAfter(proposal, "Description");
+  const reviewNotes = fencedBlockAfter(proposal, "App Review notes");
+
+  // The live listing sold "Log stair-stepper workouts in Ascend or import
+  // supported workouts from Apple Health", and the live review notes told the
+  // reviewer to exercise the app that way. #437 deleted both paths on
+  // 2026-08-08, which makes each sentence a Guideline 2.1/2.3 problem as well
+  // as an untruth.
+  //
+  // Both words survive in exactly one place each: the sentence that denies the
+  // feature. Those sentences are asserted, then cut, and whatever still says
+  // "manual" or "import" afterwards is the promise coming back.
+  const denials = {
+    description: [
+      "Every climb and every record in Ascend comes from a session you performed in Ascend. There is no manual entry and no importing from other apps."
+    ],
+    "review notes": [
+      "There is no manual entry and no import.",
+      "Typed-in workouts and Apple Health workout import were both removed"
+    ]
+  };
+  const forbidden = [
+    [/\blog(ging|s|ged)?\b/i, "promises logging"],
+    [/\bmanual(ly)?\b/i, "promises manual entry"],
+    [/\bimport(s|ing|ed)?\b/i, "promises importing"]
+  ];
+
+  const violations = [];
+  for (const [label, text] of [
+    ["description", description],
+    ["review notes", reviewNotes]
+  ]) {
+    let remainder = text;
+    for (const denial of denials[label]) {
+      assert.ok(
+        remainder.includes(denial),
+        `${label} no longer states the exclusion: ${denial}`
+      );
+      remainder = remainder.replace(denial, "");
+    }
+    for (const [pattern, promise] of forbidden) {
+      if (pattern.test(remainder)) {
+        violations.push(`${label}: ${promise}`);
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+
+  // Apple caps Notes for Review at 4,000 bytes, and the bracketed fields still
+  // have to grow into whatever is left.
+  const noteBytes = Buffer.byteLength(reviewNotes, "utf8");
+  assert.ok(
+    noteBytes <= 3_850,
+    `App Review notes are ${noteBytes} bytes; keep them under 3,850 so the filled-in credentials and video URL still fit Apple's 4,000-byte field`
+  );
+  assert.match(reviewNotes, /\[STABLE HTTPS URL, NO LOGIN\]/);
+});
+
+test("the demo seeder only creates sessions the app can still record", async () => {
+  const seeder = await source("demoSeed");
+
+  for (const [pattern, retiredSource] of [
+    [/source:\s*"manual"/, "manual"],
+    [/source:\s*"apple_health"/, "apple_health"]
+  ]) {
+    assert.doesNotMatch(
+      seeder,
+      pattern,
+      `seed-demo-user.mjs still seeds a ${retiredSource} workout, a source #437 removed from the app on 2026-08-08`
+    );
+  }
 });
 
 test("the public website consistently presents Ascend as racing", async () => {


### PR DESCRIPTION
## What this is

The pre-submission audit's finding 2: the live en-US description and the live App Review notes both sell manual workout entry and Apple Health workout import. #437 deleted both on 2026-08-08. A reviewer following the notes finds nothing (Guideline 2.1) and customers are sold a feature that does not exist (Guideline 2.3). It blocks submission.

**No App Store Connect write happened, and none should happen from this PR.** Everything here is proposed text plus in-repo corrections.

## Two things only the captain can do

1. **Record and attach the demo video.** The notes are written around it and say so in paragraph 2. Ascend's core flow needs motion-capable AirPods or Beats plus a physical stair stepper, which a reviewer does not have, so Apple's own guidance is video-or-hardware. The video must be recorded on the submitted build, show the headphones, the machine, a live tower race with splits and leaderboard movement, the finish, and a guided routine start to finish, and be hosted at a stable HTTPS URL with no login, expiry or geographic restriction. **The notes do not stand alone without it.**
2. **Apply the copy in App Store Connect**, and fill the bracketed fields in the notes: both accounts' credentials, both sets of Google backup codes, the video URL, and the reviewer contact line. `docs/app-store-racing-repositioning-proposal.md` carries a seven-item checklist of everything in the notes this repository cannot prove on its own - read it before pasting.

## What changed in the repo

- **`docs/app-store-racing-repositioning-proposal.md`** now carries the App Review notes (previously listed as out of scope), a claim-by-claim traceability table against build `2026081101`, and three description corrections that came out of verifying it.
- **`scripts/seed-demo-user.mjs`** stopped seeding a `manual` and an `apple_health` workout into dev and staging. It was manufacturing history from sources the app can no longer produce.
- **`scripts/test/outward-racing-copy.test.mjs`** gained two tests: one that scans the proposed description and notes for logging/manual/import language (allowing exactly the sentences that *deny* the features) and enforces the notes' byte budget, and one that keeps the retired sources out of the seeder.

## Three corrections beyond the reported problem

Verifying every sentence against build `2026081101` (commit `650acdbc`) turned up three more:

| Was | Is | Why |
|---|---|---|
| "Every attempt ever posted on that tower is the field you are racing." | "Every climber who has raced that tower lines up beside you, each running their best attempt." | `reconcileUserBestEntries` in `functions/src/liveReplayLeaderboard.ts` derives one entry per climber, their best attempt on that context's metric. The old line promised a denser field than the app shows. |
| Just Climb absent | "Or start a Just Climb when you only want the work, with a step goal if you want one." | It is one of three `HomeStartAction` cases and produces real recorded sessions. Omitting it undersold the app. |
| "Live Climbs and guided routines require compatible motion-equipped AirPods or Beats." | "Every session in Ascend - a tower race, a Just Climb, or a guided routine - is counted by motion sensors in compatible AirPods or Beats, and needs a stair stepper to climb." | Just Climb routes into `LiveClimbSessionView` behind the same `HeadphoneMotionReadinessService` gate. The stair stepper was left implicit. |

## One thing worth the captain's attention

The watchOS target (#471) landed **after** build `2026081101` and ships embedded in the iOS bundle. Its entire content today is "No climb running - start one on your iPhone." If a build carrying it is what gets attached, a reviewer meets a watch app these notes do not describe, which Guideline 2.3.1 says should be described. Checklist item 6 in the proposal names it. Not fixed here - out of scope for a copy change.

Also note finding 1 of the same audit: Delete Account is currently **not** reachable from the subscription gate, because the gate auto-presents a Superwall paywall with no close control. The notes claim it is. Checklist item 5 says to delete that clause if the separate fix has not landed in the submitted build - it is the one sentence a reviewer can disprove in ten seconds.

## Proposed content for `data/ascend-support-page-and-product-page-package/app-store-copy.md`

Firstmate owns that file, so this PR does not touch it. It records what is **live**, and it is accurate right now - the stale sentence in it is the stale sentence in App Store Connect. Replace it with the following **after** the copy is applied, so the repo keeps exactly one record of what is live:

<details>
<summary>Full replacement file</summary>

````markdown
# Ascend App Store copy

Locale: en-US

Records the listing currently live in App Store Connect; the proposed racing listing is `docs/app-store-racing-repositioning-proposal.md`.

## App name

Ascend: Stair Stepper Racing

Character count: 28 of 30.

## Subtitle

Race real towers from any gym

Character count: 29 of 30.

## Keywords

```text
climber,stepmill,climb,steps,cardio,leaderboard,running,vertical,workout,compete,records,stairs,hiit
```

UTF-8 byte count: 100 of 100.

## Description

```text
Tower running is a real sport. Ascend puts it on the machine in front of you.

Athletes race the stairwells of the world's tallest buildings. Getting into one of those races takes a skyscraper, an event date, a travel budget, and a place in a limited field.

Ascend is that sport, on a stair stepper, on any day, from any gym.

Pick a tower. Race its real step count. Take your rank.

RACE REAL TOWERS

Choose a landmark and attack its actual step count: the Empire State Building, Taipei 101, the Eiffel Tower, Burj Khalifa, and more.
Motion sensors in compatible AirPods or Beats count your steps in real time.
Every climber who has raced that tower lines up beside you, each running their best attempt.
Watch your position move while you climb.

CLIMB THE LEADERBOARDS

Every tower keeps its own rankings.
Compare finish times, cadence, and steps against real climbers.
Reach the podium, then defend it.

CLAIM FIRST ASCENTS

Every new tower opens with one permanent prize: the First Ascent.
The first finisher claims it forever, even after someone posts a faster time.
Be ready when the next tower drops.

BREAK YOUR OWN RECORDS

Best Efforts turns the races you finish into a record book only you can break.
Most steps, longest climb, strongest pace, and more, each tied back to the session that set it.
See the work stack up instead of disappearing when the session ends.

TRAIN BETWEEN RACES

Guided routines build structured intervals and changing intensity into a stair session.
Pair a Bluetooth chest strap for live heart rate and effort zones.
Or start a Just Climb when you only want the work, with a step goal if you want one.
Every finished session lands in the same history as your races.

SHARE THE CLIMB

Build a share card from the tower you raced and the result you posted.

Ascend is built for people who take the stair stepper seriously.
It is not a generic activity tracker and it is not a social feed.
Every climb and every record in Ascend comes from a session you performed in Ascend. There is no manual entry and no importing from other apps.

An auto-renewing subscription is required after onboarding.
Available plans, billing terms, and any eligible trial are shown before purchase.
Subscriptions can be managed through your Apple Account, and eligible purchases can be restored in Ascend.

Every session in Ascend - a tower race, a Just Climb, or a guided routine - is counted by motion sensors in compatible AirPods or Beats, and needs a stair stepper to climb.
Apple Health is optional and is used only to attach heart rate and active-energy calories recorded while you were climbing in Ascend.
A Bluetooth heart-rate monitor is optional.
Ascend is not a medical device and does not provide medical advice.
```

Character count: 2,738 of 4,000.

## App Review notes

Filled in from the template in `docs/app-store-racing-repositioning-proposal.md`, with the credentials, backup codes, demo-video URL and contact line the captain supplied at submission.
The template is 3,810 bytes before those fields are filled; Apple's limit on the field is 4,000.

## Product-page URLs

- Support URL: `https://ascendstepper.com/support`
- Privacy Policy URL: `https://ascendstepper.com/privacy`
````

</details>

## Verification

- `node --test scripts/test/*.test.mjs` - 547 pass, 0 fail.
- Repo-wide sweep for manual-entry / Health-import claims: the only remaining hits are prohibitions (`docs/app-store-brief.md`, `docs/app-store-screenshots-brief.md`), the removal-evidence tests, and `WorkoutSource.manual` / `.appleHealth` display names, which exist solely so pre-#437 stored rows keep rendering.
- Description: 2,738 of 4,000 characters. App Review notes: 3,810 of 4,000 bytes before the bracketed fields are filled.

Closes #478
