### PR TITLE
Gate the production catalogue on artwork it cannot publish without

### DIFF
--- a/.claude/skills/live-climb-content/SKILL.md
+++ b/.claude/skills/live-climb-content/SKILL.md
@@ -153,7 +153,11 @@ node scripts/sync-climb-images.mjs sync --from staging --to production --confirm
 
 Writes to production require `--confirm-production`. Sync copies only missing/changed objects (md5 compare) and never deletes. When adding a climb: upload images to dev/staging first, validate in-app, then sync to production alongside (or before) the catalog deploy that references them.
 
-`releaseState` is not per-environment: one catalogue file deploys to dev, staging, and production, so promoting a climb to `available` commits every environment to having its artwork. Audit the production bucket before that deploy, not after it.
+`audit` fails when any `available` climb lacks a **complete** hero/card/thumb set - a partial set reads worse than none, because the card is the browse surface. It honors the same versioned-then-legacy fallback the app does (`FirebaseClimbImageRepository.candidateRemotePaths`), and it refuses to read a zero-object listing as a verified-empty bucket.
+
+`releaseState` is not per-environment: one catalogue file deploys to dev, staging, and production, so promoting a climb to `available` commits every environment to having its artwork. **Images are not per-environment content and no deploy moves them** - they are copied bucket to bucket by this tool alone.
+
+That instruction used to live here as prose, and prose lost. On 2026-08-10 #467 promoted 28 World Tour venues to `available`; their artwork had been uploaded to dev and staging only, and production had last received images in a single manual bulk copy on 2026-07-06. Twenty-eight of the 58 browsable climbs rendered as empty cards for fifteen days, through launch. `deploy-production.yml` now runs `audit --project production` immediately before the Hosting deploy, so the catalogue cannot publish past missing artwork; `scripts/test/climb-image-publication.test.mjs` pins that ordering.
 
 ## Workflow
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -300,6 +300,9 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
+      # Workload Identity Federation needs the job's OIDC token to authenticate
+      # the climb-artwork audit against the production Storage bucket.
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -391,6 +394,43 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only storage --non-interactive --token "$FIREBASE_TOKEN"
+
+      # The Hosting deploy below publishes the climb catalogue, and publishing
+      # the catalogue is what makes a climb browsable AND what announces it:
+      # announceClimbDrops polls this manifest every five minutes and pushes
+      # every newly `available` climb to every opted-in device. So this deploy
+      # is the last moment anything can stop a climb going live without its
+      # artwork - which is what happened on 2026-08-10, when #467 promoted 28
+      # World Tour venues whose images had only ever been uploaded to dev and
+      # staging. Half the browsable catalogue rendered as empty cards for
+      # fifteen days, through launch.
+      #
+      # `releaseState` is not per-environment: one catalogue file deploys to
+      # every project, so promoting a climb commits production to having its
+      # artwork. Images are not per-environment content - they are copied
+      # bucket to bucket - so nothing about deploying the catalogue moves them.
+      # That gap was documented as a manual instruction and the manual step was
+      # not performed. This is that instruction with teeth.
+      #
+      # The audit exits non-zero when any `available` climb lacks a complete
+      # hero/card/thumb set in the production bucket, and refuses to read an
+      # empty listing as a verified-empty bucket.
+      #
+      # FIREBASE_TOKEN cannot do this: it is a firebase-tools refresh token, and
+      # the CLI has no command that lists Storage objects. The audit reads the
+      # bucket through the Admin SDK, so this job needs a Google credential -
+      # supplied by Workload Identity Federation, which mints a short-lived
+      # token from the job's OIDC identity and keeps no key in a secret.
+      - name: Authenticate to Google Cloud for the artwork audit
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Verify production carries artwork for every available climb
+        run: |
+          npm --prefix scripts ci
+          node scripts/sync-climb-images.mjs audit --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}"
 
       - name: Deploy Hosting
         env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -317,9 +317,50 @@ jobs:
         run: |
           npm --prefix functions ci
           npm --prefix web ci
