### PR TITLE
fix(share): complete walkthrough progress dots (follow-up to #492)

### DIFF
--- a/AscendApp/Features/ShareComposer/ViewModels/ShareComposerWalkthroughCoordinator.swift
+++ b/AscendApp/Features/ShareComposer/ViewModels/ShareComposerWalkthroughCoordinator.swift
@@ -46,14 +46,15 @@ final class ShareComposerWalkthroughCoordinator {
     /// How long the dot row is. Fixed for the whole walkthrough, on every path.
     ///
     /// This is deliberately not `shownMarks.count`, and the two must not be collapsed into one
-    /// value. The row's *length* never changes, so the climber never watches a dot appear or
-    /// disappear between one card and the next; only *which* dot is filled is derived from the
-    /// marks actually shown. A step this journey turns out to skip therefore reads as already
-    /// passed, which is what keeps the filled dot moving exactly one position per card.
+    /// value. The row's *length* never changes. The current dot comes from the marks actually
+    /// shown, while capacity left by an inapplicable mark is rendered as passed. That distinction
+    /// keeps the current dot moving exactly one position per displayed card without making the row
+    /// rewrite itself.
     private let progressRowLength: Int
     /// The marks this journey will actually show, which is where the filled dot's position comes
     /// from. Dropping one moves the remaining marks up a position; it never shortens the row.
     private var shownMarks: [ShareComposerCoachMark]
+    private var passedProgressStepIndices: Set<Int> = []
 
     init(
         entry: Entry,
@@ -88,6 +89,7 @@ final class ShareComposerWalkthroughCoordinator {
             message: mark.message(sourceOptions: sourceOptions, editRailOptions: editRailOptions),
             stepCount: progressRowLength,
             stepIndex: index,
+            passedStepIndices: passedProgressStepIndices,
             primaryActionTitle: mark == .filters ? "Got it" : "Next",
             showsSkip: true
         )
@@ -142,7 +144,7 @@ final class ShareComposerWalkthroughCoordinator {
         case .waitingForSourceOptions:
             // The picker is behind us, so its mark has missed its moment: present it now and it
             // would dim the composer while pointing at an anchor no longer on screen.
-            shownMarks.removeAll { $0 == .sources }
+            dropFromJourney(.sources)
             transition(to: .waitingForStatsSheet)
         case .presenting, .waitingForStatsSheet, .waitingForSticker, .finished:
             break
@@ -163,12 +165,13 @@ final class ShareComposerWalkthroughCoordinator {
     /// Whatever the climber added, the walkthrough carries on: the edit step describes the rail the
     /// selected sticker actually offers, and a sticker with no rail at all drops that step from the
     /// journey and hands over to the filter mark rather than waiting for a control that will never
-    /// appear. The row keeps its length; the dropped step reads as already passed.
+    /// appear. The current dot still follows displayed cards one position at a time, the row keeps
+    /// its fixed length, and the unused position is visibly passed.
     func stickerSelected(_ sticker: ShareStickerInstance?) {
         guard state == .waitingForSticker, let sticker else { return }
 
         guard let options = ShareComposerEditRailOptions(sticker: sticker) else {
-            shownMarks.removeAll { $0 == .editRail }
+            dropFromJourney(.editRail)
             transition(to: .presenting(.filters))
             return
         }
@@ -203,6 +206,12 @@ final class ShareComposerWalkthroughCoordinator {
             restingFocusTarget = Self.target(for: leaving)
         }
         state = newState
+    }
+
+    private func dropFromJourney(_ mark: ShareComposerCoachMark) {
+        guard shownMarks.contains(mark) else { return }
+        shownMarks.removeAll { $0 == mark }
+        passedProgressStepIndices.insert(shownMarks.count)
     }
 
     private func finish() {

--- a/AscendApp/Shared/Components/CoachMarks/CoachMarkOverlay.swift
+++ b/AscendApp/Shared/Components/CoachMarks/CoachMarkOverlay.swift
@@ -187,11 +187,21 @@ struct CoachMarkOverlay: View {
         HStack(spacing: 6) {
             ForEach(0..<presentation.stepCount, id: \.self) { step in
                 Circle()
-                    .fill(step == presentation.stepIndex ? Color.accent : .white.opacity(0.22))
+                    .fill(progressDotColor(for: step))
                     .frame(width: 6, height: 6)
             }
         }
         .accessibilityHidden(true)
+    }
+
+    private func progressDotColor(for step: Int) -> Color {
+        if step == presentation.stepIndex {
+            return Color.accent
+        }
+        if presentation.passedStepIndices.contains(step) {
+            return Color.accent.opacity(0.45)
+        }
+        return .white.opacity(0.22)
     }
 
     private var actionButtons: some View {

--- a/AscendApp/Shared/Components/CoachMarks/CoachMarkPresentation.swift
+++ b/AscendApp/Shared/Components/CoachMarks/CoachMarkPresentation.swift
@@ -6,6 +6,7 @@ struct CoachMarkPresentation: Equatable {
     let message: String
     let stepCount: Int
     let stepIndex: Int
+    let passedStepIndices: Set<Int>
     let primaryActionTitle: String
     let showsSkip: Bool
     /// A target that already carries its own accent outline can opt out of a second ring.
@@ -17,6 +18,7 @@ struct CoachMarkPresentation: Equatable {
         message: String,
         stepCount: Int,
         stepIndex: Int,
+        passedStepIndices: Set<Int> = [],
         primaryActionTitle: String,
         showsSkip: Bool,
         drawsSpotlightRing: Bool = true
@@ -25,6 +27,7 @@ struct CoachMarkPresentation: Equatable {
         self.message = message
         self.stepCount = stepCount
         self.stepIndex = stepIndex
+        self.passedStepIndices = passedStepIndices
         self.primaryActionTitle = primaryActionTitle
         self.showsSkip = showsSkip
         self.drawsSpotlightRing = drawsSpotlightRing

--- a/AscendAppTests/ShareComposerWalkthroughTests.swift
+++ b/AscendAppTests/ShareComposerWalkthroughTests.swift
@@ -113,9 +113,9 @@ struct ShareComposerWalkthroughTests {
         #expect(fixture.store.hasSeenWalkthrough)
     }
 
-    /// The row is four dots on the first card and four on the last, and the filled dot moves by
-    /// exactly one position between them. The skipped edit step reads as already passed rather
-    /// than deleting a dot from the row or leaving a gap in it.
+    /// The row is four dots on the first card and four on the last, and the current dot moves by
+    /// exactly one position between them. The skipped edit step is explicitly passed rather than
+    /// deleting a dot from the row or leaving an indistinguishable pending dot.
     @Test(.bug(id: 491))
     func aStickerWithNoEditRailKeepsTheRowAtFourDotsAdvancingOneAtATime() {
         let fixture = DefaultsFixture()
@@ -135,6 +135,7 @@ struct ShareComposerWalkthroughTests {
         #expect(displayed.map(\.mark) == [.sources, .stats, .filters])
         #expect(displayed.map(\.stepCount) == [4, 4, 4])
         #expect(displayed.map(\.stepIndex) == [0, 1, 2])
+        #expect(displayed.map(\.passedStepIndices) == [[], [], [3]])
         #expect(zip(displayed, displayed.dropFirst()).allSatisfy { $1.stepIndex - $0.stepIndex == 1 })
 
         coordinator.advance()
@@ -407,7 +408,8 @@ struct ShareComposerWalkthroughTests {
             DisplayedCard(
                 mark: mark,
                 stepIndex: presentation.stepIndex,
-                stepCount: presentation.stepCount
+                stepCount: presentation.stepCount,
+                passedStepIndices: presentation.passedStepIndices
             )
         ]
     }
@@ -459,6 +461,7 @@ private struct DisplayedCard: Equatable {
     let mark: ShareComposerCoachMark
     let stepIndex: Int
     let stepCount: Int
+    let passedStepIndices: Set<Int>
 }
 
 /// The three shapes the edit rail draws differently: a plain metric offers every control, while a

--- a/docs/quality/contracts/issue-491.md
+++ b/docs/quality/contracts/issue-491.md
@@ -28,8 +28,8 @@ If the wait runs out, the mark names only the tabs already known to be there and
 - [ ] AC-3: The stats mark truthfully explains available session stats and ready-made groups, including how an item is added and then moved, resized, or deleted.
 - [ ] AC-4: The edit-rail mark explains the controls the selected sticker's own rail offers, naming arrangement and alignment only when that sticker shows them, and always naming font, color, and panel treatment.
 Whatever the climber adds, the walkthrough carries on: a sticker with no rail at all hands straight over to the filters mark rather than waiting for a control that will never appear.
-The dot row keeps one fixed length for the whole walkthrough on every path, and the filled dot moves exactly one position between every displayed card.
-A step this journey skips reads as already passed rather than deleting a dot or leaving an unfilled gap behind the current one.
+The dot row keeps one fixed length for the whole walkthrough on every path, and the current dot moves exactly one position between every displayed card.
+A step this journey skips is visibly marked as passed rather than deleting a dot or leaving an indistinguishable pending dot.
 - [ ] AC-5: The filters mark explains that filters affect the whole picture, that photo and preset backgrounds support drag and pinch, and that recap backgrounds remain fixed.
 - [ ] AC-6: Skip from any of the four steps records the whole walkthrough as seen and dismisses it.
 - [ ] AC-7: Completing the fourth step records the walkthrough as seen, and a second open presents no mark.
@@ -47,7 +47,7 @@ A step this journey skips reads as already passed rather than deleting a dot or 
 | Picker mark advanced | Dismiss the mark and wait for a background choice before presenting a composer mark. | Coordinator transition test. |
 | Composer reached from picker | Present the stats-sheet mark when the stats sheet is available. | Coordinator test and stats-sheet evidence image. |
 | Any sticker with an edit rail selected | Present the edit-rail mark describing that rail's own controls. | Parameterized coordinator test and edit-rail evidence image. |
-| Sticker with no edit rail selected | Drop the edit step from the journey and present the filters mark in its place, keeping the row at four dots and advancing the filled dot by one. | Coordinator dot-row test. |
+| Sticker with no edit rail selected | Drop the edit step from the displayed journey and present the filters mark in its place, keeping the row at four dots, advancing the current dot by one, and rendering the unused position as passed. | Coordinator dot-row test. |
 | Background chosen while the source tabs are still resolving | Drop the sources mark from the journey and carry on at the stats step, rather than presenting it over the composer. | Coordinator state-machine test. |
 | Edit-rail mark advanced | Present the filters mark. | Coordinator order test and filters evidence image. |
 | Direct composer entry | Start at stats with three coherent progress steps. | Coordinator direct-entry test; no production route constructs it, see Risk and rollout. |


### PR DESCRIPTION
## Summary

This follow-up completes the fixed-length Share Composer walkthrough progress row from issue #491.

PR #492 already landed the fixed row length.
This adds a distinct passed state for an inapplicable step, so the current filled dot advances exactly one position per displayed card while the unused position is visibly marked as passed.

This change was split into a second PR only because #492 merged before the final dot-row ruling was committed.

## Testing

- `ShareComposerWalkthroughTests`
- `CoachMarkOverlayAccessibilityTests`

The hosted test run passed 25 executions across 20 tests with zero failures.
