### PR TITLE
feat(climbs): drop the duplicate "Your best" card and fly the real First Ascent flag

### DIFF
--- a/.claude/skills/ascend-leaderboards/SKILL.md
+++ b/.claude/skills/ascend-leaderboards/SKILL.md
@@ -81,6 +81,10 @@ Two distinct surfaces - the global tab (community-wide aggregate stats) and per-
   Changing what a badge counts is a product decision, not a bug fix.
 - Per-climb leaderboards rank *completed attempts on one climb*, not aggregate community totals. They don't share a layout with the global aggregate leaderboards.
 - The static per-climb leaderboard shows **every completed attempt**, not best-per-user. A user appears as many times as they've completed the climb; this surface is the historical record of completions. Contrast with the in-session live race, which ranks against best-per-user (see the replay leaderboard architecture in `ascend-live-climbs`).
+- **The board states a climber's own time and rank once - on their own row, wearing the YOU pill - and carries no separate personal rank summary above it.**
+  Climb Detail's Leaderboard tab lost that duplicated card on 2026-08-12; History is the home for a climber's own results, and the hero card's finisher strip still carries the standing.
+  The accepted cost is that a climber ranked past the 25-row page must scroll to find themselves; reintroducing a pinned current-user row is a product decision, not a fix.
+  The predicate that survived the card, `ClimbDetailViewModel.hasPersonalCompletionStanding`, is not leftover gating: rank and rows arrive from two separate fetches, and it is the only thing stopping a climber who has just finished from being told nobody has (`ClimbLeaderboardPageContent`).
 
 ### Tie handling (applies to global and per-climb)
 - Ties are ranked using **standard competition ranking** ("1, 2, 2, 4"). Tied users share the same rank; the next rank is skipped by the count of tied users. This matches the sports convention and honors the honest outcome.

--- a/AscendApp/Features/Climbs/Models/ClimbLeaderboardPageContent.swift
+++ b/AscendApp/Features/Climbs/Models/ClimbLeaderboardPageContent.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// The single piece of board content the Climb Detail Leaderboard tab renders beneath the First
+/// Ascent line. Resolution is exhaustive: every combination of inputs maps to exactly one case, so
+/// the tab can never fall through to an unlabelled frame.
+enum ClimbLeaderboardPageContent: Equatable {
+    /// Ranked rows arrived and render.
+    case rows
+
+    /// The board is still on its way. A climber with a published completion resolves here while
+    /// the board rows lag their rank, because "no completed times yet" would be false for them.
+    case loading
+
+    /// Nobody has finished this climb, so the First Ascent is open.
+    case empty
+
+    /// The board fetch failed for a climber who already has a standing on it. The page's
+    /// "Leaderboard unavailable" line carries the state; claiming a load is in flight would not.
+    case unavailable
+
+    static func resolve(
+        hasCompletionRows: Bool,
+        isLeaderboardLoading: Bool,
+        hasPersonalCompletionStanding: Bool,
+        hasLeaderboardError: Bool,
+        publicResultSyncPhase: LiveClimbPublicResultPhase?
+    ) -> ClimbLeaderboardPageContent {
+        if hasCompletionRows {
+            return .rows
+        }
+
+        if isLeaderboardLoading {
+            return .loading
+        }
+
+        guard !hasPersonalCompletionStanding else {
+            return hasLeaderboardError ? .unavailable : .loading
+        }
+
+        switch publicResultSyncPhase {
+        case .pending, .syncingRanking:
+            return .loading
+        case .savedOnDevice, .syncFailedRetry, .published, nil:
+            return .empty
+        }
+    }
+}

--- a/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
+++ b/AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift
@@ -111,15 +111,13 @@ final class ClimbDetailViewModel {
         )
     }
 