+          npm --prefix scripts ci
 
       - name: Build web app
         run: npm --prefix web run build
+
+      # This runs before the first deploy step, not just before Hosting, so a
+      # catalogue with missing artwork stops the release without production
+      # having been touched at all.
+      #
+      # The Hosting deploy publishes the climb catalogue, and publishing the
+      # catalogue is what makes a climb browsable AND what announces it:
+      # announceClimbDrops polls this manifest every five minutes and pushes
+      # every newly `available` climb to every opted-in device. So this deploy
+      # is the last moment anything can stop a climb going live without its
+      # artwork - which is what happened on 2026-08-10, when #467 promoted 28
+      # World Tour venues whose images had only ever been uploaded to dev and
+      # staging. Half the browsable catalogue rendered as empty cards for
+      # fifteen days, through launch.
+      #
+      # `releaseState` is not per-environment: one catalogue file deploys to
+      # every project, so promoting a climb commits production to having its
+      # artwork. Images are not per-environment content - they are copied
+      # bucket to bucket - so nothing about deploying the catalogue moves them.
+      # That gap was documented as a manual instruction and the manual step was
+      # not performed. This is that instruction with teeth.
+      #
+      # The audit exits non-zero when any `available` climb lacks a complete
+      # hero/card/thumb set in the production bucket, and refuses to read an
+      # empty listing as a verified-empty bucket.
+      #
+      # FIREBASE_TOKEN cannot do this: it is a firebase-tools refresh token, and
+      # the CLI has no command that lists Storage objects. The audit reads the
+      # bucket through the Admin SDK, so this job needs a Google credential -
+      # supplied by Workload Identity Federation, which mints a short-lived
+      # token from the job's OIDC identity and keeps no key in a secret.
+      - name: Authenticate to Google Cloud for the artwork audit
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Verify production carries artwork for every available climb
+        run: node scripts/sync-climb-images.mjs audit --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}"
+
 
       # Indexes go first because onWorkoutWritten immediately queries workouts
       # by source + climbId. Functions go before Hosting because both Hosting
@@ -394,43 +435,6 @@ jobs:
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
         run: npx -y firebase-tools@15.22.1 deploy --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}" --only storage --non-interactive --token "$FIREBASE_TOKEN"
-
-      # The Hosting deploy below publishes the climb catalogue, and publishing
-      # the catalogue is what makes a climb browsable AND what announces it:
-      # announceClimbDrops polls this manifest every five minutes and pushes
-      # every newly `available` climb to every opted-in device. So this deploy
-      # is the last moment anything can stop a climb going live without its
-      # artwork - which is what happened on 2026-08-10, when #467 promoted 28
-      # World Tour venues whose images had only ever been uploaded to dev and
-      # staging. Half the browsable catalogue rendered as empty cards for
-      # fifteen days, through launch.
-      #
-      # `releaseState` is not per-environment: one catalogue file deploys to
-      # every project, so promoting a climb commits production to having its
-      # artwork. Images are not per-environment content - they are copied
-      # bucket to bucket - so nothing about deploying the catalogue moves them.
-      # That gap was documented as a manual instruction and the manual step was
-      # not performed. This is that instruction with teeth.
-      #
-      # The audit exits non-zero when any `available` climb lacks a complete
-      # hero/card/thumb set in the production bucket, and refuses to read an
-      # empty listing as a verified-empty bucket.
-      #
-      # FIREBASE_TOKEN cannot do this: it is a firebase-tools refresh token, and
-      # the CLI has no command that lists Storage objects. The audit reads the
-      # bucket through the Admin SDK, so this job needs a Google credential -
-      # supplied by Workload Identity Federation, which mints a short-lived
-      # token from the job's OIDC identity and keeps no key in a secret.
-      - name: Authenticate to Google Cloud for the artwork audit
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-      - name: Verify production carries artwork for every available climb
-        run: |
-          npm --prefix scripts ci
-          node scripts/sync-climb-images.mjs audit --project "${{ vars.FIREBASE_PROJECT_ID_PRODUCTION }}"
 
       - name: Deploy Hosting
         env:

--- a/scripts/sync-climb-images.mjs
+++ b/scripts/sync-climb-images.mjs
@@ -5,7 +5,7 @@
  *
  * Audits, diffs, uploads, and syncs climb artwork (climb-images/) across the
  * dev, staging, and production Firebase Storage buckets. Climb images are
- * remote-only content — the app ships no artwork — so every environment's
+ * remote-only content - the app ships no artwork - so every environment's
  * bucket must carry the images its hosted catalog references.
  *
  * Unlike the fixture seeders, production is a legitimate TARGET here (this is
@@ -36,11 +36,11 @@ const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "..");
 const CATALOG_PATH = resolve(REPO_ROOT, "web/public/climbs/catalog-v1.json");
 
-const IMAGE_PREFIX = "climb-images/";
-const IMAGE_SIZES = ["hero", "card", "thumb"];
+export const IMAGE_PREFIX = "climb-images/";
+export const IMAGE_SIZES = ["hero", "card", "thumb"];
 const IMAGE_CONTENT_TYPE = "image/heic";
-// Versioned paths are immutable — a new image set bumps imageSetVersion and
-// gets a new path — so clients and CDNs may cache aggressively.
+// Versioned paths are immutable - a new image set bumps imageSetVersion and
+// gets a new path - so clients and CDNs may cache aggressively.
 const IMAGE_CACHE_CONTROL = "public, max-age=604800, immutable";
 
 const apps = new Map();
@@ -106,18 +106,49 @@ function loadCatalog() {
   return JSON.parse(readFileSync(CATALOG_PATH, "utf-8"));
 }
 