-    var shouldShowPersonalRankSummary: Bool {
+    /// This climber has a published completion on this climb, so the board is not empty even on
+    /// the frame where its rows have not arrived. The leaderboard page reads it to keep the
+    /// "First Ascent open" empty state - and the still-syncing loading state - off a screen whose
+    /// owner has already finished the climb.
+    var hasPersonalCompletionStanding: Bool {
         guard personalCurrentCompletionRank != nil else { return false }
         return communityCompletedCount > 0
-    }
-
-    var personalBestCompletionDurationSeconds: TimeInterval? {
-        currentUserBestCompletion?.completionDurationSeconds ??
-            personalFinisherStatus?.bestCompletionDurationSeconds ??
-            historySummary.bestCompletionDurationSeconds.map(TimeInterval.init)
     }
 
     var personalFinisherOrder: Int? {

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -861,10 +861,6 @@ struct ClimbDetailView: View {
                 publicResultSyncStatusRow(for: status)
             }
 
-            if viewModel.shouldShowPersonalRankSummary {
-                personalLeaderboardRankSummary
-            }
-
             if shouldShowLeaderboardLoadingState {
                 leaderboardLoadingState
             } else if viewModel.hasCompletionLeaderboardRows {
@@ -880,7 +876,7 @@ struct ClimbDetailView: View {
                         leaderboardLoadingMoreState
                     }
                 }
-            } else if !viewModel.shouldShowPersonalRankSummary {
+            } else if !viewModel.hasPersonalCompletionStanding {
                 leaderboardEmptyState
             }
 
@@ -928,10 +924,8 @@ struct ClimbDetailView: View {
         identity: ResolvedUserIdentity,
         completedAt: Date
     ) -> some View {
-        HStack(alignment: .center, spacing: 8) {
-            Image(systemName: "flag.fill")
-                .font(.system(size: 11, weight: .bold))
-                .foregroundStyle(leaderboardGold)
+        HStack(alignment: .center, spacing: 4) {
+            ClimbFirstAscentMark()
 
             Text(
                 "First Ascent: \(identity.displayName) · " +
@@ -1008,57 +1002,6 @@ struct ClimbDetailView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(.vertical, 16)
-    }
-
-    @ViewBuilder
-    private var personalLeaderboardRankSummary: some View {
-        if let personalCurrentCompletionRank = viewModel.personalCurrentCompletionRank,
-           let bestCompletionDurationSeconds = viewModel.personalBestCompletionDurationSeconds {
-            HStack(spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Your best")
-                        .font(.montserratSemiBold(size: 12))
-                        .tracking(1.0)
-                        .foregroundStyle(Color.customGray)
-
-                    Text(DurationFormatter.format(duration: bestCompletionDurationSeconds))
-                        .font(.montserratBold(size: 20))
-                        .foregroundStyle(effectiveColorScheme == .dark ? .white : .black)
-                        .monospacedDigit()
-                }
-
-                Spacer(minLength: 0)
-
-                VStack(alignment: .trailing, spacing: 4) {
-                    Text(
-                        CompetitionRanking.rankLabel(
-                            personalCurrentCompletionRank.rank,
-                            isTied: personalCurrentCompletionRank.isTied,
-                            untiedPrefix: "#"
-                        )
-                    )
-                    .font(.montserratBold(size: 20))
-                    .foregroundStyle(.accent)
-                    .monospacedDigit()
-                    .accessibilityLabel(
-                        CompetitionRanking.rankAccessibilityLabel(
-                            personalCurrentCompletionRank.rank,
-                            isTied: personalCurrentCompletionRank.isTied
-                        )
-                    )
-
-                    Text("of \(personalCurrentCompletionRank.completedCount.formatted())")
-                        .font(.montserratSemiBold(size: 12))
-                        .foregroundStyle(effectiveColorScheme == .dark ? .white.opacity(0.58) : .black.opacity(0.5))
-                        .monospacedDigit()
-                }
-            }
-            .padding(14)
-            .background(
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color.accent.opacity(effectiveColorScheme == .dark ? 0.12 : 0.10))
-            )
-        }
     }
 
     private func leaderboardRow(
@@ -1461,7 +1404,7 @@ struct ClimbDetailView: View {
             return true
         }
 
-        guard !viewModel.shouldShowPersonalRankSummary,
+        guard !viewModel.hasPersonalCompletionStanding,
               let status = latestPublicResultSyncStatus else {
             return false
         }

--- a/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbDetailView.swift
@@ -861,9 +861,8 @@ struct ClimbDetailView: View {
                 publicResultSyncStatusRow(for: status)
             }
 
-            if shouldShowLeaderboardLoadingState {
-                leaderboardLoadingState
-            } else if viewModel.hasCompletionLeaderboardRows {
+            switch leaderboardPageContent {
+            case .rows:
                 VStack(spacing: 8) {
                     ForEach(moderatedCompletionLeaderboardRows) { row in
                         completionLeaderboardRowLink(for: row)
@@ -876,8 +875,12 @@ struct ClimbDetailView: View {
                         leaderboardLoadingMoreState
                     }
                 }
-            } else if !viewModel.hasPersonalCompletionStanding {
+            case .loading:
+                leaderboardLoadingState
+            case .empty:
                 leaderboardEmptyState
+            case .unavailable:
+                EmptyView()
             }
 
             if viewModel.leaderboardErrorMessage != nil,
@@ -1397,24 +1400,14 @@ struct ClimbDetailView: View {
         }
     }
 
-    private var shouldShowLeaderboardLoadingState: Bool {
-        guard !viewModel.hasCompletionLeaderboardRows else { return false }
-
-        if viewModel.isLeaderboardLoading {
-            return true
-        }
-
-        guard !viewModel.hasPersonalCompletionStanding,
-              let status = latestPublicResultSyncStatus else {
-            return false
-        }
-
-        switch status.phase {
-        case .pending, .syncingRanking:
-            return true
-        case .savedOnDevice, .syncFailedRetry, .published:
-            return false
-        }
+    private var leaderboardPageContent: ClimbLeaderboardPageContent {
+        ClimbLeaderboardPageContent.resolve(
+            hasCompletionRows: viewModel.hasCompletionLeaderboardRows,
+            isLeaderboardLoading: viewModel.isLeaderboardLoading,
+            hasPersonalCompletionStanding: viewModel.hasPersonalCompletionStanding,
+            hasLeaderboardError: viewModel.leaderboardErrorMessage != nil,
+            publicResultSyncPhase: latestPublicResultSyncStatus?.phase
+        )
     }
 
     private func publicResultSyncTitle(

--- a/AscendApp/Features/Climbs/Views/ClimbFirstAscentMark.swift
+++ b/AscendApp/Features/Climbs/Views/ClimbFirstAscentMark.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// The shipped cut-out gold summit flag, standing beside the First Ascent line the way it stands
+/// on the profile achievement shelf: resizable, `.scaledToFit()`, no clip, no tile, no stroke.
+/// Clipping a cut-out to a circle slices the flag off, and a stroke draws an edge around
+/// transparency.
+///
+/// The art is a 3:2 landscape canvas whose opaque flag occupies the middle ~55% horizontally and
+/// ~93% vertically, so `.scaledToFit()` into a square box renders a flag about 0.62 × `size` tall
+/// with a transparent gutter either side - which is why the line it sits on tightens its spacing.
+/// 34 is the smallest box where the finial, pole, pennant and mound all resolve (checked against a
+/// rendered ladder from 20 to 40); below it the flag reads as a gold smudge, above it the mark
+/// starts competing with the podium rows. It still fits the 44pt row, and First Ascent stays a
+/// permanent annotation rather than the active chase.
+struct ClimbFirstAscentMark: View {
+    static let size: CGFloat = 34
+
+    var body: some View {
+        Image("FirstAscentBadgeDetailed")
+            .resizable()
+            .scaledToFit()
+            .frame(width: Self.size, height: Self.size)
+            .accessibilityHidden(true)
+    }
+}

--- a/AscendAppTests/ClimbLeaderboardPageContentTests.swift
+++ b/AscendAppTests/ClimbLeaderboardPageContentTests.swift
@@ -1,0 +1,153 @@
+import Testing
+@testable import AscendApp
+
+/// The Leaderboard tab's board region resolves to exactly one piece of content. These pin the
+/// frames where a climber's rank and the board rows disagree, because they arrive from two
+/// separate server reads (`fetchCurrentUserBestCompletion` and `fetchCompletionLeaderboard`).
+struct ClimbLeaderboardPageContentTests {
+    @Test("A finisher whose board rows have not landed yet sees the board loading, not nothing")
+    func personalStandingWithoutRowsResolvesToLoading() {
+        let content = ClimbLeaderboardPageContent.resolve(
+            hasCompletionRows: false,
+            isLeaderboardLoading: false,
+            hasPersonalCompletionStanding: true,
+            hasLeaderboardError: false,
+            publicResultSyncPhase: nil
+        )
+
+        #expect(content == .loading)
+    }
+
+    @Test("A finisher whose board rows have not landed is never told nobody has finished")
+    func personalStandingNeverResolvesToTheEmptyState() {
+        for phase in Self.allSyncPhases {
+            for hasError in [true, false] {
+                let content = ClimbLeaderboardPageContent.resolve(
+                    hasCompletionRows: false,
+                    isLeaderboardLoading: false,
+                    hasPersonalCompletionStanding: true,
+                    hasLeaderboardError: hasError,
+                    publicResultSyncPhase: phase
+                )
+
+                #expect(content != .empty, "phase \(String(describing: phase)), error \(hasError)")
+            }
+        }
+    }
+
+    @Test("A finisher whose board fetch threw sees the unavailable line instead of a spinner")
+    func personalStandingWithAFailedFetchResolvesToUnavailable() {
+        let content = ClimbLeaderboardPageContent.resolve(
+            hasCompletionRows: false,
+            isLeaderboardLoading: false,
+            hasPersonalCompletionStanding: true,
+            hasLeaderboardError: true,
+            publicResultSyncPhase: nil
+        )
+
+        #expect(content == .unavailable)
+    }
+
+    @Test("Rows outrank every other state once they arrive")
+    func presentRowsResolveToRows() {
+        for hasStanding in [true, false] {
+            for isLoading in [true, false] {
+                for hasError in [true, false] {
+                    let content = ClimbLeaderboardPageContent.resolve(
+                        hasCompletionRows: true,
+                        isLeaderboardLoading: isLoading,
+                        hasPersonalCompletionStanding: hasStanding,
+                        hasLeaderboardError: hasError,
+                        publicResultSyncPhase: .published
+                    )
+
+                    #expect(content == .rows)
+                }
+            }
+        }
+    }
+
+    @Test("A climber with no standing and no rows still sees the First Ascent invitation")
+    func noStandingAndNoRowsResolvesToEmpty() {
+        let content = ClimbLeaderboardPageContent.resolve(
+            hasCompletionRows: false,
+            isLeaderboardLoading: false,
+            hasPersonalCompletionStanding: false,
+            hasLeaderboardError: false,
+            publicResultSyncPhase: nil
+        )
+
+        #expect(content == .empty)
+    }
+
+    @Test("A failed board fetch still leaves the empty state up for a climber with no standing")
+    func noStandingWithAFailedFetchStillResolvesToEmpty() {
+        let content = ClimbLeaderboardPageContent.resolve(
+            hasCompletionRows: false,
+            isLeaderboardLoading: false,
+            hasPersonalCompletionStanding: false,
+            hasLeaderboardError: true,
+            publicResultSyncPhase: nil
+        )
+
+        #expect(content == .empty)
+    }
+
+    @Test(
+        "A climber whose own result is still reaching the board sees loading, not the empty state",
+        arguments: [LiveClimbPublicResultPhase.pending, .syncingRanking]
+    )
+    func inFlightPublicResultResolvesToLoading(phase: LiveClimbPublicResultPhase) {
+        let content = ClimbLeaderboardPageContent.resolve(
+            hasCompletionRows: false,
+            isLeaderboardLoading: false,
+            hasPersonalCompletionStanding: false,
+            hasLeaderboardError: false,
+            publicResultSyncPhase: phase
+        )
+
+        #expect(content == .loading)
+    }
+
+    @Test(
+        "A settled public result leaves the empty state up",
+        arguments: [
+            LiveClimbPublicResultPhase.savedOnDevice,
+            .syncFailedRetry,
+            .published
+        ]
+    )
+    func settledPublicResultResolvesToEmpty(phase: LiveClimbPublicResultPhase) {
+        let content = ClimbLeaderboardPageContent.resolve(
+            hasCompletionRows: false,
+            isLeaderboardLoading: false,
+            hasPersonalCompletionStanding: false,
+            hasLeaderboardError: false,
+            publicResultSyncPhase: phase
+        )
+
+        #expect(content == .empty)
+    }
+
+    @Test("An in-flight board fetch reports itself")
+    func inFlightLeaderboardFetchResolvesToLoading() {
+        let content = ClimbLeaderboardPageContent.resolve(
+            hasCompletionRows: false,
+            isLeaderboardLoading: true,
+            hasPersonalCompletionStanding: false,
+            hasLeaderboardError: false,
+            publicResultSyncPhase: nil
+        )
+
+        #expect(content == .loading)
+    }
+
+    private static let allSyncPhases: [LiveClimbPublicResultPhase?] = [
+        nil,
+        .pending,
+        .savedOnDevice,
+        .syncingRanking,
+        .syncFailedRetry,
+        .published
+    ]
+}

--- a/AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests.swift
+++ b/AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests.swift
@@ -1,0 +1,446 @@
+import Foundation
+import SwiftUI
+import Testing
+import UIKit
+@testable import AscendApp
+
+/// Photographs Climb Detail's LEADERBOARD tab in the states a climber can land on, so a reviewer
+/// can see that the duplicated "Your best" card is gone, that the climber's own row still carries
+/// its YOU pill, and that the First Ascent line now flies the shipped cut-out gold flag.
+///
+/// `ClimbDetailView.leaderboardPage` cannot be hosted directly: it is a private member of a
+/// 2,000-line Firebase-auth-gated screen whose `.task` opens network work. So the page's chrome is
+/// reproduced here from source - same order, same copy, same Font/Color tokens, same modifiers as
+/// `ClimbDetailView.swift`'s `leaderboardPage` / `firstAscentSummaryContent` / `leaderboardRow` -
+/// while the two things actually under review are the shipping code itself: `ClimbFirstAscentMark`
+/// is the real view, and every row is a real `ModeratedReplayLeaderboardRow` built through
+/// `CrossUserIdentityAdapter`, so the YOU pill lights from the same `isCurrentUser` the app uses.
+///
+/// Drawn through a live `UIWindow` rather than `ImageRenderer`, which draws asset-catalogue art in
+/// a nested layout as blank.
+@MainActor
+@Suite(.serialized, .hostsAWindow)
+struct ClimbLeaderboardTabVisualEvidenceTests {
+    private static let firstAscentDate = Date(timeIntervalSince1970: 1_754_870_400)
+
+    /// The captain's Charminar case: he is the only finisher, so his row is the whole board. The
+    /// "Your best / 02:06 · #1 of 1" card used to sit directly above this row saying the same two
+    /// numbers.
+    @Test
+    func soleFinisherSeesOneRowAndNoDuplicateSummary() throws {
+        try Self.capture(
+            name: "climb-leaderboard-tab-sole-finisher",
+            caption: "Raced it, only finisher: one row, YOU pill, rank and time stated once",
+            rows: [Self.row(id: "you", rank: 1, name: "Tyler P.", seconds: 126, isCurrentUser: true)]
+        )
+    }
+
+    /// The same climber further down a real field. Their row is the only place their time and rank
+    /// appear, and the YOU pill is what finds it.
+    @Test
+    func rankedClimberKeepsTheYouPillOnTheirOwnRow() throws {
+        try Self.capture(
+            name: "climb-leaderboard-tab-raced",
+            caption: "Raced it, mid-field: the YOU pill is the only marker of your own row",
+            rows: [
+                Self.row(id: "1", rank: 1, name: "Marcus T.", seconds: 104),
+                Self.row(id: "2", rank: 2, name: "Priya S.", seconds: 118),
+                Self.row(id: "3", rank: 3, name: "Dana R.", seconds: 121),
+                Self.row(id: "4", rank: 4, name: "Tyler P.", seconds: 126, isCurrentUser: true),
+                Self.row(id: "5", rank: 5, name: "Owen B.", seconds: 140)
+            ]
+        )
+    }
+
+    /// Never raced it. The removed card never rendered in this state, so the only question the
+    /// photograph answers is whether the page still holds together above the board.
+    @Test
+    func climberWhoHasNotRacedStillGetsAWholePage() throws {
+        try Self.capture(
+            name: "climb-leaderboard-tab-not-raced",
+            caption: "Never raced it: First Ascent line runs straight into the board, no gap left behind",
+            rows: [
+                Self.row(id: "1", rank: 1, name: "Marcus T.", seconds: 104),
+                Self.row(id: "2", rank: 2, name: "Priya S.", seconds: 118),
+                Self.row(id: "3", rank: 3, name: "Dana R.", seconds: 121),
+                Self.row(id: "4", rank: 4, name: "Owen B.", seconds: 140)
+            ]
+        )
+    }
+
+    /// Nobody has raced it. No First Ascent holder, so the line is absent and the empty state is
+    /// the whole page - the branch that `hasPersonalCompletionStanding` still guards.
+    @Test
+    func unclaimedClimbStillDaresTheFirstFinisher() throws {
+        try Self.capture(
+            name: "climb-leaderboard-tab-unclaimed",
+            caption: "Nobody has finished: no First Ascent line, the empty state dares you",
+            rows: [],
+            firstAscentHolder: nil
+        )
+    }
+
+    // MARK: - Fixtures
+
+    private static func row(
+        id: String,
+        rank: Int,
+        name: String,
+        seconds: TimeInterval,
+        isCurrentUser: Bool = false
+    ) -> ModeratedReplayLeaderboardRow {
+        CrossUserIdentityAdapter.replayRow(
+            LiveReplayLeaderboardRow(
+                id: id,
+                rank: rank,
+                displayName: name,
+                avatarToken: String(name.prefix(1)),
+                photoURL: nil,
+                stepsAtBucket: 1_665,
+                finalSteps: 1_665,
+                deltaFromUser: 0,
+                isCurrentUser: isCurrentUser,
+                isPersonalBest: isCurrentUser,
+                completionDurationSeconds: seconds,
+                userId: "user-\(id)"
+            ),
+            blockedUserIds: [],
+            isBlockListHydrated: true
+        )
+    }
+
+    private static func firstAscent(name: String) -> ModeratedReplayFirstAscent {
+        CrossUserIdentityAdapter.firstAscent(
+            LiveReplayFirstAscent(
+                userId: "user-first-ascent",
+                displayName: name,
+                avatarToken: String(name.prefix(1)),
+                photoURL: nil,
+                completedAt: firstAscentDate
+            ),
+            currentUserId: nil,
+            blockedUserIds: [],
+            isBlockListHydrated: true
+        )
+    }
+
+    // MARK: - Capture
+
+    private static func capture(
+        name: String,
+        caption: String,
+        rows: [ModeratedReplayLeaderboardRow],
+        firstAscentHolder: ModeratedReplayFirstAscent? = firstAscent(name: "John Smith"),
+        width: CGFloat = 402
+    ) throws {
+        let content = VStack(alignment: .leading, spacing: 14) {
+            Text(caption)
+                .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                .foregroundStyle(Color.ascendAccent)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ClimbLeaderboardPageProof(rows: rows, firstAscent: firstAscentHolder)
+        }
+        .padding(20)
+        .frame(width: width, alignment: .topLeading)
+        .background(Color.black)
+        .environment(\.colorScheme, .dark)
+
+        let host = UIHostingController(rootView: content)
+        host.overrideUserInterfaceStyle = .dark
+        let window = try makeWindow(host: host, width: width)
+        defer { tearDown(window) }
+
+        var fitted: CGFloat = 400
+        for _ in 0..<10 {
+            pump(window)
+            fitted = host.sizeThatFits(
+                in: CGSize(width: width, height: CGFloat.greatestFiniteMagnitude)
+            ).height
+        }
+
+        try write(draw(window, width: width, fittingHeight: fitted), name: name)
+    }
+
+    private static func makeWindow(
+        host: UIHostingController<some View>,
+        width: CGFloat
+    ) throws -> UIWindow {
+        let scene = try #require(
+            UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }.first,
+            "test host app should expose a live UIWindowScene"
+        )
+        let window = UIWindow(windowScene: scene)
+        window.frame = CGRect(x: 0, y: 0, width: width, height: 500)
+        window.overrideUserInterfaceStyle = .dark
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        return window
+    }
+
+    private static func pump(_ window: UIWindow) {
+        window.layoutIfNeeded()
+        CATransaction.flush()
+        RunLoop.current.run(until: Date())
+    }
+
+    private static func draw(
+        _ window: UIWindow,
+        width: CGFloat,
+        fittingHeight: CGFloat
+    ) -> UIImage {
+        window.frame = CGRect(x: 0, y: 0, width: width, height: ceil(fittingHeight))
+        pump(window)
+
+        let format = UIGraphicsImageRendererFormat.default()
+        format.scale = 3
+        return UIGraphicsImageRenderer(bounds: window.bounds, format: format).image { context in
+            window.layer.render(in: context.cgContext)
+        }
+    }
+
+    private static func tearDown(_ window: UIWindow) {
+        window.isHidden = true
+        window.rootViewController = nil
+        window.windowScene = nil
+    }
+
+    private static func write(_ image: UIImage, name: String) throws {
+        let data = try #require(image.pngData(), "No PNG data for \(name)")
+        let candidates = [
+            ProcessInfo.processInfo.environment["ASCEND_EVIDENCE_DIR"],
+            NSTemporaryDirectory().appending("ascend-climb-leaderboard-evidence")
+        ].compactMap { $0 }
+
+        for directory in candidates {
+            let url = URL(filePath: directory).appending(path: "\(name).png")
+            do {
+                try FileManager.default.createDirectory(
+                    at: URL(filePath: directory),
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: url)
+                print("ASCEND_EVIDENCE_PNG \(url.path)")
+                return
+            } catch {
+                continue
+            }
+        }
+        Issue.record("No writable evidence directory for \(name)")
+    }
+}
+
+/// Reproduction of `ClimbDetailView.leaderboardPage` after the change: First Ascent line, then the
+/// board. Nothing stands between them any more.
+private struct ClimbLeaderboardPageProof: View {
+    let rows: [ModeratedReplayLeaderboardRow]
+    let firstAscent: ModeratedReplayFirstAscent?
+
+    private let gold = Color(hex: "F3D76B")
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            if let firstAscent {
+                firstAscentLine(firstAscent)
+            }
+
+            if rows.isEmpty {
+                emptyState
+            } else {
+                VStack(spacing: 8) {
+                    ForEach(rows) { row in
+                        leaderboardRow(for: row)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 4)
+        .padding(.vertical, 2)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private func firstAscentLine(_ firstAscent: ModeratedReplayFirstAscent) -> some View {
+        HStack(alignment: .center, spacing: 4) {
+            ClimbFirstAscentMark()
+
+            Text(
+                "First Ascent: \(firstAscent.identity.displayName) · " +
+                    firstAscent.completedAt.formatted(.dateTime.month(.abbreviated).day().year())
+            )
+                .font(.montserratSemiBold(size: 12))
+                .foregroundStyle(gold)
+                .lineLimit(1)
+                .minimumScaleFactor(0.78)
+        }
+        .frame(minHeight: 44)
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("No completed times yet.")
+                .font(.montserratBold(size: 18))
+                .foregroundStyle(.white)
+
+            Text("First Ascent open. The first finisher claims it forever.")
+                .font(.montserratRegular(size: 14))
+                .foregroundStyle(.white.opacity(0.66))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.vertical, 16)
+    }
+
+    private func leaderboardRow(for row: ModeratedReplayLeaderboardRow) -> some View {
+        let rank = row.rank
+        let isPodium = isPodiumRank(rank)
+        let isFirst = rank == 1
+        let rowAccent = accentColor(for: rank)
+
+        return HStack(alignment: .center, spacing: isFirst ? 14 : 12) {
+            rankView(for: row)
+
+            avatarToken(for: row, size: isFirst ? 50 : 42, borderColor: isPodium ? rowAccent : nil)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 7) {
+                    Text(row.identity.displayName)
+                        .font(.montserratBold(size: 15))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.78)
+
+                    if row.isCurrentUser {
+                        Text("YOU")
+                            .font(.montserratBold(size: 9))
+                            .foregroundStyle(.black)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .background(
+                                Capsule(style: .continuous)
+                                    .fill(Color.accent)
+                            )
+                    }
+                }
+
+                Text("\(row.finalSteps.formatted()) steps")
+                    .font(.montserratMedium(size: isFirst ? 12 : 11))
+                    .foregroundStyle(.white.opacity(0.52))
+                    .monospacedDigit()
+            }
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(durationText(for: row))
+                    .font(.montserratBold(size: isFirst ? 18 : 16))
+                    .foregroundStyle(isPodium ? rowAccent : (row.isCurrentUser ? .accent : .white))
+                    .monospacedDigit()
+
+                if let averageStepsPerMinute = row.averageStepsPerMinute {
+                    Text("\(Int(averageStepsPerMinute.rounded()).formatted()) avg SPM")
+                        .font(.montserratSemiBold(size: 11))
+                        .foregroundStyle(.white.opacity(0.52))
+                        .monospacedDigit()
+                }
+            }
+        }
+        .padding(.vertical, isFirst ? 16 : 13)
+        .padding(.horizontal, isPodium || row.isCurrentUser ? 12 : 0)
+        .background { rowBackground(for: row) }
+        .overlay(alignment: .bottom) {
+            if !isPodium && !row.isCurrentUser {
+                Rectangle()
+                    .fill(.white.opacity(0.08))
+                    .frame(height: 1)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func rankView(for row: ModeratedReplayLeaderboardRow) -> some View {
+        if row.rank == 1 {
+            Image(systemName: "crown.fill")
+                .font(.system(size: 15, weight: .bold))
+                .foregroundStyle(gold)
+                .frame(width: 34, alignment: .leading)
+        } else if let rank = row.rank {
+            Text(CompetitionRanking.rankLabel(rank, isTied: row.isTied, untiedPrefix: "#"))
+                .font(.montserratBold(size: 15))
+                .foregroundStyle(accentColor(for: rank))
+                .frame(width: 34, alignment: .leading)
+                .monospacedDigit()
+        }
+    }
+
+    @ViewBuilder
+    private func rowBackground(for row: ModeratedReplayLeaderboardRow) -> some View {
+        let rank = row.rank
+        let rowAccent = accentColor(for: rank)
+
+        if rank == 1 {
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [rowAccent.opacity(0.18), rowAccent.opacity(0.07)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(rowAccent.opacity(0.72), lineWidth: 1.4)
+                )
+        } else if isPodiumRank(rank) {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(rowAccent.opacity(0.10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .stroke(rowAccent.opacity(0.28), lineWidth: 1)
+                )
+        } else if row.isCurrentUser {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color.accent.opacity(0.12))
+        }
+    }
+
+    private func avatarToken(
+        for row: ModeratedReplayLeaderboardRow,
+        size: CGFloat,
+        borderColor: Color?
+    ) -> some View {
+        Text(row.identity.avatarToken)
+            .font(.montserratBold(size: 13))
+            .foregroundStyle(row.isCurrentUser ? .black : .white)
+            .lineLimit(1)
+            .frame(width: size, height: size)
+            .background(
+                Circle()
+                    .fill(row.isCurrentUser ? Color.accent : Color(hex: "3A3A3C"))
+            )
+            .overlay(
+                Circle()
+                    .stroke(
+                        borderColor ?? (row.isCurrentUser ? Color.accent.opacity(0.7) : .white.opacity(0.14)),
+                        lineWidth: borderColor == nil ? 1 : 2
+                    )
+            )
+    }
+
+    private func durationText(for row: ModeratedReplayLeaderboardRow) -> String {
+        guard let completionDurationSeconds = row.completionDurationSeconds else { return "--" }
+        return DurationFormatter.format(duration: completionDurationSeconds)
+    }
+
+    private func isPodiumRank(_ rank: Int?) -> Bool {
+        guard let rank else { return false }
+        return (1...3).contains(rank)
+    }
+
+    private func accentColor(for rank: Int?) -> Color {
+        switch rank {
+        case 1: return gold
+        case 2: return Color(hex: "BFC4CC")
+        case 3: return Color(hex: "C8793D")
+        default: return Color.customGray
+        }
+    }
+}


### PR DESCRIPTION
## Intent

Two presentation-only changes to a climb's Leaderboard tab in Climb Detail, from the captain's device testing on the production build (he raced Charminar and screenshotted the tab). Nothing about leaderboard data, ranking, or the First Ascent rules may change; the Overview and History tabs are out of scope and untouched.

1. REMOVE THE 'Your best' CARD. Directly under the First Ascent line sat a highlighted card reading 'Your best / 02:06' with '#1 / of 1' on the right, and immediately below it the leaderboard itself, where the climber's own row already appears with a YOU pill, the same time, and the same rank. The screen stated the climber's best time and placement twice, one above the other. The captain's reasoning: History exists precisely so a climber can see their own results, and the leaderboard row already carries it in context. Accepted scope: no 'Your best' card on the Leaderboard tab in ANY state.

2. KEEP THE YOU PILL on the climber's own row in the leaderboard. The captain called this out specifically as the thing worth keeping - it is what makes the board readable at a glance. It is retained unchanged.

3. LAYOUT MUST HOLD in both states - a climber who has raced the climb and one who has not. Verified visually in both.

4. USE THE REAL FIRST ASCENT ART. The First Ascent line read 'First Ascent: <name> - <date>' preceded by a generic 'flag.fill' SF Symbol. FirstAscentBadgeDetailed in the asset catalogue is now the captain's own cut-out gold summit flag, shipped earlier today in #473. It is now rendered the same way the achievement shelf does (ProfilePrestigeBadgeView): free-standing, .resizable().scaledToFit(), no clip, no tile, no stroke - clipping a cut-out slices the flag off and a stroke draws an edge around transparency. It had to be sized to sit correctly against that line of text and verified to still read at that size rather than assumed.

DELIBERATE DECISIONS A REVIEWER READING ONLY THE DIFF WOULD NOT KNOW:

- WHAT THE REMOVED CARD WAS DOING THAT NOTHING ELSE DOES. The captain explicitly asked this to be checked. The card's visibility flag, ClimbDetailViewModel.shouldShowPersonalRankSummary, had a SECOND unrelated job beyond showing the card: it also suppresses the leaderboardEmptyState ('No completed times yet. / First Ascent open. The first finisher claims it forever.') and suppresses the still-syncing leaderboard loading state. The climber's rank and the board rows arrive from two SEPARATE fetches (fetchCurrentUserBestCompletion vs fetchCompletionLeaderboard), so when the board fetch fails while the rank fetch succeeds, that predicate is the only thing stopping the app from telling a climber who has just finished the climb that nobody has finished it. It is therefore KEPT and RENAMED to hasPersonalCompletionStanding - a name that describes what it actually asserts now that no summary reads it. Both remaining call sites are leaderboard-page logic; this rename is not a behavior change. Reviewers should not 'simplify' this predicate away as leftover dead gating.
- personalBestCompletionDurationSeconds on the view model had the removed card as its ONLY reader, so it was deleted as dead code per the project's delete-before-you-defend principle. currentUserBestCompletion, personalFinisherStatus and personalCurrentCompletionRank all survive because other surfaces still read them (community stats, hero-card finisher strip).
- A climber who has NEVER raced the climb never saw the card at all (it required a published completion), so their layout is byte-identical to before. The removal only affects the raced state.
- BADGE SIZE WAS MEASURED, NOT GUESSED. FirstAscentBadgeDetailed is a 3:2 landscape canvas (1024x683) whose opaque flag occupies only the middle ~55% horizontally and ~93% vertically, so .scaledToFit() into a square box renders a flag about 0.62 x the box height with a transparent gutter either side. A ladder was rendered at 20/24/26/30/34/40 against the real 12pt semibold line: below 26 the flag reads as a gold smudge, at 40 it starts competing with the podium rows. 34 is the smallest box where the finial, pole, pennant and mound all resolve, and it still fits the row's 44pt minHeight. This reasoning is recorded on the new ClimbFirstAscentMark view. The HStack spacing was deliberately tightened from 8 to 4 because the art carries its own transparent gutter - that is optical compensation, not a spacing-scale violation.
- A new tiny view, ClimbFirstAscentMark, was extracted deliberately rather than inlining the Image call: it lets the visual-evidence test photograph the SHIPPING badge rather than a copy, and it gives the measured size constant a home with its rationale.
- VISUAL EVIDENCE. AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests photographs the tab in four states (sole finisher - the captain's Charminar case; mid-field with the YOU pill; never raced; unclaimed). ClimbDetailView.leaderboardPage cannot be hosted directly - it is a private member of a 2,000-line Firebase-auth-gated screen whose .task opens network work - so the page chrome is reproduced from source in the established repo pattern (see ClimbDetailOverviewLayoutSnapshotTests), while the two things actually under review are the real shipping code: ClimbFirstAscentMark is the real view, and every row is a real ModeratedReplayLeaderboardRow built through CrossUserIdentityAdapter so the YOU pill lights from the same isCurrentUser the app uses. The replica is a deliberate, documented tradeoff, not an oversight.
- VERIFICATION ALREADY RUN LOCALLY: full iOS suite green (1677 passed, 0 failed) and the unsigned Release compile check for generic/platform=iOS succeeded. An earlier full-suite run reported 727 'crashed with signal kill' - that was another agent lane contending for the shared iOS simulator, not this change; the clean rerun is green.
- KNOWN, ACCEPTED TRADEOFF worth surfacing but not a blocker: the completion board paginates at 25 rows, so a climber ranked below that no longer sees their own standing without scrolling. History and the hero card's finisher strip still carry it, and the captain was explicit that History is the right home for a climber's own results. Do not 'fix' this by reintroducing a pinned current-user row on this surface without a product decision.

## What Changed

- Removed the highlighted "Your best / #N of M" card from Climb Detail's Leaderboard tab in every state, so a climber's time and rank are stated once - on their own row, still wearing the YOU pill. `personalBestCompletionDurationSeconds` had the card as its only reader and was deleted; `shouldShowPersonalRankSummary` was kept and renamed to `hasPersonalCompletionStanding`, because rank and board rows arrive from two separate fetches and it is the only thing stopping a climber who has just finished from being told nobody has.
- Replaced the generic `flag.fill` SF Symbol on the First Ascent line with the shipped cut-out gold summit flag, extracted as `ClimbFirstAscentMark` - free-standing `.resizable().scaledToFit()` at a measured 34pt with no clip, tile, or stroke, matching how the profile achievement shelf renders it. Row spacing tightened from 8 to 4 to compensate for the art's own transparent gutter.
- Replaced the view's ad-hoc loading/empty/rows branching with `ClimbLeaderboardPageContent.resolve`, an exhaustive pure resolver over the five inputs, so the standing-without-rows race resolves to the loading state instead of a blank frame. Covered by new `ClimbLeaderboardPageContentTests` plus `ClimbLeaderboardTabVisualEvidenceTests`, which photographs the tab in four states (sole finisher, mid-field with the YOU pill, never raced, unclaimed).

Both new suites and the full 1516-test iOS suite pass, and the four visual-evidence PNGs were captured and reviewed. Known accepted tradeoff: the completion board paginates at 25 rows, so a climber ranked below that now scrolls to find their own standing - History and the hero card's finisher strip still carry it. Open follow-up from the pipeline: shipped App Store screenshot `05-every-step-ranked.png` still shows the removed card and needs a fresh capture before the next metadata push.

## Risk Assessment

✅ Low: The follow-up commit replaces a boolean with a pure, exhaustively-tested resolver that is behavior-identical to the old logic on every input combination except the reported blank frame, and the underlying change remains presentation-only with no data, ranking, or First Ascent logic touched.

## Testing

Re-ran the previously blocked verification against the warm DerivedData cache: the two target suites passed and wrote all four visual-evidence PNGs, which I reviewed directly - the sole-finisher shot confirms the duplicated 'Your best / 02:06 · #1 of 1' card is gone with the time and rank now stated once on the leaderboard row, the mid-field shot confirms the lime YOU pill still marks the climber's own row, the never-raced shot confirms the layout holds with no gap, and the unclaimed shot confirms the empty state survives; the real cut-out gold summit flag renders free-standing at 34pt in every First Ascent state with the finial, pole, pennant and mound all resolving and no clip or stroke edge. The full iOS suite then ran green at 1516 tests across 221 suites with zero failures and no simulator contention. One artifact-only note: the last row is trimmed at the bottom edge of the two multi-row captures because the test's fitting-height measurement lands a hair short, which is the screenshot bounds rather than shipping layout, and it obscures nothing under review. Per the instruction, /tmp/ascend-dd-01KZT236 was left in place for any further round; the worktree is clean.

- Evidence: Sole finisher (captain&#39;s Charminar case): one row, YOU pill, no &#39;Your best&#39; card, cut-out First Ascent flag (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZT236WA3HVZDQ2R3EY0ZPT9/climb-leaderboard-tab-sole-finisher.png</code>)
- Evidence: Mid-field raced: YOU pill is the only marker of the climber&#39;s own row (#4) (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZT236WA3HVZDQ2R3EY0ZPT9/climb-leaderboard-tab-raced.png</code>)
- Evidence: Never raced: First Ascent line runs straight into the board, no gap left behind (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZT236WA3HVZDQ2R3EY0ZPT9/climb-leaderboard-tab-not-raced.png</code>)
- Evidence: Unclaimed climb: no First Ascent line, empty state intact (local file: <code>/var/folders/m3/qgj4gq85293_kqsxz93qlp3m0000gn/T/no-mistakes-evidence/01KZT236WA3HVZDQ2R3EY0ZPT9/climb-leaderboard-tab-unclaimed.png</code>)
<details>
<summary>Evidence: Target suites + full iOS suite result</summary>

```text
$ xcodebuild ... -only-testing:AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests -only-testing:AscendAppTests/ClimbLeaderboardPageContentTests test
✔ Suite ClimbLeaderboardPageContentTests passed after 0.001 seconds.
ASCEND_EVIDENCE_PNG .../climb-leaderboard-tab-sole-finisher.png
✔ Test soleFinisherSeesOneRowAndNoDuplicateSummary() passed after 0.037 seconds.
ASCEND_EVIDENCE_PNG .../climb-leaderboard-tab-raced.png
✔ Test rankedClimberKeepsTheYouPillOnTheirOwnRow() passed after 0.035 seconds.
ASCEND_EVIDENCE_PNG .../climb-leaderboard-tab-not-raced.png
✔ Test climberWhoHasNotRacedStillGetsAWholePage() passed after 0.031 seconds.
ASCEND_EVIDENCE_PNG .../climb-leaderboard-tab-unclaimed.png
✔ Test unclaimedClimbStillDaresTheFirstFinisher() passed after 0.012 seconds.
✔ Suite ClimbLeaderboardTabVisualEvidenceTests passed after 0.119 seconds.
✔ Test run with 13 tests in 2 suites passed after 0.119 seconds.

$ xcodebuild ... test (full suite)
✔ Test run with 1516 tests in 221 suites passed after 97.759 seconds.
** TEST SUCCEEDED **
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed (2) ✅ across 3 runs (43m22s)

## Observed but deliberately out of scope

Three things the pipeline surfaced that this PR knowingly does **not** address. All were reviewed and dispositioned rather than missed.

**1. App Store screenshot 05 still pictures the removed card.** `AppStoreAssets/screenshots/iphone-6.9-en-US/05-every-step-ranked.png` shows a highlighted `Your best / 23:53 · #15 of 20` card as the first element under the tab bar - exactly what this change deletes. `AppStoreAssets/qa/review.md:62` records it as verified content, so the QA record is accurate about the PNG while the PNG no longer matches the app.

The `EVERY STEP RANKED.` headline is unaffected and stays: climbers do get their rank in real time, so the claim the screenshot makes is still true. Only the pictured card is stale. Merging code publishes nothing to the App Store, so this can only matter at the next metadata submission. **Follow-up:** fresh device capture of the raced-state Leaderboard tab, re-run `AppStoreAssets/render-screenshots.mjs`, update the review record - before the next metadata push.

Worth noting for whoever does that capture: in that screenshot the climber ranks #15 of 20 and only the top 7 rows are visible, so their own row is off-screen. That is the pagination tradeoff below, made concrete.

**2. `latestCompletedWorkout` runs an unbounded store scan on a `.task` path.** `ClimbDetailViewModel.swift:341` calls `modelContext.fetch(FetchDescriptor<Workout>())` - a whole-store scan whose cost grows with the climber's history, reached from `ClimbDetailView.swift:231` -> `viewModel.refresh`. `Workout` carries its heart-rate series inline, so a full fetch is never cheap. This is the same shape as ASCEND-IOS-1K (the 182s Home block) and it violates the CLAUDE.md tripwire directly.

It is **pre-existing** - not introduced here - and it sits in a file this change happens to edit. Widening a presentation-only change into a performance fix on a launch-adjacent screen is a separate piece of work with its own risk, so it is **filed as its own task** rather than folded in here. The bounded replacement belongs in `Shared/Repositories/`.

**3. The visual evidence does not cover the taller board row.** `ClimbLeaderboardPageProof.leaderboardRow` in the evidence suite omits the `demographicSummaryText` line that the shipping row renders between the name and the steps (`ClimbDetailView.swift:1045-1051`). The fixtures never populate demographics, so the four photographs are correct for what they show - but a real row is one text line taller for any climber who publishes age or gender. Read the screenshots as covering the standard row height only, not the taller variant.

## Known accepted tradeoffs

- **Pagination.** The completion board pages at 25 rows, so a climber ranked below that now scrolls to find their own standing. History is the intended home for a climber's own results, and the hero card's finisher strip still carries it. Reintroducing a pinned current-user row on this surface is a product decision, not a bug fix.
- **The `.loading` frame does not self-retry.** The standing-without-rows race now resolves to the existing loading state instead of a blank frame, which is strictly better, but nothing behind it re-fetches: `refreshLeaderboardSummary` re-runs only on `.task` re-appear, `.climbStateDidChange`, `.climbCatalogDidChange`, or the Retry-sync button. If this is ever seen in the field, the fix is a one-shot re-fetch when that frame is hit - not new copy.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `AscendApp/Features/Climbs/Views/ClimbDetailView.swift:879` - The removed card was the fallback content for the exact frame `hasPersonalCompletionStanding` describes, so that frame is now blank. When the predicate is true but no rows arrived and the board fetch did NOT throw, the page suppresses the loading state (:1407), suppresses the empty state (:879), renders no rows, and shows no error line (:883) - the tab is just the First Ascent line, or nothing at all. This is reachable: `refreshLeaderboardSummary` issues `fetchCompletionLeaderboard` and `fetchCurrentUserBestCompletion` concurrently via `async let` (ViewModel:177-188), both `source: .server`, so a ranking publish landing between the two round-trips returns 0 board rows and a valid personal rank. Previously the &#39;Your best&#39; card filled that frame - which is what the new doc comment says the predicate exists for. Re-adding the card is forbidden by the intent, so the fix is a product call: let the loading state through when `hasPersonalCompletionStanding` is true and rows are empty, or add a one-line &#39;board is catching up&#39; note.
- ℹ️ `AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift:341` - Pre-existing, not introduced here, but it sits in a file this change edits and violates a CLAUDE.md tripwire directly: `latestCompletedWorkout` runs `modelContext.fetch(FetchDescriptor&lt;Workout&gt;())` - a whole-store scan whose cost grows with the climber&#39;s history, on a screen `.task` path (`ClimbDetailView.swift:231` -&gt; `viewModel.refresh`). `Workout` carries its heart-rate series inline, so a full fetch is never cheap; this is the same shape as ASCEND-IOS-1K (182s Home block). It answers a bounded question - find the workout for the latest completed attempt - so it should go through a bounded query in `Shared/Repositories/`. Worth a decision on whether to fix in scope or file an issue.
- ℹ️ `AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests.swift:324` - The proof&#39;s doc comment claims the replica uses the &#39;same modifiers as ClimbDetailView.swift&#39;s ... leaderboardRow&#39;, but `ClimbLeaderboardPageProof.leaderboardRow` omits the `demographicSummaryText` line that the shipping row renders between the name and the steps (ClimbDetailView.swift:1045-1051). The fixtures never populate demographics, so the photographs are correct for what they show, but a real board row is one text line taller for any climber who publishes age/gender - which is the dimension requirement 3 (&#39;layout must hold&#39;) is about. Noting it so the evidence isn&#39;t read as covering the taller row; no behavior impact.

🔧 Fix: fix blank leaderboard frame via exhaustive page-state resolver
2 infos still open:
- ℹ️ `AscendApp/Features/Climbs/Models/ClimbLeaderboardPageContent.swift:37` - Acknowledging a tradeoff of the instructed fix, not asking for a change. The standing-without-rows frame now resolves to `.loading`, but nothing behind it is actually loading and nothing re-tries: `ClimbDetailView` has no `.refreshable`, and `refreshLeaderboardSummary` only re-runs on `.task` (re-appear), `.climbStateDidChange`, `.climbCatalogDidChange`, or the Retry-sync button. So when the race that produced this finding fires, the spinner sits there until the climber leaves the screen and comes back. That is strictly better than the blank frame it replaces and matches the instruction to reuse the existing states only; if it ever shows up in the field, the follow-up is a one-shot re-fetch when that frame is hit rather than new copy.
- ℹ️ `AscendApp/Features/Climbs/Views/ClimbDetailView.swift:882` - `case .unavailable` renders `EmptyView()` and relies on the separate `if viewModel.leaderboardErrorMessage != nil, !viewModel.isLeaderboardLoading` block at :886 to supply its content. They agree exactly today - `.unavailable` is only reachable with `hasLeaderboardError == true` and `isLeaderboardLoading == false`, which is precisely that block&#39;s condition - so there is no live defect, and the enum&#39;s doc comment records the dependency. Worth knowing that the resolver&#39;s &#39;never falls through to an unlabelled frame&#39; guarantee is only enforced for three of the four cases; a future edit to that sibling condition would silently restore the blank frame this commit fixed, and the new unit tests would not catch it. Merging the text into the switch is not the fix, since the same line must also render alongside `.rows` and `.empty`.

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed (2) ✅</summary>

- 🚨 `AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests.swift` - Testing is blocked by a full host disk, not by the change. `xcodebuild test` for the two new suites failed during Swift compilation with `No space left on device` (data volume 100% full, 127 MiB free of 926 GiB; ~236 GB of Xcode DerivedData from parallel agent lanes plus the 8.7 GB this run created). Attempts to delete the DerivedData directory this run created (`/tmp/ascend-dd-01KZT236`) were refused by the command-permission gate, so the retry could not happen; by the end even `df` could not write its output. Free disk or grant deletion of stale DerivedData, then re-run.
- ⚠️ `AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests.swift` - No visual evidence was produced for the two things actually under review - the removed &#39;Your best&#39; card and the new cut-out First Ascent flag. `ClimbLeaderboardTabVisualEvidenceTests` is written to photograph all four states (sole finisher, mid-field with YOU pill, never raced, unclaimed) and writes PNGs, but it never executed because the build ran out of disk. The layout-holds-in-both-states and badge-still-reads-at-34pt claims are therefore unverified by this run; they rest on the author&#39;s own local run.
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp-Staging&#34; -configuration Staging -destination &#34;platform=iOS Simulator,name=iPhone 16 Pro&#34; ENABLE_TESTABILITY=YES -only-testing:AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests -only-testing:AscendAppTests/ClimbLeaderboardPageContentTests test` - failed to build: `No space left on device`</code>
- <code>`grep -rn &#34;shouldShowPersonalRankSummary|personalBestCompletionDurationSeconds|personalLeaderboardRankSummary|Your best&#34; AscendApp AscendAppTests` - no stale references to the removed card or its view-model property; the only &#39;Your best&#39; hits are the out-of-scope hero-card stake line and the new test&#39;s own comments</code>
- <code>`sips -g pixelWidth -g pixelHeight AscendApp/Resources/Assets.xcassets/Images/FirstAscentBadgeDetailed.imageset/firstAscentIcon.png` - 1024x683, matching the 3:2 canvas the ClimbFirstAscentMark sizing rationale is derived from</code>
- <code>Read review of the full diff across `ClimbDetailView.swift`, `ClimbDetailViewModel.swift`, `ClimbLeaderboardPageContent.swift`, `ClimbFirstAscentMark.swift` and both new test files</code>
- <code>`df -h /System/Volumes/Data` and `du -sh ~/Library/Developer/Xcode/DerivedData` - diagnosed the build failure as a host-disk exhaustion (100% full, ~236 GB of DerivedData)</code>

🔧 Fix: verify leaderboard tab suites pass with visual evidence
2 warnings still open:
- ⚠️ `AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests.swift` - The four visual-evidence PNGs are still not captured. The re-run of `xcodebuild ... test` was still compiling third-party dependencies (RevenueCat) when I had to report, so `ClimbLeaderboardTabVisualEvidenceTests` had not executed and emitted zero `ASCEND_EVIDENCE_PNG` lines. No compile errors or test failures had appeared at that point - the run simply had not reached the test phase from a cold DerivedData. The explicit acceptance criterion (photographs of sole finisher, mid-field with the YOU pill, never raced, and unclaimed) is therefore still unmet by an independent run, and the layout-holds-in-both-states and badge-reads-at-34pt claims still rest on the author&#39;s own local run. Re-run the suite and let it reach the test phase to collect the PNGs.
- ⚠️ `AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests.swift` - A DerivedData directory at /tmp/ascend-dd-01KZT236 is still in use by the in-flight xcodebuild run and was not cleaned up, because deleting it would kill the running build. It is outside the worktree so nothing can be committed from it, but it should be removed once that run finishes - this machine runs several agent lanes against the same volume and a stale multi-GB cache is what wedged every lane earlier.
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#34;AscendApp-Staging&#34; -configuration Staging -destination &#34;platform=iOS Simulator,name=iPhone 16 Pro&#34; -derivedDataPath /tmp/ascend-dd-01KZT236 ENABLE_TESTABILITY=YES test` - launched against clean DerivedData; still in the dependency-compile phase with zero `error:` lines at report time, so neither new suite had executed</code>
- <code>`df -h /System/Volumes/Data` - confirmed round 1&#39;s blocker is gone (156 GiB free, 83% used)</code>
- <code>`xcrun simctl list devices available | grep &#39;iPhone 16 Pro&#39;` and `xcrun simctl list runtimes | grep watch` - confirmed the booted destination and the watchOS 26.2 runtime both schemes require</code>
- <code>`git diff ac0c4935..f70db4d6 -- AscendApp/Features/Climbs/Views/ClimbDetailView.swift AscendApp/Features/Climbs/ViewModels/ClimbDetailViewModel.swift` - read the shipping diff against each numbered acceptance criterion</code>
- <code>`grep -rn &#34;flag.fill&#34; AscendApp/Features/Climbs/` - confirmed the generic SF Symbol is gone from the whole Climbs feature</code>
- <code>`grep -rn &#34;Your best&#34; AscendApp/Features/Climbs/` - only surviving hits are in `TodayClimbStakeLine.swift`, a different surface</code>
- <code>`grep -rn &#34;shouldShowPersonalRankSummary\|personalBestCompletionDurationSeconds&#34; AscendApp AscendAppTests` - no stale references to the renamed predicate or deleted property</code>
- <code>Read `AscendApp/Resources/Assets.xcassets/Images/FirstAscentBadgeDetailed.imageset/firstAscentIcon.png` as an image - visually confirmed the cut-out gold summit flag on transparency</code>
- <code>Read `ClimbFirstAscentMark.swift` - verified `.resizable().scaledToFit()` at 34pt with no clip, tile, or stroke</code>
- <code>Read `ClimbLeaderboardPageContent.swift` and `ClimbLeaderboardPageContentTests.swift` - verified the resolver is exhaustive over all five inputs</code>

🔧 Fix: verify leaderboard tab suites green with captured visual evidence
✅ Re-checked - no issues remain.
- <code>`xcodebuild -project AscendApp.xcodeproj -scheme &#39;AscendApp-Staging&#39; -configuration Staging -destination &#39;platform=iOS Simulator,name=iPhone 16 Pro&#39; -derivedDataPath /tmp/ascend-dd-01KZT236 ENABLE_TESTABILITY=YES -only-testing:AscendAppTests/ClimbLeaderboardTabVisualEvidenceTests -only-testing:AscendAppTests/ClimbLeaderboardPageContentTests test` - 13 tests in 2 suites passed, emitted 4 ASCEND_EVIDENCE_PNG paths</code>
- <code>`xcodebuild ... -scheme &#39;AscendApp-Staging&#39; -configuration Staging -destination &#39;platform=iOS Simulator,name=iPhone 16 Pro&#39; ENABLE_TESTABILITY=YES test` (full suite) - 1516 tests in 221 suites passed, ** TEST SUCCEEDED **, no signal-kill contention</code>
- `Visually reviewed all four captured PNGs (sole finisher, mid-field with YOU pill, never raced, unclaimed) to confirm the 'Your best' card is gone, the YOU pill remains, and the cut-out First Ascent flag reads at 34pt without clipping or stroke`
- <code>`grep -rn &#34;Your best|shouldShowPersonalRankSummary|personalBestCompletionDurationSeconds&#34; AscendApp/ AscendAppTests/` - confirmed no lingering references to the removed card or deleted view-model property; only unrelated TodayClimbStakeLine remains</code>
- <code>Reviewed `git diff ac0c493..f70db4d` for ClimbDetailView.swift and ClimbDetailViewModel.swift to confirm the predicate was renamed rather than removed and both call sites remain leaderboard-page logic</code>
- <code>`git status --porcelain` - worktree clean, no transient artifacts left behind</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `AppStoreAssets/screenshots/iphone-6.9-en-US/05-every-step-ranked.png` - The shipped en-US App Store screenshot 05 sells the card this change deleted. Its source capture, AppStoreAssets/sources/real-ui-climb-leaderboard-20.png, shows the Leaderboard tab with a highlighted &#39;Your best / 23:53&#39; + &#39;#15 of 20&#39; card as the first element under the tab bar, directly above the leaderboard rows - the exact duplication removed here. AppStoreAssets/qa/review.md:62 records that card as verified content (&#39;the current user&#39;s complete rank summary&#39;), so the QA record is accurate about the PNG but the PNG no longer matches the app. Fixing it needs a fresh device capture of the raced-state Leaderboard tab plus a re-run of AppStoreAssets/render-screenshots.mjs and an updated review record - asset regeneration beyond a documentation pass, and it changes what is published to the App Store, so it needs your call on whether to redo it before the next metadata push.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