+/**
+ * The paths the app will actually try for one variant, in the order it tries
+ * them. This mirrors `FirebaseClimbImageRepository.candidateRemotePaths`: the
+ * versioned path first, then the unversioned legacy path. An audit that only
+ * knew the versioned path would report a legacy-served climb as MISSING, and a
+ * gate that cries wolf is a gate somebody turns off.
+ */
+export function candidateObjectPaths(climb, size) {
+  const version = climb.imageSetVersion ?? 1;
+  return [
+    `${IMAGE_PREFIX}${climb.id}/v${version}/${size}.heic`,
+    `${IMAGE_PREFIX}${climb.id}/${size}.heic`,
+  ];
+}
+
 function expectedObjectPaths(catalog) {
   const paths = new Map();
   for (const climb of catalog.climbs ?? catalog) {
-    const version = climb.imageSetVersion ?? 1;
     for (const size of IMAGE_SIZES) {
-      paths.set(
-        `${IMAGE_PREFIX}${climb.id}/v${version}/${size}.heic`,
-        {climbId: climb.id, releaseState: climb.releaseState, size}
-      );
+      paths.set(candidateObjectPaths(climb, size)[0], {
+        climbId: climb.id,
+        releaseState: climb.releaseState,
+        size,
+      });
     }
   }
   return paths;
+}
+
+/**
+ * What the app would find for one climb. A climb is only publishable when every
+ * variant resolves: a hero with no card renders worse than a climb with no
+ * artwork at all, because the card is the surface people browse.
+ */
+export function resolveClimbImageSet(climb, actual) {
+  const found = [];
+  const missing = [];
+  for (const size of IMAGE_SIZES) {
+    const hit = candidateObjectPaths(climb, size).find((path) => actual.has(path));
+    if (hit) found.push({size, path: hit});
+    else missing.push(size);
+  }
+  return {climb, found, missing, complete: missing.length === 0};
 }
 
 async function listImageObjects(projectId) {
@@ -141,34 +172,60 @@ function formatBytes(bytes) {
 async function commandAudit(flags) {
   const projectId = requireProject(flags, "project");
   const catalog = loadCatalog();
+  const climbs = catalog.climbs ?? catalog;
   const expected = expectedObjectPaths(catalog);
   const actual = await listImageObjects(projectId);
 
-  const missing = [];
-  for (const [path, info] of expected) {
-    if (!actual.has(path)) {
-      missing.push({path, ...info});
-    }
+  // A control probe, not decoration. A listing that failed and a bucket that is
+  // empty both produce an empty map, and reporting the second when it was the
+  // first is how a green audit gets published over a bucket nobody could read.
+  if (actual.size === 0) {
+    process.exitCode = 1;
+    console.log(
+      `Climb image audit - ${seedEnvironmentName(projectId)} (${projectId})\n` +
+        `  Listed ZERO objects under ${IMAGE_PREFIX}. Refusing to call that a verified ` +
+        "empty bucket: an unauthorized or misrouted listing looks identical."
+    );
+    return;
   }
+
+  const sets = climbs.map((climb) => resolveClimbImageSet(climb, actual));
+  const incompleteAvailable = sets.filter(
+    (set) => set.climb.releaseState === "available" && !set.complete
+  );
+  const incompleteOther = sets.filter(
+    (set) => set.climb.releaseState !== "available" && !set.complete
+  );
   const orphans = [...actual.keys()].filter((path) => !expected.has(path));
 
-  console.log(`Climb image audit — ${seedEnvironmentName(projectId)} (${projectId})`);
-  console.log(`  catalog climbs: ${expected.size / IMAGE_SIZES.length}`);
+  console.log(`Climb image audit - ${seedEnvironmentName(projectId)} (${projectId})`);
+  console.log(`  catalog climbs: ${sets.length}`);
   console.log(`  objects in bucket under ${IMAGE_PREFIX}: ${actual.size}`);
-  console.log(`  missing expected objects: ${missing.length}`);
-  for (const item of missing) {
-    console.log(`    MISSING [${item.releaseState}] ${item.path}`);
+  console.log(
+    `  AVAILABLE climbs: ${sets.filter((set) => set.climb.releaseState === "available").length}` +
+      ` (${incompleteAvailable.length} without a complete image set)`
+  );
+  for (const set of incompleteAvailable) {
+    const state = set.found.length === 0 ? "NO IMAGES" : `PARTIAL (${set.found.length}/3)`;
+    console.log(`    ${state} ${set.climb.id} - missing ${set.missing.join(", ")}`);
+  }
+  console.log(`  unreleased climbs without a complete set: ${incompleteOther.length}`);
+  for (const set of incompleteOther) {
+    console.log(`    [${set.climb.releaseState}] ${set.climb.id} - missing ${set.missing.join(", ")}`);
   }
   console.log(`  objects not referenced by current catalog: ${orphans.length}`);
   for (const path of orphans) {
     console.log(`    EXTRA ${path}`);
   }
 
-  const missingAvailable = missing.filter((item) => item.releaseState === "available");
-  if (missingAvailable.length > 0) {
+  if (incompleteAvailable.length > 0) {
     process.exitCode = 1;
     console.log(
-      `\n${missingAvailable.length} image(s) missing for AVAILABLE climbs — these render as placeholders in the app.`
+      `\n${incompleteAvailable.length} AVAILABLE climb(s) lack a complete image set in ` +
+        `${seedEnvironmentName(projectId)}. Every one of them renders as an empty card on the ` +
+        "browse surface. Publish the artwork before publishing the catalog:\n" +
+        `  node scripts/sync-climb-images.mjs sync --from staging --to ${seedEnvironmentName(projectId)}` +
+        `${projectId === PRODUCTION_PROJECT_ID ? " --confirm-production" : ""}`
     );
   }
 }
@@ -235,7 +292,7 @@ async function commandSync(flags) {
   );
 
   if (plan.length === 0) {
-    console.log("Nothing to copy — target is up to date.");
+    console.log("Nothing to copy - target is up to date.");
     return;
   }
 
@@ -245,8 +302,13 @@ async function commandSync(flags) {
     console.log(`  ${dryRun ? "would copy" : "copying"} ${item.path}`);
     if (dryRun) continue;
     await sourceBucket.file(item.path).copy(targetBucket.file(item.path));
+    // contentType is pinned rather than inherited. A copy carries the source
+    // object's metadata, so a source uploaded through the console with a
+    // guessed type would propagate that guess into production, where the app
+    // decodes the bytes as HEIC or shows nothing.
     await targetBucket.file(item.path).setMetadata({
       cacheControl: IMAGE_CACHE_CONTROL,
+      contentType: IMAGE_CONTENT_TYPE,
     });
   }
 
@@ -332,7 +394,11 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error.message ?? error);
-  process.exit(1);
-});
+// Guarded so the contract test can import the path helpers without the CLI
+// running - the helpers are the half that must not drift from the app.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error(error.message ?? error);
+    process.exit(1);
+  });
+}

--- a/scripts/test/climb-image-publication.test.mjs
+++ b/scripts/test/climb-image-publication.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import {readFileSync} from "node:fs";
+import test from "node:test";
+import {fileURLToPath} from "node:url";
+
+import {
+  IMAGE_PREFIX,
+  IMAGE_SIZES,
+  candidateObjectPaths,
+  resolveClimbImageSet,
+} from "../sync-climb-images.mjs";
+
+const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+function read(path) {
+  return readFileSync(`${repositoryRoot}/${path}`, "utf8");
+}
+
+function catalogClimbs() {
+  const catalog = JSON.parse(read("web/public/climbs/catalog-v1.json"));
+  return catalog.climbs ?? catalog;
+}
+
+/**
+ * The audit is only a gate if it looks where the app looks. `candidateRemotePaths`
+ * is the app's authority on that, so the two are pinned to each other rather
+ * than to a remembered convention.
+ */
+test("the audit resolves the same candidate paths the app requests", () => {
+  const repository = read(
+    "AscendApp/Features/Climbs/Repositories/FirebaseClimbImageRepository.swift"
+  );
+
+  assert.match(
+    repository,
+    /"\\\(climb\.id\)\/v\\\(climb\.imageSetVersion\)\/\\\(variant\.rawValue\)\.heic"/,
+    "the app's versioned path template changed - update candidateObjectPaths"
+  );
+  assert.match(
+    repository,
+    /"\\\(climb\.id\)\/\\\(variant\.rawValue\)\.heic"/,
+    "the app's legacy fallback path template changed - update candidateObjectPaths"
+  );
+  assert.match(
+    repository,
+    /storage\.reference\(withPath: "climb-images\/\\\(remotePath\)"\)/,
+    "the app's Storage prefix changed - update IMAGE_PREFIX"
+  );
+
+  assert.deepEqual(candidateObjectPaths({id: "macau-tower", imageSetVersion: 2}, "card"), [
+    `${IMAGE_PREFIX}macau-tower/v2/card.heic`,
+    `${IMAGE_PREFIX}macau-tower/card.heic`,
+  ]);
+  assert.deepEqual(candidateObjectPaths({id: "macau-tower"}, "hero"), [
+    `${IMAGE_PREFIX}macau-tower/v1/hero.heic`,
+    `${IMAGE_PREFIX}macau-tower/hero.heic`,
+  ]);
+});
+
+test("a climb needs every variant before it counts as published", () => {
+  const climb = {id: "az-tower", releaseState: "available"};
+  const full = new Map(
+    IMAGE_SIZES.map((size) => [`${IMAGE_PREFIX}az-tower/v1/${size}.heic`, {}])
+  );
+
+  assert.equal(resolveClimbImageSet(climb, full).complete, true);
+
+  // A hero with no card is the case that reads worse than no artwork at all:
+  // the card is the surface people browse.
+  const partial = new Map(full);
+  partial.delete(`${IMAGE_PREFIX}az-tower/v1/card.heic`);
+  const partialResult = resolveClimbImageSet(climb, partial);
+  assert.equal(partialResult.complete, false);
+  assert.deepEqual(partialResult.missing, ["card"]);
+
+  const absent = resolveClimbImageSet(climb, new Map());
+  assert.equal(absent.complete, false);
+  assert.deepEqual(absent.missing, IMAGE_SIZES);
+});
+
+test("artwork served only from the legacy path still counts as published", () => {
+  const climb = {id: "gateway-arch", imageSetVersion: 1};
+  const legacyOnly = new Map(
+    IMAGE_SIZES.map((size) => [`${IMAGE_PREFIX}gateway-arch/${size}.heic`, {}])
+  );
+
+  const result = resolveClimbImageSet(climb, legacyOnly);
+  assert.equal(result.complete, true, "the app falls back to the unversioned path");
+  assert.deepEqual(
+    result.found.map((entry) => entry.path).sort(),
+    IMAGE_SIZES.map((size) => `${IMAGE_PREFIX}gateway-arch/${size}.heic`).sort()
+  );
+});
+
+test("every available climb declares an image set the audit can demand", () => {
+  const available = catalogClimbs().filter((climb) => climb.releaseState === "available");
+
+  assert.ok(available.length > 0, "the catalog must publish at least one climb");
+  for (const climb of available) {
+    const version = climb.imageSetVersion ?? 1;
+    assert.ok(
+      Number.isInteger(version) && version >= 1,
+      `${climb.id} has a non-integer imageSetVersion, so its image path is undefined`
+    );
+    assert.equal(
+      resolveClimbImageSet(climb, new Map()).missing.length,
+      IMAGE_SIZES.length,
+      `${climb.id} must require all of ${IMAGE_SIZES.join(", ")}`
+    );
+  }
+});
+
+/**
+ * The regression pin. Publishing the catalogue is what makes a climb browsable
+ * and what triggers its drop notification, so the production Hosting deploy is
+ * the last point anything can stop a climb going live with no artwork. On
+ * 2026-08-10 nothing did, and 28 of 58 available climbs rendered as empty cards
+ * for fifteen days. This fails if the audit is removed or reordered after the
+ * deploy it guards.
+ */
+test("the production deploy audits artwork before it publishes the catalogue", () => {
+  const workflow = read(".github/workflows/deploy-production.yml");
+
+  const auditIndex = workflow.indexOf(
+    "node scripts/sync-climb-images.mjs audit --project"
+  );
+  assert.notEqual(auditIndex, -1, "deploy-production must audit production climb artwork");
+
+  const hostingIndex = workflow.indexOf("--only hosting");
+  assert.notEqual(hostingIndex, -1, "deploy-production must deploy hosting");
+  assert.ok(
+    auditIndex < hostingIndex,
+    "the artwork audit must run BEFORE the hosting deploy - after it, the empty cards are already live"
+  );
+
+  const authIndex = workflow.indexOf("google-github-actions/auth");
+  assert.notEqual(
+    authIndex,
+    -1,
+    "the audit reads the production bucket through the Admin SDK and needs a Google credential"
+  );
+  assert.ok(authIndex < auditIndex, "authentication must precede the audit");
+  assert.match(
+    workflow,
+    /id-token: write/,
+    "Workload Identity Federation needs the job's OIDC token"
+  );
+});

--- a/scripts/test/climb-image-publication.test.mjs
+++ b/scripts/test/climb-image-publication.test.mjs
@@ -133,6 +133,15 @@ test("the production deploy audits artwork before it publishes the catalogue", (
     "the artwork audit must run BEFORE the hosting deploy - after it, the empty cards are already live"
   );
 
+  // Stronger than "before Hosting": a catalogue missing artwork should stop the
+  // release without production having been touched at all.
+  const firstDeployIndex = workflow.indexOf("firebase-tools@15.22.1 deploy");
+  assert.notEqual(firstDeployIndex, -1, "deploy-production must deploy something");
+  assert.ok(
+    auditIndex < firstDeployIndex,
+    "the artwork audit must run before the FIRST deploy step, so a failure leaves production untouched"
+  );
+
   const authIndex = workflow.indexOf("google-github-actions/auth");
   assert.notEqual(
     authIndex,


### PR DESCRIPTION
## The live defect is fixed

28 of the 58 climbs marked `available` in production had **no imagery at all** (0 of 3 variants), so nearly half the browsable catalogue rendered as an empty card on the screen where a climber picks a landmark. Found by opening Messeturm Basel.

**84 objects copied staging -> production. All 28 climbs now complete. 58/58 available climbs verified.**

This half needed no release and is already live. The PR is the other half.

## Verification

Re-derived the gap independently from the hosted production catalogue (`ascendstepper.com/climbs/manifest.json` -> `catalogPath`, byte-identical to the repo file), not from the handoff list. The 28 ids matched it exactly.

| | before | after |
|---|---|---|
| `available` climbs with a complete set in production | 30 / 58 | **58 / 58** |
| objects under `climb-images/` in production | 264 | 348 |

Every one of the 28 had a complete 3/3 set in **both** staging and dev, all `image/heic`. No partial sets, so nothing was copied half-done.

Copied per-climb rather than in bulk, so exactly 84 objects moved. `capitamall-one` also differs between staging and production but is `comingSoon`, so it was deliberately left alone, as were the 30 orphaned folders for retired climbs.

**Verified from the outside, not just that the objects exist:**

- All 84 pulled over `firebasestorage.googleapis.com` (the endpoint the iOS SDK hits): **84/84 HTTP 200, `image/heic`, valid HEIC magic bytes, md5 identical to staging**, 72.0 MB downloaded.
- Both controls pass: an object known absent returns 404, and `empire-state-building/v1/card.heic` (which rendered before this fix) returns 200. A method that cannot tell absence from a broken request proves nothing.
- The **live** production Storage ruleset was fetched and evaluated against all 84 paths: every one **ALLOWs a signed-in read**, a signed-out read is DENIED, and a write is DENIED. The live ruleset is byte-identical to `storage.rules` in this repo.

## How this happened

`releaseState` is not per-environment. One catalogue file deploys to dev, staging, and production, so promoting a climb to `available` commits **every** environment to having its artwork. Images are *not* per-environment content and **no deploy moves them** - they are copied bucket to bucket by `scripts/sync-climb-images.mjs`, which nothing ever calls.

Object creation timestamps tell the whole story:

| bucket | | |
|---|---|---|
| dev | 264 objects on 2026-04-03 | 87 on 2026-08-10 |
| staging | 264 objects on 2026-04-03 | 87 on 2026-08-10 |
| **production** | 264 objects on **2026-07-06** | **nothing until today** |

Production has received climb artwork exactly once, in a single manual bulk copy before launch. On 2026-08-10, #467 promoted 28 World Tour venues from `comingSoon` to `available` and their artwork went to dev and staging only. The hosting deploy published the catalogue straight past the gap, and it stayed that way for fifteen days, through the App Store launch on 2026-08-25.

**Does a script or workflow own image publishing? Yes, and it covers production fully - but nothing invokes it.** `sync-climb-images.mjs` has always supported `--project production` with a `--confirm-production` guard, and its `audit` has always exited 1 when an `available` climb lacks images. It appears in `scripts/package.json` as `images:audit:production` and in the `live-climb-content` skill. It appears in **no workflow**. Publishing images to production has always been a hand-run command.

**And this was not unnoticed.** #466 was filed the same day as the promotion. It predicted the exact failure, named the exact command, stated plainly that *"nothing in CI guards this... that check is not wired into any workflow under `.github/workflows/`"*, and declared the copy a blocking precondition, *"captain-owned and must be run by hand."* It was still open when the app went live.

So the root cause is not a missing tool or a missed detail. **The control was prose and a hand-run command owned by one person. A precondition nothing enforces is a preference.**

## The check

The smallest thing that would have caught this: run the audit that already exists, at the moment it still matters.

`deploy-production.yml` now audits the production bucket **before the first deploy step**, so a catalogue with missing artwork stops the release with production untouched. It guards the Hosting deploy in particular, which is the last point anything can stop a climb going live without artwork - and that matters more than it looks: publishing the catalogue is also what *announces* it. `announceClimbDrops` polls the manifest every five minutes and pushes every newly `available` climb to every opted-in device. Without this gate, a drop alert can advertise a climb whose card is blank.

That did not happen this time, by luck rather than design. Production's `climb_drop_notification_state/current` holds all 58 available climbs in `announcedClimbIds` with **zero dispatch documents** - the signature of `writeBootstrapState`, the first-run path that absorbs the whole catalogue into the baseline precisely to avoid announcing it. The 28 landed in that bootstrap, so no push went out. The next promotion into an already-bootstrapped production will not be so lucky: `sendingEnabled` is `true`, and a newly `available` climb goes to every opted-in device within five minutes of the deploy.

Two consequences worth your attention, neither actioned here: those 28 climbs are now permanently marked announced, so they went live with no drop alert and cannot be re-announced; and the same bootstrap means production has never actually exercised the send path.

The audit is hardened so it can carry that weight:

- **Fails on an incomplete set, not just an absent one.** A hero with no card reads worse than no artwork at all, because the card is the browse surface.
- **Resolves the same versioned-then-legacy candidates the app does**, pinned by test to `FirebaseClimbImageRepository.candidateRemotePaths`. An audit that flagged a legacy-served climb as missing would be a gate somebody turns off.
- **Refuses to read a zero-object listing as a verified-empty bucket.** A listing that failed and a bucket that is empty both return nothing.
- `sync` now **pins `contentType`** on the copy instead of inheriting it, so a source object typed by guesswork cannot propagate that guess into production.

**The gate is proven, not assumed.** I reproduced the exact failure against the real production bucket by temporarily promoting `capitamall-one` (`comingSoon`, genuinely no artwork in production) to `available`: the audit exited **1** and named it. Restored, it exits **0**. Both mutations of the new contract test were confirmed to fail when what they guard is removed.

`scripts/test/climb-image-publication.test.mjs` (5 tests) pins the ordering, so deleting the audit or moving it after any deploy step fails CI. Full suite: **585/585 pass.**

## One thing needs your decision before merge

The audit reads the bucket through the Admin SDK, and **CI has no credential that can reach the production bucket.** `FIREBASE_TOKEN` cannot do it: it is a firebase-tools refresh token and the CLI has no command that lists Storage objects. An unauthenticated probe cannot help either - `climb-images/` requires `isSignedIn()`, and I confirmed it returns 403 for present and absent objects alike, so existence does not leak.

The wiring is in place (`google-github-actions/auth`, `id-token: write`, existing `GCP_*` secret names), but it needs one IAM decision from you. `GCP_WORKLOAD_IDENTITY_PROVIDER` / `GCP_SERVICE_ACCOUNT_EMAIL` already exist but point at **staging**, whose pool is pinned to `refs/heads/develop` - and production deploys run from `main`. Two shapes:

- **A. Dedicated production identity (recommended).** New WIF pool + provider in `ascend-prod-9c8f2` scoped to `refs/heads/main`, and a service account granted only `roles/storage.objectViewer` on the production bucket. Least privilege, no change to the staging trust boundary.
- **B. Reuse the staging deployer.** Relax the staging provider's attribute condition to accept `refs/heads/main` and grant `gha-staging-deployer@ascend-staging-fa7d5` cross-project `roles/storage.objectViewer` on the production bucket. Smaller setup, but it widens what the staging identity can be used from.

**Do not merge before one of these is provisioned** - the audit step will fail closed and block production deploys. It fails closed by design; that is the correct behavior for this gate, but it needs its credential first.

Closes #466
